### PR TITLE
Update doc to explain the exception name based on the language used

### DIFF
--- a/apps/web/src/app/(docs)/docs/guide/beta-migration/page.mdx
+++ b/apps/web/src/app/(docs)/docs/guide/beta-migration/page.mdx
@@ -226,7 +226,7 @@ You execute processes by calling `.commands.run()` method. By default, the metho
 
 You can specify the timeout for the command execution by passing `timeoutMs`/`timeout` option. The default timeout is 60 seconds.
 
-If the command fails with a non-zero exit a `ProcessExitError`/`ProcessExitException` is raised and you can catch and inspect the error for more info.
+If the command fails with a non-zero exit it will raise `ProcessExitError` in Javascript, or `ProcessExitException` in Python, and you can catch and inspect the error for more info.
 
 <CodeGroup isRunnable={false}>
 ```js


### PR DESCRIPTION
Docs don't explain what language the exception names are for. Update the docs to reflect that.