### PR TITLE
Add recursive watch

### DIFF
--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -4,7 +4,7 @@ import { ConnectionConfig, ConnectionOpts, defaultUsername } from '../connection
 import { EnvdApiClient, handleEnvdApiError } from '../envd/api'
 import { createRpcLogger } from '../logs'
 import { Filesystem } from './filesystem'
-import { FilesystemEvent } from './filesystem/watchHandle'
+import { FilesystemEvent, FilesystemEventType } from './filesystem/watchHandle'
 import { Process } from './process'
 import { Pty } from './pty'
 import { SandboxApi } from './sandboxApi'
@@ -67,7 +67,8 @@ export class Sandbox extends SandboxApi {
 
     const sbx = new this({ sandboxId, ...config }) as InstanceType<S>
 
-    if (sandboxOpts?.onFileCreation) await sbx.files.watch('/', sandboxOpts.onFileCreation)
+    if (sandboxOpts?.onFileCreation)
+      await sbx.files.watch('/', sandboxOpts.onFileCreation, { eventTypes: new Set([FilesystemEventType.CREATE])})
 
     return sbx
   }
@@ -77,7 +78,8 @@ export class Sandbox extends SandboxApi {
 
     const sbx = new this({ sandboxId, ...config }) as InstanceType<S>
 
-    if (opts?.onFileCreation) await sbx.files.watch('/', opts.onFileCreation)
+    if (opts?.onFileCreation)
+      await sbx.files.watch('/', opts.onFileCreation, { eventTypes: new Set([FilesystemEventType.CREATE])})
 
     return sbx
   }

--- a/packages/js-sdk/tests/sandbox/connect.test.ts
+++ b/packages/js-sdk/tests/sandbox/connect.test.ts
@@ -23,7 +23,7 @@ test('connect', async () => {
 test.skipIf(isDebug)('connect with file creation handler', async () => {
   const sbx = await Sandbox.create(template, { timeoutMs: 10_000 })
   const dirPath = '/new-dir2'
-  onTestFinished(() =>  sbx.files.remove(dirPath))
+  onTestFinished(async () =>  await sbx.files.remove(dirPath))
 
   let trigger: () => void
 

--- a/packages/js-sdk/tests/sandbox/create.test.ts
+++ b/packages/js-sdk/tests/sandbox/create.test.ts
@@ -45,7 +45,7 @@ test.skipIf(isDebug)('create with file creation handler', async () => {
     }
   }
   const sbx = await Sandbox.create(template, { timeoutMs: 5_000, onFileCreation })
-  onTestFinished(() =>  sbx.files.remove(dirPath))
+  onTestFinished(async () =>  await sbx.files.remove(dirPath))
 
   const ok = await sbx.files.makeDir(dirPath)
   assert.isTrue(ok)

--- a/packages/js-sdk/tests/sandbox/files/list.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/list.test.ts
@@ -4,7 +4,7 @@ import { sandboxTest } from '../../setup.js'
 
 sandboxTest('list directory', async ({ sandbox }) => {
   const dirName = 'test_directory4'
-  onTestFinished(() =>  sandbox.files.remove(dirName))
+  onTestFinished(async () =>  await sandbox.files.remove(dirName))
 
   await sandbox.files.makeDir(dirName)
 

--- a/packages/js-sdk/tests/sandbox/files/list.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/list.test.ts
@@ -1,9 +1,10 @@
-import { assert } from 'vitest'
+import { assert, onTestFinished } from 'vitest'
 
 import { sandboxTest } from '../../setup.js'
 
 sandboxTest('list directory', async ({ sandbox }) => {
   const dirName = 'test_directory4'
+  onTestFinished(() =>  sandbox.files.remove(dirName))
 
   await sandbox.files.makeDir(dirName)
 

--- a/packages/js-sdk/tests/sandbox/files/watch.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/watch.test.ts
@@ -1,7 +1,7 @@
-import { expect } from 'vitest'
+import { expect, onTestFinished } from 'vitest'
 
-import { sandboxTest } from '../../setup.js'
 import { FilesystemEventType, NotFoundError } from '../../../src'
+import { sandboxTest } from '../../setup.js'
 
 sandboxTest('watch directory changes', async ({ sandbox }) => {
   const dirname = 'test_watch_dir'
@@ -20,7 +20,7 @@ sandboxTest('watch directory changes', async ({ sandbox }) => {
 
 
   const handle = await sandbox.files.watch(dirname, async (event) => {
-    if (event.type === FilesystemEventType.WRITE && event.name === filename) {
+    if (event.type === FilesystemEventType.WRITE && event.name === `/home/user/${dirname}/${filename}`) {
       trigger()
     }
   })
@@ -36,4 +36,50 @@ sandboxTest('watch non-existing directory', async ({ sandbox }) => {
   const dirname = 'non_existing_watch_dir'
 
   await expect(sandbox.files.watch(dirname, () => { })).rejects.toThrowError(NotFoundError)
+})
+
+sandboxTest('watch recursive directory changes', async ({ sandbox }) => {
+  const parentDir = 'a'
+  const childDir = 'b'
+  const fileName = 'test_watch.txt'
+  const filePath = `/${parentDir}/${childDir}/${fileName}`
+  const content = 'This file will be watched.'
+  onTestFinished(() =>  {
+    sandbox.files.remove('/'+parentDir)
+  })
+
+  let trigger1: () => void
+  let trigger2: () => void
+
+  const eventPromise1 = new Promise<void>((resolve) => {
+    trigger1 = resolve
+  })
+
+  const eventPromise2 = new Promise<void>((resolve) => {
+    trigger2 = resolve
+  })
+
+  // watch nested dir creation
+  const handle1 = await sandbox.files.watch('/', async (event) => {
+    if (event.type === FilesystemEventType.CREATE && event.name === `/${parentDir}/${childDir}`) {
+      trigger1()
+    }
+  })
+
+  // watch nested file creation
+  const handle2 = await sandbox.files.watch('/', async (event) => {
+    if (event.type === FilesystemEventType.CREATE && event.name === filePath) {
+      trigger2()
+    }
+  })
+
+  await sandbox.files.makeDir('/a')
+  await sandbox.files.makeDir('/a/b')
+  await sandbox.files.write(filePath, content)
+
+  await eventPromise1
+  await eventPromise2
+
+  await handle1.close()
+  await handle2.close()
 })


### PR DESCRIPTION
### Description
-  users can now pass a `onFileCreation` listener via the `Sandbox.create` and ` Sandbox.connect` methods.
- Handling of recursive nature of events and tests reflect [changes in envd](https://github.com/e2b-dev/infra/pull/179)
- boyscouting: added a few cleanup functions that remove some created files during tests so that we don't have to restart `envd` to run subsequent tests

### Tests
```bash
cd /packages/js-sdk
pnpm test
```