### PR TITLE
Experimental stateless JavaScript SDK

### DIFF
--- a/.github/workflows/js_rc.yml
+++ b/.github/workflows/js_rc.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   release:
     name: Release Candidate
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'rc') }}
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'js-rc') }}
     runs-on: ubuntu-latest
     defaults:
         run:

--- a/.github/workflows/js_rc.yml
+++ b/.github/workflows/js_rc.yml
@@ -1,0 +1,55 @@
+name: JS SDK Release Candidate
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release Candidate
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'rc') }}
+    runs-on: ubuntu-latest
+    defaults:
+        run:
+            working-directory: packages/js-sdk
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+
+    - uses: pnpm/action-setup@v3
+
+    - name: Setup Node.js 20
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        registry-url: 'https://registry.npmjs.org'
+        cache: pnpm
+
+    - name: Configure pnpm
+      run: |
+        pnpm config set auto-install-peers true
+        pnpm config set exclude-links-from-lockfile true
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Release Candidate
+      run: |
+        npm version prerelease --preid=${{ github.head_ref }}
+        npm publish --tag rc
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Commit new versions
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git commit -am "[skip ci] Release new versions" || exit 0
+        git push
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2b",
-  "version": "0.12.2-stateless-sdk.1",
+  "version": "0.12.2-stateless-sdk.2",
   "description": "E2B SDK that give agents cloud environments",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2b",
-  "version": "0.12.1",
+  "version": "0.12.2-stateless-sdk.0",
   "description": "E2B SDK that give agents cloud environments",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2b",
-  "version": "0.12.2-stateless-sdk.3",
+  "version": "0.12.2-stateless-sdk.4",
   "description": "E2B SDK that give agents cloud environments",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2b",
-  "version": "0.12.2-stateless-sdk.4",
+  "version": "0.12.2-stateless-sdk.5",
   "description": "E2B SDK that give agents cloud environments",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2b",
-  "version": "0.12.2-stateless-sdk.0",
+  "version": "0.12.2-stateless-sdk.1",
   "description": "E2B SDK that give agents cloud environments",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2b",
-  "version": "0.12.2-stateless-sdk.5",
+  "version": "0.12.2-stateless-sdk.6",
   "description": "E2B SDK that give agents cloud environments",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2b",
-  "version": "0.12.2-stateless-sdk.6",
+  "version": "0.12.2-stateless-sdk.7",
   "description": "E2B SDK that give agents cloud environments",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/packages/js-sdk/src/api/schema.gen.ts
+++ b/packages/js-sdk/src/api/schema.gen.ts
@@ -49,6 +49,23 @@ export interface paths {
       };
     };
   };
