### PR TITLE
Add domain parameter to SDK

### DIFF
--- a/.changeset/tasty-items-cross.md
+++ b/.changeset/tasty-items-cross.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Add domain parameter to JS SDK

--- a/.changeset/warm-bears-suffer.md
+++ b/.changeset/warm-bears-suffer.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Add domain parameter to Python SDK

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,4 +1,5 @@
 import * as boxen from 'boxen'
+import * as e2b from 'e2b'
 
 import { getUserConfig } from './user'
 import { asBold, asPrimary } from './utils/format'
@@ -50,3 +51,5 @@ export function ensureAccessToken() {
     return accessToken
   }
 }
+
+export const client = new e2b.APIClient()

--- a/packages/cli/src/commands/sandbox/list.ts
+++ b/packages/cli/src/commands/sandbox/list.ts
@@ -2,10 +2,10 @@ import * as tablePrinter from 'console-table-printer'
 import * as commander from 'commander'
 import * as e2b from 'e2b'
 
-import { ensureAPIKey } from 'src/api'
+import { ensureAPIKey, client } from 'src/api'
 
 const listRunningSandboxes = e2b.withAPIKey(
-  e2b.api.path('/sandboxes').method('get').create(),
+  client.api.path('/sandboxes').method('get').create(),
 )
 
 export const listCommand = new commander.Command('list')

