### PR TITLE
Fixes missing required argument "route_id" in create_deployment()

### DIFF
--- a/api-service/app.py
+++ b/api-service/app.py
@@ -50,10 +50,11 @@ async def generate():
 
     run_id = str(uuid.uuid4())
     project_id = body["projectID"]
+    route_id = body["routeID"]
     model_config = body["modelConfig"]
     prompt = body["prompt"]
 
-    await db.create_deployment(run_id=run_id, project_id=project_id)
+    await db.create_deployment(run_id=run_id, project_id=project_id, route_id=route_id)
     playground = None
 
     try:

--- a/api-service/database/database.py
+++ b/api-service/database/database.py
@@ -25,11 +25,13 @@ class Database:
         self,
         run_id: str,
         project_id: str,
+        route_id: str,
     ) -> None:
         await self.client.table(TABLE_DEPLOYMENTS).insert(
             {
                 "id": run_id,
                 "project_id": project_id,
+                "route_id": route_id,
                 "state": DeploymentState.Generating.value,
             },
         ).execute()


### PR DESCRIPTION
Fixes `"null value in column "route_id" of relation "deployments" violates not-null constraint"` error that occurs when `/api/service/generate` is called:


```bash
e2b-api-1  | [2023-04-24 04:51:15,420] ERROR in app: Exception on request POST /generate
e2b-api-1  | Traceback (most recent call last):
e2b-api-1  |   File "/app/.venv/lib/python3.10/site-packages/quart/app.py", line 1650, in handle_request
e2b-api-1  |     return await self.full_dispatch_request(request_context)
e2b-api-1  |   File "/app/.venv/lib/python3.10/site-packages/quart/app.py", line 1675, in full_dispatch_request
e2b-api-1  |     result = await self.handle_user_exception(error)
e2b-api-1  |   File "/app/.venv/lib/python3.10/site-packages/quart/app.py", line 1107, in handle_user_exception
e2b-api-1  |     raise error
e2b-api-1  |   File "/app/.venv/lib/python3.10/site-packages/quart/app.py", line 1673, in full_dispatch_request
e2b-api-1  |     result = await self.dispatch_request(request_context)
e2b-api-1  |   File "/app/.venv/lib/python3.10/site-packages/quart/app.py", line 1718, in dispatch_request
e2b-api-1  |     return await self.ensure_async(handler)(**request_.view_args)
e2b-api-1  |   File "/app/app.py", line 56, in generate
e2b-api-1  |     await db.create_deployment(run_id=run_id, project_id=project_id)
e2b-api-1  |   File "/app/database/database.py", line 29, in create_deployment
e2b-api-1  |     await self.client.table(TABLE_DEPLOYMENTS).insert(
e2b-api-1  |   File "/app/.venv/lib/python3.10/site-packages/postgrest/_async/request_builder.py", line 68, in execute
e2b-api-1  |     raise APIError(r.json())
e2b-api-1  | postgrest.exceptions.APIError: {'code': '23502', 'details': 'Failing row contains (e1978c15-fe14-4d96-9ebf-aa02b20f44b6, 2023-04-24 04:51:15.405415+00, null, happy-moons-attack, null, generating, null, ).', 'hint': None, 'message': 'null value in column "route_id" of relation "deployments" violates not-null constraint'}
```

**Steps to reproduce the error:**
- Clone https://github.com/e2b-dev/e2b
- `npm install`
- `npm start`
- Create a new API and provide any prompt
- Click "Run" 
- Observe the error in your shell