+  "/sandboxes/{sandboxID}": {
+    /** Kill a sandbox */
+    delete: {
+      parameters: {
+        path: {
+          sandboxID: components["parameters"]["sandboxID"];
+        };
+      };
+      responses: {
+        /** The sandbox was killed successfully */
+        204: never;
+        401: components["responses"]["401"];
+        404: components["responses"]["404"];
+        500: components["responses"]["500"];
+      };
+    };
+  };
   "/sandboxes/{sandboxID}/refreshes": {
     /** Refresh the sandbox extending its time to live */
     post: {

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -32,4 +32,6 @@ export type { Action } from './sandbox/index'
 
 export { Sandbox }
 export default Sandbox
-export * as stateless from './sandbox/stateless'
+
+// Experimental
+export * as experimental_stateless from './sandbox/stateless'

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -20,7 +20,7 @@ export { Process, ProcessMessage, ProcessOutput } from './sandbox/process'
 export type { ProcessManager } from './sandbox/process'
 export type { EnvVars } from './sandbox/envVars'
 export { runCode, CodeRuntime } from './runCode' // Export CodeRuntime enum as value, not as type, so it can be actually used in consumer code
-import { Sandbox } from './sandbox/index'
+import { Sandbox } from './sandbox'
 
 import { DataAnalysis } from './templates/dataAnalysis'
 export { DataAnalysis as CodeInterpreter }
@@ -32,3 +32,4 @@ export type { Action } from './sandbox/index'
 
 export { Sandbox }
 export default Sandbox
+export * as stateless from './sandbox/stateless'

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -412,8 +412,7 @@ export class Sandbox extends SandboxConnection {
       startAndWait: async (optsOrCmd: string | ProcessOpts) => {
         const opts = typeof optsOrCmd === 'string' ? { cmd: optsOrCmd } : optsOrCmd
         const process = await this.process.start(opts)
-        const out = await process.wait()
-        return out
+        return process.wait(opts.timeout)
       }
     }
 

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -18,7 +18,7 @@ export type DownloadFileFormat =
   | 'blob'
   | 'buffer'
   | 'arraybuffer'
-  | 'text';
+  | 'text'
 
 export interface SandboxOpts extends SandboxConnectionOpts {
   onScanPorts?: ScanOpenPortsHandler;
@@ -37,7 +37,7 @@ export interface Action<S extends Sandbox = Sandbox, T = {
 
 /**
  * E2B cloud sandbox gives your agent a full cloud development environment that's sandboxed.
- * 
+ *
  * That means:
  * - Access to Linux OS
  * - Using filesystem (create, list, and delete files and dirs)
@@ -47,16 +47,16 @@ export interface Action<S extends Sandbox = Sandbox, T = {
  *
  * Check usage docs - https://e2b.dev/docs/sandbox/overview
  *
- * These cloud sandboxes are meant to be used for agents. Like a sandboxed playgrounds, where the agent can do whatever it wants. 
- * 
+ * These cloud sandboxes are meant to be used for agents. Like a sandboxed playgrounds, where the agent can do whatever it wants.
+ *
  * Use the {@link Sandbox.create} method to create a new sandbox.
- * 
+ *
  * @example
  * ```ts
  * import { Sandbox } from '@e2b/sdk'
- * 
+ *
  * const sandbox = await Sandbox.create()
- * 
+ *
  * await sandbox.close()
  * ```
  */
@@ -81,7 +81,7 @@ export class Sandbox extends SandboxConnection {
 
   /**
    * Use `Sandbox.create()` instead.
-   * 
+   *
    * @hidden
    * @hide
    * @internal
@@ -428,7 +428,7 @@ export class Sandbox extends SandboxConnection {
    * If a file with the same name already exists, it will be overwritten.
    */
   get fileURL() {
-    const protocol = this.getProtocol('http', this.opts.__debug_devEnv !== "local")
+    const protocol = this.getProtocol('http', this.opts.__debug_devEnv !== 'local')
     const hostname = this.getHostname(this.opts.__debug_port || ENVD_PORT)
     return `${protocol}://${hostname}${FILE_ROUTE}`
   }
@@ -463,7 +463,7 @@ export class Sandbox extends SandboxConnection {
    * ```
    * @constructs Sandbox
    */
-  static async create<S extends typeof Sandbox>(this: S): Promise<InstanceType<S>>;
+  static async create<S extends typeof Sandbox>(this: S): Promise<InstanceType<S>>
   /**
    * Creates a new Sandbox from the template with the specified ID.
    * @param template Sandbox template ID or name
@@ -474,7 +474,7 @@ export class Sandbox extends SandboxConnection {
    * const sandbox = await Sandbox.create("sandboxTemplateID")
    * ```
    */
-  static async create<S extends typeof Sandbox>(this: S, template: string): Promise<InstanceType<S>>;
+  static async create<S extends typeof Sandbox>(this: S, template: string): Promise<InstanceType<S>>
   /**
    * Creates a new Sandbox from the specified options.
    * @param opts Sandbox options
@@ -488,7 +488,7 @@ export class Sandbox extends SandboxConnection {
    * })
    * ```
    */
-  static async create<S extends typeof Sandbox>(this: S, opts: SandboxOpts): Promise<InstanceType<S>>;
+  static async create<S extends typeof Sandbox>(this: S, opts: SandboxOpts): Promise<InstanceType<S>>
   static async create(optsOrTemplate?: string | SandboxOpts) {
     const opts: SandboxOpts | undefined = typeof optsOrTemplate === 'string' ? { template: optsOrTemplate } : optsOrTemplate
     const sandbox = new Sandbox(opts)
@@ -506,14 +506,14 @@ export class Sandbox extends SandboxConnection {
    * ```ts
    * const sandbox = await Sandbox.create()
    * const sandboxID = sandbox.id
-   * 
+   *
    * await sandbox.keepAlive(300 * 1000)
    * await sandbox.close()
-   * 
+   *
    * const reconnectedSandbox = await Sandbox.reconnect(sandboxID)
    * ```
    */
-  static async reconnect<S extends typeof Sandbox>(this: S, sandboxID: string): Promise<InstanceType<S>>;
+  static async reconnect<S extends typeof Sandbox>(this: S, sandboxID: string): Promise<InstanceType<S>>
   /**
    * Reconnects to an existing Sandbox.
    * @param opts Sandbox options
@@ -523,16 +523,16 @@ export class Sandbox extends SandboxConnection {
    * ```ts
    * const sandbox = await Sandbox.create()
    * const sandboxID = sandbox.id
-   * 
+   *
    * await sandbox.keepAlive(300 * 1000)
    * await sandbox.close()
-   * 
+   *
    * const reconnectedSandbox = await Sandbox.reconnect({
    *   sandboxID,
    * })
    * ```
    */
-  static async reconnect<S extends typeof Sandbox>(this: S, opts: Omit<SandboxOpts, 'id' | 'template'> & { sandboxID: string }): Promise<InstanceType<S>>;
+  static async reconnect<S extends typeof Sandbox>(this: S, opts: Omit<SandboxOpts, 'id' | 'template'> & { sandboxID: string }): Promise<InstanceType<S>>
   static async reconnect<S extends typeof Sandbox>(this: S, sandboxIDorOpts: string | Omit<SandboxOpts, 'id' | 'template'> & { sandboxID: string }): Promise<InstanceType<S>> {
     let id: string
     let opts: SandboxOpts
@@ -544,7 +544,7 @@ export class Sandbox extends SandboxConnection {
       opts = sandboxIDorOpts
     }
 
-    const sandboxIDAndClientID = id.split("-")
+    const sandboxIDAndClientID = id.split('-')
     const sandboxID = sandboxIDAndClientID[0]
     const clientID = sandboxIDAndClientID[1]
     opts.__sandbox = { sandboxID, clientID, templateID: 'unknown' }
@@ -569,7 +569,7 @@ export class Sandbox extends SandboxConnection {
    * sandbox.addAction('readFile', (sandbox, args) => sandbox.filesystem.read(args.path))
    * ```
    */
-  addAction<T = { [name: string]: any }>(action: Action<this, T>): this;
+  addAction<T = { [name: string]: any }>(action: Action<this, T>): this
   /**
    * Add a new action with a specified name.
    *
@@ -589,7 +589,7 @@ export class Sandbox extends SandboxConnection {
    * sandbox.addAction(readFile)
    * ```
    */
-  addAction<T = { [name: string]: any }>(name: string, action: Action<this, T>): this;
+  addAction<T = { [name: string]: any }>(name: string, action: Action<this, T>): this
   addAction<T = { [name: string]: any }>(actionOrName: string | Action<this, T>, action?: Action<this, T>): this {
     if (typeof actionOrName === 'string') {
       if (!action) throw new Error('Action is required')
@@ -736,7 +736,7 @@ export class Sandbox extends SandboxConnection {
         cwd: '/',
       })
     } catch (err) {
-      this.logger.debug?.("start command not started", err)
+      this.logger.debug?.('start command not started', err)
     }
   }
 }

--- a/packages/js-sdk/src/sandbox/sandboxConnection.ts
+++ b/packages/js-sdk/src/sandbox/sandboxConnection.ts
@@ -84,6 +84,9 @@ const listSandboxes = withAPIKey(
 const createSandbox = withAPIKey(
   api.path('/sandboxes').method('post').create(),
 )
+const killSandbox = withAPIKey(
+  api.path('/sandboxes/{sandboxID}').method('delete').create(),
+)
 const refreshSandbox = withAPIKey(
   api.path('/sandboxes/{sandboxID}/refreshes').method('post').create(),
 )
@@ -178,6 +181,34 @@ export class SandboxConnection {
         if (error.status === 500) {
           throw new Error(
             `Error listing sandboxes - (${error.status}) server error: ${error.data.message}`,
+          )
+        }
+      }
+      throw e
+    }
+  }
+
+  /**
+   * List all running sandboxes
+   * @param sandboxID ID of the sandbox to kill
+   * @param apiKey API key to use for authentication. If not provided, the `E2B_API_KEY` environment variable will be used.
+   */
+  static async kill(sandboxID: string, apiKey?: string): Promise<void> {
+    const id = sandboxID.split('-')[0]
+    apiKey = getApiKey(apiKey)
+    try {
+      await killSandbox(apiKey, {sandboxID: id})
+    } catch (e) {
+      if (e instanceof killSandbox.Error) {
+        const error = e.getActualType()
+        if (error.status === 401) {
+          throw new Error(
+            `Error killing sandbox (${sandboxID}) - (${error.status}) unauthenticated: ${error.data.message}`,
+          )
+        }
+        if (error.status === 500) {
+          throw new Error(
+            `Error killing sandbox (${sandboxID}) - (${error.status}) server error: ${error.data.message}`,
           )
         }
       }
@@ -527,6 +558,8 @@ export class SandboxConnection {
     try {
       // eslint-disable-next-line no-constant-condition
       while (true) {
+        await wait(SANDBOX_REFRESH_PERIOD)
+
         if (!this.isOpen) {
           this.logger.debug?.(
             `Cannot refresh sandbox ${this.id} - it was closed`,
@@ -534,14 +567,11 @@ export class SandboxConnection {
           return
         }
 
-        await wait(SANDBOX_REFRESH_PERIOD)
-
         try {
-          this.logger.debug?.(`Refreshed sandbox "${sandboxID}"`)
-
           await refreshSandbox(this.apiKey, {
             sandboxID, duration: 0,
           })
+          this.logger.debug?.(`Refreshed sandbox "${sandboxID}"`)
         } catch (e) {
           if (e instanceof refreshSandbox.Error) {
             const error = e.getActualType()

--- a/packages/js-sdk/src/sandbox/stateless.ts
+++ b/packages/js-sdk/src/sandbox/stateless.ts
@@ -15,20 +15,22 @@ export async function create(lifetime: number, opts: SandboxOpts={}): Promise<st
 }
 
 /**
- * Starts a new process.
+ * Executes a command in a sandbox and waits until it finishes.
  * @overload
+ * @param cmd Command to run
  * @param sandboxId Sandbox ID
  * @returns Process output
  */
 /**
- * Starts a new process and wait until it finishes.
+ * Executes a command in a sandbox and waits until it finishes.
+ * @param cmd Command to run
  * @param sandboxID Sandbox ID
  * @param opts Process options
  * @returns Process output
  */
-export async function exec(sandboxID: string, opts: ProcessOpts & {apiKey: string}): Promise<ProcessOutput> {
-  const s = await Sandbox.reconnect({sandboxID, apiKey: opts.apiKey })
-  const result = await s.process.startAndWait(opts)
+export async function exec(cmd: string, sandboxID: string, opts?: Omit<ProcessOpts, 'cmd'> & {apiKey: string}): Promise<ProcessOutput> {
+  const s = await Sandbox.reconnect({sandboxID, apiKey: opts?.apiKey })
+  const result = await s.process.startAndWait({...opts, cmd})
   await s.close()
   return result
 }

--- a/packages/js-sdk/src/sandbox/stateless.ts
+++ b/packages/js-sdk/src/sandbox/stateless.ts
@@ -1,0 +1,45 @@
+import { Sandbox, SandboxOpts } from './index'
+import { ProcessOpts, ProcessOutput } from './process'
+
+/**
+ * Creates a new sandbox.
+ * @param lifetime Lifetime of the sandbox in milliseconds
+ * @param opts Sandbox options
+ * @returns Sandbox ID
+ */
+export async function create(lifetime: number, opts: SandboxOpts={}): Promise<string> {
+  const s = await Sandbox.create(opts)
+  await s.keepAlive(lifetime)
+  await s.close()
+  return s.id
+}
+
+/**
+ * Starts a new process.
+ * @overload
+ * @param sandboxId Sandbox ID
+ * @returns Process output
+ */
+/**
+ * Starts a new process and wait until it finishes.
+ * @param sandboxID Sandbox ID
+ * @param opts Process options
+ * @returns Process output
+ */
+export async function exec(sandboxID: string, opts: ProcessOpts & {apiKey: string}): Promise<ProcessOutput> {
+  const s = await Sandbox.reconnect({sandboxID, apiKey: opts.apiKey })
+  const result = await s.process.startAndWait(opts)
+  await s.close()
+  return result
+}
+
+
+
+/**
+ * Kills a sandbox.
+ * @param sandboxID Sandbox ID
+ * @param apiKey API key
+ */
+export async function kill(sandboxID: string, apiKey?: string): Promise<void> {
+  await Sandbox.kill(sandboxID, apiKey)
+}

--- a/packages/js-sdk/src/sandbox/stateless.ts
+++ b/packages/js-sdk/src/sandbox/stateless.ts
@@ -51,3 +51,16 @@ export async function downloadFile({ apiKey, sandboxID }: { sandboxID: string, a
   await s.close()
   return result
 }
+
+/**
+ * Uploads a file to a sandbox.
+ * @param apiKey API key
+ * @param sandboxID ID of the sandbox to which the file will be uploaded
+ * @param path Path where the file will be stored inside the sandbox
+ * @param content The content of the file as a byte array
+ */
+export async function uploadFile({ apiKey, sandboxID }: { sandboxID: string, apiKey?: string }, { path, content }: { path: string, content: Uint8Array }) {
+  const s = await Sandbox.reconnect({ apiKey, sandboxID })
+  await s.filesystem.writeBytes(path, content)
+  await s.close()
+}

--- a/packages/js-sdk/src/sandbox/stateless.ts
+++ b/packages/js-sdk/src/sandbox/stateless.ts
@@ -23,7 +23,7 @@ export async function create({ apiKey }: { apiKey?: string }, { keepAliveFor, ..
  * @returns Process' output
  */
 export async function exec({ apiKey, sandboxID }: { sandboxID: string, apiKey?: string }, opts: ProcessOpts) {
-  const s = await Sandbox.reconnect({ apiKey, sandboxID })
+  const s = await Sandbox.reconnect({ apiKey, sandboxID, timeout: opts.timeout })
   const result = await s.process.startAndWait({ ...opts })
   await s.close()
   return result

--- a/packages/js-sdk/src/sandbox/stateless.ts
+++ b/packages/js-sdk/src/sandbox/stateless.ts
@@ -10,8 +10,12 @@ import { ProcessOpts } from './process'
  */
 export async function create({ apiKey }: { apiKey?: string }, { keepAliveFor, ...opts }: Omit<SandboxOpts, 'apiKey'> & { keepAliveFor: number }) {
   const s = await Sandbox.create({ apiKey, ...opts })
-  await s.keepAlive(keepAliveFor)
-  await s.close()
+  try {
+    await s.keepAlive(keepAliveFor)
+  } finally {
+    await s.close()
+  }
+
   return s.id
 }
 
@@ -24,9 +28,12 @@ export async function create({ apiKey }: { apiKey?: string }, { keepAliveFor, ..
  */
 export async function exec({ apiKey, sandboxID }: { sandboxID: string, apiKey?: string }, opts: ProcessOpts) {
   const s = await Sandbox.reconnect({ apiKey, sandboxID, timeout: opts.timeout })
-  const result = await s.process.startAndWait({ ...opts })
-  await s.close()
-  return result
+  try {
+    const result = await s.process.startAndWait({ ...opts })
+    return result
+  } finally {
+    await s.close()
+  }
 }
 
 /**
@@ -47,9 +54,12 @@ export function kill({ apiKey, sandboxID }: { sandboxID: string, apiKey?: string
  */
 export async function downloadFile({ apiKey, sandboxID }: { sandboxID: string, apiKey?: string }, { path }: { path: string }) {
   const s = await Sandbox.reconnect({ apiKey, sandboxID })
-  const result = await s.filesystem.readBytes(path)
-  await s.close()
-  return result
+  try {
+    const result = await s.filesystem.readBytes(path)
+    return result
+  } finally {
+    await s.close()
+  }
 }
 
 /**
@@ -61,6 +71,9 @@ export async function downloadFile({ apiKey, sandboxID }: { sandboxID: string, a
  */
 export async function uploadFile({ apiKey, sandboxID }: { sandboxID: string, apiKey?: string }, { path, content }: { path: string, content: Uint8Array }) {
   const s = await Sandbox.reconnect({ apiKey, sandboxID })
-  await s.filesystem.writeBytes(path, content)
-  await s.close()
+  try {
+    await s.filesystem.writeBytes(path, content)
+  } finally {
+    await s.close()
+  }
 }

--- a/packages/js-sdk/src/sandbox/stateless.ts
+++ b/packages/js-sdk/src/sandbox/stateless.ts
@@ -1,47 +1,53 @@
 import { Sandbox, SandboxOpts } from './index'
-import { ProcessOpts, ProcessOutput } from './process'
+import { ProcessOpts } from './process'
 
 /**
- * Creates a new sandbox.
- * @param lifetime Lifetime of the sandbox in milliseconds
- * @param opts Sandbox options
- * @returns Sandbox ID
+ * Creates a new sandbox and keeps it alive for the specified time.
+ * @param apiKey API key
+ * @param keepAliveFor Automatically kill the sandbox after specified number of milliseconds
+ * @param opts Sandbox creation options
+ * @returns ID of the created sandbox
  */
-export async function create(lifetime: number, opts: SandboxOpts={}): Promise<string> {
-  const s = await Sandbox.create(opts)
-  await s.keepAlive(lifetime)
+export async function create({ apiKey }: { apiKey?: string }, { keepAliveFor, ...opts }: Omit<SandboxOpts, 'apiKey'> & { keepAliveFor: number }) {
+  const s = await Sandbox.create({ apiKey, ...opts })
+  await s.keepAlive(keepAliveFor)
   await s.close()
   return s.id
 }
 
 /**
- * Executes a command in a sandbox and waits until it finishes.
- * @overload
- * @param cmd Command to run
- * @param sandboxId Sandbox ID
- * @returns Process output
- */
-/**
- * Executes a command in a sandbox and waits until it finishes.
- * @param cmd Command to run
- * @param sandboxID Sandbox ID
+ * Executes a command inside a sandbox.
+ * @param apiKey API key
+ * @param sandboxID ID of the sandbox in which execute the command
  * @param opts Process options
- * @returns Process output
+ * @returns Process' output
  */
-export async function exec(cmd: string, sandboxID: string, opts?: Omit<ProcessOpts, 'cmd'> & {apiKey: string}): Promise<ProcessOutput> {
-  const s = await Sandbox.reconnect({sandboxID, apiKey: opts?.apiKey })
-  const result = await s.process.startAndWait({...opts, cmd})
+export async function exec({ apiKey, sandboxID }: { sandboxID: string, apiKey?: string }, opts: ProcessOpts) {
+  const s = await Sandbox.reconnect({ apiKey, sandboxID })
+  const result = await s.process.startAndWait({ ...opts })
   await s.close()
   return result
 }
 
-
-
 /**
  * Kills a sandbox.
- * @param sandboxID Sandbox ID
  * @param apiKey API key
+ * @param sandboxID ID of the sandbox to kill
  */
-export async function kill(sandboxID: string, apiKey?: string): Promise<void> {
-  await Sandbox.kill(sandboxID, apiKey)
+export function kill({ apiKey, sandboxID }: { sandboxID: string, apiKey?: string }): Promise<void> {
+  return Sandbox.kill(sandboxID, apiKey)
+}
+
+/**
+ * Downloads a file from a sandbox and returns its contents as a byte array.
+ * @param apiKey API key
+ * @param sandboxID ID of the sandbox from which to download a file
+ * @param path Path to a file inside the sandbox to download
+ * @returns File's contents as a byte array
+ */
+export async function downloadFile({ apiKey, sandboxID }: { sandboxID: string, apiKey?: string }, { path }: { path: string }) {
+  const s = await Sandbox.reconnect({ apiKey, sandboxID })
+  const result = await s.filesystem.readBytes(path)
+  await s.close()
+  return result
 }

--- a/packages/js-sdk/testground/stateless.cjs
+++ b/packages/js-sdk/testground/stateless.cjs
@@ -1,24 +1,18 @@
-const { experimental_stateless } = require('../dist/index')
-const {
-  create,
-  exec,
-  kill,
-  downloadFile,
-} = experimental_stateless
+const e2b = require('../dist/index')
 
 async function main() {
   const apiKey = '...'
   const lifetime = 60_000 * 5 // 5 minutes
 
   console.log('> Creating sandbox...')
-  const sandboxID = await create({ apiKey }, {
+  const sandboxID = await e2b.experimental_stateless.create({ apiKey }, {
     keepAliveFor: lifetime,
   })
   console.log('...sandbox created, sandbox id -', sandboxID)
 
   const cmd = 'echo hello world'
   console.log(`\n> Executing command "${cmd}"...`)
-  await exec({
+  await e2b.experimental_stateless.exec({
     apiKey,
     sandboxID
   }, {
@@ -33,7 +27,7 @@ async function main() {
   console.log('...command finished')
 
   console.log('\n> Downloading file...')
-  const content = await downloadFile({
+  const content = await e2b.experimental_stateless.downloadFile({
     apiKey,
     sandboxID,
   }, {
@@ -42,7 +36,7 @@ async function main() {
   console.log('...downloaded file:\n', content.toString())
 
   console.log(`\n> Killing sandbox "${sandboxID}"...`)
-  await kill({
+  await e2b.experimental_stateless.kill({
     apiKey,
     sandboxID,
   })
@@ -53,3 +47,4 @@ main()
   .then(() => {
     console.log('\n\nFinished')
   })
+

--- a/packages/js-sdk/testground/stateless.cjs
+++ b/packages/js-sdk/testground/stateless.cjs
@@ -26,12 +26,22 @@ async function main() {
   })
   console.log('...command finished')
 
+  console.log('\n> Uploading file...')
+  await e2b.experimental_stateless.uploadFile({
+    apiKey,
+    sandboxID,
+  }, {
+    path: '/tmp/hello.txt',
+    content: new TextEncoder().encode('hello world'),
+  })
+  console.log('...file uploaded')
+
   console.log('\n> Downloading file...')
   const content = await e2b.experimental_stateless.downloadFile({
     apiKey,
     sandboxID,
   }, {
-    path: '/etc/hosts'
+    path: '/tmp/hello.txt'
   })
   console.log('...downloaded file:\n', content.toString())
 
@@ -47,4 +57,3 @@ main()
   .then(() => {
     console.log('\n\nFinished')
   })
-

--- a/packages/js-sdk/testground/stateless.cjs
+++ b/packages/js-sdk/testground/stateless.cjs
@@ -1,0 +1,53 @@
+const { experimental_stateless } = require('../dist/index')
+const {
+  create,
+  exec,
+  kill,
+  downloadFile,
+} = experimental_stateless
+
+async function main() {
+  const apiKey = '...'
+  const lifetime = 60_000 * 5 // 5 minutes
+
+  const sandboxID = await create({ apiKey }, {
+    keepAliveFor: lifetime,
+  })
+
+  exec({
+    apiKey,
+    sandboxID
+  }, {
+    cmd: 'echo hello',
+    onStdout: (data) => {
+      console.log(data)
+    },
+    onStderr: (data) => {
+      console.error(data)
+    },
+  })
+    .then(() => {
+      console.log('Kill sandbox...')
+      return kill({
+        apiKey,
+        sandboxID,
+      })
+    })
+    .then(() => {
+      console.log('...killed')
+    })
+
+  const content = await downloadFile({
+    apiKey,
+    sandboxID,
+  }, {
+    path: '/etc/hosts'
+  })
+  console.log('downloaded file', content)
+  console.log('downloaded file content as string:', content.toString())
+}
+
+main()
+  .then(() => {
+    console.log('done')
+  })

--- a/packages/js-sdk/testground/stateless.cjs
+++ b/packages/js-sdk/testground/stateless.cjs
@@ -10,15 +10,19 @@ async function main() {
   const apiKey = '...'
   const lifetime = 60_000 * 5 // 5 minutes
 
+  console.log('> Creating sandbox...')
   const sandboxID = await create({ apiKey }, {
     keepAliveFor: lifetime,
   })
+  console.log('...sandbox created, sandbox id -', sandboxID)
 
-  exec({
+  const cmd = 'echo hello world'
+  console.log(`\n> Executing command "${cmd}"...`)
+  await exec({
     apiKey,
     sandboxID
   }, {
-    cmd: 'echo hello',
+    cmd,
     onStdout: (data) => {
       console.log(data)
     },
@@ -26,28 +30,26 @@ async function main() {
       console.error(data)
     },
   })
-    .then(() => {
-      console.log('Kill sandbox...')
-      return kill({
-        apiKey,
-        sandboxID,
-      })
-    })
-    .then(() => {
-      console.log('...killed')
-    })
+  console.log('...command finished')
 
+  console.log('\n> Downloading file...')
   const content = await downloadFile({
     apiKey,
     sandboxID,
   }, {
     path: '/etc/hosts'
   })
-  console.log('downloaded file', content)
-  console.log('downloaded file content as string:', content.toString())
+  console.log('...downloaded file:\n', content.toString())
+
+  console.log(`\n> Killing sandbox "${sandboxID}"...`)
+  await kill({
+    apiKey,
+    sandboxID,
+  })
+  console.log('...sandbox killed')
 }
 
 main()
   .then(() => {
-    console.log('done')
+    console.log('\n\nFinished')
   })

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -36,7 +36,7 @@ components:
       required: true
       schema:
         type: string
-#  ------ Deprecated --------
+    #  ------ Deprecated --------
     envID:
       name: envID
       in: path
@@ -49,7 +49,7 @@ components:
       required: true
       schema:
         type: string
-#  ----------------------
+  #  ----------------------
 
   responses:
     400:
@@ -199,7 +199,7 @@ components:
         message:
           type: string
           description: Error
-#  ------ Deprecated --------
+    #  ------ Deprecated --------
     Environment:
       required:
         - envID
@@ -306,7 +306,7 @@ components:
 tags:
   - name: templates
   - name: sandboxes
-#  ------ Deprecated --------
+  #  ------ Deprecated --------
   - name: instances
   - name: envs
 # ---------------------------
@@ -326,7 +326,7 @@ paths:
       description: List all running sandboxes
       tags: [sandboxes]
       security:
-        - ApiKeyAuth: [ ]
+        - ApiKeyAuth: []
       responses:
         200:
           description: Successfully returned all running sandboxes
@@ -365,6 +365,24 @@ paths:
           $ref: "#/components/responses/401"
         400:
           $ref: "#/components/responses/400"
+        500:
+          $ref: "#/components/responses/500"
+
+  /sandboxes/{sandboxID}:
+    delete:
+      description: Kill a sandbox
+      tags: [sandboxes]
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/sandboxID"
+      responses:
+        204:
+          description: The sandbox was killed successfully
+        404:
+          $ref: "#/components/responses/404"
+        401:
+          $ref: "#/components/responses/401"
         500:
           $ref: "#/components/responses/500"
 
@@ -774,7 +792,7 @@ paths:
       description: List all running instances
       tags: [instances]
       security:
-        - ApiKeyAuth: [ ]
+        - ApiKeyAuth: []
       responses:
         200:
           description: Successfully returned all running instances


### PR DESCRIPTION
# Experimental stateless JavaScript SDK for E2B

The stateless version of our SDK allows you to spin up a sandbox from a client without managing the sandbox lifecycle on the client. The sandbox stays stateful though.

## Installation
```sh
npm i e2b@0.12.2-stateless-sdk.6
```

## Usage
```js
import * as e2b from 'e2b'

const apiKey = '...'
const lifetime = 60_000 * 5 // 5 minutes

console.log('> Creating sandbox...')
const sandboxID = await e2b.experimental_stateless.create({ apiKey }, {
  keepAliveFor: lifetime,
})
console.log('...sandbox created, sandbox id -', sandboxID)

const cmd = 'echo hello world'
console.log(`\n> Executing command "${cmd}"...`)
// This will stream command's stdout and stderr
await e2b.experimental_stateless.exec({
  apiKey,
  sandboxID
}, {
  cmd,
  onStdout: (data) => {
    console.log(data)
  },
  onStderr: (data) => {
    console.error(data)
  },
})
// Or you can wait and get the full output in the `result` object after the command has finished running:
// const result = await e2b.experimental_stateless.exec(...)
console.log('...command finished')

console.log('\n> Uploading file...')
await e2b.experimental_stateless.uploadFile({
  apiKey,
  sandboxID,
}, {
  path: '/tmp/hello.txt',
  content: new TextEncoder().encode('hello world'),
})
console.log('...file uploaded')

console.log('\n> Downloading file...')
const content = await e2b.experimental_stateless.downloadFile({
  apiKey,
  sandboxID,
}, {
  path: '/tmp/hello.txt'
})
console.log('...downloaded file:\n', content.toString())

console.log(`\n> Killing sandbox "${sandboxID}"...`)
await e2b.experimental_stateless.kill({
  apiKey,
  sandboxID,
})
console.log('...sandbox killed')
```

There are three methods on `stateless` module:
- `create` - creates a sandbox for a specified time in `ms`, returns `id` of the sandbox, you can specify template or the sandbox will be created with the `base` template
- `exec` - executes the command in specified sandbox
- `downloadFile` - downloads a file from the sandbox as a byte array
- `uploadFile` - uploads a file to a sandbox
- `kill` - destroys the sandbox immediately 