### PR TITLE
remove artifact.read() and leave only download()

### DIFF
--- a/.changeset/blue-shirts-sneeze.md
+++ b/.changeset/blue-shirts-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@e2b/python-sdk': minor
+---
+
+Make artifact.download() return bytes and remove the artifact.read() method

--- a/packages/python-sdk/e2b/templates/data_analysis.py
+++ b/packages/python-sdk/e2b/templates/data_analysis.py
@@ -21,14 +21,8 @@ class Artifact(BaseModel):
     def __hash__(self):
         return hash(self.name)
 
-    def read(self) -> bytes:
+    def download(self) -> bytes:
         return self._session.download_file(self.name)
-
-    def download(self, path: Optional[str] = None) -> None:
-        data = self.read()
-        with open(path or self.name, "wb") as f:
-            f.write(data)
-
 
 class DataAnalysis(SyncSession):
     env_id = "Python3-DataAnalysis"


### PR DESCRIPTION
The goal of this PR is to have the same API for downloading artifacts for both JS and Python SDK:

Python
```python
artifact_bytes = artifact.download()
```

JS
```js
const artifact_buffer = await artifact.download()
```

Python SDK had `artifact.read()`  and `artifact.download()`. The `read` method returned `bytes` and `download` wrote to a local file. I got rid of the original `download` method (leaving writing to a file to the user) and renamed the original `read` to `download`.