### PR TITLE
Fix links from apps/doc to apps/web

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,4 @@ This repository is a monorepo containing:
 1. [Python SDK](/packages/python-sdk)
 1. [JS SDK](/packages/js-sdk)
 1. [CLI](/packages/cli)
-1. [Documentation](/apps/docs/)
+1. [Documentation](/apps/web/)

--- a/apps/web/src/utils/consts.ts
+++ b/apps/web/src/utils/consts.ts
@@ -41,7 +41,7 @@ export const mdLangToLangShort: Record<string, LangShort> = {
 
 export const languageNames: Record<string, string> = {
   js: 'JavaScript & TypeScript',
-  ts: '⚠️ FIXME See note in apps/docs/src/utils/consts.ts', // Please avoid using `ts`, see note above
+  ts: '⚠️ FIXME See note in apps/web/src/utils/consts.ts', // Please avoid using `ts`, see note above
   javascript: 'JavaScript',
   typescript: 'TypeScript',
 


### PR DESCRIPTION
Corrected documentation links in the README.md for "Documentation" and utils/const.ts.

Review Required for `pnpm run dev:docs`: The dev:docs script in package.json currently links to apps/docs and cannot be run locally unless it is changed to apps/web. 

Didn't want to change the package.json right away, thought i'd let you know about this first instead. 