### PR TITLE
Supabase - Changed group name for a new user

### DIFF
--- a/supabase/functions/new_user/index.ts
+++ b/supabase/functions/new_user/index.ts
@@ -8,7 +8,7 @@ serve(async (req) => {
 
   const body = {
     email: data.record.email,
-    userGroup: 'signUpUser'
+    userGroup: 'Supabase Authenticated'
   }
   console.log(`New user with email: ${body.email} created`)
 

--- a/supabase/functions/new_user/index.ts
+++ b/supabase/functions/new_user/index.ts
@@ -8,7 +8,7 @@ serve(async (req) => {
 
   const body = {
     email: data.record.email,
-    userGroup: 'Supabase Authenticated'
+    userGroup: 'Authenticated'
   }
   console.log(`New user with email: ${body.email} created`)
 


### PR DESCRIPTION
I am open for other suggestions. The reason for choosing this name:
- It's descriptive
- Will be always true
