### PR TITLE
Deprecate `id` parameter when spawning `Sandbox` and add `template` parameter instead

### DIFF
--- a/.changeset/moody-zebras-doubt.md
+++ b/.changeset/moody-zebras-doubt.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Update template naming field when using CLI

--- a/.changeset/nasty-poets-press.md
+++ b/.changeset/nasty-poets-press.md
@@ -1,0 +1,6 @@
+---
+"@e2b/python-sdk": patch
+"@e2b/sdk": patch
+---
+
+Deprecate id Sandbox parameter and add template parameter

--- a/apps/docs/src/app/cli/commands/page.mdx
+++ b/apps/docs/src/app/cli/commands/page.mdx
@@ -17,7 +17,7 @@ e2b build
 ```
 
 <Note>
-Running `e2b build` without specifying a template with the `[id]` argument will rebuild template defined by the `e2b.toml` config.
+Running `e2b build` without specifying a template with the `[template]` argument will rebuild template defined by the `e2b.toml` config.
 
 If there is no `e2b.toml` config a new template will be created.
 </Note>
@@ -25,7 +25,7 @@ If there is no `e2b.toml` config a new template will be created.
 #### **Arguments**
 
 <Options>
-  <Option type="[id]">
+  <Option type="[template]">
     Specify the template you want to rebuild. You can use the template name or ID.
   </Option>
 </Options>
@@ -68,7 +68,7 @@ e2b template init
 
 ## `delete`
 
-Delete the sandbox template specified by the `[id]` argument, `e2b.toml` config in the working directory, or by an interactive selection.
+Delete the sandbox template specified by the `[template]` argument, `e2b.toml` config in the working directory, or by an interactive selection.
 By default, the root directory is the current working directory.
 
 This command also deletes the `e2b.toml` config.
@@ -78,13 +78,13 @@ e2b delete
 ```
 
 <Note>
-Running `e2b delete` without specifying a template with the `[id]` argument will delete the template defined by the `e2b.toml` config.
+Running `e2b delete` without specifying a template with the `[template]` argument will delete the template defined by the `e2b.toml` config.
 </Note>
 
 #### **Arguments**
 
 <Options>
-  <Option type="[id]">
+  <Option type="[template]">
     Specify the template you want to delete. You can use the template name or ID.
   </Option>
 </Options>
@@ -147,13 +147,13 @@ e2b shell
 ```
 
 <Note>
-Running `e2b shell` without specifying a template with the `[id]` argument will spawn sandbox defined by the `e2b.toml` config.
+Running `e2b shell` without specifying a template with the `[template]` argument will spawn sandbox defined by the `e2b.toml` config.
 </Note>
 
 #### **Arguments**
 
 <Options>
-  <Option type="[id]" name="template-name-or-id">
+  <Option type="[template]">
     Specify the template you want to spawn sandbox from. You can use the template name or ID.
   </Option>
 </Options>

--- a/apps/docs/src/app/guide/custom-sandbox/page.mdx
+++ b/apps/docs/src/app/guide/custom-sandbox/page.mdx
@@ -129,9 +129,9 @@ This will create the `e2b.toml` file storing the sandbox config.
 <CodeGroup isFileName title="e2b.toml" isRunnable={false}>
 ```toml
 # This is a config for E2B sandbox template
-template = "1wdqsf9le9gk21ztb4mo"
+template_id = "1wdqsf9le9gk21ztb4mo"
 dockerfile = "e2b.Dockerfile"
-name = "my-agent-sandbox"
+template_name = "my-agent-sandbox"
 ```
 </CodeGroup>
 

--- a/apps/docs/src/app/guide/custom-sandbox/page.mdx
+++ b/apps/docs/src/app/guide/custom-sandbox/page.mdx
@@ -129,7 +129,7 @@ This will create the `e2b.toml` file storing the sandbox config.
 <CodeGroup isFileName title="e2b.toml" isRunnable={false}>
 ```toml
 # This is a config for E2B sandbox template
-id = "1wdqsf9le9gk21ztb4mo"
+template = "1wdqsf9le9gk21ztb4mo"
 dockerfile = "e2b.Dockerfile"
 name = "my-agent-sandbox"
 ```
@@ -153,7 +153,7 @@ e2b build
 
 Now you can use the [E2B SDK](/getting-started/installation) to spawn & control your new custom sandbox.
 
-The sandbox template name is `my-agent-sandbox`. We'll use it as an unique identifier and pass it to the SDK as the `id` parameter.
+The sandbox template name is `my-agent-sandbox`. We'll use it as an unique identifier and pass it to the SDK as the `template` parameter.
 This way, we'll be able to spawn our custom sandbox and control it with the SDK.
 
 <CodeGroup title="Spawn & control your custom sandbox" isRunnable={true}>

--- a/apps/docs/src/app/guide/custom-sandbox/page.mdx
+++ b/apps/docs/src/app/guide/custom-sandbox/page.mdx
@@ -161,7 +161,7 @@ This way, we'll be able to spawn our custom sandbox and control it with the SDK.
 import { Sandbox } from '@e2b/sdk'
 
 // Spawn your custom sandbox
-const sandbox = await Sandbox.create({ id: 'my-agent-sandbox' }) // $HighlightLine
+const sandbox = await Sandbox.create({ template: 'my-agent-sandbox' }) // $HighlightLine
 
 // Interact with sandbox. Learn more here:
 // https://e2b.dev/docs/sandbox/overview
@@ -174,7 +174,7 @@ await sandbox.close()
 from e2b import Sandbox
 
 # Spawn your custom sandbox
-sandbox = Sandbox(id="my-agent-sandbox") # $HighlightLine
+sandbox = Sandbox(template="my-agent-sandbox") # $HighlightLine
 
 # Interact with sandbox. Learn more here:
 # https://e2b.dev/docs/sandbox/overview

--- a/apps/docs/src/app/sandbox/custom/page.mdx
+++ b/apps/docs/src/app/sandbox/custom/page.mdx
@@ -32,7 +32,7 @@ Once you build your custom sandbox template, you can spawn multiple isolated san
 
       # Create new sandbox
       sandbox = Sandbox(
-        template="<sandbox-template-id>", # You get sandbox ID from the CLI after you run `$ e2b build`
+        template="<sandbox-template>", # You get sandbox template from the CLI after you run `$ e2b build`
       )
 
       # Close sandbox once done

--- a/apps/docs/src/app/sandbox/custom/page.mdx
+++ b/apps/docs/src/app/sandbox/custom/page.mdx
@@ -20,7 +20,7 @@ Once you build your custom sandbox template, you can spawn multiple isolated san
 
       // Create new sandbox
       const sandbox = await Sandbox.create({
-        id: '<sandbox-template-id>', // You get sandbox ID from the CLI after you run `$ e2b build`
+        template: '<sandbox-template-id>', // You get sandbox template ID from the CLI after you run `$ e2b build`
       })
 
       // Close sandbox once done
@@ -32,7 +32,7 @@ Once you build your custom sandbox template, you can spawn multiple isolated san
 
       # Create new sandbox
       sandbox = Sandbox(
-        id="<sandbox-template-id>", # You get sandbox ID from the CLI after you run `$ e2b build`
+        template="<sandbox-template-id>", # You get sandbox ID from the CLI after you run `$ e2b build`
       )
 
       # Close sandbox once done

--- a/apps/docs/src/app/sandbox/templates/overview/page.mdx
+++ b/apps/docs/src/app/sandbox/templates/overview/page.mdx
@@ -32,8 +32,8 @@ Follow our [guide](/guide/custom-sandbox) on how to create a custom sandbox.
 
       // Create new sandbox
       const sandbox = await Sandbox.create({
-        // You get sandbox ID from the CLI after you run `$ e2b build`
-        template: '<sandbox-template-id>',  // $HighlightLine
+        // You get sandbox template from the CLI after you run `$ e2b build`
+        template: '<sandbox-template>',  // $HighlightLine
       })
 
       // Close sandbox once done
@@ -45,8 +45,8 @@ Follow our [guide](/guide/custom-sandbox) on how to create a custom sandbox.
 
       # Create new sandbox
       sandbox = Sandbox(
-        # You get sandbox ID from the CLI after you run `$ e2b build`
-        template="<sandbox-template-id>", # $HighlightLine
+        # You get sandbox template from the CLI after you run `$ e2b build`
+        template="<sandbox-template>", # $HighlightLine
       )
 
       # Close sandbox once done

--- a/apps/docs/src/app/sandbox/templates/overview/page.mdx
+++ b/apps/docs/src/app/sandbox/templates/overview/page.mdx
@@ -33,7 +33,7 @@ Follow our [guide](/guide/custom-sandbox) on how to create a custom sandbox.
       // Create new sandbox
       const sandbox = await Sandbox.create({
         // You get sandbox ID from the CLI after you run `$ e2b build`
-        id: '<sandbox-template-id>',  // $HighlightLine
+        template: '<sandbox-template-id>',  // $HighlightLine
       })
 
       // Close sandbox once done
@@ -46,7 +46,7 @@ Follow our [guide](/guide/custom-sandbox) on how to create a custom sandbox.
       # Create new sandbox
       sandbox = Sandbox(
         # You get sandbox ID from the CLI after you run `$ e2b build`
-        id="<sandbox-template-id>", # $HighlightLine
+        template="<sandbox-template-id>", # $HighlightLine
       )
 
       # Close sandbox once done

--- a/apps/docs/src/app/sandbox/templates/premade/page.mdx
+++ b/apps/docs/src/app/sandbox/templates/premade/page.mdx
@@ -21,7 +21,7 @@ To get your started quickly, we offer two premade sandboxes.
   Template File
 </Link>
 <div className="pr-1 w-[320px] flex items-center justify-start space-x-2 border border-gray-600 rounded">
-  <span className="font-mono text-sm w-8 h-8 flex items-center justify-center border-r border-gray-600">id</span>
+  <span className="font-mono text-sm w-8 h-8 flex items-center justify-center border-r border-gray-600">template</span>
   <span className="font-mono text-sm text-gray-200">base</span>
 </div>
 
@@ -49,7 +49,7 @@ The base sandbox has all the features of the [Sandbox API](/api/envs) available.
 </Link>
 
 <div className="pr-1 w-[320px] flex items-center justify-start space-x-2 border border-gray-600 rounded">
-  <span className="font-mono text-sm w-8 h-8 flex items-center justify-center border-r border-gray-600">id</span>
+  <span className="font-mono text-sm w-8 h-8 flex items-center justify-center border-r border-gray-600">template</span>
   <span className="font-mono text-sm text-gray-200">Python3-CodeInterpreter</span>
 </div>
 
@@ -201,4 +201,3 @@ sandbox.close()
 - Stream code errors
 - Upload file
 - Download file */}
-

--- a/apps/docs/src/app/sandbox/templates/start-cmd/page.mdx
+++ b/apps/docs/src/app/sandbox/templates/start-cmd/page.mdx
@@ -61,9 +61,9 @@ You can find the start command for the sandbox template in the `e2b.toml`:
 <CodeGroup isFileName title="e2b.toml" isRunnable={false}>
 ```toml
 # This is a config for E2B sandbox template
