### PR TITLE
Fix CLI

### DIFF
--- a/.changeset/curly-bears-protect.md
+++ b/.changeset/curly-bears-protect.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Remove content type and fix bug

--- a/packages/cli/src/commands/env/create.ts
+++ b/packages/cli/src/commands/env/create.ts
@@ -88,9 +88,7 @@ export const createCommand = new commander.Command('create')
 
       if (!fs.existsSync(tarPath)) throw new Error(`Tar file ${tarPath} does not exist`)
 
-      const buildContextBlob = new Blob([fs.readFileSync(tarPath)], {
-        type: 'application/gzip',
-      })
+      const buildContextBlob = new Blob([fs.readFileSync(tarPath)])
       let dockerfileContent
       if (fs.existsSync(`${root}/Dockerfile`)) {
         dockerfileContent = fs.readFileSync(`${root}/Dockerfile`, 'utf-8')

--- a/packages/cli/src/utils/filesystem.ts
+++ b/packages/cli/src/utils/filesystem.ts
@@ -5,6 +5,7 @@ import * as fsPromise from 'fs/promises'
 import gitIgnore, { Ignore } from 'ignore'
 import * as path from 'path'
 import tar from 'tar-fs'
+import * as util from 'util'
 
 const walk = util.promisify(fsWalk.walk)
 


### PR DESCRIPTION
- remove content type (otherwise go won't accept the request - the openapi3filter doesn't support application/gzip)
- fix missing import