### PR TITLE
Add redirect to the careers Notion page

### DIFF
--- a/apps/reverse-proxy/vercel.json
+++ b/apps/reverse-proxy/vercel.json
@@ -37,6 +37,11 @@
   ],
   "redirects": [
     {
+      "source": "/careers",
+      "destination": "https://e2bdev.notion.site/Careers-at-E2B-2163f176991f43f69b0984bf2a142920",
+      "permanent": true
+    },
+    {
       "source": "/docs",
       "has": [
         {


### PR DESCRIPTION
Adds a redirect rule for the `https://e2b.dev/careers` route to redirect to `https://e2bdev.notion.site/Careers-at-E2B-2163f176991f43f69b0984bf2a142920?pvs=74`