-id = "1wdqsf9le9gk21ztb4mo"
+template_id = "1wdqsf9le9gk21ztb4mo"
 dockerfile = "e2b.Dockerfile"
-name = "my-agent-sandbox"
+template_name = "my-agent-sandbox"
 start_cmd = "npm start"  # $HighlightLine
 ```
 </CodeGroup>

--- a/apps/docs/src/code/js/agents/clone_repo.js
+++ b/apps/docs/src/code/js/agents/clone_repo.js
@@ -3,7 +3,7 @@ import { Sandbox } from '@e2b/sdk'
 // 1. Start the playground sandbox
 const sandbox = await Sandbox.create({
   // You can pass your own sandbox template id
-  id: 'base',
+  template: 'base',
   apiKey: process.env.E2B_API_KEY,
 })
 

--- a/apps/docs/src/code/js/agents/code_exec.js
+++ b/apps/docs/src/code/js/agents/code_exec.js
@@ -3,7 +3,7 @@ import { Sandbox } from '@e2b/sdk'
 // 1. Start the playground sandbox
 const sandbox = await Sandbox.create({
   // You can pass your own sandbox template id
-  id: 'base',
+  template: 'base',
 })
 
 // 2. Save the JavaScript code to a file inside the playground

--- a/apps/docs/src/code/js/agents/install_deps_npm.js
+++ b/apps/docs/src/code/js/agents/install_deps_npm.js
@@ -2,7 +2,7 @@ import { Sandbox } from '@e2b/sdk'
 
 // 1. Start the playground sandbox
 const sandbox = await Sandbox.create({
-  id: 'base', // $HighlightLine
+  template: 'base', // $HighlightLine
   apiKey: process.env.E2B_API_KEY,
 })
 

--- a/apps/docs/src/code/js/agents/start_process.js
+++ b/apps/docs/src/code/js/agents/start_process.js
@@ -3,7 +3,7 @@ import { Sandbox } from '@e2b/sdk'
 // 1. Start the playground sandbox
 const sandbox = await Sandbox.create({
   // You can pass your own sandbox template id
-  id: 'base',
+  template: 'base',
   apiKey: process.env.E2B_API_KEY,
 })
 

--- a/apps/docs/src/code/js/basics/download_file.js
+++ b/apps/docs/src/code/js/basics/download_file.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 import fs from 'node:fs'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 const buffer = await sandbox.downloadFile('path/to/remote/file/inside/sandbox') // $HighlightLine
 // Save file to local filesystem

--- a/apps/docs/src/code/js/basics/fs_ls.js
+++ b/apps/docs/src/code/js/basics/fs_ls.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
 })
 
 const dirContent = await sandbox.filesystem.list('/') // $HighlightLine

--- a/apps/docs/src/code/js/basics/fs_mkdir.js
+++ b/apps/docs/src/code/js/basics/fs_mkdir.js
@@ -1,6 +1,6 @@
 import { Sandbox } from '@e2b/sdk'
 
-const sandbox = await Sandbox.create({ id: 'base' })
+const sandbox = await Sandbox.create({ template: 'base' })
 
 // Create a new directory '/dir'
 await sandbox.filesystem.makeDir('/dir') // $HighlightLine

--- a/apps/docs/src/code/js/basics/fs_read.js
+++ b/apps/docs/src/code/js/basics/fs_read.js
@@ -1,6 +1,6 @@
 import { Sandbox } from '@e2b/sdk'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 const fileContent = await sandbox.filesystem.read('/etc/hosts') // $HighlightLine
 console.log(fileContent)

--- a/apps/docs/src/code/js/basics/fs_read_bytes.js
+++ b/apps/docs/src/code/js/basics/fs_read_bytes.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import { Sandbox } from '@e2b/sdk'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 // File bytes will read file's content as bytes
 // `fileBytes` as a Uint8Array

--- a/apps/docs/src/code/js/basics/fs_watch.js
+++ b/apps/docs/src/code/js/basics/fs_watch.js
@@ -1,6 +1,6 @@
 import { Sandbox } from '@e2b/sdk'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 // Start filesystem watcher for the /home directory
 const watcher = sandbox.filesystem.watchDir('/home') // $HighlightLine

--- a/apps/docs/src/code/js/basics/fs_write.js
+++ b/apps/docs/src/code/js/basics/fs_write.js
@@ -1,6 +1,6 @@
 import { Sandbox } from '@e2b/sdk'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 // `filesystem.write()` will:
 // - create the file if it doesn't exist

--- a/apps/docs/src/code/js/basics/fs_write_bytes.js
+++ b/apps/docs/src/code/js/basics/fs_write_bytes.js
@@ -1,6 +1,6 @@
 import { Sandbox } from '@e2b/sdk'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 // Let's convert string to bytes for testing purposes
 const encoder = new TextEncoder('utf-8')

--- a/apps/docs/src/code/js/basics/get_url.js
+++ b/apps/docs/src/code/js/basics/get_url.js
@@ -1,6 +1,6 @@
 import { Sandbox } from '@e2b/sdk'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 const url = sandbox.getHostname() // $HighlightLine
 console.log('https://' + url)

--- a/apps/docs/src/code/js/basics/get_url_port.js
+++ b/apps/docs/src/code/js/basics/get_url_port.js
@@ -1,6 +1,6 @@
 import { Sandbox } from '@e2b/sdk'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 const openPort = 3000
 const url = sandbox.getHostname(openPort) // $HighlightLine

--- a/apps/docs/src/code/js/basics/process_env_vars.js
+++ b/apps/docs/src/code/js/basics/process_env_vars.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
   envVars: {FOO: 'Hello'},
 })
 

--- a/apps/docs/src/code/js/basics/process_exit.js
+++ b/apps/docs/src/code/js/basics/process_exit.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
   onExit: () => console.log('[sandbox]', 'process ended'), // $HighlightLine
 })
 

--- a/apps/docs/src/code/js/basics/process_start.js
+++ b/apps/docs/src/code/js/basics/process_start.js
@@ -1,6 +1,6 @@
 import { Sandbox } from '@e2b/sdk'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 const npmInit = await sandbox.process.start({
   cmd: 'npm init -y', // $HighlightLine

--- a/apps/docs/src/code/js/basics/process_stop.js
+++ b/apps/docs/src/code/js/basics/process_stop.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
 })
 
 const npmInit = await sandbox.process.start({

--- a/apps/docs/src/code/js/basics/process_stream_stderr.js
+++ b/apps/docs/src/code/js/basics/process_stream_stderr.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
 })
 
 // This command will fail and output to stderr because Golang isn't installed in the cloud playground

--- a/apps/docs/src/code/js/basics/process_stream_stdout.js
+++ b/apps/docs/src/code/js/basics/process_stream_stdout.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
   onStdout: (output) => console.log('sandbox', output.line), // $HighlightLine
 })
 

--- a/apps/docs/src/code/js/basics/process_write_stdin.js
+++ b/apps/docs/src/code/js/basics/process_write_stdin.js
@@ -1,6 +1,6 @@
 import { Sandbox } from '@e2b/sdk'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 // This example will print back the string we send to the process using `sendStdin()`
 

--- a/apps/docs/src/code/js/basics/scan_ports.js
+++ b/apps/docs/src/code/js/basics/scan_ports.js
@@ -21,7 +21,7 @@ function printNewPortAndURL(openPorts, sandbox) {
 }
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
   onScanPorts: (openPorts) => printNewPortAndURL(openPorts, sandbox), // $HighlightLine
 })
 

--- a/apps/docs/src/code/js/basics/set_env_vars.js
+++ b/apps/docs/src/code/js/basics/set_env_vars.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
   envVars: {FOO: 'Hello'}, // $HighlightLine
 })
 

--- a/apps/docs/src/code/js/basics/upload_file.js
+++ b/apps/docs/src/code/js/basics/upload_file.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 import fs from 'node:fs'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 // If you're in the server environment
 const filename = 'data.csv' // $HighlightLine

--- a/apps/docs/src/code/js/code_exec/process.js
+++ b/apps/docs/src/code/js/code_exec/process.js
@@ -3,7 +3,7 @@ import { Sandbox } from '@e2b/sdk'
 // 1. Start the playground sandbox
 const sandbox = await Sandbox.create({
   // You can pass your own sandbox template id
-  id: 'base',
+  template: 'base',
   apiKey: process.env.E2B_API_KEY,
 })
 

--- a/apps/docs/src/code/js/cwd/filesystem.js
+++ b/apps/docs/src/code/js/cwd/filesystem.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
   cwd: '/home/user/code', // $HighlightLine
 })
 

--- a/apps/docs/src/code/js/cwd/process.js
+++ b/apps/docs/src/code/js/cwd/process.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
   cwd: '/code', // $HighlightLine
 })
 

--- a/apps/docs/src/code/js/cwd/sandbox.js
+++ b/apps/docs/src/code/js/cwd/sandbox.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
   cwd: '/code', // $HighlightLine
 })
 

--- a/apps/docs/src/code/js/logging/e2b_logging.js
+++ b/apps/docs/src/code/js/logging/e2b_logging.js
@@ -9,7 +9,7 @@ const logger = {
 }
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
   apiKey: process.env.E2B_API_KEY,
   logger, // $HighlightLine
 })

--- a/apps/docs/src/code/js/processes/background_processes.js
+++ b/apps/docs/src/code/js/processes/background_processes.js
@@ -1,7 +1,7 @@
 import { Sandbox } from '@e2b/sdk'
 
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
   apiKey: process.env.E2B_API_KEY,
 })
 

--- a/apps/docs/src/code/js/quickstart.js
+++ b/apps/docs/src/code/js/quickstart.js
@@ -3,7 +3,7 @@ import { Sandbox } from '@e2b/sdk'
 // 1. Start cloud playground
 const sandbox = await Sandbox.create({
   // $HighlightLine
-  id: 'base', // or you can pass your own sandbox template id
+  template: 'base', // or you can pass your own sandbox template id
   apiKey: process.env.E2B_API_KEY,
 })
 

--- a/apps/docs/src/code/js/reconnect/reconnect.js
+++ b/apps/docs/src/code/js/reconnect/reconnect.js
@@ -4,7 +4,7 @@ async function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 // Do something in the sandbox
 await sandbox.filesystem.write('hello.txt', 'Hello World!')

--- a/apps/docs/src/code/js/reconnect/reconnect_1.js
+++ b/apps/docs/src/code/js/reconnect/reconnect_1.js
@@ -4,4 +4,4 @@ async function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })

--- a/apps/docs/src/code/js/timeout/timeout_filesystem.js
+++ b/apps/docs/src/code/js/timeout/timeout_filesystem.js
@@ -1,6 +1,6 @@
 import { Sandbox } from '@e2b/sdk'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 // Timeout 3s for the write operation
 await sandbox.filesystem.write('hello.txt', 'Hello World!', {timeout: 3000}) // $HighlightLine

--- a/apps/docs/src/code/js/timeout/timeout_process.js
+++ b/apps/docs/src/code/js/timeout/timeout_process.js
@@ -1,6 +1,6 @@
 import { Sandbox } from '@e2b/sdk'
 
-const sandbox = await Sandbox.create({id: 'base'})
+const sandbox = await Sandbox.create({ template: 'base' })
 
 // Timeout 3s for the process to start
 const npmInit = await sandbox.process.start({

--- a/apps/docs/src/code/js/timeout/timeout_sandbox.js
+++ b/apps/docs/src/code/js/timeout/timeout_sandbox.js
@@ -2,7 +2,7 @@ import { Sandbox } from '@e2b/sdk'
 
 // Timeout 3s for the sandbox to open
 const sandbox = await Sandbox.create({
-  id: 'base',
+  template: 'base',
   timeout: 3000, // $HighlightLine
 })
 

--- a/apps/docs/src/code/python/agents/clone_repo.py
+++ b/apps/docs/src/code/python/agents/clone_repo.py
@@ -13,7 +13,7 @@ def main():
     # 1. Start the playground sandbox
     sandbox = Sandbox(
         # Select the right runtime
-        id="base",
+        template="base",
         api_key=E2B_API_KEY,
     )
 

--- a/apps/docs/src/code/python/agents/code_exec.py
+++ b/apps/docs/src/code/python/agents/code_exec.py
@@ -8,7 +8,7 @@ def print_out(output):
 # 1. Start the playground sandbox
 sandbox = Sandbox(
     # You can pass your own sandbox template id
-    id="base",
+    template="base",
 )
 
 # 2. Save the JavaScript code to a file inside the playground

--- a/apps/docs/src/code/python/agents/start_process.py
+++ b/apps/docs/src/code/python/agents/start_process.py
@@ -13,7 +13,7 @@ def main():
     # 1. Start the playground sandbox
     sandbox = Sandbox(
         # Select the right runtime
-        id="base",
+        template="base",
         api_key=E2B_API_KEY,
     )
 

--- a/apps/docs/src/code/python/basics/download_file.py
+++ b/apps/docs/src/code/python/basics/download_file.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 file_in_bytes = sandbox.download_file("path/to/remote/file/inside/sandbox")  # $HighlightLine
 # Save file to local filesystem

--- a/apps/docs/src/code/python/basics/fs_ls.py
+++ b/apps/docs/src/code/python/basics/fs_ls.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 # List the root directory
 content = sandbox.filesystem.list("/")  # $HighlightLine

--- a/apps/docs/src/code/python/basics/fs_mkdir.py
+++ b/apps/docs/src/code/python/basics/fs_mkdir.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 # Create a new directory '/dir'
 sandbox.filesystem.make_dir("/dir")  # $HighlightLine

--- a/apps/docs/src/code/python/basics/fs_read.py
+++ b/apps/docs/src/code/python/basics/fs_read.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 # Read the '/etc/hosts' file
 file_content = sandbox.filesystem.read("/etc/hosts")  # $HighlightLine

--- a/apps/docs/src/code/python/basics/fs_read_bytes.py
+++ b/apps/docs/src/code/python/basics/fs_read_bytes.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 # File bytes will read file's content as bytes
 # `file_bytes` as a bytearray

--- a/apps/docs/src/code/python/basics/fs_watch.py
+++ b/apps/docs/src/code/python/basics/fs_watch.py
@@ -12,7 +12,7 @@ def create_watcher(sandbox):  # $HighlightLine
     watcher.start()  # $HighlightLine
 
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 create_watcher(sandbox)  # $HighlightLine
 

--- a/apps/docs/src/code/python/basics/fs_write.py
+++ b/apps/docs/src/code/python/basics/fs_write.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 # `filesystem.write()` will:
 # - create the file if it doesn't exist

--- a/apps/docs/src/code/python/basics/fs_write_bytes.py
+++ b/apps/docs/src/code/python/basics/fs_write_bytes.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 content_in_bytes = bytearray(b"Hello world")
 

--- a/apps/docs/src/code/python/basics/get_url.py
+++ b/apps/docs/src/code/python/basics/get_url.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 url = sandbox.get_hostname()  # $HighlightLine
 print("https://" + url)

--- a/apps/docs/src/code/python/basics/get_url_port.py
+++ b/apps/docs/src/code/python/basics/get_url_port.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 open_port = 3000
 url = sandbox.get_hostname(open_port)  # $HighlightLine

--- a/apps/docs/src/code/python/basics/process_env_vars.py
+++ b/apps/docs/src/code/python/basics/process_env_vars.py
@@ -1,7 +1,7 @@
 from e2b import Sandbox
 
 sandbox = Sandbox(
-    id="base",
+    template="base",
     env_vars={"FOO": "Hello"}
 )
 

--- a/apps/docs/src/code/python/basics/process_exit.py
+++ b/apps/docs/src/code/python/basics/process_exit.py
@@ -1,7 +1,7 @@
 from e2b import Sandbox
 
 sandbox = Sandbox(
-    id="base",
+    template="base",
     on_exit=lambda: print("[sandbox]", "process ended"),  # $HighlightLine
 )
 

--- a/apps/docs/src/code/python/basics/process_start.py
+++ b/apps/docs/src/code/python/basics/process_start.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 npm_init = sandbox.process.start("npm init -y")  # $HighlightLine
 npm_init.wait()

--- a/apps/docs/src/code/python/basics/process_stop.py
+++ b/apps/docs/src/code/python/basics/process_stop.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 npm_init = sandbox.process.start("npm init -y")
 npm_init.kill()  # $HighlightLine

--- a/apps/docs/src/code/python/basics/process_stream_stderr.py
+++ b/apps/docs/src/code/python/basics/process_stream_stderr.py
@@ -1,7 +1,7 @@
 from e2b import Sandbox
 
 sandbox = Sandbox(
-    id="base",
+    template="base",
     on_stderr=lambda output: print("[sandbox]", output.line),  # $HighlightLine
 )
 

--- a/apps/docs/src/code/python/basics/process_stream_stdout.py
+++ b/apps/docs/src/code/python/basics/process_stream_stdout.py
@@ -1,7 +1,7 @@
 from e2b import Sandbox
 
 sandbox = Sandbox(
-    id="base",
+    template="base",
     on_stdout=lambda output: print("sandbox", output.line),  # $HighlightLine
 )
 

--- a/apps/docs/src/code/python/basics/process_write_stdin.py
+++ b/apps/docs/src/code/python/basics/process_write_stdin.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 # This example will print back the string we send to the process using `send_stdin()`
 

--- a/apps/docs/src/code/python/basics/scan_ports.py
+++ b/apps/docs/src/code/python/basics/scan_ports.py
@@ -23,7 +23,7 @@ def print_new_port_and_url(open_ports, sandbox):
 
 
 sandbox = Sandbox(
-    id="base",
+    template="base",
     on_scan_ports=lambda open_ports: print_new_port_and_url(open_ports, sandbox)  # $HighlightLine
 )
 

--- a/apps/docs/src/code/python/basics/set_env_vars.py
+++ b/apps/docs/src/code/python/basics/set_env_vars.py
@@ -1,7 +1,7 @@
 from e2b import Sandbox
 
 sandbox = Sandbox(
-    id="base",
+    template="base",
     env_vars={"FOO": "Hello"},  # $HighlightLine
 )
 

--- a/apps/docs/src/code/python/basics/upload_file.py
+++ b/apps/docs/src/code/python/basics/upload_file.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 with open("path/to/local/file", "rb") as f:
     remote_path = sandbox.upload_file(f)  # $HighlightLine

--- a/apps/docs/src/code/python/code_exec/process.py
+++ b/apps/docs/src/code/python/code_exec/process.py
@@ -13,7 +13,7 @@ def main():
     # 1. Start the playground sandbox
     sandbox = Sandbox(
         # You can pass your own sandbox template id
-        id="base",
+        template="base",
         api_key=E2B_API_KEY,
     )
 

--- a/apps/docs/src/code/python/cwd/filesystem.py
+++ b/apps/docs/src/code/python/cwd/filesystem.py
@@ -1,7 +1,7 @@
 from e2b import Sandbox
 
 sandbox = Sandbox(
-    id="base",
+    template="base",
     cwd="/home/user/code"  # $HighlightLine
 )
 sandbox.filesystem.write("hello.txt", "Welcome to E2B!")  # $HighlightLine

--- a/apps/docs/src/code/python/cwd/process.py
+++ b/apps/docs/src/code/python/cwd/process.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base", cwd="/code")  # $HighlightLine
+sandbox = Sandbox(template="base", cwd="/code")  # $HighlightLine
 sandbox_cwd = sandbox.process.start("pwd")  # $HighlightLine
 sandbox_cwd.wait()
 print(sandbox_cwd.output.stdout)

--- a/apps/docs/src/code/python/cwd/sandbox.py
+++ b/apps/docs/src/code/python/cwd/sandbox.py
@@ -1,7 +1,7 @@
 from e2b import Sandbox
 
 sandbox = Sandbox(
-    id="base",
+    template="base",
     cwd="/code",  # $HighlightLine
 )
 

--- a/apps/docs/src/code/python/logging/e2b_logging.py
+++ b/apps/docs/src/code/python/logging/e2b_logging.py
@@ -30,7 +30,7 @@ e2b_logger.addHandler(handler)  # $HighlightLine
 
 
 def main():
-    sandbox = Sandbox(id="base", api_key=E2B_API_KEY)
+    sandbox = Sandbox(template="base", api_key=E2B_API_KEY)
     sandbox.filesystem.write("test.txt", "Hello World")
     sandbox.close()
 

--- a/apps/docs/src/code/python/processes/background_processes.py
+++ b/apps/docs/src/code/python/processes/background_processes.py
@@ -11,7 +11,7 @@ def print_stdout(output):
 
 
 def main():
-    sandbox = Sandbox(id="base", api_key=E2B_API_KEY)
+    sandbox = Sandbox(template="base", api_key=E2B_API_KEY)
 
     # Start a server process in the background
     # We are not using `background_server.wait()` - that would wait for the process to finish running

--- a/apps/docs/src/code/python/timeout/timeout_filesystem.py
+++ b/apps/docs/src/code/python/timeout/timeout_filesystem.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 # Timeout 3s for the write operation
 sandbox.filesystem.write("test.txt", "Hello World", timeout=3)  # $HighlightLine

--- a/apps/docs/src/code/python/timeout/timeout_process.py
+++ b/apps/docs/src/code/python/timeout/timeout_process.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox(id="base")
+sandbox = Sandbox(template="base")
 
 # Timeout 3s for the process to start
 npm_init = sandbox.process.start("npm init -y", timeout=3)  # $HighlightLine

--- a/apps/docs/src/code/python/timeout/timeout_sandbox.py
+++ b/apps/docs/src/code/python/timeout/timeout_sandbox.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
 # Timeout 3s for the sandbox to open
-sandbox = Sandbox(id="base", timeout=3)  # $HighlightLine
+sandbox = Sandbox(template="base", timeout=3)  # $HighlightLine
 
 sandbox.close()

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -42,11 +42,11 @@ export const buildCommand = new commander.Command('build')
     )} config`,
   )
   .argument(
-    '[id]',
+    '[template]',
     `Specify ${asBold(
-      '[id]',
-    )} of sandbox template to rebuild it. If you don's specify ${asBold(
-      '[id]',
+      '[template]',
+    )} to rebuild it. If you don's specify ${asBold(
+      '[template]',
     )} and there is no ${asLocal('e2b.toml')} a new sandbox will be created`,
   )
   .addOption(pathOption)
