### PR TITLE
Fix sandbox ID returned from SDKs `list` methods

### DIFF
--- a/.changeset/blue-buckets-pump.md
+++ b/.changeset/blue-buckets-pump.md
@@ -1,0 +1,6 @@
+---
+"@e2b/python-sdk": patch
+"e2b": patch
+---
+
+Fix sandbox ID returned by list method

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -27,7 +27,7 @@ export { DataAnalysis as CodeInterpreter }
 
 export { Artifact, DataAnalysis } from './templates/dataAnalysis'
 export type { RunPythonOpts } from './templates/dataAnalysis'
-export type { SandboxMetadata } from './sandbox/sandboxConnection'
+export type { SandboxMetadata, RunningSandbox } from './sandbox/sandboxConnection'
 export type { Action } from './sandbox/index'
 
 export { Sandbox }

--- a/packages/python-sdk/e2b/__init__.py
+++ b/packages/python-sdk/e2b/__init__.py
@@ -22,7 +22,6 @@ sandbox.close()
 ```
 """
 
-
 from .api import (
     E2BApiClient,
     client,
@@ -55,6 +54,7 @@ from .sandbox import (
     ProcessOutput,
     TerminalOutput,
     run_code,
+    RunningSandbox,
 )
 from .templates import (
     DataAnalysis,

--- a/packages/python-sdk/e2b/sandbox/__init__.py
+++ b/packages/python-sdk/e2b/sandbox/__init__.py
@@ -27,3 +27,4 @@ from .terminal import (
     TerminalManager,
     TerminalOutput,
 )
+from .sandbox_connection import RunningSandbox


### PR DESCRIPTION
The sanbdox ID returned from SDKs `list` method was missing the client id part user had to manually create the whole valid ID.

Now the sandbox ID field returned by the list method has the whole ID and the client ID is removed from the object.