### PR TITLE
chore(js-sdk): Log session init/termination by default

### DIFF
--- a/.changeset/rare-moons-dream.md
+++ b/.changeset/rare-moons-dream.md
@@ -1,0 +1,5 @@
+---
+'@e2b/sdk': patch
+---
+
+Log session init/termination by default

--- a/packages/js-sdk/src/session/sessionConnection.ts
+++ b/packages/js-sdk/src/session/sessionConnection.ts
@@ -72,11 +72,13 @@ export class SessionConnection {
       )
     }
     this.logger = opts.logger ?? {
-      // by default, we log to the console, only warnings and errors
+      // by default, we log to the console
+      // we don't log debug messages by default
+      info: console.info,
       warn: console.warn,
       error: console.error,
     }
-    this.logger.info?.(`Session for code snippet "${opts.id}" initialized`)
+    this.logger.info?.(`Session "${opts.id}" initialized`)
   }
 
   /**


### PR DESCRIPTION
Mostly to test automatic deployment