### PR TITLE
CLI add build args

### DIFF
--- a/.changeset/strange-readers-scream.md
+++ b/.changeset/strange-readers-scream.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Add possibility to pass docker build args

--- a/apps/docs/src/app/cli/commands/page.mdx
+++ b/apps/docs/src/app/cli/commands/page.mdx
@@ -109,6 +109,9 @@ If there is no `e2b.toml` config a new template will be created.
   <Option type="--memory-mb" name="memory-mb">
     Specify the amount of memory in megabytes that will be used to run the sandbox. Must be an even number. The default value is 512.
   </Option>
+  <Option type="--build-arg" name="build-arg">
+    Specify a build argument for the Dockerfile. The format is `key=value`. You can use this option multiple times.
+  </Option>
 </Options>
 
 ## `template delete`

--- a/apps/docs/src/app/sandbox/templates/template-file/page.mdx
+++ b/apps/docs/src/app/sandbox/templates/template-file/page.mdx
@@ -23,7 +23,7 @@ The Dockerfile must be Debian based (e.g. Ubuntu). Only the following [Dockerfil
   - `COPY`
   - `RUN`
   - `WORKDIR`
-
+  - `ARG`
 
 ## Example
 

--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -100,9 +100,8 @@ export const buildCommand = new commander.Command('build')
     parseInt,
   )
   .option(
-    '--docker-build-args [args]',
+    '--docker-build-args <args...>',
     'specify additional build arguments for the Docker build command. The format should be <varname>=<value>.',
-    parseInt,
   )
   .alias('bd')
   .action(

--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -100,7 +100,7 @@ export const buildCommand = new commander.Command('build')
     parseInt,
   )
   .option(
-    '--docker-build-args <args...>',
+    '--docker-build-arg <args...>',
     'specify additional build arguments for the Docker build command. The format should be <varname>=<value>.',
   )
   .alias('bd')

--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -115,7 +115,7 @@ export const buildCommand = new commander.Command('build')
         config?: string
         cpuCount?: number
         memoryMb?: number
-        buildArgs?: [string]
+        dockerBuildArgs?: [string]
       },
     ) => {
       try {
@@ -127,10 +127,9 @@ export const buildCommand = new commander.Command('build')
           process.exit(1)
         }
 
-        // TODO: pass directly?
         const dockerBuildArgs: {[key: string]: string} = {}
-        if (opts.buildArgs) {
-            opts.buildArgs.forEach((arg) => {
+        if (opts.dockerBuildArgs) {
+            opts.dockerBuildArgs.forEach((arg) => {
                 const [key, value] = arg.split('=')
                 dockerBuildArgs[key] = value
             })

--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -100,8 +100,8 @@ export const buildCommand = new commander.Command('build')
     parseInt,
   )
   .option(
-    '--docker-build-arg <args...>',
-    'specify additional build arguments for the Docker build command. The format should be <varname>=<value>.',
+    '--build-arg <args...>',
+    'specify additional build arguments for the build command. The format should be <varname>=<value>.',
   )
   .alias('bd')
   .action(
@@ -115,7 +115,7 @@ export const buildCommand = new commander.Command('build')
         config?: string
         cpuCount?: number
         memoryMb?: number
-        dockerBuildArgs?: [string]
+        buildArgs?: [string]
       },
     ) => {
       try {
@@ -127,9 +127,10 @@ export const buildCommand = new commander.Command('build')
           process.exit(1)
         }
 
+        // TODO: pass directly?
         const dockerBuildArgs: {[key: string]: string} = {}
-        if (opts.dockerBuildArgs) {
-            opts.dockerBuildArgs.forEach((arg) => {
+        if (opts.buildArgs) {
+            opts.buildArgs.forEach((arg) => {
                 const [key, value] = arg.split('=')
                 dockerBuildArgs[key] = value
             })

--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -115,7 +115,7 @@ export const buildCommand = new commander.Command('build')
         config?: string
         cpuCount?: number
         memoryMb?: number
-        dockerBuildArgs?: [string]
+        buildArgs?: [string]
       },
     ) => {
       try {
@@ -128,8 +128,8 @@ export const buildCommand = new commander.Command('build')
         }
 
         const dockerBuildArgs: {[key: string]: string} = {}
-        if (opts.dockerBuildArgs) {
-            opts.dockerBuildArgs.forEach((arg) => {
+        if (opts.buildArgs) {
+            opts.buildArgs.forEach((arg) => {
                 const [key, value] = arg.split('=')
                 dockerBuildArgs[key] = value
             })


### PR DESCRIPTION
This feature allows users to pass arguments used during the template build.

E.g.:
```
e2b template build --build-arg="HELLO=WORLD" --build-arg="MULTIPLE=True"
```