@@ -67,7 +67,7 @@ export const buildCommand = new commander.Command('build')
   .alias('bd')
   .action(
     async (
-      id: string | undefined,
+      template: string | undefined,
       opts: {
         path?: string;
         dockerfile?: string;
@@ -87,7 +87,7 @@ export const buildCommand = new commander.Command('build')
           process.exit(1)
         }
 
-        let envID = id
+        let envID = template
         let dockerfile = opts.dockerfile
         let startCmd = opts.cmd
 
@@ -104,18 +104,18 @@ export const buildCommand = new commander.Command('build')
           console.log(
             `Found sandbox template ${asFormattedSandboxTemplate(
               {
-                envID: config.id,
+                envID: config.template,
                 aliases: config.name ? [config.name] : undefined,
               },
               relativeConfigPath,
             )}`,
           )
-          envID = config.id
+          envID = config.template
           dockerfile = opts.dockerfile || config.dockerfile
           startCmd = opts.cmd || config.start_cmd
         }
 
-        if (config && id && config.id !== id) {
+        if (config && template && config.template !== template) {
           // error: you can't specify different ID than the one in config
           console.error("You can't specify different ID than the one in config. If you want to build a new sandbox template remove the config file.")
           process.exit(1)
@@ -189,7 +189,7 @@ export const buildCommand = new commander.Command('build')
         await saveConfig(
           configPath,
           {
-            id: build.envID,
+            template: build.envID,
             dockerfile: dockerfileRelativePath,
             name,
             start_cmd: startCmd,
@@ -255,7 +255,7 @@ async function waitForBuildFinish(
         const pythonExample = asPython(`from e2b import Sandbox
 
 # Start sandbox
-sandbox = Sandbox(id="${aliases?.length ? aliases[0] : template.data.envID}")
+sandbox = Sandbox(template="${aliases?.length ? aliases[0] : template.data.envID}")
 
 # Interact with sandbox. Learn more here:
 # https://e2b.dev/docs/sandbox/overview
@@ -266,7 +266,7 @@ sandbox.close()`)
         const typescriptExample = asTypescript(`import { Sandbox } from '@e2b/sdk'
 
 // Start sandbox
-const sandbox = await Sandbox.create({ id: '${aliases?.length ? aliases[0] : template.data.envID}' })
+const sandbox = await Sandbox.create({ template: '${aliases?.length ? aliases[0] : template.data.envID}' })
 
 // Interact with sandbox. Learn more here:
 // https://e2b.dev/docs/sandbox/overview

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -104,18 +104,18 @@ export const buildCommand = new commander.Command('build')
           console.log(
             `Found sandbox template ${asFormattedSandboxTemplate(
               {
-                envID: config.template,
-                aliases: config.name ? [config.name] : undefined,
+                envID: config.template_id,
+                aliases: config.template_name ? [config.template_name] : undefined,
               },
               relativeConfigPath,
             )}`,
           )
-          envID = config.template
+          envID = config.template_id
           dockerfile = opts.dockerfile || config.dockerfile
           startCmd = opts.cmd || config.start_cmd
         }
 
-        if (config && template && config.template !== template) {
+        if (config && template && config.template_id !== template) {
           // error: you can't specify different ID than the one in config
           console.error("You can't specify different ID than the one in config. If you want to build a new sandbox template remove the config file.")
           process.exit(1)
@@ -126,12 +126,12 @@ export const buildCommand = new commander.Command('build')
           respectDockerignore: true,
         })
 
-        if (newName && config?.name && newName !== config?.name) {
+        if (newName && config?.template_name && newName !== config?.template_name) {
           console.log(
-            `The sandbox template name will be changed from ${asLocal(config.name)} to ${asLocal(newName)}.`,
+            `The sandbox template name will be changed from ${asLocal(config.template_name)} to ${asLocal(newName)}.`,
           )
         }
-        const name = newName || config?.name
+        const name = newName || config?.template_name
 
         console.log(
           `Preparing sandbox template building (${filePaths.length} files in Docker build context). ${!filePaths.length ? `If you are using ${asLocal('.dockerignore')} check if it is configured correctly.` : ''}`,
@@ -189,9 +189,9 @@ export const buildCommand = new commander.Command('build')
         await saveConfig(
           configPath,
           {
-            template: build.envID,
+            template_id: build.envID,
             dockerfile: dockerfileRelativePath,
-            name,
+            template_name: name,
             start_cmd: startCmd,
           },
           true,

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -47,7 +47,7 @@ export const buildCommand = new commander.Command('build')
       '[template]',
     )} to rebuild it. If you don's specify ${asBold(
       '[template]',
-    )} and there is no ${asLocal('e2b.toml')} a new sandbox will be created`,
+    )} and there is no ${asLocal('e2b.toml')} a new sandbox template will be created`,
   )
   .addOption(pathOption)
   .option(

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -31,7 +31,7 @@ export const deleteCommand = new commander.Command('delete')
       '[template]',
     )} to delete it. If you don's specify ${asBold(
       '[template]',
-    )} the command will try delete sandbox template defined by ${asLocal('e2b.toml')}.`,
+    )} the command will try to delete sandbox template defined by ${asLocal('e2b.toml')}.`,
   )
   .addOption(pathOption)
   .addOption(selectMultipleOption)

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -26,33 +26,33 @@ const deleteEnv = e2b.withAccessToken(
 export const deleteCommand = new commander.Command('delete')
   .description(`Delete sanbdox template and ${asLocal(configName)} config`)
   .argument(
-    '[id]',
+    '[template]',
     `Specify ${asBold(
-      '[id]',
-    )} of sandbox template to delete it. If you don's specify ${asBold(
-      '[id]',
+      '[template]',
+    )} to delete it. If you don's specify ${asBold(
+      '[template]',
     )} the command will try delete sandbox template defined by ${asLocal('e2b.toml')}.`,
   )
   .addOption(pathOption)
   .addOption(selectMultipleOption)
   .alias('dl')
   .option('-y, --yes', 'Skip manual delete confirmation')
-  .action(async (id, opts: { path?: string, yes?: boolean, select?: boolean }) => {
+  .action(async (template, opts: { path?: string, yes?: boolean, select?: boolean }) => {
     try {
       const accessToken = ensureAccessToken()
 
       const root = getRoot(opts.path)
 
-      const envs: (Pick<E2BConfig, 'id'> & { configPath?: string })[] = []
+      const envs: (Pick<E2BConfig, 'template'> & { configPath?: string })[] = []
 
-      if (id) {
+      if (template) {
         envs.push({
-          id,
+          template,
         })
       } else if (opts.select) {
         const allEnvs = await listSandboxTemplates({ accessToken })
         const selectedEnvs = await getPromptEnvs(allEnvs, 'Select sandbox templates to delete')
-        envs.push(...selectedEnvs.map(e => ({ id: e.envID, ...e })))
+        envs.push(...selectedEnvs.map(e => ({ template: e.envID, ...e })))
 
         if (!envs || envs.length === 0) {
           console.log('No sandbox templates selected')
@@ -65,7 +65,7 @@ export const deleteCommand = new commander.Command('delete')
           : undefined
 
         if (!config) {
-          console.log(`No ${asLocal(configName)} found in ${asLocalRelative(root)}. Specify sandbox template ${asBold('[id]')} or use interactive mode with ${asBold('-s')} flag.`)
+          console.log(`No ${asLocal(configName)} found in ${asLocalRelative(root)}. Specify sandbox template with ${asBold('[template]')} argument or use interactive mode with ${asBold('-s')} flag.`)
           return
         }
 
@@ -76,12 +76,12 @@ export const deleteCommand = new commander.Command('delete')
       }
 
       if (!envs || envs.length === 0) {
-        console.log(`No sandbox templates selected. Specify sandbox template  ${asBold('[id]')} or use interactive mode with  ${asBold('-s')} flag.`)
+        console.log(`No sandbox templates selected. Specify sandbox template with ${asBold('[template]')} argument or use interactive mode with  ${asBold('-s')} flag.`)
         return
       }
 
       console.log(chalk.default.red(chalk.default.underline('\nSandbox templates to delete')))
-      envs.forEach(e => console.log(asFormattedSandboxTemplate({ ...e, envID: e.id }, e.configPath)))
+      envs.forEach(e => console.log(asFormattedSandboxTemplate({ ...e, envID: e.template }, e.configPath)))
       process.stdout.write('\n')
 
       if (!opts.yes) {
@@ -98,8 +98,8 @@ export const deleteCommand = new commander.Command('delete')
 
       await Promise.all(
         envs.map(async e => {
-          console.log(`- Deleting sandbox template ${asFormattedSandboxTemplate({ ...e, envID: e.id }, e.configPath)}`)
-          await deleteEnv(accessToken, { envID: e.id })
+          console.log(`- Deleting sandbox template ${asFormattedSandboxTemplate({ ...e, envID: e.template }, e.configPath)}`)
+          await deleteEnv(accessToken, { envID: e.template })
           if (e.configPath) {
             await deleteConfig(e.configPath)
           }

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -43,16 +43,16 @@ export const deleteCommand = new commander.Command('delete')
 
       const root = getRoot(opts.path)
 
-      const envs: (Pick<E2BConfig, 'template'> & { configPath?: string })[] = []
+      const envs: (Pick<E2BConfig, 'template_id'> & { configPath?: string })[] = []
 
       if (template) {
         envs.push({
-          template,
+          template_id: template,
         })
       } else if (opts.select) {
         const allEnvs = await listSandboxTemplates({ accessToken })
         const selectedEnvs = await getPromptEnvs(allEnvs, 'Select sandbox templates to delete')
-        envs.push(...selectedEnvs.map(e => ({ template: e.envID, ...e })))
+        envs.push(...selectedEnvs.map(e => ({ template_id: e.envID, ...e })))
 
         if (!envs || envs.length === 0) {
           console.log('No sandbox templates selected')
@@ -81,7 +81,7 @@ export const deleteCommand = new commander.Command('delete')
       }
 
       console.log(chalk.default.red(chalk.default.underline('\nSandbox templates to delete')))
-      envs.forEach(e => console.log(asFormattedSandboxTemplate({ ...e, envID: e.template }, e.configPath)))
+      envs.forEach(e => console.log(asFormattedSandboxTemplate({ ...e, envID: e.template_id }, e.configPath)))
       process.stdout.write('\n')
 
       if (!opts.yes) {
@@ -98,8 +98,8 @@ export const deleteCommand = new commander.Command('delete')
 
       await Promise.all(
         envs.map(async e => {
-          console.log(`- Deleting sandbox template ${asFormattedSandboxTemplate({ ...e, envID: e.template }, e.configPath)}`)
-          await deleteEnv(accessToken, { envID: e.template })
+          console.log(`- Deleting sandbox template ${asFormattedSandboxTemplate({ ...e, envID: e.template_id }, e.configPath)}`)
+          await deleteEnv(accessToken, { envID: e.template_id })
           if (e.configPath) {
             await deleteConfig(e.configPath)
           }

--- a/packages/cli/src/commands/shell.ts
+++ b/packages/cli/src/commands/shell.ts
@@ -12,16 +12,16 @@ import { pathOption } from '../options'
 
 export const shellCommand = new commander.Command('shell')
   .description('Connect terminal to sandbox')
-  .argument('[id]', `Connect to sandbox specified by ${asBold('[id]')}`)
+  .argument('[template]', `Connect to sandbox specified by ${asBold('[template]')}`)
   .addOption(pathOption)
   .alias('sh')
-  .action(async (id: string | undefined, opts: {
+  .action(async (template: string | undefined, opts: {
     name?: string;
     path?: string;
   }) => {
     try {
       const apiKey = ensureAPIKey()
-      let envID = id
+      let envID = template
 
       const root = getRoot(opts.path)
       const configPath = getConfigPath(root)
@@ -35,13 +35,13 @@ export const shellCommand = new commander.Command('shell')
         console.log(
           `Found sandbox template ${asFormattedSandboxTemplate(
             {
-              envID: config.id,
+              envID: config.template,
               aliases: config.name ? [config.name] : undefined,
             },
             relativeConfigPath,
           )}`,
         )
-        envID = config.id
+        envID = config.template
       }
 
       if (!envID) {
@@ -50,9 +50,8 @@ export const shellCommand = new commander.Command('shell')
         )
         process.exit(1)
       }
-      const template: Pick<e2b.components['schemas']['Environment'], 'envID'> = { envID: envID }
 
-      await connectSandbox({ apiKey, template: template })
+      await connectSandbox({ apiKey, template: { envID } })
       // We explicitly call exit because the sandbox is keeping the program alive.
       // We also don't want to call sandbox.close because that would disconnect other users from the edit session.
       process.exit(0)
@@ -71,7 +70,7 @@ export async function connectSandbox({
 }) {
   const sandbox = await e2b.Sandbox.create({
     apiKey,
-    id: template.envID,
+    template: template.envID,
   })
 
   if (sandbox.terminal) {

--- a/packages/cli/src/commands/shell.ts
+++ b/packages/cli/src/commands/shell.ts
@@ -35,13 +35,13 @@ export const shellCommand = new commander.Command('shell')
         console.log(
           `Found sandbox template ${asFormattedSandboxTemplate(
             {
-              envID: config.template,
-              aliases: config.name ? [config.name] : undefined,
+              envID: config.template_id,
+              aliases: config.template_name ? [config.template_name] : undefined,
             },
             relativeConfigPath,
           )}`,
         )
-        envID = config.template
+        envID = config.template_id
       }
 
       if (!envID) {

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -21,7 +21,6 @@ export type { ProcessManager } from './sandbox/process'
 export type { EnvVars } from './sandbox/envVars'
 export { runCode, CodeRuntime } from './runCode' // Export CodeRuntime enum as value, not as type, so it can be actually used in consumer code
 import { Sandbox } from './sandbox/index'
-// export { runCmd } from './runCmd'
 
 import { DataAnalysis } from './templates/dataAnalysis'
 export { DataAnalysis as CodeInterpreter }
@@ -32,5 +31,3 @@ export type { Action } from './sandbox/index'
 
 export { Sandbox }
 export default Sandbox
-
-// export { Sandbox }

--- a/packages/js-sdk/src/runCmd.ts
+++ b/packages/js-sdk/src/runCmd.ts
@@ -2,7 +2,7 @@ import { Sandbox } from './sandbox'
 
 export async function runCmd(command: string, opts?: { apiKey?: string }) {
   const sandbox = await Sandbox.create({
-    id: 'Bash',
+    template: 'Bash',
     apiKey: opts?.apiKey || process?.env?.E2B_API_KEY || '', // Sandbox.create will throw an error if the API key is not provided so no need to check here
   })
 

--- a/packages/js-sdk/src/runCmd.ts
+++ b/packages/js-sdk/src/runCmd.ts
@@ -2,7 +2,6 @@ import { Sandbox } from './sandbox'
 
 export async function runCmd(command: string, opts?: { apiKey?: string }) {
   const sandbox = await Sandbox.create({
-    template: 'Bash',
     apiKey: opts?.apiKey || process?.env?.E2B_API_KEY || '', // Sandbox.create will throw an error if the API key is not provided so no need to check here
   })
 

--- a/packages/js-sdk/src/runCode.ts
+++ b/packages/js-sdk/src/runCode.ts
@@ -58,7 +58,7 @@ export async function runCode(
   }
 
   const sandbox = await Sandbox.create({
-    id: envID,
+    template: envID,
     apiKey: opts?.apiKey || process?.env?.E2B_API_KEY || '', // Sandbox.create will throw an error if the API key is not provided so no need to check here
   })
 

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -467,15 +467,15 @@ export class Sandbox extends SandboxConnection {
   static async create(): Promise<Sandbox>;
   /**
    * Creates a new Sandbox from the template with the specified ID.
-   * @param id Sandbox ID
+   * @param template Sandbox template ID or name
    * @returns New Sandbox
    *
    * @example
    * ```ts
