### PR TITLE
Fix Getting Started Examples

### DIFF
--- a/apps/web/src/app/(docs)/docs/hello-world/js/page.mdx
+++ b/apps/web/src/app/(docs)/docs/hello-world/js/page.mdx
@@ -139,7 +139,7 @@ ANTHROPIC_API_KEY="anthropic-api-key"
 
 <CodeGroup isRunnable={false}>
 ```bash {{ language: 'python' }}
-npm i @anthropic-ai/sdk
+npm i @anthropic-ai/sdk@0.28.0
 ```
 </CodeGroup>
 

--- a/apps/web/src/app/(docs)/docs/hello-world/js/page.mdx
+++ b/apps/web/src/app/(docs)/docs/hello-world/js/page.mdx
@@ -51,7 +51,7 @@ Usually, all you need from the model is just support for tool use. If the LLM do
 Create the `model.ts` file and paste the following code.
 <CodeGroup isFileName title="model.ts" isRunnable={false}>
 ```ts
-import { Tool } from '@anthropic-ai/sdk/src/resources/beta/tools'
+import { Anthropic } from '@anthropic-ai/sdk'
 
 export const MODEL_NAME = 'claude-3-opus-20240229'
 
@@ -67,7 +67,7 @@ you are a python data scientist. you are given tasks to complete and you run pyt
 - you can run any python code you want, everything is running in a secure sandbox environment.
 `
 
-export const tools: Tool[] = [
+export const tools: Anthropic.Tool[] = [
   {
     name: 'execute_python',
     description: 'Execute python code in a Jupyter notebook cell and returns any result, stdout, stderr, display_data, and error.',
@@ -166,7 +166,7 @@ const anthropic = new Anthropic()
 async function chat(codeInterpreter: CodeInterpreter, userMessage: string): Promise<Execution | undefined> {
   console.log('Waiting for Claude...')
 
-  const msg = await anthropic.beta.tools.messages.create({
+  const msg = await anthropic.messages.create({
     model: MODEL_NAME,
     system: SYSTEM_PROMPT,
     max_tokens: 4096,

--- a/apps/web/src/app/(docs)/docs/hello-world/py/page.mdx
+++ b/apps/web/src/app/(docs)/docs/hello-world/py/page.mdx
@@ -157,7 +157,7 @@ client = Anthropic()
 def chat(code_interpreter: CodeInterpreter, user_message: str) -> Tuple[List[Result], Logs]:
     print(f"\n{'='*50}\nUser Message: {user_message}\n{'='*50}")
 
-    message = client.beta.tools.messages.create(
+    message = client.messages.create(
         model=MODEL_NAME,
         system=SYSTEM_PROMPT,
         max_tokens=4096,

--- a/apps/web/src/app/(docs)/docs/hello-world/py/page.mdx
+++ b/apps/web/src/app/(docs)/docs/hello-world/py/page.mdx
@@ -130,7 +130,7 @@ ANTHROPIC_API_KEY="anthropic-api-key"
 
 <CodeGroup isRunnable={false}>
 ```bash {{ language: 'python' }}
-pip install anthropic
+pip install anthropic==0.35.0
 ```
 </CodeGroup>
 


### PR DESCRIPTION
The current Getting Started examples are broken because 1) they don't specify the Anthropic SDK version and 2) they use exports from a deprecated beta version.

The example code has now been migrated in the cookbook (https://github.com/e2b-dev/e2b-cookbook/commit/d28460156cf07e23c114581dc6dfafb71493418d) so I'm copying it into the documentation here to fix the examples.

The Anthropic SDK version has also been notes to avoid our examples suddenly breaking in the future.