### PR TITLE
Improve and add docstring in SDKs

### DIFF
--- a/.changeset/hot-socks-boil.md
+++ b/.changeset/hot-socks-boil.md
@@ -1,0 +1,6 @@
+---
+"@e2b/python-sdk": patch
+"@e2b/sdk": patch
+---
+
+Improve SDK docs

--- a/packages/js-sdk/src/sandbox/filesystem.ts
+++ b/packages/js-sdk/src/sandbox/filesystem.ts
@@ -8,17 +8,69 @@ export interface FileInfo {
   name: string
 }
 
+/**
+ * Manager for interacting with the filesystem in the sandbox.
+ */
 export interface FilesystemManager {
-  readonly write: (
-    path: string,
-    content: string,
-    opts?: CallOpts,
-  ) => Promise<void>;
-  readonly writeBytes: (path: string, content: Uint8Array) => Promise<void>;
-  readonly read: (path: string, opts?: CallOpts) => Promise<string>;
-  readonly readBytes: (path: string) => Promise<Uint8Array>;
-  readonly remove: (path: string, opts?: CallOpts) => Promise<void>;
-  readonly list: (path: string, opts?: CallOpts) => Promise<FileInfo[]>;
-  readonly makeDir: (path: string, opts?: CallOpts) => Promise<void>;
-  readonly watchDir: (path: string) => FilesystemWatcher;
+  /**
+   * Writes content to a new file on path.
+   * @param path Path to a new file. For example '/dirA/dirB/newFile.txt' when creating 'newFile.txt'
+   * @param content Content to write to a new file
+   * @param opts Call options
+   * @param {timeout} [opts.timeout] Timeout for call in milliseconds (default is 60 seconds)
+   */
+  write(path: string, content: string, opts?: CallOpts): Promise<void>;
+  /**
+   * Write array of bytes to a file.
+   * This can be used when you cannot represent the data as an UTF-8 string.
+   *
+   * A new file will be created if it doesn't exist.
+   * If the file already exists, it will be overwritten.
+   * 
+   * @param path path to a file
+   * @param content byte array representing the content to write
+   */
+  writeBytes(path: string, content: Uint8Array): Promise<void>;
+  /**
+   * Reads the whole content of a file.
+   * @param path Path to a file
+   * @param opts Call options
+   * @param {timeout} [opts.timeout] Timeout for call in milliseconds (default is 60 seconds)
+   * @returns Content of a file
+   */
+  read(path: string, opts?: CallOpts): Promise<string>;
+  /**
+   * Reads the whole content of a file as an array of bytes.
+   * @param path path to a file
+   * @returns byte array representing the content of a file
+   */
+  readBytes(path: string): Promise<Uint8Array>;
+  /**
+   * Removes a file or a directory.
+   * @param path Path to a file or a directory
+   * @param opts Call options
+   * @param {timeout} [opts.timeout] Timeout for call in milliseconds (default is 60 seconds)
+   */
+  remove(path: string, opts?: CallOpts): Promise<void>;
+  /**
+   * List files in a directory.
+   * @param path Path to a directory
+   * @param opts Call options
+   * @param {timeout} [opts.timeout] Timeout for call in milliseconds (default is 60 seconds)
+   * @returns Array of files in a directory
+   */
+  list(path: string, opts?: CallOpts): Promise<FileInfo[]>;
+  /**
+   * Creates a new directory and all directories along the way if needed on the specified pth.
+   * @param path Path to a new directory. For example '/dirA/dirB' when creating 'dirB'.
+   * @param opts Call options
+   * @param {timeout} [opts.timeout] Timeout for call in milliseconds (default is 60 seconds)
+   */
+  makeDir(path: string, opts?: CallOpts): Promise<void>;
+  /**
+   * Watches directory for filesystem events.
+   * @param path Path to a directory that will be watched
+   * @returns New watcher
+   */
+  watchDir(path: string): FilesystemWatcher;
 }

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -60,8 +60,17 @@ export interface Action<T = { [key: string]: any }> {
  * 
  */
 export class Sandbox extends SandboxConnection {
+  /**
+   * Terminal manager used to create interactive terminals.
+   */
   readonly terminal: TerminalManager
+  /**
+   * Filesystem manager used to manage files.
+   */
   readonly filesystem: FilesystemManager
+  /**
+   * Process manager used to run commands.
+   */
   readonly process: ProcessManager
 
   readonly _actions: Map<string, Action<any>> = new Map()
@@ -75,13 +84,6 @@ export class Sandbox extends SandboxConnection {
 
     // Init Filesystem handler
     this.filesystem = {
-      /**
-       * List files in a directory.
-       * @param path Path to a directory
-       * @param opts Call options
-       * @param {timeout} [opts.timeout] Timeout for call in milliseconds (default is 60 seconds)
-       * @returns Array of files in a directory
-       */
       list: async (path, opts?: CallOpts) => {
         return (await this._call(
           filesystemService,
@@ -90,13 +92,6 @@ export class Sandbox extends SandboxConnection {
           opts,
         )) as FileInfo[]
       },
-      /**
-       * Reads the whole content of a file.
-       * @param path Path to a file
-       * @param opts Call options
-       * @param {timeout} [opts.timeout] Timeout for call in milliseconds (default is 60 seconds)
-       * @returns Content of a file
-       */
       read: async (path, opts?: CallOpts) => {
         return (await this._call(
           filesystemService,
@@ -105,12 +100,6 @@ export class Sandbox extends SandboxConnection {
           opts,
         )) as string
       },
-      /**
-       * Removes a file or a directory.
-       * @param path Path to a file or a directory
-       * @param opts Call options
-       * @param {timeout} [opts.timeout] Timeout for call in milliseconds (default is 60 seconds)
-       */
       remove: async (path, opts?: CallOpts) => {
         await this._call(
           filesystemService,
@@ -119,15 +108,6 @@ export class Sandbox extends SandboxConnection {
           opts,
         )
       },
-      /**
-       * Writes content to a new file on path.
-       * 
-
-       * @param path Path to a new file. For example '/dirA/dirB/newFile.txt' when creating 'newFile.txt'
-       * @param content Content to write to a new file
-       * @param opts Call options
-       * @param {timeout} [opts.timeout] Timeout for call in milliseconds (default is 60 seconds)
-       */
       write: async (path, content, opts?: CallOpts) => {
         await this._call(
           filesystemService,
@@ -136,16 +116,6 @@ export class Sandbox extends SandboxConnection {
           opts,
         )
       },
-      /**
-       * Write array of bytes to a file.
-       * This can be used when you cannot represent the data as an UTF-8 string.
-       *
-       * A new file will be created if it doesn't exist.
-       * If the file already exists, it will be overwritten.
-       * 
-       * @param path path to a file
-       * @param content byte array representing the content to write
-       */
       writeBytes: async (path: string, content: Uint8Array) => {
         // We need to convert the byte array to base64 string without using browser or node specific APIs.
         // This should be achieved by the node polyfills.
@@ -155,11 +125,6 @@ export class Sandbox extends SandboxConnection {
           base64Content,
         ])
       },
-      /**
-       * Reads the whole content of a file as an array of bytes.
-       * @param path path to a file
-       * @returns byte array representing the content of a file
-       */
       readBytes: async (path: string) => {
         const base64Content = (await this._call(
           filesystemService,
@@ -170,12 +135,6 @@ export class Sandbox extends SandboxConnection {
         // This should be achieved by the node polyfills.
         return Buffer.from(base64Content, 'base64')
       },
-      /**
-       * Creates a new directory and all directories along the way if needed on the specified pth.
-       * @param path Path to a new directory. For example '/dirA/dirB' when creating 'dirB'.
-       * @param opts Call options
-       * @param {timeout} [opts.timeout] Timeout for call in milliseconds (default is 60 seconds)
-       */
       makeDir: async (path, opts?: CallOpts) => {
         await this._call(
           filesystemService,
@@ -184,11 +143,6 @@ export class Sandbox extends SandboxConnection {
           opts,
         )
       },
-      /**
-       * Watches directory for filesystem events.
-       * @param path Path to a directory that will be watched
-       * @returns New watcher
-       */
       watchDir: (path: string) => {
         this.logger.debug?.(`Watching directory "${path}"`)
         const npath = normalizePath(_resolvePath(path))

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -33,6 +33,32 @@ export interface Action<T = { [key: string]: any }> {
   (sandbox: Sandbox, args: T): string | Promise<string>
 }
 
+/**
+ * E2B cloud sandbox gives your agent a full cloud development environment that's sandboxed.
+ * 
+ * That means:
+ * - Access to Linux OS
+ * - Using filesystem (create, list, and delete files and dirs)
+ * - Run processes
+ * - Sandboxed - you can run any code
+ * - Access to the internet
+ *
+ * Check usage docs - https://e2b.dev/docs/sandbox/overview
+ *
+ * These cloud sandboxes are meant to be used for agents. Like a sandboxed playgrounds, where the agent can do whatever it wants. 
+ * 
+ * Use the {@link Sandbox.create} method to create a new sandbox.
+ * 
+ * @example
+ * ```ts
+ * import { Sandbox } from '@e2b/sdk'
+ * 
+ * const sandbox = await Sandbox.create()
+ * 
+ * await sandbox.close()
+ * ```
+ * 
+ */
 export class Sandbox extends SandboxConnection {
   readonly terminal: TerminalManager
   readonly filesystem: FilesystemManager
@@ -95,6 +121,8 @@ export class Sandbox extends SandboxConnection {
       },
       /**
        * Writes content to a new file on path.
+       * 
+
        * @param path Path to a new file. For example '/dirA/dirB/newFile.txt' when creating 'newFile.txt'
        * @param content Content to write to a new file
        * @param opts Call options
@@ -112,6 +140,9 @@ export class Sandbox extends SandboxConnection {
        * Write array of bytes to a file.
        * This can be used when you cannot represent the data as an UTF-8 string.
        *
+       * A new file will be created if it doesn't exist.
+       * If the file already exists, it will be overwritten.
+       * 
        * @param path path to a file
        * @param content byte array representing the content to write
        */

--- a/packages/js-sdk/src/sandbox/process.ts
+++ b/packages/js-sdk/src/sandbox/process.ts
@@ -164,6 +164,9 @@ export interface ProcessOpts {
   timeout?: number;
 }
 
+/**
+ * Manager for starting and interacting with processes in the sandbox.
+ */
 export interface ProcessManager {
   /**
    * Starts a new process.

--- a/packages/js-sdk/src/sandbox/terminal.ts
+++ b/packages/js-sdk/src/sandbox/terminal.ts
@@ -111,6 +111,9 @@ export type TerminalOpts = {
   timeout?: number;
 };
 
+/**
+ * Manager for starting and interacting with terminal sessions in the sandbox.
+ */
 export interface TerminalManager {
-  readonly start: (opts: TerminalOpts) => Promise<Terminal>;
+  start(opts: TerminalOpts): Promise<Terminal>;
 }

--- a/packages/python-sdk/e2b/__init__.py
+++ b/packages/python-sdk/e2b/__init__.py
@@ -1,3 +1,28 @@
+"""
+Secure sandboxed cloud environments made for AI agents and AI apps
+
+Check usage docs - https://e2b.dev/docs/sandbox/overview
+
+E2B Sandbox is a secure sandboxed cloud environment made for AI agents and AI
+apps. Sandboxes allow AI agents and apps to have long running cloud secure
+environments. In these environments, large language models can use the same
+tools as humans do.
+
+
+```py
+from e2b import Sandbox
+
+# Create sandbox
+sandbox = Sandbox()
+
+# Let an LLM use the sandbox here
+
+# Close sandbox once done
+sandbox.close()
+```
+"""
+
+
 from .api import (
     E2BApiClient,
     client,

--- a/packages/python-sdk/e2b/sandbox/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox/filesystem.py
@@ -54,6 +54,9 @@ class FilesystemManager:
         Write content to a file as a byte array.
         This can be used when you cannot represent the data as an UTF-8 string.
 
+        A new file will be created if it doesn't exist.
+        If the file already exists, it will be overwritten.
+
         :param path: path to a file
         :param timeout: timeout for the call
         :param content: byte array representing the content to write
@@ -89,6 +92,9 @@ class FilesystemManager:
     ) -> None:
         """
         Write content to a file.
+
+        A new file will be created if it doesn't exist.
+        If the file already exists, it will be overwritten.
 
         :param path: Path to a file
         :param content: Content to write

--- a/packages/python-sdk/e2b/sandbox/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox/filesystem.py
@@ -23,6 +23,10 @@ class FileInfo(BaseModel):
 
 
 class FilesystemManager:
+    """
+    Manager for interacting with the filesystem in the sandbox.
+    """
+
     _service_name = "filesystem"
 
     def __init__(self, sandbox: SandboxConnection):

--- a/packages/python-sdk/e2b/sandbox/main.py
+++ b/packages/python-sdk/e2b/sandbox/main.py
@@ -22,12 +22,13 @@ class Sandbox(SandboxConnection):
     E2B cloud sandbox gives your agent a full cloud development environment that's sandboxed.
 
     That means:
-
     - Access to Linux OS
     - Using filesystem (create, list, and delete files and dirs)
     - Run processes
     - Sandboxed - you can run any code
     - Access to the internet
+
+    Check usage docs - https://e2b.dev/docs/sandbox/overview
 
     These cloud sandboxes are meant to be used for agents. Like a sandboxed playgrounds, where the agent can do whatever it wants.
     """


### PR DESCRIPTION
- Add missing module dostring in Python
- Add missing class and property dostrings for JS
- Update docstrings with links to docs
- Clarify usage of `filesystem.write*` methods
- Move dostrings to the interfaces