--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -27,25 +27,27 @@ import {
 import { configName, getConfigPath, loadConfig, saveConfig } from 'src/config'
 import * as child_process from 'child_process'
 
+import { client } from 'src/api'
+
 const templateCheckInterval = 500 // 0.5 sec
 
 const getTemplate = e2b.withAccessToken(
-  e2b.api
+  client.api
     .path('/templates/{templateID}/builds/{buildID}/status')
     .method('get')
     .create(),
 )
 
 const requestTemplateBuild = e2b.withAccessToken(
-  e2b.api.path('/templates').method('post').create(),
+  client.api.path('/templates').method('post').create(),
 )
 
 const requestTemplateRebuild = e2b.withAccessToken(
-  e2b.api.path('/templates/{templateID}').method('post').create(),
+  client.api.path('/templates/{templateID}').method('post').create(),
 )
 
 const triggerTemplateBuild = e2b.withAccessToken(
-  e2b.api
+  client.api
     .path('/templates/{templateID}/builds/{buildID}')
     .method('post')
     .create(),
@@ -364,9 +366,8 @@ async function waitForBuildFinish(
         const pythonExample = asPython(`from e2b import Sandbox
 
 # Start sandbox
-sandbox = Sandbox(template="${
-          aliases?.length ? aliases[0] : template.data.templateID
-        }")
+sandbox = Sandbox(template="${aliases?.length ? aliases[0] : template.data.templateID
+          }")
 
 # Interact with sandbox. Learn more here:
 # https://e2b.dev/docs/sandbox/overview
@@ -377,9 +378,8 @@ sandbox.close()`)
         const typescriptExample = asTypescript(`import { Sandbox } from 'e2b'
 
 // Start sandbox
-const sandbox = await Sandbox.create({ template: '${
-          aliases?.length ? aliases[0] : template.data.templateID
-        }' })
+const sandbox = await Sandbox.create({ template: '${aliases?.length ? aliases[0] : template.data.templateID
+          }' })
 
 // Interact with sandbox. Learn more here:
 // https://e2b.dev/docs/sandbox/overview
@@ -534,24 +534,21 @@ async function requestBuildTemplate(
 
     if (error.code === 401) {
       throw new Error(
-        `Authentication error: ${res.statusText}, ${
-          error.message ?? 'no message'
+        `Authentication error: ${res.statusText}, ${error.message ?? 'no message'
         }`,
       )
     }
 
     if (error.code === 404) {
       throw new Error(
-        `Sandbox template you want to build ${
-          templateID ? `(${templateID})` : ''
-        } not found: ${res.statusText}, ${error.message ?? 'no message'}\n${
-          hasConfig
-            ? `This could be caused by ${asLocalRelative(
-                configPath,
-              )} belonging to a deleted template or a template that you don't own. If so you can delete the ${asLocalRelative(
-                configPath,
-              )} and start building the template again.`
-            : ''
+        `Sandbox template you want to build ${templateID ? `(${templateID})` : ''
+        } not found: ${res.statusText}, ${error.message ?? 'no message'}\n${hasConfig
+          ? `This could be caused by ${asLocalRelative(
+            configPath,
+          )} belonging to a deleted template or a template that you don't own. If so you can delete the ${asLocalRelative(
+            configPath,
+          )} and start building the template again.`
+          : ''
         }`,
       )
     }
@@ -585,8 +582,7 @@ async function triggerBuild(
 
     if (error.code === 401) {
       throw new Error(
-        `Authentication error: ${res.statusText}, ${
-          error.message ?? 'no message'
+        `Authentication error: ${res.statusText}, ${error.message ?? 'no message'
         }`,
       )
     }

--- a/packages/cli/src/commands/template/delete.ts
+++ b/packages/cli/src/commands/template/delete.ts
@@ -24,9 +24,10 @@ import { getRoot } from 'src/utils/filesystem'
 import { listSandboxTemplates } from './list'
 import { getPromptTemplates } from 'src/utils/templatePrompt'
 import { confirm } from 'src/utils/confirm'
+import { client } from 'src/api'
 
 const deleteTemplate = e2b.withAccessToken(
-  e2b.api.path('/templates/{templateID}').method('delete').create(),
+  client.api.path('/templates/{templateID}').method('delete').create(),
 )
 
 export const deleteCommand = new commander.Command('delete')
@@ -133,8 +134,7 @@ export const deleteCommand = new commander.Command('delete')
 
         if (!opts.yes) {
           const confirmed = await confirm(
-            `Do you really want to delete ${
-              templates.length === 1 ? 'this template' : 'these templates'
+            `Do you really want to delete ${templates.length === 1 ? 'this template' : 'these templates'
             }?`,
           )
 

--- a/packages/cli/src/commands/template/list.ts
+++ b/packages/cli/src/commands/template/list.ts
@@ -5,9 +5,10 @@ import * as e2b from 'e2b'
 import { ensureAccessToken } from 'src/api'
 import { listAliases } from '../../utils/format'
 import { sortTemplatesAliases } from 'src/utils/templateSort'
+import { client } from 'src/api'
 
 const listTemplates = e2b.withAccessToken(
-  e2b.api.path('/templates').method('get').create(),
+  client.api.path('/templates').method('get').create(),
 )
 
 export const listCommand = new commander.Command('list')

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -10,7 +10,7 @@ const { Fetcher } = fetcher
 class APIClient {
   private client = Fetcher.for<paths>()
 
-  constructor(private opts: {
+  constructor(private opts?: {
     secure?: boolean,
     domain?: string,
     debug?: boolean,
@@ -25,15 +25,15 @@ class APIClient {
   }
 
   get secure() {
-    return this.opts.secure ?? SECURE
+    return this.opts?.secure ?? SECURE
   }
 
   get domain() {
-    return this.opts.domain ?? DOMAIN
+    return this.opts?.domain ?? DOMAIN
   }
 
   get debug() {
-    return this.opts.debug ?? DEBUG
+    return this.opts?.debug ?? DEBUG
   }
 
   get apiDomain() {

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -1,22 +1,53 @@
 import * as fetcher from 'openapi-typescript-fetch'
 import type { OpArgType, TypedFetch } from 'openapi-typescript-fetch'
 
-import { API_HOST } from '../constants'
 import type { components, paths } from './schema.gen'
 import { defaultHeaders } from './metadata'
+import { DEBUG, DOMAIN, SECURE } from '../constants'
 
 const { Fetcher } = fetcher
 
-const client = Fetcher.for<paths>()
+class APIClient {
+  private client = Fetcher.for<paths>()
 
-type ClientType = typeof client
+  constructor(private opts: {
+    secure?: boolean,
+    domain?: string,
+    debug?: boolean,
+  }
+  ) {
+    this.client.configure({
+      baseUrl: this.apiHost,
+      init: {
+        headers: defaultHeaders,
+      },
+    })
+  }
 
-client.configure({
-  baseUrl: API_HOST,
-  init: {
-    headers: defaultHeaders,
-  },
-})
+  get secure() {
+    return this.opts.secure ?? SECURE
+  }
+
+  get domain() {
+    return this.opts.domain ?? DOMAIN
+  }
+
+  get debug() {
+    return this.opts.debug ?? DEBUG
+  }
+
+  get apiDomain() {
+    return this.debug ? 'localhost:3000' : `api.${this.domain}`
+  }
+
+  get apiHost() {
+    return `${this.secure && !this.debug ? 'https' : 'http'}://${this.apiDomain}`
+  }
+
+  get api() {
+    return this.client
+  }
+}
 
 type WithAccessToken<T> = (
   accessToken: string,
@@ -66,5 +97,5 @@ export function withAPIKey<T>(f: TypedFetch<T>) {
   }
 }
 
-export default client
-export type { components, paths, ClientType }
+export type { components, paths }
+export { APIClient }

--- a/packages/js-sdk/src/constants.ts
+++ b/packages/js-sdk/src/constants.ts
@@ -2,9 +2,8 @@ export const SANDBOX_REFRESH_PERIOD = 5_000 // 5s
 export const WS_RECONNECT_INTERVAL = 150 // 150ms
 
 export const TIMEOUT = 60_000 // 60s
-
-const DEBUG = process?.env?.E2B_DEBUG
-const DOMAIN = process?.env?.E2B_DOMAIN || 'e2b.dev'
+export const DEBUG = process?.env?.E2B_DEBUG
+export const DOMAIN = process?.env?.E2B_DOMAIN || 'e2b.dev'
 export const SECURE = (process?.env?.E2B_SECURE || 'true').toLowerCase() === 'true'
 export const API_DOMAIN = DEBUG ? 'localhost:3000' : `api.${DOMAIN}`
 export const API_HOST = `${SECURE && !DEBUG ? 'https' : 'http'}://${API_DOMAIN}`

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -1,5 +1,5 @@
-export { default as api, withAPIKey, withAccessToken } from './api'
-export type { ClientType, components, paths } from './api'
+export { APIClient, withAPIKey, withAccessToken } from './api'
+export type { components, paths } from './api'
 
 export { SANDBOX_DOMAIN, API_HOST } from './constants'
 export type { SandboxOpts, DownloadFileFormat } from './sandbox'

--- a/packages/js-sdk/src/sandbox/sandboxConnection.ts
+++ b/packages/js-sdk/src/sandbox/sandboxConnection.ts
@@ -64,6 +64,9 @@ export interface SandboxConnectionOpts {
    */
   id?: string;
   apiKey?: string;
+  /**
+   * Domain to use for the API requests. If not provided, the `E2B_DOMAIN` environment variable will be used.
+   */
   domain?: string;
   cwd?: string;
   envVars?: EnvVars;
@@ -162,6 +165,7 @@ export class SandboxConnection {
    * List all running sandboxes
    * 
    * @param apiKey API key to use for authentication. If not provided, the `E2B_API_KEY` environment variable will be used.
+   * @param domain Domain to use for the API requests. If not provided, the `E2B_DOMAIN` environment variable will be used.
    */
   static async list(apiKey?: string, domain?: string): Promise<RunningSandbox[]> {
     apiKey = getApiKey(apiKey)
@@ -207,6 +211,7 @@ export class SandboxConnection {
    * List all running sandboxes
    * @param sandboxID ID of the sandbox to kill
    * @param apiKey API key to use for authentication. If not provided, the `E2B_API_KEY` environment variable will be used.
+   * @param domain Domain to use for the API requests. If not provided, the `E2B_DOMAIN` environment variable will be used.
    */
   static async kill(sandboxID: string, apiKey?: string, domain?: string): Promise<void> {
     apiKey = getApiKey(apiKey)

--- a/packages/python-sdk/e2b/__init__.py
+++ b/packages/python-sdk/e2b/__init__.py
@@ -26,10 +26,7 @@ from .api import (
     E2BApiClient,
     client,
 )
-from .constants import (
-    SANDBOX_DOMAIN,
-    API_HOST,
-)
+from .constants import DOMAIN
 from .sandbox import (
     Sandbox,
     FilesystemOperation,

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -1,7 +1,7 @@
 from importlib.metadata import version
 from typing import Union
 
-from e2b.constants import API_HOST
+from e2b.constants import DOMAIN, PROTOCOL, DEBUG
 from e2b.api.metadata import default_headers
 
 
@@ -16,11 +16,6 @@ else:
     import e2b.api.v2.client.exceptions as exceptions
 
 
-# Defining the host is optional and defaults to https://api.e2b.dev
-# See configuration.py for a list of all supported configuration parameters.
-configuration = client.Configuration(
-    host=API_HOST,
-)
 
 
 class E2BApiClient(client.ApiClient):
@@ -28,9 +23,17 @@ class E2BApiClient(client.ApiClient):
         self,
         api_key: Union[str, None] = None,
         access_token: Union[str, None] = None,
+        domain: str = DOMAIN,
         *args,
         **kwargs,
     ):
+        prefix = "" if DEBUG else f"api."
+        api_host = f"{PROTOCOL}://{prefix}{domain}"
+
+        # Defining the host is optional and defaults to https://api.e2b.dev
+        # See configuration.py for a list of all supported configuration parameters.
+        configuration = client.Configuration(host=api_host)
+
         configuration.api_key["ApiKeyAuth"] = api_key
         configuration.access_token = access_token
 
@@ -38,4 +41,4 @@ class E2BApiClient(client.ApiClient):
         self.default_headers = default_headers
 
 
-__all__ = ["E2BApiClient", "configuration", "client", "models"]
+__all__ = ["E2BApiClient", "client", "models"]

--- a/packages/python-sdk/e2b/constants.py
+++ b/packages/python-sdk/e2b/constants.py
@@ -4,16 +4,13 @@ SANDBOX_REFRESH_PERIOD = 5  # seconds
 
 TIMEOUT = 60
 
-DOMAIN = os.getenv("E2B_DOMAIN") or "e2b.dev"
+
 SECURE = os.getenv("E2B_SECURE", "TRUE").upper() == "TRUE"
 DEBUG = os.getenv("E2B_DEBUG") or False
-
-API_DOMAIN = "localhost:3000" if DEBUG else f"api.{DOMAIN}"
 PROTOCOL = "https" if SECURE and not DEBUG else "http"
-API_HOST = f"{PROTOCOL}://{API_DOMAIN}"
 
 
-SANDBOX_DOMAIN = DOMAIN
+DOMAIN = os.getenv("E2B_DOMAIN") or "e2b.dev"
 
 ENVD_PORT = 49982
 WS_ROUTE = "/ws"

--- a/packages/python-sdk/e2b/sandbox/main.py
+++ b/packages/python-sdk/e2b/sandbox/main.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, List, Literal, Optional, IO, TypeVar, Un
 from typing_extensions import Self
 
 from e2b.api import models
-from e2b.constants import TIMEOUT, ENVD_PORT, FILE_ROUTE
+from e2b.constants import TIMEOUT, ENVD_PORT, FILE_ROUTE, DOMAIN
 from e2b.sandbox.code_snippet import CodeSnippetManager, OpenPort
 from e2b.sandbox.env_vars import EnvVars
 from e2b.sandbox.filesystem import FilesystemManager
@@ -77,6 +77,7 @@ class Sandbox(SandboxConnection):
         on_exit: Optional[Union[Callable[[int], Any], Callable[[], Any]]] = None,
         metadata: Optional[Dict[str, str]] = None,
         timeout: Optional[float] = TIMEOUT,
+        domain: str = DOMAIN,
         _sandbox: Optional[models.Sandbox] = None,
         _debug_hostname: Optional[str] = None,
         _debug_port: Optional[int] = None,
@@ -101,6 +102,7 @@ class Sandbox(SandboxConnection):
         :param on_exit: A default callback that is called when the process exits
         :param metadata: A dictionary of strings that is stored alongside the running sandbox. You can see this metadata when you list running sandboxes.
         :param timeout: Timeout for sandbox to initialize in seconds, default is 60 seconds
+        :param domain: The domain to use for the API
         """
 
         template = id or template or "base"
@@ -146,6 +148,7 @@ class Sandbox(SandboxConnection):
             _debug_port=_debug_port,
             _debug_dev_env=_debug_dev_env,
             timeout=timeout,
+            domain=domain,
         )
         self._actions: Dict[str, Action[Self]] = {}
 
@@ -254,6 +257,7 @@ class Sandbox(SandboxConnection):
         on_exit: Optional[Union[Callable[[int], Any], Callable[[], Any]]] = None,
         timeout: Optional[float] = TIMEOUT,
         api_key: Optional[str] = None,
+        domain: str = DOMAIN,
         _debug_hostname: Optional[str] = None,
         _debug_port: Optional[int] = None,
         _debug_dev_env: Optional[Literal["remote", "local"]] = None,
@@ -270,7 +274,7 @@ class Sandbox(SandboxConnection):
         :param on_exit: A default callback that is called when the process exits
         :param timeout: Timeout for sandbox to initialize in seconds, default is 60 seconds
         :param api_key: The API key to use, if not provided, the `E2B_API_KEY` environment variable is used
-
+        :param domain: The domain to use for the API
 
         ```py
         sandbox = Sandbox()
@@ -295,6 +299,7 @@ class Sandbox(SandboxConnection):
             on_exit=on_exit,
             timeout=timeout,
             api_key=api_key,
+            domain=domain,
             _sandbox=models.Sandbox(
                 sandbox_id=sandbox_id,
                 client_id=client_id,


### PR DESCRIPTION
Add `domain` parameter to SDK create, list, and kill methods to allow specifying sandbox API domain with a different way than just the `E2B_DOMAIN` env var.