### PR TITLE
CodeGroupAutoload

### DIFF
--- a/apps/docs/src/app/playgrounds/overview/page.mdx
+++ b/apps/docs/src/app/playgrounds/overview/page.mdx
@@ -22,11 +22,4 @@ The AI playgorunds run on E2B's cloud infrastructure. Use our [SDK](/getting-sta
 
 Here's a quick code example showing how to create an AI Playground.
 
-<CodeGroup>
-```python {{ language: 'python', snippet: 'python/basics/init.py' }}
-```
-```js {{ language: 'js', snippet: 'js/basics/init.js' }}
-```
-</CodeGroup>
-
-Head over to [SDK Basics](/getting-started/basics) to see more quick start examples.
+<CodeGroupAutoload path="basics/init" />

--- a/apps/docs/src/components/Code.tsx
+++ b/apps/docs/src/components/Code.tsx
@@ -78,7 +78,6 @@ function CodePanel({
   code?: string
 }) {
   let child = Children.only(children)
-
   if (isValidElement(child)) {
     tag = child.props.tag ?? tag
     label = child.props.label ?? label
@@ -250,14 +249,13 @@ export function CodeGroup({
   children,
   title,
   ...props
-}: React.ComponentPropsWithoutRef<typeof CodeGroupPanels> & { title: string }) {
+}: React.ComponentPropsWithoutRef<typeof CodeGroupPanels> & { title?: string }) {
   let languages =
     Children.map(children, (child) =>
       getPanelTitle(isValidElement(child) ? child.props : {})
     ) ?? []
   let tabGroupProps = useTabGroupProps(languages)
   let hasTabs = Children.count(children) > 1
-
   let containerClassName =
     'not-prose my-6 overflow-hidden rounded-2xl bg-zinc-900 shadow-md dark:ring-1 dark:ring-white/10'
   let header = (
@@ -318,4 +316,15 @@ export function Pre({
   }
 
   return <CodeGroup {...props}>{children}</CodeGroup>
+}
+
+/**
+ * Special Component just for MDX files, processed by Remark
+ */
+export function CodeGroupAutoload({children}) {
+  if (!children) {
+    console.warn(`CodeGroupAutoload: No children provided – something is wrong with your MDX file`)
+    return null
+  }
+  return <CodeGroup>{children}</CodeGroup>
 }

--- a/apps/docs/src/components/mdx.tsx
+++ b/apps/docs/src/components/mdx.tsx
@@ -7,7 +7,7 @@ import { Prose } from '@/components/Prose'
 
 export const a = Link
 export { Button } from '@/components/Button'
-export { CodeGroup, Code as code, Pre as pre } from '@/components/Code'
+export { CodeGroupAutoload, CodeGroup, Code as code, Pre as pre } from '@/components/Code'
 
 export function wrapper({ children }: { children: React.ReactNode }) {
   return (


### PR DESCRIPTION
`````
/* BEFORE */
<CodeGroup>
```python {{ language: 'python', snippet: 'python/basics/init.py' }}
```
```js {{ language: 'js', snippet: 'js/basics/init.js' }}
```
</CodeGroup>

/* AFTER */
<CodeGroupAutoload path="basics/init" />
`````