### PR TITLE
Auto-generate API reference markdown files for the CLI

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": false
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
     "@types/inquirer": "^9.0.7",
     "@types/node": "^18.18.6",
     "@types/update-notifier": "6.0.5",
+    "json2md": "^2.0.1",
     "knip": "^2.33.4",
     "npm-check-updates": "^16.14.6",
     "tsup": "^7.2.0",

--- a/packages/cli/scripts/generate_api_ref.sh
+++ b/packages/cli/scripts/generate_api_ref.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 ## Run it in the `cli/` directory
 mkdir -p api_ref
 
-npx tsup && echo && node dist/index.js -cmd2md
+npx tsup && echo && NODE_ENV=development node dist/index.js -cmd2md
 
 # move to docs (for later use)
 #for file in api_ref/*.md; do

--- a/packages/cli/scripts/generate_api_ref.sh
+++ b/packages/cli/scripts/generate_api_ref.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script generates the CLI API reference markdown files
+## Run it in the `cli/` directory
+mkdir -p api_ref
+
+npx tsup && echo && node dist/index.js -cmd2md
+
+# move to docs (for later use)
+#for file in api_ref/*.md; do
+#    # Extract the filename without extension
+#    filename=$(basename "$file" .md)
+#
+#    # Create the directory if it doesn't exist
+#    mkdir -p "../../apps/web/src/app/(docs)/docs/api-reference/cli/$filename"
+#
+#    # Move the file to the new location and rename it to page.mdx
+#    mv "$file" "../../apps/web/src/app/(docs)/docs/api-reference/cli/$filename/page.mdx"
+#done

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,15 +16,19 @@ updateNotifier
   })
   .notify()
 
-const prog = program
-  .version(packageJSON.version, undefined, 'display E2B CLI version')
-  .addOption(new commander.Option('-cmd2md').hideHelp())
+const prog = program.version(
+  packageJSON.version,
+  undefined,
+  'display E2B CLI version'
+)
 
 if (process.env.NODE_ENV === 'development') {
-  prog.on('option:-cmd2md', () => {
-    commands2md(program.commands as any)
-    process.exit(0)
-  })
+  prog
+    .addOption(new commander.Option('-cmd2md').hideHelp())
+    .on('option:-cmd2md', () => {
+      commands2md(program.commands as any)
+      process.exit(0)
+    })
 }
 
 prog.parse()

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,10 +2,11 @@
 
 import * as updateNotifier from 'update-notifier'
 
+import * as commander from 'commander'
 import * as packageJSON from '../package.json'
 import { program } from './commands'
-import * as commander from 'commander'
-import * as stripAnsi from 'strip-ansi'
+import { commands2md } from './utils/commands2md'
+import { parse } from 'path'
 
 export const pkg = packageJSON
 
@@ -18,25 +19,9 @@ updateNotifier
 
 program
   .version(packageJSON.version, undefined, 'display E2B CLI version')
-  .addOption(new commander.Option('-cmd2json').hideHelp())
-  .on('option:-cmd2json', () => {
-    process.stdout.write(
-      JSON.stringify(
-        program.commands
-          .map((x: any) => ({
-            command: x.name(),
-            description: stripAnsi.default(x.description()),
-            options: x.options.map((y: any) => ({
-              flags: y.flags,
-              description: stripAnsi.default(y.description),
-              defaultValue: y.defaultValue,
-            })),
-          }))
-          .sort((row1: any, row2: any) =>
-            row1.name().localeCompare(row2.name()),
-          ),
-      ),
-    )
+  .addOption(new commander.Option('-cmd2md').hideHelp())
+  .on('option:-cmd2md', () => {
+    commands2md(program.commands as any)
     process.exit(0)
   })
   .parse()

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,6 @@ import * as commander from 'commander'
 import * as packageJSON from '../package.json'
 import { program } from './commands'
 import { commands2md } from './utils/commands2md'
-import { parse } from 'path'
 
 export const pkg = packageJSON
 
@@ -17,11 +16,15 @@ updateNotifier
   })
   .notify()
 
-program
+const prog = program
   .version(packageJSON.version, undefined, 'display E2B CLI version')
   .addOption(new commander.Option('-cmd2md').hideHelp())
