### PR TITLE
Fix `install_system_packages` method in the Python SDK

### DIFF
--- a/.changeset/fifty-cats-divide.md
+++ b/.changeset/fifty-cats-divide.md
@@ -1,0 +1,5 @@
+---
+'@e2b/python-sdk': patch
+---
+
+Fix the "install_system_packages" method in the Python SDK

--- a/packages/python-sdk/e2b/templates/data_analysis.py
+++ b/packages/python-sdk/e2b/templates/data_analysis.py
@@ -118,7 +118,7 @@ class DataAnalysis(Session):
         if isinstance(package_names, list):
             package_names = " ".join(package_names)
 
-        process = self.process.start(f"apt-get {package_names}", timeout=timeout)
+        process = self.process.start(f"apt-get install {package_names}", timeout=timeout)
         process.wait()
 
         if process.exit_code != 0:


### PR DESCRIPTION
It was `apt-get {package}` instead of `apt-get install {package}`