-   * const sandbox = await Sandbox.create("sandboxID")
+   * const sandbox = await Sandbox.create("sandboxTemplateID")
    * ```
    */
-  static async create(id: string): Promise<Sandbox>;
+  static async create(template: string): Promise<Sandbox>;
   /**
    * Creates a new Sandbox from the specified options.
    * @param opts Sandbox options
@@ -484,14 +484,14 @@ export class Sandbox extends SandboxConnection {
    * @example
    * ```ts
    * const sandbox = await Sandbox.create({
-   *   id: "sandboxID",
+   *   template: "sandboxTemplate",
    *   onStdout: console.log,
    * })
    * ```
    */
   static async create(opts: SandboxOpts): Promise<Sandbox>;
-  static async create(optsOrID?: string | SandboxOpts) {
-    const opts = typeof optsOrID === 'string' ? { id: optsOrID } : optsOrID
+  static async create(optsOrTemplate?: string | SandboxOpts) {
+    const opts = typeof optsOrTemplate === 'string' ? { template: optsOrTemplate } : optsOrTemplate
     return new Sandbox(opts)
       ._open({ timeout: opts?.timeout })
       .then(async (sandbox) => {

--- a/packages/js-sdk/src/sandbox/sandboxConnection.ts
+++ b/packages/js-sdk/src/sandbox/sandboxConnection.ts
@@ -34,6 +34,11 @@ export interface Logger {
 }
 
 export interface SandboxConnectionOpts {
+  /**
+   * Sandbox Template ID or name.
+   * 
+   * If not specified, the 'base' template will be used.
+   */
   template?: string;
   /**
    * @deprecated Use `template` instead.

--- a/packages/js-sdk/src/sandbox/sandboxConnection.ts
+++ b/packages/js-sdk/src/sandbox/sandboxConnection.ts
@@ -34,6 +34,12 @@ export interface Logger {
 }
 
 export interface SandboxConnectionOpts {
+  template?: string;
+  /**
+   * @deprecated Use `template` instead.
+   * 
+   * Sandbox Template ID or name.
+   */
   id?: string;
   apiKey?: string;
   cwd?: string;
@@ -102,9 +108,8 @@ export class SandboxConnection {
   }
 
   private get templateID(): string {
-    return this.opts.id || 'base'
+    return this.opts.template || this.opts.id || 'base'
   }
-
 
   /**
    * Keep the sandbox alive for the specified duration.
@@ -127,8 +132,6 @@ export class SandboxConnection {
       instanceID: this.sandbox?.instanceID, duration,
     })
   }
-
-
 
   /**
    * Get the hostname for the sandbox or for the specified sandbox's port.
@@ -337,93 +340,93 @@ export class SandboxConnection {
   private async connectRpc() {
     const hostname = this.getHostname(this.opts.__debug_port || ENVD_PORT)
 
-      if (!hostname) {
-        throw new Error('Cannot get sandbox\'s hostname')
+    if (!hostname) {
+      throw new Error('Cannot get sandbox\'s hostname')
+    }
+
+    const protocol = this.opts.__debug_devEnv === 'local' ? 'ws' : 'wss'
+    const sandboxURL = `${protocol}://${hostname}${WS_ROUTE}`
+
+    this.rpc.onError((err) => {
+      // not warn, because this is somewhat expected behaviour during initialization
+      this.logger.debug?.(
+        `Error in WebSocket of sandbox "${this.sandbox?.instanceID}": ${err.message ?? err.code ?? err.toString()
+        }. Trying to reconnect...`,
+      )
+    })
+
+    let isFinished = false
+    let resolveOpening: (() => void) | undefined
+    let rejectOpening: (() => void) | undefined
+
+    const openingPromise = new Promise<void>((resolve, reject) => {
+      resolveOpening = () => {
+        if (isFinished) return
+        isFinished = true
+        resolve()
       }
+      rejectOpening = () => {
+        if (isFinished) return
+        isFinished = true
+        reject()
+      }
+    })
 
