### PR TITLE
Add missing parentheses in `sandbox.close()` call

### DIFF
--- a/apps/docs/src/app/sandbox/templates/premade/page.mdx
+++ b/apps/docs/src/app/sandbox/templates/premade/page.mdx
@@ -98,7 +98,7 @@ for (const artifact of artifacts) {
 }
 
 // 4. Close sandbox
-await sandbox.close
+await sandbox.close()
 ```
 
 ```python {{ language: 'python' }}


### PR DESCRIPTION
`sandbox.close` would be a no-op without parentheses to invoke the function.