### PR TITLE
Add redirectd from `/` pages for docs and dashboard

### DIFF
--- a/apps/dashboard/next.config.js
+++ b/apps/dashboard/next.config.js
@@ -8,10 +8,17 @@ const nextConfig = {
         source: '/ingest/:path*',
         destination: 'https://app.posthog.com/:path*',
       },
+    ]
+  },
+  async redirects() {
+    return [
+      // This is for local development and vercel previews - otherwise you would have to always add /dashboard to the url
       {
         source: '/',
         destination: '/dashboard',
-      },
+        permanent: false,
+        basePath: false,
+      }
     ]
   }
 }

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -17,11 +17,14 @@ const withMDX = nextMDX({
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
   basePath: '/docs',
-  async rewrites() {
+  async redirects() {
     return [
+      // This is for local development and vercel previews - otherwise you would have to always add /docs to the url
       {
         source: '/',
         destination: '/docs',
+        permanent: false,
+        basePath: false,
       }
     ]
   }


### PR DESCRIPTION
This is an improvement for local development and vercel previews - otherwise you would have to always add `/dashboard` or `/docs` to the url.