### PR TITLE
Update metadata.py to not use deprecated Sandbox.create() method

### DIFF
--- a/apps/docs/src/code/python/basics/metadata.py
+++ b/apps/docs/src/code/python/basics/metadata.py
@@ -1,6 +1,6 @@
 from e2b import Sandbox
 
-sandbox = Sandbox.create(
+sandbox = Sandbox(
     template='base',
     metadata={"user_id": "uniqueID"},  # $HighlightLine
 )


### PR DESCRIPTION
Sandbox.create() is deprecated in favor of Sandbox(), updating docs example.