### PR TITLE
feat(js-sdk): JS SDK logging

### DIFF
--- a/packages/js-sdk/src/utils/logger.ts
+++ b/packages/js-sdk/src/utils/logger.ts
@@ -1,17 +1,65 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type LogID = string | (() => string)
 
-class Logger {
-  constructor(public readonly logID: LogID, public readonly isEnabled = false) {}
+export const levels = ['debug', 'info', 'warn', 'error']
+export const levelsOrNone = [...levels, 'none']
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+export type LogLevelOrNone = LogLevel | 'none'
 
-  error(...args: any[]) {
-    console.error(`\x1b[31m[${this.id()} ERROR]\x1b[0m`, ...args)
+interface Logger {
+  debug(...args: any[]): void
+  info(...args: any[]): void
+  warn(...args: any[]): void
+  error(...args: any[]): void
+}
+
+const colors = {
+  debug: '\x1b[90m', // gray
+  info: '\x1b[36m', // cyan
+  warn: '\x1b[33m', // yellow
+  error: '\x1b[31m', // red
+}
+
+class Logger {
+  constructor(
+    public readonly logID: LogID,
+    public readonly consoleLogLevel: LogLevelOrNone = 'info',
+    public readonly customLogger?: Logger,
+  ) {
+    if (!levelsOrNone.includes(consoleLogLevel)) {
+      throw new Error(
+        `Invalid consoleLogLevel: "${consoleLogLevel}", supported values: ${levelsOrNone.join(
+          ', ',
+        )}, default: "info"`,
+      )
+    }
   }
 
-  log(...args: any[]) {
-    if (this.isEnabled) {
-      console.log(`\x1b[36m[${this.id()}]\x1b[0m`, ...args)
-    }
+  debug(...args: any[]) {
+    return this.log('debug', ...args)
+  }
+
+  info(...args: any[]) {
+    return this.log('info', ...args)
+  }
+
+  warn(...args: any[]) {
+    return this.log('warn', ...args)
+  }
+
+  error(...args: any[]) {
+    return this.log('error', ...args)
+  }
+
+  private log(level: LogLevel, ...args: any[]) {
+    // is there's custom logger, use it
+    if (this.customLogger) return this.customLogger[level](...args)
+
+    // if level is lower than consoleLogLevel, don't log
+    if (levels.indexOf(level) < levels.indexOf(this.consoleLogLevel)) return
+    const color = colors[level]
+    const consoleMethod = console[level]
+    consoleMethod(`${color}[${this.id()} ${level.toUpperCase()}]\x1b[0m`, ...args)
   }
 
   private id() {


### PR DESCRIPTION
I've considered using [debug](https://github.com/debug-js/debug), [loglevel](https://github.com/pimterry/loglevel), and [logging](https://www.npmjs.com/package/logging)... AFAIK there's not one true way of doing logging in the JS ecosystem that would:

* support multiple levels (debug, info, warn, error)
* allow overriding via custom loggers
* allow using both custom logger and console logging
* does not require changing existing project structure

I've decided to go with minimal changes to the codebase and maximum explicitness to avoid confusing of SDK users.

Log INFO and above to console
```
const session = await Session.create({
  id: 'Nodejs',
  apiKey: process.env.E2B_API_KEY,
})
```

Log DEBUG and above to console, aka **verbose mode**
```
const session = await Session.create({
  id: 'Nodejs',
  apiKey: process.env.E2B_API_KEY,
  consoleLogLevel: 'debug',
})
```

Log WARN and ERROR to console, aka **quiet mode**
```
const session = await Session.create({
  id: 'Nodejs',
  apiKey: process.env.E2B_API_KEY,
  consoleLogLevel: 'warn',
})
```

Log NOTHING to console, aka **silent mode**
```
const session = await Session.create({
  id: 'Nodejs',
  apiKey: process.env.E2B_API_KEY,
  consoleLogLevel: 'none',
})
```

Log NOTHING to console and provide custom logger, aka **custom mode**
```
const session = await Session.create({
  id: 'Nodejs',
  apiKey: process.env.E2B_API_KEY,
  consoleLogLevel: 'none',
  customLogger: ... 
})
```

Log WARN and ERROR to console, and provide custom logger, aka **quiet** console and verbose custom logger
```
const session = await Session.create({
  id: 'Nodejs',
  apiKey: process.env.E2B_API_KEY,
  consoleLogLevel: 'warn',
  customLogger: ... 
})
```