-      const protocol = this.opts.__debug_devEnv === 'local' ? 'ws' : 'wss'
-      const sandboxURL = `${protocol}://${hostname}${WS_ROUTE}`
+    this.rpc.onOpen(() => {
+      this.logger.debug?.(
+        `Connected to sandbox "${this.sandbox?.instanceID}"`,
+      )
+      resolveOpening?.()
+    })
 
-      this.rpc.onError((err) => {
-        // not warn, because this is somewhat expected behaviour during initialization
+    this.rpc.onClose(async () => {
+      this.logger.debug?.(
+        `Closing WebSocket connection to sandbox "${this.sandbox?.instanceID}"`,
+      )
+      if (this.isOpen) {
+        await wait(WS_RECONNECT_INTERVAL)
         this.logger.debug?.(
-          `Error in WebSocket of sandbox "${this.sandbox?.instanceID}": ${err.message ?? err.code ?? err.toString()
-          }. Trying to reconnect...`,
+          `Reconnecting to sandbox "${this.sandbox?.instanceID}"`,
         )
-      })
-
-      let isFinished = false
-      let resolveOpening: (() => void) | undefined
-      let rejectOpening: (() => void) | undefined
-
-      const openingPromise = new Promise<void>((resolve, reject) => {
-        resolveOpening = () => {
-          if (isFinished) return
-          isFinished = true
-          resolve()
-        }
-        rejectOpening = () => {
-          if (isFinished) return
-          isFinished = true
-          reject()
-        }
-      })
-
-      this.rpc.onOpen(() => {
-        this.logger.debug?.(
-          `Connected to sandbox "${this.sandbox?.instanceID}"`,
-        )
-        resolveOpening?.()
-      })
-
-      this.rpc.onClose(async () => {
-        this.logger.debug?.(
-          `Closing WebSocket connection to sandbox "${this.sandbox?.instanceID}"`,
-        )
-        if (this.isOpen) {
-          await wait(WS_RECONNECT_INTERVAL)
+        try {
+          // When the WS connection closes the subscribers in devbookd are removed.
+          // We want to delete the subscriber handlers here so there are no orphans.
+          this.subscribers = []
+          await this.rpc.connect(sandboxURL)
           this.logger.debug?.(
-            `Reconnecting to sandbox "${this.sandbox?.instanceID}"`,
+            `Reconnected to sandbox "${this.sandbox?.instanceID}"`,
           )
-          try {
-            // When the WS connection closes the subscribers in devbookd are removed.
-            // We want to delete the subscriber handlers here so there are no orphans.
-            this.subscribers = []
-            await this.rpc.connect(sandboxURL)
-            this.logger.debug?.(
-              `Reconnected to sandbox "${this.sandbox?.instanceID}"`,
-            )
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } catch (err: any) {
-            // not warn, because this is somewhat expected behaviour during initialization
-            this.logger.debug?.(
-              `Failed reconnecting to sandbox "${this.sandbox?.instanceID}": ${err.message ?? err.code ?? err.toString()
-              }`,
-            )
-          }
-        } else {
-          rejectOpening?.()
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+          // not warn, because this is somewhat expected behaviour during initialization
+          this.logger.debug?.(
+            `Failed reconnecting to sandbox "${this.sandbox?.instanceID}": ${err.message ?? err.code ?? err.toString()
+            }`,
+          )
         }
-      })
-
-      this.rpc.onNotification.push(this.handleNotification.bind(this))
-
-      try {
-        this.logger.debug?.(
-          `Connection to sandbox "${this.sandbox?.instanceID}"`,
-        )
-        await this.rpc.connect(sandboxURL)
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (err: any) {
-        // not warn, because this is somewhat expected behaviour during initialization
-        this.logger.debug?.(
-          `Error connecting to sandbox "${this.sandbox?.instanceID}": ${err.message ?? err.code ?? err.toString()
-          }`,
-        )
+      } else {
+        rejectOpening?.()
       }
+    })
 
-      await openingPromise
+    this.rpc.onNotification.push(this.handleNotification.bind(this))
+
+    try {
+      this.logger.debug?.(
+        `Connection to sandbox "${this.sandbox?.instanceID}"`,
+      )
+      await this.rpc.connect(sandboxURL)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      // not warn, because this is somewhat expected behaviour during initialization
+      this.logger.debug?.(
+        `Error connecting to sandbox "${this.sandbox?.instanceID}": ${err.message ?? err.code ?? err.toString()
+        }`,
+      )
+    }
+
+    await openingPromise
   }
   private handleNotification(data: IRpcNotification) {
     this.logger.debug?.('Handling notification:', data)

--- a/packages/js-sdk/src/templates/dataAnalysis.ts
+++ b/packages/js-sdk/src/templates/dataAnalysis.ts
@@ -20,15 +20,15 @@ export interface RunPythonOpts extends Omit<ProcessOpts, 'cmd'> {
   onArtifact?: (artifact: Artifact) => Promise<void> | void;
 }
 
-const DataAnalysisEnvId = 'Python3-DataAnalysis'
-
 export class DataAnalysis extends Sandbox {
-  constructor(opts: Omit<SandboxOpts, 'id'>) {
-    super({ id: DataAnalysisEnvId, ...opts })
+  private static template = 'Python3-DataAnalysis'
+
+  constructor(opts: Omit<SandboxOpts, 'template'>) {
+    super({ template: DataAnalysis.template, ...opts })
   }
 
   static override async create(): Promise<DataAnalysis>;
-  static override async create(opts?: Omit<SandboxOpts, 'id'>) {
+  static override async create(opts?: Omit<SandboxOpts, 'template'>) {
     return new DataAnalysis({ ...opts })
       ._open({ timeout: opts?.timeout })
       .then(async (sandbox) => {

--- a/packages/python-sdk/e2b/sandbox/main.py
+++ b/packages/python-sdk/e2b/sandbox/main.py
@@ -75,7 +75,7 @@ class Sandbox(SandboxConnection):
         Create a new cloud sandbox.
 
         :param id: [Deprecated] Use `template` param instead.
-        :param template: ID of the sandbox template or the name of prepared template.
+        :param template: ID of the sandbox template or the name of prepared template. If not specified a 'base' template will be used.
         Can be one of the following premade sandbox templates or a custom sandbox template ID:
         - `base` - A basic sandbox with a Linux environment
         - `Python3-DataAnalysis` - A Python3 sandbox with data analysis tools

--- a/packages/python-sdk/e2b/sandbox/main.py
+++ b/packages/python-sdk/e2b/sandbox/main.py
@@ -55,7 +55,8 @@ class Sandbox(SandboxConnection):
 
     def __init__(
         self,
-        id: str = "base",
+        template: str = "base",
+        id: Optional[str] = None,
         api_key: Optional[str] = None,
         cwd: Optional[str] = None,
         env_vars: Optional[EnvVars] = None,
@@ -72,10 +73,12 @@ class Sandbox(SandboxConnection):
         """
         Create a new cloud sandbox.
 
-        :param id: ID of the sandbox template or the name of prepared template.
+        :param id: [Deprecated] Use `template` param instead.
+        :param template: ID of the sandbox template or the name of prepared template.
         Can be one of the following premade sandbox templates or a custom sandbox template ID:
         - `base` - A basic sandbox with a Linux environment
         - `Python3-DataAnalysis` - A Python3 sandbox with data analysis tools
+
 
         :param api_key: The API key to use, if not provided, the `E2B_API_KEY` environment variable is used
         :param cwd: The current working directory to use
@@ -86,7 +89,14 @@ class Sandbox(SandboxConnection):
         :param timeout: Timeout for sandbox to initialize in seconds, default is 60 seconds
         """
 
-        logger.info(f"Creating sandbox {id if isinstance(id, str) else type(id)}")
+        template = id or template or "base"
+
+        if id:
+            logger.warning("The id parameter is deprecated, use template instead.")
+
+        logger.info(
+            f"Creating sandbox {template if isinstance(template, str) else type(template)}"
+        )
         if cwd and cwd.startswith("~"):
             cwd = cwd.replace("~", "/home/user")
 
@@ -103,7 +113,7 @@ class Sandbox(SandboxConnection):
             on_exit=on_exit,
         )
         super().__init__(
-            id=id,
+            template=template,
             api_key=api_key,
             cwd=cwd,
             env_vars=env_vars,
@@ -203,10 +213,10 @@ class Sandbox(SandboxConnection):
 
         :param timeout: Specify the duration, in seconds to give the method to finish its execution before it times out (default is 60 seconds). If set to None, the method will continue to wait until it completes, regardless of time
         """
-        logger.info(f"Opening sandbox {self._id}")
+        logger.info(f"Opening sandbox {self._template}")
         super()._open(timeout=timeout)
         self._code_snippet._subscribe()
-        logger.info(f"Sandbox {self._id} opened")
+        logger.info(f"Sandbox {self._template} opened")
         if self.cwd:
             self.filesystem.make_dir(self.cwd)
 

--- a/packages/python-sdk/e2b/sandbox/run_code.py
+++ b/packages/python-sdk/e2b/sandbox/run_code.py
@@ -55,7 +55,7 @@ def run_code(
             f'Invalid runtime "{runtime}". Please contact us (hello@e2b.dev) if you need support for this runtime'
         )
 
-    sandbox = Sandbox(id=env_id, api_key=api_key)
+    sandbox = Sandbox(template=env_id, api_key=api_key)
     sandbox.filesystem.write(filepath, code)
 
     proc = sandbox.process.start(cmd=f"{binary} {filepath}")

--- a/packages/python-sdk/e2b/sandbox/sandbox_connection.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_connection.py
@@ -68,7 +68,7 @@ class SandboxConnection:
 
     def __init__(
         self,
-        id: str,
+        template: str,
         api_key: Optional[str] = None,
         cwd: Optional[str] = None,
         env_vars: Optional[EnvVars] = None,
@@ -87,7 +87,7 @@ class SandboxConnection:
 
         self.cwd = cwd
         self.env_vars = env_vars or {}
-        self._id = id
+        self._template = template
         self._api_key = api_key
         self._debug_hostname = _debug_hostname
         self._debug_port = _debug_port
@@ -101,7 +101,7 @@ class SandboxConnection:
         self._rpc: Optional[SandboxRpc] = None
         self._finished = DeferredFuture(self._process_cleanup)
 
-        logger.info(f"Sandbox for template {self._id} initialized")
+        logger.info(f"Sandbox for template {self._template} initialized")
 
         self._open(timeout=timeout)
 
@@ -217,7 +217,7 @@ class SandboxConnection:
                     api = client.InstancesApi(api_client)
 
                     self._sandbox = api.instances_post(
-                        models.NewInstance(envID=self._id),
+                        models.NewInstance(envID=self._template),
                         _request_timeout=timeout,
                     )
                     logger.info(

--- a/packages/python-sdk/e2b/templates/data_analysis.py
+++ b/packages/python-sdk/e2b/templates/data_analysis.py
@@ -27,7 +27,7 @@ class Artifact(BaseModel):
 
 
 class DataAnalysis(Sandbox):
-    env_id = "Python3-DataAnalysis"
+    template = "Python3-DataAnalysis"
 
     def __init__(
         self,
@@ -43,7 +43,7 @@ class DataAnalysis(Sandbox):
     ):
         self.on_artifact = on_artifact
         super().__init__(
-            id=self.env_id,
+            template=self.template,
             api_key=api_key,
             cwd=cwd,
             env_vars=env_vars,


### PR DESCRIPTION
- [x] Change JS SDK
- [x] Change Python SDK
- [x] Change in CLI
- [x] Update docs examples
- [x] Update docs text mentions of the `id`
- [x] Decide on `id` vs `template` vs `template_id` in the e2b.toml
- [x] Test