### PR TITLE
Fix sandbox kill command

### DIFF
--- a/.changeset/sweet-masks-suffer.md
+++ b/.changeset/sweet-masks-suffer.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Fix CLI kill sandbox command

--- a/packages/cli/src/commands/sandbox/kill.ts
+++ b/packages/cli/src/commands/sandbox/kill.ts
@@ -4,10 +4,6 @@ import { ensureAPIKey } from 'src/api'
 import { asBold } from 'src/utils/format'
 import * as e2b from 'e2b'
 
-
-const killSandbox = e2b.withAPIKey(
-  e2b.api.path('/sandboxes/{sandboxID}').method('delete').create(),
-)
 export const killCommand = new commander.Command('kill')
   .description('kill sandbox')
   .argument('<sandboxID>', `kill the sandbox specified by ${asBold('<sandboxID>')}`)
@@ -21,7 +17,7 @@ export const killCommand = new commander.Command('kill')
         process.exit(1)
       }
 
-      await killSandbox(apiKey, { sandboxID })
+      await e2b.Sandbox.kill(sandboxID, apiKey)
 
       console.log(`Sandbox ${asBold(sandboxID)} has been killed`)
     } catch (err: any) {


### PR DESCRIPTION
CLI `e2b sandbox kill` command didn't work with sandboxIDs provided by the `e2b sandbox list`. This PR fixes that.