### PR TITLE
Fix install:all; poetry error fixed by adding --no-root flag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "next build",
     "start:api": "cd api-service && cross-env PYTHONUNBUFFERED=1 poetry run uvicorn app:app --reload --host 0.0.0.0 --port 49155",
     "start:playground": "cd api-service/playground && npm run dev",
-    "install:api-service": "cd api-service && poetry install --with dev && cd playground && npm install",
+    "install:api-service": "cd api-service && poetry install --with dev --no-root && cd playground && npm install",
     "install:api-playground": "cd api-service/playground && npm install",
     "install:all": "npm install && npm run install:api-service && npm run install:api-playground",
     "start": "docker compose build && (npm run db:reset || true && npm run db:start && docker compose up)",


### PR DESCRIPTION
Found it from here: https://github.com/python-poetry/poetry/issues/689#issuecomment-755452534

The `--no-root` flag stops poetry from trying to install the package. https://python-poetry.org/docs/cli/#:~:text=If%20you%20want%20to%20skip%20this%20installation%2C%20use%20the%20%2D%2Dno%2Droot%20option