### PR TITLE
Use __future__ annotation to fix backwards compatibility for union

### DIFF
--- a/.changeset/five-lemons-join.md
+++ b/.changeset/five-lemons-join.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Fix Python 3.8 compatibility

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from importlib.metadata import version
 
 from e2b.constants import API_HOST

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -1,9 +1,9 @@
-from __future__ import annotations
-
 from importlib.metadata import version
+from typing import Union
 
 from e2b.constants import API_HOST
 from e2b.api.metadata import default_headers
+
 
 pydantic_version = version("pydantic")
 if pydantic_version < "2.0.0":
@@ -26,8 +26,8 @@ configuration = client.Configuration(
 class E2BApiClient(client.ApiClient):
     def __init__(
         self,
-        api_key: str | None = None,
-        access_token: str | None = None,
+        api_key: Union[str, None] = None,
+        access_token: Union[str, None] = None,
         *args,
         **kwargs,
     ):


### PR DESCRIPTION
In python 3.9 and below you can't do something like str | None in the type definition of a function's arguments. However, this can be fixed by using __future__. 

Python stores the annotations as strings and doesn't try to evaluate them. This allows you to write type hints using Python 3.10's syntax in a Python 3.9 environment. When the code is actually run, the annotations aren't evaluated, so there's no issue with the interpreter not understanding the | operator for union types. 