### PR TITLE
Add start cmd option for the build in the CLI

### DIFF
--- a/.changeset/stale-eels-care.md
+++ b/.changeset/stale-eels-care.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Add extra build feature

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -60,6 +60,10 @@ export const buildCommand = new commander.Command('build')
     '-n, --name <template-name>',
     'Specify sandbox template name. You can use the template name to start the sandbox with SDK. The template name must be lowercase and contain only letters, numbers, dashes and underscores',
   )
+  .option(
+    '-c, --start-cmd <cmd>',
+    'Specify command that will be executed when the sandbox is started',
+  )
   .alias('bd')
   .action(
     async (
@@ -68,6 +72,7 @@ export const buildCommand = new commander.Command('build')
         path?: string;
         dockerfile?: string;
         name?: string;
+        startCmd?: string;
       },
     ) => {
       try {
@@ -84,6 +89,7 @@ export const buildCommand = new commander.Command('build')
 
         let envID = id
         let dockerfile = opts.dockerfile
+        let startCmd = opts.startCmd
 
         const root = getRoot(opts.path)
         const configPath = getConfigPath(root)
@@ -105,7 +111,8 @@ export const buildCommand = new commander.Command('build')
             )}`,
           )
           envID = config.id
-          dockerfile = config.dockerfile
+          dockerfile = opts.dockerfile || config.dockerfile
+          startCmd = opts.startCmd || config.start_cmd
         }
 
         if (config && id && config.id !== id) {
@@ -165,6 +172,10 @@ export const buildCommand = new commander.Command('build')
           body.append('alias', name)
         }
 
+        if (startCmd) {
+          body.append('startCmd', startCmd)
+        }
+
         const build = await buildTemplate(accessToken, body, envID)
 
         console.log(
@@ -180,7 +191,8 @@ export const buildCommand = new commander.Command('build')
           {
             id: build.envID,
             dockerfile: dockerfileRelativePath,
-            name: name,
+            name,
+            start_cmd: startCmd,
           },
           true,
         )

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -61,7 +61,7 @@ export const buildCommand = new commander.Command('build')
     'Specify sandbox template name. You can use the template name to start the sandbox with SDK. The template name must be lowercase and contain only letters, numbers, dashes and underscores',
   )
   .option(
-    '-c, --start-cmd <cmd>',
+    '-c, --cmd <start-command>',
     'Specify command that will be executed when the sandbox is started',
   )
   .alias('bd')
@@ -72,7 +72,7 @@ export const buildCommand = new commander.Command('build')
         path?: string;
         dockerfile?: string;
         name?: string;
-        startCmd?: string;
+        cmd?: string;
       },
     ) => {
       try {
@@ -89,7 +89,7 @@ export const buildCommand = new commander.Command('build')
 
         let envID = id
         let dockerfile = opts.dockerfile
-        let startCmd = opts.startCmd
+        let startCmd = opts.cmd
 
         const root = getRoot(opts.path)
         const configPath = getConfigPath(root)
@@ -112,7 +112,7 @@ export const buildCommand = new commander.Command('build')
           )
           envID = config.id
           dockerfile = opts.dockerfile || config.dockerfile
-          startCmd = opts.startCmd || config.start_cmd
+          startCmd = opts.cmd || config.start_cmd
         }
 
         if (config && id && config.id !== id) {

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -17,6 +17,7 @@ export const configSchema = yup.object({
   name: yup.string(),
   id: yup.string().required(),
   dockerfile: yup.string().required(),
+  start_cmd: yup.string(),
 })
 
 export type E2BConfig = yup.InferType<typeof configSchema>;


### PR DESCRIPTION
This start command is provided during template build, executed on FC start and snapshotted with the sandbox template. After starting sandbox users will have this command already running there.