-  .on('option:-cmd2md', () => {
+
+if (process.env.NODE_ENV === 'development') {
+  prog.on('option:-cmd2md', () => {
     commands2md(program.commands as any)
     process.exit(0)
   })
-  .parse()
+}
+
+prog.parse()

--- a/packages/cli/src/utils/commands2md.ts
+++ b/packages/cli/src/utils/commands2md.ts
@@ -1,0 +1,82 @@
+import { Command } from 'commander'
+import fs from 'fs'
+import json2md from 'json2md'
+import path from 'path'
+
+/**
+ * Converts command objects to Markdown documentation.
+ * This function takes an array of command objects and generates a structured
+ * Markdown document describing each command, its usage, options, and subcommands.
+ * @returns A string containing the entire markdown documentation for all commands.
+ */
+export function commands2md(commands: Command[]): void {
+  const outputDir = 'api_ref'
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true })
+  }
+
+  function commandToMd(
+    command: any,
+    parentName: string = ''
+  ): [string, string] {
+    const commandName = command.name() as string
+    const fullName = parentName ? `${parentName} ${commandName}` : commandName
+
+    const mdStructure = [
+      { h1: `e2b ${fullName}` },
+      { p: command.description() },
+      { h2: 'Usage' },
+      {
+        code: {
+          language: 'bash',
+          content: `e2b ${fullName} ${command.usage()}`,
+        },
+      },
+      ...(command.options.length > 0
+        ? [
+            { h2: 'Options' },
+            {
+              ul: command.options.map(
+                (y: any) =>
+                  `\`${y.flags}: ${y.description} ${
+                    y.defaultValue !== undefined
+                      ? `[default: ${y.defaultValue}]`
+                      : ''
+                  }\``
+              ),
+            },
+          ]
+        : []),
+    ]
+
+    let mdContent = json2md(mdStructure)
+
+    // Process subcommands
+    command.commands.forEach((subcommand: any) => {
+      const [, subMdContent] = commandToMd(subcommand, fullName)
+      mdContent += subMdContent + '\n\n'
+    })
+
+    // Clean the mdContent
+    mdContent = mdContent
+      .replace(/</g, '<')
+      .replace(/>/g, '>')
+      .replace(/\[1m/g, '')
+      .replace(/\[22m/g, '')
+
+    return [fullName, mdContent]
+  }
+
+  commands.forEach((command: any) => {
+    try {
+      const [commandName, mdContent] = commandToMd(command)
+      const fileName = `${commandName}.md`
+      const filePath = path.join(outputDir, fileName)
+      fs.writeFileSync(filePath, mdContent)
+      console.log(`Generated documentation for ${commandName} at ${filePath}`)
+    } catch (error) {
+      console.error(`Error processing command: ${command.name()}`)
+      console.error(error)
+    }
+  })
+}

--- a/packages/cli/src/utils/commands2md.ts
+++ b/packages/cli/src/utils/commands2md.ts
@@ -57,12 +57,15 @@ export function commands2md(commands: Command[]): void {
       mdContent += subMdContent + '\n\n'
     })
 
-    // Clean the mdContent
+    // Clean the mdContent from terminal colors and escape HTML characters
     mdContent = mdContent
       .replace(/</g, '<')
       .replace(/>/g, '>')
       .replace(/\[1m/g, '')
       .replace(/\[22m/g, '')
+      .replace(/\[34m/g, '')
+      .replace(/\[39m/g, '')
+      .replace(/\[38;2;255;183;102m/g, '')
 
     return [fullName, mdContent]
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       '@types/update-notifier':
         specifier: 6.0.5
         version: 6.0.5
+      json2md:
+        specifier: ^2.0.1
+        version: 2.0.1
       knip:
         specifier: ^2.33.4
         version: 2.35.0
@@ -4354,6 +4357,9 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  indento@1.1.13:
+    resolution: {integrity: sha512-YZWk3mreBEM7sBPddsiQnW9Z8SGg/gNpFfscJq00HCDS7pxcQWWWMSVKJU7YkTRyDu1Zv2s8zaK8gQWKmCXHlg==}
+
   individual@3.0.0:
     resolution: {integrity: sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==}
 
@@ -4715,6 +4721,9 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  json2md@2.0.1:
+    resolution: {integrity: sha512-VbwmZ83qmUfKBS2pUOHlzNKEZFPBeJSbzEok3trMYyboZUgdHNn1XZfc1uT8UZs1GHCrmRUBXCfqw4YmmQuOhw==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -12038,6 +12047,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  indento@1.1.13: {}
+
   individual@3.0.0: {}
 
   inflight@1.0.6:
@@ -12350,6 +12361,10 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
+
+  json2md@2.0.1:
+    dependencies:
+      indento: 1.1.13
 
   json5@1.0.2:
     dependencies:


### PR DESCRIPTION
# Description
-  upgraded the `-cmd2json` root option to `-cmd2md`
-  it calls a `commands2md` utils custom function that converts command objects to Markdown documentation
- this function writes all root command documentation files into the `api_ref/` 
- boyscouting: added root `.prettierrc`

# Test
```bash
cd packages/cli
./scripts/generate_api_ref.sh 
ls ./api_ref
```

# Considerations
This could eventually be used directly as .mdx in the docs nextjs app, it would look like this with current styling and TOC:
<img width="352" alt="Screenshot 2024-09-20 at 11 47 42" src="https://github.com/user-attachments/assets/6598c7af-3bfe-4dba-9ba0-29a903bd0739">
<img width="873" alt="Screenshot 2024-09-20 at 11 47 34" src="https://github.com/user-attachments/assets/3faef3d2-3bfd-4eb8-ba1f-98666ca6da3a">
<img width="927" alt="Screenshot 2024-09-20 at 12 14 52" src="https://github.com/user-attachments/assets/5f148eb7-cd62-46f3-913e-ee3f706b1c60">
