### PR TITLE
Use `Buffer.from()` when writing a file

### DIFF
--- a/apps/docs/src/code/js/basics/download_file.js
+++ b/apps/docs/src/code/js/basics/download_file.js
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 
 const sandbox = await Sandbox.create({ template: 'base' })
 
-const buffer = await sandbox.downloadFile('path/to/remote/file/inside/sandbox') // $HighlightLine
+const buffer = await sandbox.downloadFile('path/to/remote/file/inside/sandbox', 'buffer') // $HighlightLine
 // Save file to local filesystem
 fs.writeFileSync('path/to/local/file', buffer)
 


### PR DESCRIPTION
Recreated PR from @ggorlen (https://github.com/e2b-dev/E2B/pull/360) after bigger changes on `main`.

Running the JS [file download snippet](https://e2b.dev/docs/sandbox/api/download#use-case-for-downloading-files) in Node 20 gave me:
```
Uncaught:
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of ArrayBuffer
```
on `writeFileSync`.

But using [Buffer.from(buffer)](https://stackoverflow.com/a/46779188/6243352) fixed the issue and wrote the CSV file successfully. I haven't tested this extensively since I'm working with a remote client who's using the library on his end, so more validation that this change makes sense would be good before merging (this may be specific to our text file use case).