### PR TITLE
Add `download_url`/`downloadUrl` method to sandbox

### DIFF
--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -80,16 +80,6 @@ export class Sandbox extends SandboxApi {
     return `${port}-${this.sandboxId}.${this.connectionConfig.domain}`
   }
 
-  uploadUrl(path?: string) {
-    const url = new URL('/files', this.envdApiUrl)
-    url.searchParams.set('username', defaultUsername)
-    if (path) {
-      url.searchParams.set('path', path)
-    }
-
-    return url.toString()
-  }
-
   async isRunning(opts?: Pick<ConnectionOpts, 'requestTimeoutMs'>): Promise<boolean> {
     const signal = this.connectionConfig.getSignal(opts?.requestTimeoutMs)
 
@@ -115,5 +105,23 @@ export class Sandbox extends SandboxApi {
 
   async kill(opts?: Pick<SandboxOpts, 'requestTimeoutMs'>) {
     await Sandbox.kill(this.sandboxId, { ...this.connectionConfig, ...opts })
+  }
+
+  uploadUrl(path?: string) {
+    return this.fileUrl(path)
+  }
+
+  downloadUrl(path: string) {
+    return this.fileUrl(path)
+  }
+
+  private fileUrl(path?: string) {
+    const url = new URL('/files', this.envdApiUrl)
+    url.searchParams.set('username', defaultUsername)
+    if (path) {
+      url.searchParams.set('path', path)
+    }
+
+    return url.toString()
   }
 }

--- a/packages/python-sdk/e2b/sandbox/main.py
+++ b/packages/python-sdk/e2b/sandbox/main.py
@@ -32,7 +32,7 @@ class SandboxSetup(ABC):
     @abstractmethod
     def sandbox_id(self) -> str: ...
 
-    def upload_url(self, path: Optional[str] = None) -> str:
+    def _file_url(self, path: Optional[str] = None) -> str:
         url = urllib.parse.urljoin(self.envd_api_url, ENVD_API_FILES_ROUTE)
         query = {"path": path} if path else {}
         query = {**query, "username": "user"}
@@ -44,6 +44,12 @@ class SandboxSetup(ABC):
         url = urllib.parse.urljoin(url, f"?{params}")
 
         return url
+
+    def download_url(self, path: str) -> str:
+        return self._file_url(path)
+
+    def upload_url(self, path: Optional[str] = None) -> str:
+        return self._file_url(path)
 
     def get_host(self, port: int) -> str:
         if self.connection_config.debug:


### PR DESCRIPTION
If you want to download a file from sandbox you need to use the SDK right now.
The download URL method we are adding lets you get the link to a file in sandbox that you can then use to download the file, for example on the frontend, with a direct link.

### Tasks
- [ ] Test the changes (JS+TS SDKs)
- [ ] Update Core SDK in Code Interpreter so this functionality is enabled there too