### PR TITLE
Improve file watcher in Python Sync SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,5 @@ generate-js:
 
 generate-python:
 	cd packages/python-sdk && make generate-api
-	buf generate --template spec/envd/buf-python.gen.yaml
-	cd packages/python-sdk && ./scripts/fix-python-pb.sh
+	cd spec/envd && buf generate --template buf-python.gen.yaml
+	cd packages/python-sdk && ./scripts/fix-python-pb.sh && black .

--- a/apps/web/src/code/python/basics/fs_watch.py
+++ b/apps/web/src/code/python/basics/fs_watch.py
@@ -2,19 +2,9 @@ import time
 
 from e2b import Sandbox
 
-watcher = None
+sandbox = Sandbox()
 
-
-def create_watcher(sandbox):  # $HighlightLine
-    # Start filesystem watcher for the /home directory
-    watcher = sandbox.filesystem.watch_dir("/home")  # $HighlightLine
-    watcher.add_event_listener(lambda event: print(event))  # $HighlightLine
-    watcher.start()  # $HighlightLine
-
-
-sandbox = Sandbox(template="base")
-
-create_watcher(sandbox)  # $HighlightLine
+watcher = sandbox.files.watch("/home")  # $HighlightLine
 
 # Create files in the /home directory inside the playground
 # We'll receive notifications for these events through the watcher we created above.
@@ -22,7 +12,11 @@ for i in range(10):
     # `filesystem.write()` will trigger two events:
     # 1. 'Create' when the file is created
     # 2. 'Write' when the file is written to
-    sandbox.filesystem.write(f"/home/file{i}.txt", f"Hello World {i}!")
+    sandbox.files.write(f"/home/file{i}.txt", f"Hello World {i}!")
     time.sleep(1)
 
-sandbox.close()
+for event in watcher.get():
+    print(f"Event: {event.type} {event.name}")  # $HighlightLine
+
+watcher.stop()
+sandbox.kill()

--- a/apps/web/src/code/python/basics/fs_watch.py
+++ b/apps/web/src/code/python/basics/fs_watch.py
@@ -4,7 +4,7 @@ from e2b import Sandbox
 
 sandbox = Sandbox()
 
-watcher = sandbox.files.watch("/home")  # $HighlightLine
+watcher = sandbox.files.watch_dir("/home")  # $HighlightLine
 
 # Create files in the /home directory inside the playground
 # We'll receive notifications for these events through the watcher we created above.

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -352,7 +352,7 @@ export class Filesystem {
    * @param opts Options for the request
    * @returns New watcher
    */
-  async watch(
+  async watchDir(
     path: string,
     onEvent: (event: FilesystemEvent) => void | Promise<void>,
     opts?: FilesystemRequestOpts & {

--- a/packages/js-sdk/src/sandbox/filesystem/watchHandle.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/watchHandle.ts
@@ -54,7 +54,7 @@ export class WatchHandle {
   /**
    * Stop watching the directory.
    */
-  async close() {
+  async stop() {
     this.handleStop()
   }
 

--- a/packages/js-sdk/tests/sandbox/files/watch.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/watch.test.ts
@@ -18,7 +18,7 @@ sandboxTest('watch directory changes', async ({ sandbox }) => {
     trigger = resolve
   })
 
-  const handle = await sandbox.files.watch(dirname, async (event) => {
+  const handle = await sandbox.files.watchDir(dirname, async (event) => {
     if (event.type === FilesystemEventType.WRITE && event.name === filename) {
       trigger()
     }
@@ -34,7 +34,7 @@ sandboxTest('watch directory changes', async ({ sandbox }) => {
 sandboxTest('watch non-existing directory', async ({ sandbox }) => {
   const dirname = 'non_existing_watch_dir'
 
-  await expect(sandbox.files.watch(dirname, () => {})).rejects.toThrowError(
+  await expect(sandbox.files.watchDir(dirname, () => {})).rejects.toThrowError(
     NotFoundError
   )
 })
@@ -44,7 +44,7 @@ sandboxTest('watch file', async ({ sandbox }) => {
   const content = 'This file will be watched.'
   await sandbox.files.write(filename, content)
 
-  await expect(sandbox.files.watch(filename, () => {})).rejects.toThrowError(
+  await expect(sandbox.files.watchDir(filename, () => {})).rejects.toThrowError(
     SandboxError
   )
 })

--- a/packages/js-sdk/tests/sandbox/files/watch.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/watch.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'vitest'
 
 import { sandboxTest } from '../../setup.js'
-import { FilesystemEventType, NotFoundError } from '../../../src'
+import { FilesystemEventType, NotFoundError, SandboxError } from '../../../src'
 
 sandboxTest('watch directory changes', async ({ sandbox }) => {
   const dirname = 'test_watch_dir'
@@ -14,10 +14,9 @@ sandboxTest('watch directory changes', async ({ sandbox }) => {
 
   let trigger: () => void
 
-  const eventPromise = new Promise<void>(resolve => {
+  const eventPromise = new Promise<void>((resolve) => {
     trigger = resolve
   })
-
 
   const handle = await sandbox.files.watch(dirname, async (event) => {
     if (event.type === FilesystemEventType.WRITE && event.name === filename) {
@@ -29,11 +28,23 @@ sandboxTest('watch directory changes', async ({ sandbox }) => {
 
   await eventPromise
 
-  await handle.close()
+  await handle.stop()
 })
 
 sandboxTest('watch non-existing directory', async ({ sandbox }) => {
   const dirname = 'non_existing_watch_dir'
 
-  await expect(sandbox.files.watch(dirname, () => { })).rejects.toThrowError(NotFoundError)
+  await expect(sandbox.files.watch(dirname, () => {})).rejects.toThrowError(
+    NotFoundError
+  )
+})
+
+sandboxTest('watch file', async ({ sandbox }) => {
+  const filename = 'test_watch.txt'
+  const content = 'This file will be watched.'
+  await sandbox.files.write(filename, content)
+
+  await expect(sandbox.files.watch(filename, () => {})).rejects.toThrowError(
+    SandboxError
+  )
 })

--- a/packages/python-sdk/e2b/envd/filesystem/filesystem_connect.py
+++ b/packages/python-sdk/e2b/envd/filesystem/filesystem_connect.py
@@ -83,11 +83,11 @@ class FilesystemClient:
             json=json,
             **opts,
         )
-        self._watch_dir_poll = connect.Client(
+        self._watch_dir_get = connect.Client(
             pool=pool,
             async_pool=async_pool,
-            url=f"{base_url}/{FilesystemName}/WatchDirPoll",
-            response_type=filesystem_dot_filesystem__pb2.WatchDirPollResponse,
+            url=f"{base_url}/{FilesystemName}/WatchDirGet",
+            response_type=filesystem_dot_filesystem__pb2.WatchDirGetResponse,
             compressor=compressor,
             json=json,
             **opts,
@@ -172,15 +172,15 @@ class FilesystemClient:
     ) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.WatchDirStartResponse]:
         return self._watch_dir_start.acall_unary(req, **opts)
 
-    def watch_dir_poll(
-        self, req: filesystem_dot_filesystem__pb2.WatchDirPollRequest, **opts
-    ) -> filesystem_dot_filesystem__pb2.WatchDirPollResponse:
-        return self._watch_dir_poll.call_unary(req, **opts)
+    def watch_dir_get(
+        self, req: filesystem_dot_filesystem__pb2.WatchDirGetRequest, **opts
+    ) -> filesystem_dot_filesystem__pb2.WatchDirGetResponse:
+        return self._watch_dir_get.call_unary(req, **opts)
 
-    def awatch_dir_poll(
-        self, req: filesystem_dot_filesystem__pb2.WatchDirPollRequest, **opts
-    ) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.WatchDirPollResponse]:
-        return self._watch_dir_poll.acall_unary(req, **opts)
+    def awatch_dir_get(
+        self, req: filesystem_dot_filesystem__pb2.WatchDirGetRequest, **opts
+    ) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.WatchDirGetResponse]:
+        return self._watch_dir_get.acall_unary(req, **opts)
 
     def watch_dir_stop(
         self, req: filesystem_dot_filesystem__pb2.WatchDirStopRequest, **opts

--- a/packages/python-sdk/e2b/envd/filesystem/filesystem_connect.py
+++ b/packages/python-sdk/e2b/envd/filesystem/filesystem_connect.py
@@ -10,7 +10,16 @@ FilesystemName = "filesystem.Filesystem"
 
 
 class FilesystemClient:
-    def __init__(self, base_url: str, *, pool: Optional[ConnectionPool] = None, async_pool: Optional[AsyncConnectionPool] = None, compressor=None, json=False, **opts):
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        pool: Optional[ConnectionPool] = None,
+        async_pool: Optional[AsyncConnectionPool] = None,
+        compressor=None,
+        json=False,
+        **opts,
+    ):
         self._stat = connect.Client(
             pool=pool,
             async_pool=async_pool,
@@ -18,7 +27,7 @@ class FilesystemClient:
             response_type=filesystem_dot_filesystem__pb2.StatResponse,
             compressor=compressor,
             json=json,
-            **opts
+            **opts,
         )
         self._make_dir = connect.Client(
             pool=pool,
@@ -27,7 +36,7 @@ class FilesystemClient:
             response_type=filesystem_dot_filesystem__pb2.MakeDirResponse,
             compressor=compressor,
             json=json,
-            **opts
+            **opts,
         )
         self._move = connect.Client(
             pool=pool,
@@ -36,7 +45,7 @@ class FilesystemClient:
             response_type=filesystem_dot_filesystem__pb2.MoveResponse,
             compressor=compressor,
             json=json,
-            **opts
+            **opts,
         )
         self._list_dir = connect.Client(
             pool=pool,
@@ -45,16 +54,7 @@ class FilesystemClient:
             response_type=filesystem_dot_filesystem__pb2.ListDirResponse,
             compressor=compressor,
             json=json,
-            **opts
-        )
-        self._watch_dir = connect.Client(
-            pool=pool,
-            async_pool=async_pool,
-            url=f"{base_url}/{FilesystemName}/WatchDir",
-            response_type=filesystem_dot_filesystem__pb2.WatchDirResponse,
-            compressor=compressor,
-            json=json,
-            **opts
+            **opts,
         )
         self._remove = connect.Client(
             pool=pool,
@@ -63,41 +63,131 @@ class FilesystemClient:
             response_type=filesystem_dot_filesystem__pb2.RemoveResponse,
             compressor=compressor,
             json=json,
-            **opts
+            **opts,
+        )
+        self._watch_dir = connect.Client(
+            pool=pool,
+            async_pool=async_pool,
+            url=f"{base_url}/{FilesystemName}/WatchDir",
+            response_type=filesystem_dot_filesystem__pb2.WatchDirResponse,
+            compressor=compressor,
+            json=json,
+            **opts,
+        )
+        self._watch_dir_start = connect.Client(
+            pool=pool,
+            async_pool=async_pool,
+            url=f"{base_url}/{FilesystemName}/WatchDirStart",
+            response_type=filesystem_dot_filesystem__pb2.WatchDirStartResponse,
+            compressor=compressor,
+            json=json,
+            **opts,
+        )
+        self._watch_dir_poll = connect.Client(
+            pool=pool,
+            async_pool=async_pool,
+            url=f"{base_url}/{FilesystemName}/WatchDirPoll",
+            response_type=filesystem_dot_filesystem__pb2.WatchDirPollResponse,
+            compressor=compressor,
+            json=json,
+            **opts,
+        )
+        self._watch_dir_stop = connect.Client(
+            pool=pool,
+            async_pool=async_pool,
+            url=f"{base_url}/{FilesystemName}/WatchDirStop",
+            response_type=filesystem_dot_filesystem__pb2.WatchDirStopResponse,
+            compressor=compressor,
+            json=json,
+            **opts,
         )
 
-    def stat(self, req: filesystem_dot_filesystem__pb2.StatRequest, **opts) -> filesystem_dot_filesystem__pb2.StatResponse:
+    def stat(
+        self, req: filesystem_dot_filesystem__pb2.StatRequest, **opts
+    ) -> filesystem_dot_filesystem__pb2.StatResponse:
         return self._stat.call_unary(req, **opts)
 
-    def astat(self, req: filesystem_dot_filesystem__pb2.StatRequest, **opts) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.StatResponse]:
+    def astat(
+        self, req: filesystem_dot_filesystem__pb2.StatRequest, **opts
+    ) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.StatResponse]:
         return self._stat.acall_unary(req, **opts)
 
-    def make_dir(self, req: filesystem_dot_filesystem__pb2.MakeDirRequest, **opts) -> filesystem_dot_filesystem__pb2.MakeDirResponse:
+    def make_dir(
+        self, req: filesystem_dot_filesystem__pb2.MakeDirRequest, **opts
+    ) -> filesystem_dot_filesystem__pb2.MakeDirResponse:
         return self._make_dir.call_unary(req, **opts)
 
-    def amake_dir(self, req: filesystem_dot_filesystem__pb2.MakeDirRequest, **opts) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.MakeDirResponse]:
+    def amake_dir(
+        self, req: filesystem_dot_filesystem__pb2.MakeDirRequest, **opts
+    ) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.MakeDirResponse]:
         return self._make_dir.acall_unary(req, **opts)
 
-    def move(self, req: filesystem_dot_filesystem__pb2.MoveRequest, **opts) -> filesystem_dot_filesystem__pb2.MoveResponse:
+    def move(
+        self, req: filesystem_dot_filesystem__pb2.MoveRequest, **opts
+    ) -> filesystem_dot_filesystem__pb2.MoveResponse:
         return self._move.call_unary(req, **opts)
 
-    def amove(self, req: filesystem_dot_filesystem__pb2.MoveRequest, **opts) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.MoveResponse]:
+    def amove(
+        self, req: filesystem_dot_filesystem__pb2.MoveRequest, **opts
+    ) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.MoveResponse]:
         return self._move.acall_unary(req, **opts)
 
-    def list_dir(self, req: filesystem_dot_filesystem__pb2.ListDirRequest, **opts) -> filesystem_dot_filesystem__pb2.ListDirResponse:
+    def list_dir(
+        self, req: filesystem_dot_filesystem__pb2.ListDirRequest, **opts
+    ) -> filesystem_dot_filesystem__pb2.ListDirResponse:
         return self._list_dir.call_unary(req, **opts)
 
-    def alist_dir(self, req: filesystem_dot_filesystem__pb2.ListDirRequest, **opts) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.ListDirResponse]:
+    def alist_dir(
+        self, req: filesystem_dot_filesystem__pb2.ListDirRequest, **opts
+    ) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.ListDirResponse]:
         return self._list_dir.acall_unary(req, **opts)
 
-    def watch_dir(self, req: filesystem_dot_filesystem__pb2.WatchDirRequest , **opts) -> Generator[filesystem_dot_filesystem__pb2.WatchDirResponse, Any, None]:
-        return self._watch_dir.call_server_stream(req, **opts)
-
-    def awatch_dir(self, req: filesystem_dot_filesystem__pb2.WatchDirRequest , **opts) -> AsyncGenerator[filesystem_dot_filesystem__pb2.WatchDirResponse, Any]:
-        return self._watch_dir.acall_server_stream(req, **opts)
-
-    def remove(self, req: filesystem_dot_filesystem__pb2.RemoveRequest, **opts) -> filesystem_dot_filesystem__pb2.RemoveResponse:
+    def remove(
+        self, req: filesystem_dot_filesystem__pb2.RemoveRequest, **opts
+    ) -> filesystem_dot_filesystem__pb2.RemoveResponse:
         return self._remove.call_unary(req, **opts)
 
-    def aremove(self, req: filesystem_dot_filesystem__pb2.RemoveRequest, **opts) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.RemoveResponse]:
+    def aremove(
+        self, req: filesystem_dot_filesystem__pb2.RemoveRequest, **opts
+    ) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.RemoveResponse]:
         return self._remove.acall_unary(req, **opts)
+
+    def watch_dir(
+        self, req: filesystem_dot_filesystem__pb2.WatchDirRequest, **opts
+    ) -> Generator[filesystem_dot_filesystem__pb2.WatchDirResponse, Any, None]:
+        return self._watch_dir.call_server_stream(req, **opts)
+
+    def awatch_dir(
+        self, req: filesystem_dot_filesystem__pb2.WatchDirRequest, **opts
+    ) -> AsyncGenerator[filesystem_dot_filesystem__pb2.WatchDirResponse, Any]:
+        return self._watch_dir.acall_server_stream(req, **opts)
+
+    def watch_dir_start(
+        self, req: filesystem_dot_filesystem__pb2.WatchDirRequest, **opts
+    ) -> filesystem_dot_filesystem__pb2.WatchDirStartResponse:
+        return self._watch_dir_start.call_unary(req, **opts)
+
+    def awatch_dir_start(
+        self, req: filesystem_dot_filesystem__pb2.WatchDirRequest, **opts
+    ) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.WatchDirStartResponse]:
+        return self._watch_dir_start.acall_unary(req, **opts)
+
+    def watch_dir_poll(
+        self, req: filesystem_dot_filesystem__pb2.WatchDirPollRequest, **opts
+    ) -> filesystem_dot_filesystem__pb2.WatchDirPollResponse:
+        return self._watch_dir_poll.call_unary(req, **opts)
+
+    def awatch_dir_poll(
+        self, req: filesystem_dot_filesystem__pb2.WatchDirPollRequest, **opts
+    ) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.WatchDirPollResponse]:
+        return self._watch_dir_poll.acall_unary(req, **opts)
+
+    def watch_dir_stop(
+        self, req: filesystem_dot_filesystem__pb2.WatchDirStopRequest, **opts
+    ) -> filesystem_dot_filesystem__pb2.WatchDirStopResponse:
+        return self._watch_dir_stop.call_unary(req, **opts)
+
+    def awatch_dir_stop(
+        self, req: filesystem_dot_filesystem__pb2.WatchDirStopRequest, **opts
+    ) -> Coroutine[Any, Any, filesystem_dot_filesystem__pb2.WatchDirStopResponse]:
+        return self._watch_dir_stop.acall_unary(req, **opts)

--- a/packages/python-sdk/e2b/envd/filesystem/filesystem_pb2.py
+++ b/packages/python-sdk/e2b/envd/filesystem/filesystem_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x1b\x66ilesystem/filesystem.proto\x12\nfilesystem"G\n\x0bMoveRequest\x12\x16\n\x06source\x18\x01 \x01(\tR\x06source\x12 \n\x0b\x64\x65stination\x18\x02 \x01(\tR\x0b\x64\x65stination";\n\x0cMoveResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"$\n\x0eMakeDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path">\n\x0fMakeDirResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"#\n\rRemoveRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"\x10\n\x0eRemoveResponse"!\n\x0bStatRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path";\n\x0cStatResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"]\n\tEntryInfo\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12(\n\x04type\x18\x02 \x01(\x0e\x32\x14.filesystem.FileTypeR\x04type\x12\x12\n\x04path\x18\x03 \x01(\tR\x04path"$\n\x0eListDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"B\n\x0fListDirResponse\x12/\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x15.filesystem.EntryInfoR\x07\x65ntries"%\n\x0fWatchDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"P\n\x0f\x46ilesystemEvent\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12)\n\x04type\x18\x02 \x01(\x0e\x32\x15.filesystem.EventTypeR\x04type"\xfe\x01\n\x10WatchDirResponse\x12?\n\x05start\x18\x01 \x01(\x0b\x32\'.filesystem.WatchDirResponse.StartEventH\x00R\x05start\x12=\n\nfilesystem\x18\x02 \x01(\x0b\x32\x1b.filesystem.FilesystemEventH\x00R\nfilesystem\x12\x46\n\tkeepalive\x18\x03 \x01(\x0b\x32&.filesystem.WatchDirResponse.KeepAliveH\x00R\tkeepalive\x1a\x0c\n\nStartEvent\x1a\x0b\n\tKeepAliveB\x07\n\x05\x65vent"5\n\x15WatchDirStartResponse\x12\x1c\n\twatcherId\x18\x01 \x01(\tR\twatcherId"K\n\x12WatchDirGetRequest\x12\x1d\n\nwatcher_id\x18\x01 \x01(\tR\twatcherId\x12\x16\n\x06offset\x18\x02 \x01(\rR\x06offset"J\n\x13WatchDirGetResponse\x12\x33\n\x06\x65vents\x18\x01 \x03(\x0b\x32\x1b.filesystem.FilesystemEventR\x06\x65vents"3\n\x13WatchDirStopRequest\x12\x1c\n\twatcherId\x18\x01 \x01(\tR\twatcherId"\x16\n\x14WatchDirStopResponse*R\n\x08\x46ileType\x12\x19\n\x15\x46ILE_TYPE_UNSPECIFIED\x10\x00\x12\x12\n\x0e\x46ILE_TYPE_FILE\x10\x01\x12\x17\n\x13\x46ILE_TYPE_DIRECTORY\x10\x02*\x98\x01\n\tEventType\x12\x1a\n\x16\x45VENT_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11\x45VENT_TYPE_CREATE\x10\x01\x12\x14\n\x10\x45VENT_TYPE_WRITE\x10\x02\x12\x15\n\x11\x45VENT_TYPE_REMOVE\x10\x03\x12\x15\n\x11\x45VENT_TYPE_RENAME\x10\x04\x12\x14\n\x10\x45VENT_TYPE_CHMOD\x10\x05\x32\x88\x05\n\nFilesystem\x12\x39\n\x04Stat\x12\x17.filesystem.StatRequest\x1a\x18.filesystem.StatResponse\x12\x42\n\x07MakeDir\x12\x1a.filesystem.MakeDirRequest\x1a\x1b.filesystem.MakeDirResponse\x12\x39\n\x04Move\x12\x17.filesystem.MoveRequest\x1a\x18.filesystem.MoveResponse\x12\x42\n\x07ListDir\x12\x1a.filesystem.ListDirRequest\x1a\x1b.filesystem.ListDirResponse\x12?\n\x06Remove\x12\x19.filesystem.RemoveRequest\x1a\x1a.filesystem.RemoveResponse\x12G\n\x08WatchDir\x12\x1b.filesystem.WatchDirRequest\x1a\x1c.filesystem.WatchDirResponse0\x01\x12O\n\rWatchDirStart\x12\x1b.filesystem.WatchDirRequest\x1a!.filesystem.WatchDirStartResponse\x12N\n\x0bWatchDirGet\x12\x1e.filesystem.WatchDirGetRequest\x1a\x1f.filesystem.WatchDirGetResponse\x12Q\n\x0cWatchDirStop\x12\x1f.filesystem.WatchDirStopRequest\x1a .filesystem.WatchDirStopResponseBi\n\x0e\x63om.filesystemB\x0f\x46ilesystemProtoP\x01\xa2\x02\x03\x46XX\xaa\x02\nFilesystem\xca\x02\nFilesystem\xe2\x02\x16\x46ilesystem\\GPBMetadata\xea\x02\nFilesystemb\x06proto3'
+    b'\n\x1b\x66ilesystem/filesystem.proto\x12\nfilesystem"G\n\x0bMoveRequest\x12\x16\n\x06source\x18\x01 \x01(\tR\x06source\x12 \n\x0b\x64\x65stination\x18\x02 \x01(\tR\x0b\x64\x65stination";\n\x0cMoveResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"$\n\x0eMakeDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path">\n\x0fMakeDirResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"#\n\rRemoveRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"\x10\n\x0eRemoveResponse"!\n\x0bStatRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path";\n\x0cStatResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"]\n\tEntryInfo\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12(\n\x04type\x18\x02 \x01(\x0e\x32\x14.filesystem.FileTypeR\x04type\x12\x12\n\x04path\x18\x03 \x01(\tR\x04path"$\n\x0eListDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"B\n\x0fListDirResponse\x12/\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x15.filesystem.EntryInfoR\x07\x65ntries"%\n\x0fWatchDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"P\n\x0f\x46ilesystemEvent\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12)\n\x04type\x18\x02 \x01(\x0e\x32\x15.filesystem.EventTypeR\x04type"\xfe\x01\n\x10WatchDirResponse\x12?\n\x05start\x18\x01 \x01(\x0b\x32\'.filesystem.WatchDirResponse.StartEventH\x00R\x05start\x12=\n\nfilesystem\x18\x02 \x01(\x0b\x32\x1b.filesystem.FilesystemEventH\x00R\nfilesystem\x12\x46\n\tkeepalive\x18\x03 \x01(\x0b\x32&.filesystem.WatchDirResponse.KeepAliveH\x00R\tkeepalive\x1a\x0c\n\nStartEvent\x1a\x0b\n\tKeepAliveB\x07\n\x05\x65vent"6\n\x15WatchDirStartResponse\x12\x1d\n\nwatcher_id\x18\x01 \x01(\tR\twatcherId"3\n\x12WatchDirGetRequest\x12\x1d\n\nwatcher_id\x18\x01 \x01(\tR\twatcherId"J\n\x13WatchDirGetResponse\x12\x33\n\x06\x65vents\x18\x01 \x03(\x0b\x32\x1b.filesystem.FilesystemEventR\x06\x65vents"4\n\x13WatchDirStopRequest\x12\x1d\n\nwatcher_id\x18\x01 \x01(\tR\twatcherId"\x16\n\x14WatchDirStopResponse*R\n\x08\x46ileType\x12\x19\n\x15\x46ILE_TYPE_UNSPECIFIED\x10\x00\x12\x12\n\x0e\x46ILE_TYPE_FILE\x10\x01\x12\x17\n\x13\x46ILE_TYPE_DIRECTORY\x10\x02*\x98\x01\n\tEventType\x12\x1a\n\x16\x45VENT_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11\x45VENT_TYPE_CREATE\x10\x01\x12\x14\n\x10\x45VENT_TYPE_WRITE\x10\x02\x12\x15\n\x11\x45VENT_TYPE_REMOVE\x10\x03\x12\x15\n\x11\x45VENT_TYPE_RENAME\x10\x04\x12\x14\n\x10\x45VENT_TYPE_CHMOD\x10\x05\x32\x88\x05\n\nFilesystem\x12\x39\n\x04Stat\x12\x17.filesystem.StatRequest\x1a\x18.filesystem.StatResponse\x12\x42\n\x07MakeDir\x12\x1a.filesystem.MakeDirRequest\x1a\x1b.filesystem.MakeDirResponse\x12\x39\n\x04Move\x12\x17.filesystem.MoveRequest\x1a\x18.filesystem.MoveResponse\x12\x42\n\x07ListDir\x12\x1a.filesystem.ListDirRequest\x1a\x1b.filesystem.ListDirResponse\x12?\n\x06Remove\x12\x19.filesystem.RemoveRequest\x1a\x1a.filesystem.RemoveResponse\x12G\n\x08WatchDir\x12\x1b.filesystem.WatchDirRequest\x1a\x1c.filesystem.WatchDirResponse0\x01\x12O\n\rWatchDirStart\x12\x1b.filesystem.WatchDirRequest\x1a!.filesystem.WatchDirStartResponse\x12N\n\x0bWatchDirGet\x12\x1e.filesystem.WatchDirGetRequest\x1a\x1f.filesystem.WatchDirGetResponse\x12Q\n\x0cWatchDirStop\x12\x1f.filesystem.WatchDirStopRequest\x1a .filesystem.WatchDirStopResponseBi\n\x0e\x63om.filesystemB\x0f\x46ilesystemProtoP\x01\xa2\x02\x03\x46XX\xaa\x02\nFilesystem\xca\x02\nFilesystem\xe2\x02\x16\x46ilesystem\\GPBMetadata\xea\x02\nFilesystemb\x06proto3'
 )
 
 _globals = globals()
@@ -27,10 +27,10 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["DESCRIPTOR"]._serialized_options = (
         b"\n\016com.filesystemB\017FilesystemProtoP\001\242\002\003FXX\252\002\nFilesystem\312\002\nFilesystem\342\002\026Filesystem\\GPBMetadata\352\002\nFilesystem"
     )
-    _globals["_FILETYPE"]._serialized_start = 1294
-    _globals["_FILETYPE"]._serialized_end = 1376
-    _globals["_EVENTTYPE"]._serialized_start = 1379
-    _globals["_EVENTTYPE"]._serialized_end = 1531
+    _globals["_FILETYPE"]._serialized_start = 1272
+    _globals["_FILETYPE"]._serialized_end = 1354
+    _globals["_EVENTTYPE"]._serialized_start = 1357
+    _globals["_EVENTTYPE"]._serialized_end = 1509
     _globals["_MOVEREQUEST"]._serialized_start = 43
     _globals["_MOVEREQUEST"]._serialized_end = 114
     _globals["_MOVERESPONSE"]._serialized_start = 116
@@ -64,15 +64,15 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_WATCHDIRRESPONSE_KEEPALIVE"]._serialized_start = 987
     _globals["_WATCHDIRRESPONSE_KEEPALIVE"]._serialized_end = 998
     _globals["_WATCHDIRSTARTRESPONSE"]._serialized_start = 1009
-    _globals["_WATCHDIRSTARTRESPONSE"]._serialized_end = 1062
-    _globals["_WATCHDIRGETREQUEST"]._serialized_start = 1064
-    _globals["_WATCHDIRGETREQUEST"]._serialized_end = 1139
-    _globals["_WATCHDIRGETRESPONSE"]._serialized_start = 1141
-    _globals["_WATCHDIRGETRESPONSE"]._serialized_end = 1215
-    _globals["_WATCHDIRSTOPREQUEST"]._serialized_start = 1217
-    _globals["_WATCHDIRSTOPREQUEST"]._serialized_end = 1268
-    _globals["_WATCHDIRSTOPRESPONSE"]._serialized_start = 1270
-    _globals["_WATCHDIRSTOPRESPONSE"]._serialized_end = 1292
-    _globals["_FILESYSTEM"]._serialized_start = 1534
-    _globals["_FILESYSTEM"]._serialized_end = 2182
+    _globals["_WATCHDIRSTARTRESPONSE"]._serialized_end = 1063
+    _globals["_WATCHDIRGETREQUEST"]._serialized_start = 1065
+    _globals["_WATCHDIRGETREQUEST"]._serialized_end = 1116
+    _globals["_WATCHDIRGETRESPONSE"]._serialized_start = 1118
+    _globals["_WATCHDIRGETRESPONSE"]._serialized_end = 1192
+    _globals["_WATCHDIRSTOPREQUEST"]._serialized_start = 1194
+    _globals["_WATCHDIRSTOPREQUEST"]._serialized_end = 1246
+    _globals["_WATCHDIRSTOPRESPONSE"]._serialized_start = 1248
+    _globals["_WATCHDIRSTOPRESPONSE"]._serialized_end = 1270
+    _globals["_FILESYSTEM"]._serialized_start = 1512
+    _globals["_FILESYSTEM"]._serialized_end = 2160
 # @@protoc_insertion_point(module_scope)

--- a/packages/python-sdk/e2b/envd/filesystem/filesystem_pb2.py
+++ b/packages/python-sdk/e2b/envd/filesystem/filesystem_pb2.py
@@ -14,65 +14,65 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n%spec/envd/filesystem/filesystem.proto\x12\nfilesystem"G\n\x0bMoveRequest\x12\x16\n\x06source\x18\x01 \x01(\tR\x06source\x12 \n\x0b\x64\x65stination\x18\x02 \x01(\tR\x0b\x64\x65stination";\n\x0cMoveResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"$\n\x0eMakeDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path">\n\x0fMakeDirResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"#\n\rRemoveRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"\x10\n\x0eRemoveResponse"!\n\x0bStatRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path";\n\x0cStatResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"]\n\tEntryInfo\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12(\n\x04type\x18\x02 \x01(\x0e\x32\x14.filesystem.FileTypeR\x04type\x12\x12\n\x04path\x18\x03 \x01(\tR\x04path"$\n\x0eListDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"B\n\x0fListDirResponse\x12/\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x15.filesystem.EntryInfoR\x07\x65ntries"%\n\x0fWatchDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"P\n\x0f\x46ilesystemEvent\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12)\n\x04type\x18\x02 \x01(\x0e\x32\x15.filesystem.EventTypeR\x04type"\xfe\x01\n\x10WatchDirResponse\x12?\n\x05start\x18\x01 \x01(\x0b\x32\'.filesystem.WatchDirResponse.StartEventH\x00R\x05start\x12=\n\nfilesystem\x18\x02 \x01(\x0b\x32\x1b.filesystem.FilesystemEventH\x00R\nfilesystem\x12\x46\n\tkeepalive\x18\x03 \x01(\x0b\x32&.filesystem.WatchDirResponse.KeepAliveH\x00R\tkeepalive\x1a\x0c\n\nStartEvent\x1a\x0b\n\tKeepAliveB\x07\n\x05\x65vent"5\n\x15WatchDirStartResponse\x12\x1c\n\twatcherId\x18\x01 \x01(\tR\twatcherId"K\n\x13WatchDirPollRequest\x12\x1c\n\twatcherId\x18\x01 \x01(\tR\twatcherId\x12\x16\n\x06offset\x18\x02 \x01(\rR\x06offset"K\n\x14WatchDirPollResponse\x12\x33\n\x06\x65vents\x18\x01 \x03(\x0b\x32\x1b.filesystem.FilesystemEventR\x06\x65vents"3\n\x13WatchDirStopRequest\x12\x1c\n\twatcherId\x18\x01 \x01(\tR\twatcherId"\x16\n\x14WatchDirStopResponse*R\n\x08\x46ileType\x12\x19\n\x15\x46ILE_TYPE_UNSPECIFIED\x10\x00\x12\x12\n\x0e\x46ILE_TYPE_FILE\x10\x01\x12\x17\n\x13\x46ILE_TYPE_DIRECTORY\x10\x02*\x98\x01\n\tEventType\x12\x1a\n\x16\x45VENT_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11\x45VENT_TYPE_CREATE\x10\x01\x12\x14\n\x10\x45VENT_TYPE_WRITE\x10\x02\x12\x15\n\x11\x45VENT_TYPE_REMOVE\x10\x03\x12\x15\n\x11\x45VENT_TYPE_RENAME\x10\x04\x12\x14\n\x10\x45VENT_TYPE_CHMOD\x10\x05\x32\x8b\x05\n\nFilesystem\x12\x39\n\x04Stat\x12\x17.filesystem.StatRequest\x1a\x18.filesystem.StatResponse\x12\x42\n\x07MakeDir\x12\x1a.filesystem.MakeDirRequest\x1a\x1b.filesystem.MakeDirResponse\x12\x39\n\x04Move\x12\x17.filesystem.MoveRequest\x1a\x18.filesystem.MoveResponse\x12\x42\n\x07ListDir\x12\x1a.filesystem.ListDirRequest\x1a\x1b.filesystem.ListDirResponse\x12?\n\x06Remove\x12\x19.filesystem.RemoveRequest\x1a\x1a.filesystem.RemoveResponse\x12G\n\x08WatchDir\x12\x1b.filesystem.WatchDirRequest\x1a\x1c.filesystem.WatchDirResponse0\x01\x12O\n\rWatchDirStart\x12\x1b.filesystem.WatchDirRequest\x1a!.filesystem.WatchDirStartResponse\x12Q\n\x0cWatchDirPoll\x12\x1f.filesystem.WatchDirPollRequest\x1a .filesystem.WatchDirPollResponse\x12Q\n\x0cWatchDirStop\x12\x1f.filesystem.WatchDirStopRequest\x1a .filesystem.WatchDirStopResponseBi\n\x0e\x63om.filesystemB\x0f\x46ilesystemProtoP\x01\xa2\x02\x03\x46XX\xaa\x02\nFilesystem\xca\x02\nFilesystem\xe2\x02\x16\x46ilesystem\\GPBMetadata\xea\x02\nFilesystemb\x06proto3'
+    b'\n\x1b\x66ilesystem/filesystem.proto\x12\nfilesystem"G\n\x0bMoveRequest\x12\x16\n\x06source\x18\x01 \x01(\tR\x06source\x12 \n\x0b\x64\x65stination\x18\x02 \x01(\tR\x0b\x64\x65stination";\n\x0cMoveResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"$\n\x0eMakeDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path">\n\x0fMakeDirResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"#\n\rRemoveRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"\x10\n\x0eRemoveResponse"!\n\x0bStatRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path";\n\x0cStatResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"]\n\tEntryInfo\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12(\n\x04type\x18\x02 \x01(\x0e\x32\x14.filesystem.FileTypeR\x04type\x12\x12\n\x04path\x18\x03 \x01(\tR\x04path"$\n\x0eListDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"B\n\x0fListDirResponse\x12/\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x15.filesystem.EntryInfoR\x07\x65ntries"%\n\x0fWatchDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"P\n\x0f\x46ilesystemEvent\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12)\n\x04type\x18\x02 \x01(\x0e\x32\x15.filesystem.EventTypeR\x04type"\xfe\x01\n\x10WatchDirResponse\x12?\n\x05start\x18\x01 \x01(\x0b\x32\'.filesystem.WatchDirResponse.StartEventH\x00R\x05start\x12=\n\nfilesystem\x18\x02 \x01(\x0b\x32\x1b.filesystem.FilesystemEventH\x00R\nfilesystem\x12\x46\n\tkeepalive\x18\x03 \x01(\x0b\x32&.filesystem.WatchDirResponse.KeepAliveH\x00R\tkeepalive\x1a\x0c\n\nStartEvent\x1a\x0b\n\tKeepAliveB\x07\n\x05\x65vent"5\n\x15WatchDirStartResponse\x12\x1c\n\twatcherId\x18\x01 \x01(\tR\twatcherId"K\n\x12WatchDirGetRequest\x12\x1d\n\nwatcher_id\x18\x01 \x01(\tR\twatcherId\x12\x16\n\x06offset\x18\x02 \x01(\rR\x06offset"J\n\x13WatchDirGetResponse\x12\x33\n\x06\x65vents\x18\x01 \x03(\x0b\x32\x1b.filesystem.FilesystemEventR\x06\x65vents"3\n\x13WatchDirStopRequest\x12\x1c\n\twatcherId\x18\x01 \x01(\tR\twatcherId"\x16\n\x14WatchDirStopResponse*R\n\x08\x46ileType\x12\x19\n\x15\x46ILE_TYPE_UNSPECIFIED\x10\x00\x12\x12\n\x0e\x46ILE_TYPE_FILE\x10\x01\x12\x17\n\x13\x46ILE_TYPE_DIRECTORY\x10\x02*\x98\x01\n\tEventType\x12\x1a\n\x16\x45VENT_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11\x45VENT_TYPE_CREATE\x10\x01\x12\x14\n\x10\x45VENT_TYPE_WRITE\x10\x02\x12\x15\n\x11\x45VENT_TYPE_REMOVE\x10\x03\x12\x15\n\x11\x45VENT_TYPE_RENAME\x10\x04\x12\x14\n\x10\x45VENT_TYPE_CHMOD\x10\x05\x32\x88\x05\n\nFilesystem\x12\x39\n\x04Stat\x12\x17.filesystem.StatRequest\x1a\x18.filesystem.StatResponse\x12\x42\n\x07MakeDir\x12\x1a.filesystem.MakeDirRequest\x1a\x1b.filesystem.MakeDirResponse\x12\x39\n\x04Move\x12\x17.filesystem.MoveRequest\x1a\x18.filesystem.MoveResponse\x12\x42\n\x07ListDir\x12\x1a.filesystem.ListDirRequest\x1a\x1b.filesystem.ListDirResponse\x12?\n\x06Remove\x12\x19.filesystem.RemoveRequest\x1a\x1a.filesystem.RemoveResponse\x12G\n\x08WatchDir\x12\x1b.filesystem.WatchDirRequest\x1a\x1c.filesystem.WatchDirResponse0\x01\x12O\n\rWatchDirStart\x12\x1b.filesystem.WatchDirRequest\x1a!.filesystem.WatchDirStartResponse\x12N\n\x0bWatchDirGet\x12\x1e.filesystem.WatchDirGetRequest\x1a\x1f.filesystem.WatchDirGetResponse\x12Q\n\x0cWatchDirStop\x12\x1f.filesystem.WatchDirStopRequest\x1a .filesystem.WatchDirStopResponseBi\n\x0e\x63om.filesystemB\x0f\x46ilesystemProtoP\x01\xa2\x02\x03\x46XX\xaa\x02\nFilesystem\xca\x02\nFilesystem\xe2\x02\x16\x46ilesystem\\GPBMetadata\xea\x02\nFilesystemb\x06proto3'
 )
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(
-    DESCRIPTOR, "spec.envd.filesystem.filesystem_pb2", _globals
+    DESCRIPTOR, "filesystem.filesystem_pb2", _globals
 )
 if not _descriptor._USE_C_DESCRIPTORS:
     _globals["DESCRIPTOR"]._loaded_options = None
     _globals["DESCRIPTOR"]._serialized_options = (
         b"\n\016com.filesystemB\017FilesystemProtoP\001\242\002\003FXX\252\002\nFilesystem\312\002\nFilesystem\342\002\026Filesystem\\GPBMetadata\352\002\nFilesystem"
     )
-    _globals["_FILETYPE"]._serialized_start = 1305
-    _globals["_FILETYPE"]._serialized_end = 1387
-    _globals["_EVENTTYPE"]._serialized_start = 1390
-    _globals["_EVENTTYPE"]._serialized_end = 1542
-    _globals["_MOVEREQUEST"]._serialized_start = 53
-    _globals["_MOVEREQUEST"]._serialized_end = 124
-    _globals["_MOVERESPONSE"]._serialized_start = 126
-    _globals["_MOVERESPONSE"]._serialized_end = 185
-    _globals["_MAKEDIRREQUEST"]._serialized_start = 187
-    _globals["_MAKEDIRREQUEST"]._serialized_end = 223
-    _globals["_MAKEDIRRESPONSE"]._serialized_start = 225
-    _globals["_MAKEDIRRESPONSE"]._serialized_end = 287
-    _globals["_REMOVEREQUEST"]._serialized_start = 289
-    _globals["_REMOVEREQUEST"]._serialized_end = 324
-    _globals["_REMOVERESPONSE"]._serialized_start = 326
-    _globals["_REMOVERESPONSE"]._serialized_end = 342
-    _globals["_STATREQUEST"]._serialized_start = 344
-    _globals["_STATREQUEST"]._serialized_end = 377
-    _globals["_STATRESPONSE"]._serialized_start = 379
-    _globals["_STATRESPONSE"]._serialized_end = 438
-    _globals["_ENTRYINFO"]._serialized_start = 440
-    _globals["_ENTRYINFO"]._serialized_end = 533
-    _globals["_LISTDIRREQUEST"]._serialized_start = 535
-    _globals["_LISTDIRREQUEST"]._serialized_end = 571
-    _globals["_LISTDIRRESPONSE"]._serialized_start = 573
-    _globals["_LISTDIRRESPONSE"]._serialized_end = 639
-    _globals["_WATCHDIRREQUEST"]._serialized_start = 641
-    _globals["_WATCHDIRREQUEST"]._serialized_end = 678
-    _globals["_FILESYSTEMEVENT"]._serialized_start = 680
-    _globals["_FILESYSTEMEVENT"]._serialized_end = 760
-    _globals["_WATCHDIRRESPONSE"]._serialized_start = 763
-    _globals["_WATCHDIRRESPONSE"]._serialized_end = 1017
-    _globals["_WATCHDIRRESPONSE_STARTEVENT"]._serialized_start = 983
-    _globals["_WATCHDIRRESPONSE_STARTEVENT"]._serialized_end = 995
-    _globals["_WATCHDIRRESPONSE_KEEPALIVE"]._serialized_start = 997
-    _globals["_WATCHDIRRESPONSE_KEEPALIVE"]._serialized_end = 1008
-    _globals["_WATCHDIRSTARTRESPONSE"]._serialized_start = 1019
-    _globals["_WATCHDIRSTARTRESPONSE"]._serialized_end = 1072
-    _globals["_WATCHDIRPOLLREQUEST"]._serialized_start = 1074
-    _globals["_WATCHDIRPOLLREQUEST"]._serialized_end = 1149
-    _globals["_WATCHDIRPOLLRESPONSE"]._serialized_start = 1151
-    _globals["_WATCHDIRPOLLRESPONSE"]._serialized_end = 1226
-    _globals["_WATCHDIRSTOPREQUEST"]._serialized_start = 1228
-    _globals["_WATCHDIRSTOPREQUEST"]._serialized_end = 1279
-    _globals["_WATCHDIRSTOPRESPONSE"]._serialized_start = 1281
-    _globals["_WATCHDIRSTOPRESPONSE"]._serialized_end = 1303
-    _globals["_FILESYSTEM"]._serialized_start = 1545
-    _globals["_FILESYSTEM"]._serialized_end = 2196
+    _globals["_FILETYPE"]._serialized_start = 1294
+    _globals["_FILETYPE"]._serialized_end = 1376
+    _globals["_EVENTTYPE"]._serialized_start = 1379
+    _globals["_EVENTTYPE"]._serialized_end = 1531
+    _globals["_MOVEREQUEST"]._serialized_start = 43
+    _globals["_MOVEREQUEST"]._serialized_end = 114
+    _globals["_MOVERESPONSE"]._serialized_start = 116
+    _globals["_MOVERESPONSE"]._serialized_end = 175
+    _globals["_MAKEDIRREQUEST"]._serialized_start = 177
+    _globals["_MAKEDIRREQUEST"]._serialized_end = 213
+    _globals["_MAKEDIRRESPONSE"]._serialized_start = 215
+    _globals["_MAKEDIRRESPONSE"]._serialized_end = 277
+    _globals["_REMOVEREQUEST"]._serialized_start = 279
+    _globals["_REMOVEREQUEST"]._serialized_end = 314
+    _globals["_REMOVERESPONSE"]._serialized_start = 316
+    _globals["_REMOVERESPONSE"]._serialized_end = 332
+    _globals["_STATREQUEST"]._serialized_start = 334
+    _globals["_STATREQUEST"]._serialized_end = 367
+    _globals["_STATRESPONSE"]._serialized_start = 369
+    _globals["_STATRESPONSE"]._serialized_end = 428
+    _globals["_ENTRYINFO"]._serialized_start = 430
+    _globals["_ENTRYINFO"]._serialized_end = 523
+    _globals["_LISTDIRREQUEST"]._serialized_start = 525
+    _globals["_LISTDIRREQUEST"]._serialized_end = 561
+    _globals["_LISTDIRRESPONSE"]._serialized_start = 563
+    _globals["_LISTDIRRESPONSE"]._serialized_end = 629
+    _globals["_WATCHDIRREQUEST"]._serialized_start = 631
+    _globals["_WATCHDIRREQUEST"]._serialized_end = 668
+    _globals["_FILESYSTEMEVENT"]._serialized_start = 670
+    _globals["_FILESYSTEMEVENT"]._serialized_end = 750
+    _globals["_WATCHDIRRESPONSE"]._serialized_start = 753
+    _globals["_WATCHDIRRESPONSE"]._serialized_end = 1007
+    _globals["_WATCHDIRRESPONSE_STARTEVENT"]._serialized_start = 973
+    _globals["_WATCHDIRRESPONSE_STARTEVENT"]._serialized_end = 985
+    _globals["_WATCHDIRRESPONSE_KEEPALIVE"]._serialized_start = 987
+    _globals["_WATCHDIRRESPONSE_KEEPALIVE"]._serialized_end = 998
+    _globals["_WATCHDIRSTARTRESPONSE"]._serialized_start = 1009
+    _globals["_WATCHDIRSTARTRESPONSE"]._serialized_end = 1062
+    _globals["_WATCHDIRGETREQUEST"]._serialized_start = 1064
+    _globals["_WATCHDIRGETREQUEST"]._serialized_end = 1139
+    _globals["_WATCHDIRGETRESPONSE"]._serialized_start = 1141
+    _globals["_WATCHDIRGETRESPONSE"]._serialized_end = 1215
+    _globals["_WATCHDIRSTOPREQUEST"]._serialized_start = 1217
+    _globals["_WATCHDIRSTOPREQUEST"]._serialized_end = 1268
+    _globals["_WATCHDIRSTOPRESPONSE"]._serialized_start = 1270
+    _globals["_WATCHDIRSTOPRESPONSE"]._serialized_end = 1292
+    _globals["_FILESYSTEM"]._serialized_start = 1534
+    _globals["_FILESYSTEM"]._serialized_end = 2182
 # @@protoc_insertion_point(module_scope)

--- a/packages/python-sdk/e2b/envd/filesystem/filesystem_pb2.py
+++ b/packages/python-sdk/e2b/envd/filesystem/filesystem_pb2.py
@@ -7,57 +7,72 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import symbol_database as _symbol_database
 from google.protobuf.internal import builder as _builder
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
 
-
-
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1b\x66ilesystem/filesystem.proto\x12\nfilesystem\"G\n\x0bMoveRequest\x12\x16\n\x06source\x18\x01 \x01(\tR\x06source\x12 \n\x0b\x64\x65stination\x18\x02 \x01(\tR\x0b\x64\x65stination\";\n\x0cMoveResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry\"$\n\x0eMakeDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path\">\n\x0fMakeDirResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry\"#\n\rRemoveRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path\"\x10\n\x0eRemoveResponse\"!\n\x0bStatRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path\";\n\x0cStatResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry\"]\n\tEntryInfo\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12(\n\x04type\x18\x02 \x01(\x0e\x32\x14.filesystem.FileTypeR\x04type\x12\x12\n\x04path\x18\x03 \x01(\tR\x04path\"$\n\x0eListDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path\"B\n\x0fListDirResponse\x12/\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x15.filesystem.EntryInfoR\x07\x65ntries\"%\n\x0fWatchDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path\"\xe1\x02\n\x10WatchDirResponse\x12?\n\x05start\x18\x01 \x01(\x0b\x32\'.filesystem.WatchDirResponse.StartEventH\x00R\x05start\x12N\n\nfilesystem\x18\x02 \x01(\x0b\x32,.filesystem.WatchDirResponse.FilesystemEventH\x00R\nfilesystem\x12\x46\n\tkeepalive\x18\x03 \x01(\x0b\x32&.filesystem.WatchDirResponse.KeepAliveH\x00R\tkeepalive\x1a\x0c\n\nStartEvent\x1aP\n\x0f\x46ilesystemEvent\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12)\n\x04type\x18\x02 \x01(\x0e\x32\x15.filesystem.EventTypeR\x04type\x1a\x0b\n\tKeepAliveB\x07\n\x05\x65vent*R\n\x08\x46ileType\x12\x19\n\x15\x46ILE_TYPE_UNSPECIFIED\x10\x00\x12\x12\n\x0e\x46ILE_TYPE_FILE\x10\x01\x12\x17\n\x13\x46ILE_TYPE_DIRECTORY\x10\x02*\x98\x01\n\tEventType\x12\x1a\n\x16\x45VENT_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11\x45VENT_TYPE_CREATE\x10\x01\x12\x14\n\x10\x45VENT_TYPE_WRITE\x10\x02\x12\x15\n\x11\x45VENT_TYPE_REMOVE\x10\x03\x12\x15\n\x11\x45VENT_TYPE_RENAME\x10\x04\x12\x14\n\x10\x45VENT_TYPE_CHMOD\x10\x05\x32\x94\x03\n\nFilesystem\x12\x39\n\x04Stat\x12\x17.filesystem.StatRequest\x1a\x18.filesystem.StatResponse\x12\x42\n\x07MakeDir\x12\x1a.filesystem.MakeDirRequest\x1a\x1b.filesystem.MakeDirResponse\x12\x39\n\x04Move\x12\x17.filesystem.MoveRequest\x1a\x18.filesystem.MoveResponse\x12\x42\n\x07ListDir\x12\x1a.filesystem.ListDirRequest\x1a\x1b.filesystem.ListDirResponse\x12G\n\x08WatchDir\x12\x1b.filesystem.WatchDirRequest\x1a\x1c.filesystem.WatchDirResponse0\x01\x12?\n\x06Remove\x12\x19.filesystem.RemoveRequest\x1a\x1a.filesystem.RemoveResponseBi\n\x0e\x63om.filesystemB\x0f\x46ilesystemProtoP\x01\xa2\x02\x03\x46XX\xaa\x02\nFilesystem\xca\x02\nFilesystem\xe2\x02\x16\x46ilesystem\\GPBMetadata\xea\x02\nFilesystemb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
+    b'\n%spec/envd/filesystem/filesystem.proto\x12\nfilesystem"G\n\x0bMoveRequest\x12\x16\n\x06source\x18\x01 \x01(\tR\x06source\x12 \n\x0b\x64\x65stination\x18\x02 \x01(\tR\x0b\x64\x65stination";\n\x0cMoveResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"$\n\x0eMakeDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path">\n\x0fMakeDirResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"#\n\rRemoveRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"\x10\n\x0eRemoveResponse"!\n\x0bStatRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path";\n\x0cStatResponse\x12+\n\x05\x65ntry\x18\x01 \x01(\x0b\x32\x15.filesystem.EntryInfoR\x05\x65ntry"]\n\tEntryInfo\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12(\n\x04type\x18\x02 \x01(\x0e\x32\x14.filesystem.FileTypeR\x04type\x12\x12\n\x04path\x18\x03 \x01(\tR\x04path"$\n\x0eListDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"B\n\x0fListDirResponse\x12/\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x15.filesystem.EntryInfoR\x07\x65ntries"%\n\x0fWatchDirRequest\x12\x12\n\x04path\x18\x01 \x01(\tR\x04path"P\n\x0f\x46ilesystemEvent\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12)\n\x04type\x18\x02 \x01(\x0e\x32\x15.filesystem.EventTypeR\x04type"\xfe\x01\n\x10WatchDirResponse\x12?\n\x05start\x18\x01 \x01(\x0b\x32\'.filesystem.WatchDirResponse.StartEventH\x00R\x05start\x12=\n\nfilesystem\x18\x02 \x01(\x0b\x32\x1b.filesystem.FilesystemEventH\x00R\nfilesystem\x12\x46\n\tkeepalive\x18\x03 \x01(\x0b\x32&.filesystem.WatchDirResponse.KeepAliveH\x00R\tkeepalive\x1a\x0c\n\nStartEvent\x1a\x0b\n\tKeepAliveB\x07\n\x05\x65vent"5\n\x15WatchDirStartResponse\x12\x1c\n\twatcherId\x18\x01 \x01(\tR\twatcherId"K\n\x13WatchDirPollRequest\x12\x1c\n\twatcherId\x18\x01 \x01(\tR\twatcherId\x12\x16\n\x06offset\x18\x02 \x01(\rR\x06offset"K\n\x14WatchDirPollResponse\x12\x33\n\x06\x65vents\x18\x01 \x03(\x0b\x32\x1b.filesystem.FilesystemEventR\x06\x65vents"3\n\x13WatchDirStopRequest\x12\x1c\n\twatcherId\x18\x01 \x01(\tR\twatcherId"\x16\n\x14WatchDirStopResponse*R\n\x08\x46ileType\x12\x19\n\x15\x46ILE_TYPE_UNSPECIFIED\x10\x00\x12\x12\n\x0e\x46ILE_TYPE_FILE\x10\x01\x12\x17\n\x13\x46ILE_TYPE_DIRECTORY\x10\x02*\x98\x01\n\tEventType\x12\x1a\n\x16\x45VENT_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11\x45VENT_TYPE_CREATE\x10\x01\x12\x14\n\x10\x45VENT_TYPE_WRITE\x10\x02\x12\x15\n\x11\x45VENT_TYPE_REMOVE\x10\x03\x12\x15\n\x11\x45VENT_TYPE_RENAME\x10\x04\x12\x14\n\x10\x45VENT_TYPE_CHMOD\x10\x05\x32\x8b\x05\n\nFilesystem\x12\x39\n\x04Stat\x12\x17.filesystem.StatRequest\x1a\x18.filesystem.StatResponse\x12\x42\n\x07MakeDir\x12\x1a.filesystem.MakeDirRequest\x1a\x1b.filesystem.MakeDirResponse\x12\x39\n\x04Move\x12\x17.filesystem.MoveRequest\x1a\x18.filesystem.MoveResponse\x12\x42\n\x07ListDir\x12\x1a.filesystem.ListDirRequest\x1a\x1b.filesystem.ListDirResponse\x12?\n\x06Remove\x12\x19.filesystem.RemoveRequest\x1a\x1a.filesystem.RemoveResponse\x12G\n\x08WatchDir\x12\x1b.filesystem.WatchDirRequest\x1a\x1c.filesystem.WatchDirResponse0\x01\x12O\n\rWatchDirStart\x12\x1b.filesystem.WatchDirRequest\x1a!.filesystem.WatchDirStartResponse\x12Q\n\x0cWatchDirPoll\x12\x1f.filesystem.WatchDirPollRequest\x1a .filesystem.WatchDirPollResponse\x12Q\n\x0cWatchDirStop\x12\x1f.filesystem.WatchDirStopRequest\x1a .filesystem.WatchDirStopResponseBi\n\x0e\x63om.filesystemB\x0f\x46ilesystemProtoP\x01\xa2\x02\x03\x46XX\xaa\x02\nFilesystem\xca\x02\nFilesystem\xe2\x02\x16\x46ilesystem\\GPBMetadata\xea\x02\nFilesystemb\x06proto3'
+)
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'filesystem.filesystem_pb2', _globals)
+_builder.BuildTopDescriptorsAndMessages(
+    DESCRIPTOR, "spec.envd.filesystem.filesystem_pb2", _globals
+)
 if not _descriptor._USE_C_DESCRIPTORS:
-  _globals['DESCRIPTOR']._loaded_options = None
-  _globals['DESCRIPTOR']._serialized_options = b'\n\016com.filesystemB\017FilesystemProtoP\001\242\002\003FXX\252\002\nFilesystem\312\002\nFilesystem\342\002\026Filesystem\\GPBMetadata\352\002\nFilesystem'
-  _globals['_FILETYPE']._serialized_start=1026
-  _globals['_FILETYPE']._serialized_end=1108
-  _globals['_EVENTTYPE']._serialized_start=1111
-  _globals['_EVENTTYPE']._serialized_end=1263
-  _globals['_MOVEREQUEST']._serialized_start=43
-  _globals['_MOVEREQUEST']._serialized_end=114
-  _globals['_MOVERESPONSE']._serialized_start=116
-  _globals['_MOVERESPONSE']._serialized_end=175
-  _globals['_MAKEDIRREQUEST']._serialized_start=177
-  _globals['_MAKEDIRREQUEST']._serialized_end=213
-  _globals['_MAKEDIRRESPONSE']._serialized_start=215
-  _globals['_MAKEDIRRESPONSE']._serialized_end=277
-  _globals['_REMOVEREQUEST']._serialized_start=279
-  _globals['_REMOVEREQUEST']._serialized_end=314
-  _globals['_REMOVERESPONSE']._serialized_start=316
-  _globals['_REMOVERESPONSE']._serialized_end=332
-  _globals['_STATREQUEST']._serialized_start=334
-  _globals['_STATREQUEST']._serialized_end=367
-  _globals['_STATRESPONSE']._serialized_start=369
-  _globals['_STATRESPONSE']._serialized_end=428
-  _globals['_ENTRYINFO']._serialized_start=430
-  _globals['_ENTRYINFO']._serialized_end=523
-  _globals['_LISTDIRREQUEST']._serialized_start=525
-  _globals['_LISTDIRREQUEST']._serialized_end=561
-  _globals['_LISTDIRRESPONSE']._serialized_start=563
-  _globals['_LISTDIRRESPONSE']._serialized_end=629
-  _globals['_WATCHDIRREQUEST']._serialized_start=631
-  _globals['_WATCHDIRREQUEST']._serialized_end=668
-  _globals['_WATCHDIRRESPONSE']._serialized_start=671
-  _globals['_WATCHDIRRESPONSE']._serialized_end=1024
-  _globals['_WATCHDIRRESPONSE_STARTEVENT']._serialized_start=908
-  _globals['_WATCHDIRRESPONSE_STARTEVENT']._serialized_end=920
-  _globals['_WATCHDIRRESPONSE_FILESYSTEMEVENT']._serialized_start=922
-  _globals['_WATCHDIRRESPONSE_FILESYSTEMEVENT']._serialized_end=1002
-  _globals['_WATCHDIRRESPONSE_KEEPALIVE']._serialized_start=1004
-  _globals['_WATCHDIRRESPONSE_KEEPALIVE']._serialized_end=1015
-  _globals['_FILESYSTEM']._serialized_start=1266
-  _globals['_FILESYSTEM']._serialized_end=1670
+    _globals["DESCRIPTOR"]._loaded_options = None
+    _globals["DESCRIPTOR"]._serialized_options = (
+        b"\n\016com.filesystemB\017FilesystemProtoP\001\242\002\003FXX\252\002\nFilesystem\312\002\nFilesystem\342\002\026Filesystem\\GPBMetadata\352\002\nFilesystem"
+    )
+    _globals["_FILETYPE"]._serialized_start = 1305
+    _globals["_FILETYPE"]._serialized_end = 1387
+    _globals["_EVENTTYPE"]._serialized_start = 1390
+    _globals["_EVENTTYPE"]._serialized_end = 1542
+    _globals["_MOVEREQUEST"]._serialized_start = 53
+    _globals["_MOVEREQUEST"]._serialized_end = 124
+    _globals["_MOVERESPONSE"]._serialized_start = 126
+    _globals["_MOVERESPONSE"]._serialized_end = 185
+    _globals["_MAKEDIRREQUEST"]._serialized_start = 187
+    _globals["_MAKEDIRREQUEST"]._serialized_end = 223
+    _globals["_MAKEDIRRESPONSE"]._serialized_start = 225
+    _globals["_MAKEDIRRESPONSE"]._serialized_end = 287
+    _globals["_REMOVEREQUEST"]._serialized_start = 289
+    _globals["_REMOVEREQUEST"]._serialized_end = 324
+    _globals["_REMOVERESPONSE"]._serialized_start = 326
+    _globals["_REMOVERESPONSE"]._serialized_end = 342
+    _globals["_STATREQUEST"]._serialized_start = 344
+    _globals["_STATREQUEST"]._serialized_end = 377
+    _globals["_STATRESPONSE"]._serialized_start = 379
+    _globals["_STATRESPONSE"]._serialized_end = 438
+    _globals["_ENTRYINFO"]._serialized_start = 440
+    _globals["_ENTRYINFO"]._serialized_end = 533
+    _globals["_LISTDIRREQUEST"]._serialized_start = 535
+    _globals["_LISTDIRREQUEST"]._serialized_end = 571
+    _globals["_LISTDIRRESPONSE"]._serialized_start = 573
+    _globals["_LISTDIRRESPONSE"]._serialized_end = 639
+    _globals["_WATCHDIRREQUEST"]._serialized_start = 641
+    _globals["_WATCHDIRREQUEST"]._serialized_end = 678
+    _globals["_FILESYSTEMEVENT"]._serialized_start = 680
+    _globals["_FILESYSTEMEVENT"]._serialized_end = 760
+    _globals["_WATCHDIRRESPONSE"]._serialized_start = 763
+    _globals["_WATCHDIRRESPONSE"]._serialized_end = 1017
+    _globals["_WATCHDIRRESPONSE_STARTEVENT"]._serialized_start = 983
+    _globals["_WATCHDIRRESPONSE_STARTEVENT"]._serialized_end = 995
+    _globals["_WATCHDIRRESPONSE_KEEPALIVE"]._serialized_start = 997
+    _globals["_WATCHDIRRESPONSE_KEEPALIVE"]._serialized_end = 1008
+    _globals["_WATCHDIRSTARTRESPONSE"]._serialized_start = 1019
+    _globals["_WATCHDIRSTARTRESPONSE"]._serialized_end = 1072
+    _globals["_WATCHDIRPOLLREQUEST"]._serialized_start = 1074
+    _globals["_WATCHDIRPOLLREQUEST"]._serialized_end = 1149
+    _globals["_WATCHDIRPOLLRESPONSE"]._serialized_start = 1151
+    _globals["_WATCHDIRPOLLRESPONSE"]._serialized_end = 1226
+    _globals["_WATCHDIRSTOPREQUEST"]._serialized_start = 1228
+    _globals["_WATCHDIRSTOPREQUEST"]._serialized_end = 1279
+    _globals["_WATCHDIRSTOPRESPONSE"]._serialized_start = 1281
+    _globals["_WATCHDIRSTOPRESPONSE"]._serialized_end = 1303
+    _globals["_FILESYSTEM"]._serialized_start = 1545
+    _globals["_FILESYSTEM"]._serialized_end = 2196
 # @@protoc_insertion_point(module_scope)

--- a/packages/python-sdk/e2b/envd/filesystem/filesystem_pb2.pyi
+++ b/packages/python-sdk/e2b/envd/filesystem/filesystem_pb2.pyi
@@ -2,7 +2,13 @@ from google.protobuf.internal import containers as _containers
 from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
-from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+from typing import (
+    ClassVar as _ClassVar,
+    Iterable as _Iterable,
+    Mapping as _Mapping,
+    Optional as _Optional,
+    Union as _Union,
+)
 
 DESCRIPTOR: _descriptor.FileDescriptor
 
@@ -20,6 +26,7 @@ class EventType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     EVENT_TYPE_REMOVE: _ClassVar[EventType]
     EVENT_TYPE_RENAME: _ClassVar[EventType]
     EVENT_TYPE_CHMOD: _ClassVar[EventType]
+
 FILE_TYPE_UNSPECIFIED: FileType
 FILE_TYPE_FILE: FileType
 FILE_TYPE_DIRECTORY: FileType
@@ -36,7 +43,9 @@ class MoveRequest(_message.Message):
     DESTINATION_FIELD_NUMBER: _ClassVar[int]
     source: str
     destination: str
-    def __init__(self, source: _Optional[str] = ..., destination: _Optional[str] = ...) -> None: ...
+    def __init__(
+        self, source: _Optional[str] = ..., destination: _Optional[str] = ...
+    ) -> None: ...
 
 class MoveResponse(_message.Message):
     __slots__ = ("entry",)
@@ -86,7 +95,12 @@ class EntryInfo(_message.Message):
     name: str
     type: FileType
     path: str
-    def __init__(self, name: _Optional[str] = ..., type: _Optional[_Union[FileType, str]] = ..., path: _Optional[str] = ...) -> None: ...
+    def __init__(
+        self,
+        name: _Optional[str] = ...,
+        type: _Optional[_Union[FileType, str]] = ...,
+        path: _Optional[str] = ...,
+    ) -> None: ...
 
 class ListDirRequest(_message.Message):
     __slots__ = ("path",)
@@ -98,7 +112,9 @@ class ListDirResponse(_message.Message):
     __slots__ = ("entries",)
     ENTRIES_FIELD_NUMBER: _ClassVar[int]
     entries: _containers.RepeatedCompositeFieldContainer[EntryInfo]
-    def __init__(self, entries: _Optional[_Iterable[_Union[EntryInfo, _Mapping]]] = ...) -> None: ...
+    def __init__(
+        self, entries: _Optional[_Iterable[_Union[EntryInfo, _Mapping]]] = ...
+    ) -> None: ...
 
 class WatchDirRequest(_message.Message):
     __slots__ = ("path",)
@@ -112,13 +128,17 @@ class FilesystemEvent(_message.Message):
     TYPE_FIELD_NUMBER: _ClassVar[int]
     name: str
     type: EventType
-    def __init__(self, name: _Optional[str] = ..., type: _Optional[_Union[EventType, str]] = ...) -> None: ...
+    def __init__(
+        self, name: _Optional[str] = ..., type: _Optional[_Union[EventType, str]] = ...
+    ) -> None: ...
 
 class WatchDirResponse(_message.Message):
     __slots__ = ("start", "filesystem", "keepalive")
+
     class StartEvent(_message.Message):
         __slots__ = ()
         def __init__(self) -> None: ...
+
     class KeepAlive(_message.Message):
         __slots__ = ()
         def __init__(self) -> None: ...
@@ -128,7 +148,12 @@ class WatchDirResponse(_message.Message):
     start: WatchDirResponse.StartEvent
     filesystem: FilesystemEvent
     keepalive: WatchDirResponse.KeepAlive
-    def __init__(self, start: _Optional[_Union[WatchDirResponse.StartEvent, _Mapping]] = ..., filesystem: _Optional[_Union[FilesystemEvent, _Mapping]] = ..., keepalive: _Optional[_Union[WatchDirResponse.KeepAlive, _Mapping]] = ...) -> None: ...
+    def __init__(
+        self,
+        start: _Optional[_Union[WatchDirResponse.StartEvent, _Mapping]] = ...,
+        filesystem: _Optional[_Union[FilesystemEvent, _Mapping]] = ...,
+        keepalive: _Optional[_Union[WatchDirResponse.KeepAlive, _Mapping]] = ...,
+    ) -> None: ...
 
 class WatchDirStartResponse(_message.Message):
     __slots__ = ("watcherId",)
@@ -136,19 +161,23 @@ class WatchDirStartResponse(_message.Message):
     watcherId: str
     def __init__(self, watcherId: _Optional[str] = ...) -> None: ...
 
-class WatchDirPollRequest(_message.Message):
-    __slots__ = ("watcherId", "offset")
-    WATCHERID_FIELD_NUMBER: _ClassVar[int]
+class WatchDirGetRequest(_message.Message):
+    __slots__ = ("watcher_id", "offset")
+    WATCHER_ID_FIELD_NUMBER: _ClassVar[int]
     OFFSET_FIELD_NUMBER: _ClassVar[int]
-    watcherId: str
+    watcher_id: str
     offset: int
-    def __init__(self, watcherId: _Optional[str] = ..., offset: _Optional[int] = ...) -> None: ...
+    def __init__(
+        self, watcher_id: _Optional[str] = ..., offset: _Optional[int] = ...
+    ) -> None: ...
 
-class WatchDirPollResponse(_message.Message):
+class WatchDirGetResponse(_message.Message):
     __slots__ = ("events",)
     EVENTS_FIELD_NUMBER: _ClassVar[int]
     events: _containers.RepeatedCompositeFieldContainer[FilesystemEvent]
-    def __init__(self, events: _Optional[_Iterable[_Union[FilesystemEvent, _Mapping]]] = ...) -> None: ...
+    def __init__(
+        self, events: _Optional[_Iterable[_Union[FilesystemEvent, _Mapping]]] = ...
+    ) -> None: ...
 
 class WatchDirStopRequest(_message.Message):
     __slots__ = ("watcherId",)

--- a/packages/python-sdk/e2b/envd/filesystem/filesystem_pb2.pyi
+++ b/packages/python-sdk/e2b/envd/filesystem/filesystem_pb2.pyi
@@ -106,18 +106,19 @@ class WatchDirRequest(_message.Message):
     path: str
     def __init__(self, path: _Optional[str] = ...) -> None: ...
 
+class FilesystemEvent(_message.Message):
+    __slots__ = ("name", "type")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    TYPE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    type: EventType
+    def __init__(self, name: _Optional[str] = ..., type: _Optional[_Union[EventType, str]] = ...) -> None: ...
+
 class WatchDirResponse(_message.Message):
     __slots__ = ("start", "filesystem", "keepalive")
     class StartEvent(_message.Message):
         __slots__ = ()
         def __init__(self) -> None: ...
-    class FilesystemEvent(_message.Message):
-        __slots__ = ("name", "type")
-        NAME_FIELD_NUMBER: _ClassVar[int]
-        TYPE_FIELD_NUMBER: _ClassVar[int]
-        name: str
-        type: EventType
-        def __init__(self, name: _Optional[str] = ..., type: _Optional[_Union[EventType, str]] = ...) -> None: ...
     class KeepAlive(_message.Message):
         __slots__ = ()
         def __init__(self) -> None: ...
@@ -125,6 +126,36 @@ class WatchDirResponse(_message.Message):
     FILESYSTEM_FIELD_NUMBER: _ClassVar[int]
     KEEPALIVE_FIELD_NUMBER: _ClassVar[int]
     start: WatchDirResponse.StartEvent
-    filesystem: WatchDirResponse.FilesystemEvent
+    filesystem: FilesystemEvent
     keepalive: WatchDirResponse.KeepAlive
-    def __init__(self, start: _Optional[_Union[WatchDirResponse.StartEvent, _Mapping]] = ..., filesystem: _Optional[_Union[WatchDirResponse.FilesystemEvent, _Mapping]] = ..., keepalive: _Optional[_Union[WatchDirResponse.KeepAlive, _Mapping]] = ...) -> None: ...
+    def __init__(self, start: _Optional[_Union[WatchDirResponse.StartEvent, _Mapping]] = ..., filesystem: _Optional[_Union[FilesystemEvent, _Mapping]] = ..., keepalive: _Optional[_Union[WatchDirResponse.KeepAlive, _Mapping]] = ...) -> None: ...
+
+class WatchDirStartResponse(_message.Message):
+    __slots__ = ("watcherId",)
+    WATCHERID_FIELD_NUMBER: _ClassVar[int]
+    watcherId: str
+    def __init__(self, watcherId: _Optional[str] = ...) -> None: ...
+
+class WatchDirPollRequest(_message.Message):
+    __slots__ = ("watcherId", "offset")
+    WATCHERID_FIELD_NUMBER: _ClassVar[int]
+    OFFSET_FIELD_NUMBER: _ClassVar[int]
+    watcherId: str
+    offset: int
+    def __init__(self, watcherId: _Optional[str] = ..., offset: _Optional[int] = ...) -> None: ...
+
+class WatchDirPollResponse(_message.Message):
+    __slots__ = ("events",)
+    EVENTS_FIELD_NUMBER: _ClassVar[int]
+    events: _containers.RepeatedCompositeFieldContainer[FilesystemEvent]
+    def __init__(self, events: _Optional[_Iterable[_Union[FilesystemEvent, _Mapping]]] = ...) -> None: ...
+
+class WatchDirStopRequest(_message.Message):
+    __slots__ = ("watcherId",)
+    WATCHERID_FIELD_NUMBER: _ClassVar[int]
+    watcherId: str
+    def __init__(self, watcherId: _Optional[str] = ...) -> None: ...
+
+class WatchDirStopResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...

--- a/packages/python-sdk/e2b/envd/filesystem/filesystem_pb2.pyi
+++ b/packages/python-sdk/e2b/envd/filesystem/filesystem_pb2.pyi
@@ -156,20 +156,16 @@ class WatchDirResponse(_message.Message):
     ) -> None: ...
 
 class WatchDirStartResponse(_message.Message):
-    __slots__ = ("watcherId",)
-    WATCHERID_FIELD_NUMBER: _ClassVar[int]
-    watcherId: str
-    def __init__(self, watcherId: _Optional[str] = ...) -> None: ...
+    __slots__ = ("watcher_id",)
+    WATCHER_ID_FIELD_NUMBER: _ClassVar[int]
+    watcher_id: str
+    def __init__(self, watcher_id: _Optional[str] = ...) -> None: ...
 
 class WatchDirGetRequest(_message.Message):
-    __slots__ = ("watcher_id", "offset")
+    __slots__ = ("watcher_id",)
     WATCHER_ID_FIELD_NUMBER: _ClassVar[int]
-    OFFSET_FIELD_NUMBER: _ClassVar[int]
     watcher_id: str
-    offset: int
-    def __init__(
-        self, watcher_id: _Optional[str] = ..., offset: _Optional[int] = ...
-    ) -> None: ...
+    def __init__(self, watcher_id: _Optional[str] = ...) -> None: ...
 
 class WatchDirGetResponse(_message.Message):
     __slots__ = ("events",)
@@ -180,10 +176,10 @@ class WatchDirGetResponse(_message.Message):
     ) -> None: ...
 
 class WatchDirStopRequest(_message.Message):
-    __slots__ = ("watcherId",)
-    WATCHERID_FIELD_NUMBER: _ClassVar[int]
-    watcherId: str
-    def __init__(self, watcherId: _Optional[str] = ...) -> None: ...
+    __slots__ = ("watcher_id",)
+    WATCHER_ID_FIELD_NUMBER: _ClassVar[int]
+    watcher_id: str
+    def __init__(self, watcher_id: _Optional[str] = ...) -> None: ...
 
 class WatchDirStopResponse(_message.Message):
     __slots__ = ()

--- a/packages/python-sdk/e2b/envd/process/process_connect.py
+++ b/packages/python-sdk/e2b/envd/process/process_connect.py
@@ -10,7 +10,16 @@ ProcessName = "process.Process"
 
 
 class ProcessClient:
-    def __init__(self, base_url: str, *, pool: Optional[ConnectionPool] = None, async_pool: Optional[AsyncConnectionPool] = None, compressor=None, json=False, **opts):
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        pool: Optional[ConnectionPool] = None,
+        async_pool: Optional[AsyncConnectionPool] = None,
+        compressor=None,
+        json=False,
+        **opts,
+    ):
         self._list = connect.Client(
             pool=pool,
             async_pool=async_pool,
@@ -18,7 +27,7 @@ class ProcessClient:
             response_type=process_dot_process__pb2.ListResponse,
             compressor=compressor,
             json=json,
-            **opts
+            **opts,
         )
         self._connect = connect.Client(
             pool=pool,
@@ -27,7 +36,7 @@ class ProcessClient:
             response_type=process_dot_process__pb2.ConnectResponse,
             compressor=compressor,
             json=json,
-            **opts
+            **opts,
         )
         self._start = connect.Client(
             pool=pool,
@@ -36,7 +45,7 @@ class ProcessClient:
             response_type=process_dot_process__pb2.StartResponse,
             compressor=compressor,
             json=json,
-            **opts
+            **opts,
         )
         self._update = connect.Client(
             pool=pool,
@@ -45,7 +54,7 @@ class ProcessClient:
             response_type=process_dot_process__pb2.UpdateResponse,
             compressor=compressor,
             json=json,
-            **opts
+            **opts,
         )
         self._stream_input = connect.Client(
             pool=pool,
@@ -54,7 +63,7 @@ class ProcessClient:
             response_type=process_dot_process__pb2.StreamInputResponse,
             compressor=compressor,
             json=json,
-            **opts
+            **opts,
         )
         self._send_input = connect.Client(
             pool=pool,
@@ -63,7 +72,7 @@ class ProcessClient:
             response_type=process_dot_process__pb2.SendInputResponse,
             compressor=compressor,
             json=json,
-            **opts
+            **opts,
         )
         self._send_signal = connect.Client(
             pool=pool,
@@ -72,47 +81,75 @@ class ProcessClient:
             response_type=process_dot_process__pb2.SendSignalResponse,
             compressor=compressor,
             json=json,
-            **opts
+            **opts,
         )
 
-    def list(self, req: process_dot_process__pb2.ListRequest, **opts) -> process_dot_process__pb2.ListResponse:
+    def list(
+        self, req: process_dot_process__pb2.ListRequest, **opts
+    ) -> process_dot_process__pb2.ListResponse:
         return self._list.call_unary(req, **opts)
 
-    def alist(self, req: process_dot_process__pb2.ListRequest, **opts) -> Coroutine[Any, Any, process_dot_process__pb2.ListResponse]:
+    def alist(
+        self, req: process_dot_process__pb2.ListRequest, **opts
+    ) -> Coroutine[Any, Any, process_dot_process__pb2.ListResponse]:
         return self._list.acall_unary(req, **opts)
 
-    def connect(self, req: process_dot_process__pb2.ConnectRequest , **opts) -> Generator[process_dot_process__pb2.ConnectResponse, Any, None]:
+    def connect(
+        self, req: process_dot_process__pb2.ConnectRequest, **opts
+    ) -> Generator[process_dot_process__pb2.ConnectResponse, Any, None]:
         return self._connect.call_server_stream(req, **opts)
 
-    def aconnect(self, req: process_dot_process__pb2.ConnectRequest , **opts) -> AsyncGenerator[process_dot_process__pb2.ConnectResponse, Any]:
+    def aconnect(
+        self, req: process_dot_process__pb2.ConnectRequest, **opts
+    ) -> AsyncGenerator[process_dot_process__pb2.ConnectResponse, Any]:
         return self._connect.acall_server_stream(req, **opts)
 
-    def start(self, req: process_dot_process__pb2.StartRequest , **opts) -> Generator[process_dot_process__pb2.StartResponse, Any, None]:
+    def start(
+        self, req: process_dot_process__pb2.StartRequest, **opts
+    ) -> Generator[process_dot_process__pb2.StartResponse, Any, None]:
         return self._start.call_server_stream(req, **opts)
 
-    def astart(self, req: process_dot_process__pb2.StartRequest , **opts) -> AsyncGenerator[process_dot_process__pb2.StartResponse, Any]:
+    def astart(
+        self, req: process_dot_process__pb2.StartRequest, **opts
+    ) -> AsyncGenerator[process_dot_process__pb2.StartResponse, Any]:
         return self._start.acall_server_stream(req, **opts)
 
-    def update(self, req: process_dot_process__pb2.UpdateRequest, **opts) -> process_dot_process__pb2.UpdateResponse:
+    def update(
+        self, req: process_dot_process__pb2.UpdateRequest, **opts
+    ) -> process_dot_process__pb2.UpdateResponse:
         return self._update.call_unary(req, **opts)
 
-    def aupdate(self, req: process_dot_process__pb2.UpdateRequest, **opts) -> Coroutine[Any, Any, process_dot_process__pb2.UpdateResponse]:
+    def aupdate(
+        self, req: process_dot_process__pb2.UpdateRequest, **opts
+    ) -> Coroutine[Any, Any, process_dot_process__pb2.UpdateResponse]:
         return self._update.acall_unary(req, **opts)
 
-    def stream_input(self, req: process_dot_process__pb2.StreamInputRequest, **opts) -> process_dot_process__pb2.StreamInputResponse:
+    def stream_input(
+        self, req: process_dot_process__pb2.StreamInputRequest, **opts
+    ) -> process_dot_process__pb2.StreamInputResponse:
         return self._stream_input.call_client_stream(req, **opts)
 
-    def astream_input(self, req: process_dot_process__pb2.StreamInputRequest, **opts) -> Coroutine[Any, Any, process_dot_process__pb2.StreamInputResponse]:
+    def astream_input(
+        self, req: process_dot_process__pb2.StreamInputRequest, **opts
+    ) -> Coroutine[Any, Any, process_dot_process__pb2.StreamInputResponse]:
         return self._stream_input.acall_client_stream(req, **opts)
 
-    def send_input(self, req: process_dot_process__pb2.SendInputRequest, **opts) -> process_dot_process__pb2.SendInputResponse:
+    def send_input(
+        self, req: process_dot_process__pb2.SendInputRequest, **opts
+    ) -> process_dot_process__pb2.SendInputResponse:
         return self._send_input.call_unary(req, **opts)
 
-    def asend_input(self, req: process_dot_process__pb2.SendInputRequest, **opts) -> Coroutine[Any, Any, process_dot_process__pb2.SendInputResponse]:
+    def asend_input(
+        self, req: process_dot_process__pb2.SendInputRequest, **opts
+    ) -> Coroutine[Any, Any, process_dot_process__pb2.SendInputResponse]:
         return self._send_input.acall_unary(req, **opts)
 
-    def send_signal(self, req: process_dot_process__pb2.SendSignalRequest, **opts) -> process_dot_process__pb2.SendSignalResponse:
+    def send_signal(
+        self, req: process_dot_process__pb2.SendSignalRequest, **opts
+    ) -> process_dot_process__pb2.SendSignalResponse:
         return self._send_signal.call_unary(req, **opts)
 
-    def asend_signal(self, req: process_dot_process__pb2.SendSignalRequest, **opts) -> Coroutine[Any, Any, process_dot_process__pb2.SendSignalResponse]:
+    def asend_signal(
+        self, req: process_dot_process__pb2.SendSignalRequest, **opts
+    ) -> Coroutine[Any, Any, process_dot_process__pb2.SendSignalResponse]:
         return self._send_signal.acall_unary(req, **opts)

--- a/packages/python-sdk/e2b/envd/process/process_pb2.py
+++ b/packages/python-sdk/e2b/envd/process/process_pb2.py
@@ -7,83 +7,86 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import symbol_database as _symbol_database
 from google.protobuf.internal import builder as _builder
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
 
-
-
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15process/process.proto\x12\x07process\"\\\n\x03PTY\x12%\n\x04size\x18\x01 \x01(\x0b\x32\x11.process.PTY.SizeR\x04size\x1a.\n\x04Size\x12\x12\n\x04\x63ols\x18\x01 \x01(\rR\x04\x63ols\x12\x12\n\x04rows\x18\x02 \x01(\rR\x04rows\"\xc3\x01\n\rProcessConfig\x12\x10\n\x03\x63md\x18\x01 \x01(\tR\x03\x63md\x12\x12\n\x04\x61rgs\x18\x02 \x03(\tR\x04\x61rgs\x12\x34\n\x04\x65nvs\x18\x03 \x03(\x0b\x32 .process.ProcessConfig.EnvsEntryR\x04\x65nvs\x12\x15\n\x03\x63wd\x18\x04 \x01(\tH\x00R\x03\x63wd\x88\x01\x01\x1a\x37\n\tEnvsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x06\n\x04_cwd\"\r\n\x0bListRequest\"n\n\x0bProcessInfo\x12.\n\x06\x63onfig\x18\x01 \x01(\x0b\x32\x16.process.ProcessConfigR\x06\x63onfig\x12\x10\n\x03pid\x18\x02 \x01(\rR\x03pid\x12\x15\n\x03tag\x18\x03 \x01(\tH\x00R\x03tag\x88\x01\x01\x42\x06\n\x04_tag\"B\n\x0cListResponse\x12\x32\n\tprocesses\x18\x01 \x03(\x0b\x32\x14.process.ProcessInfoR\tprocesses\"\x8c\x01\n\x0cStartRequest\x12\x30\n\x07process\x18\x01 \x01(\x0b\x32\x16.process.ProcessConfigR\x07process\x12#\n\x03pty\x18\x02 \x01(\x0b\x32\x0c.process.PTYH\x00R\x03pty\x88\x01\x01\x12\x15\n\x03tag\x18\x03 \x01(\tH\x01R\x03tag\x88\x01\x01\x42\x06\n\x04_ptyB\x06\n\x04_tag\"p\n\rUpdateRequest\x12\x32\n\x07process\x18\x01 \x01(\x0b\x32\x18.process.ProcessSelectorR\x07process\x12#\n\x03pty\x18\x02 \x01(\x0b\x32\x0c.process.PTYH\x00R\x03pty\x88\x01\x01\x42\x06\n\x04_pty\"\x10\n\x0eUpdateResponse\"\x87\x04\n\x0cProcessEvent\x12\x38\n\x05start\x18\x01 \x01(\x0b\x32 .process.ProcessEvent.StartEventH\x00R\x05start\x12\x35\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x1f.process.ProcessEvent.DataEventH\x00R\x04\x64\x61ta\x12\x32\n\x03\x65nd\x18\x03 \x01(\x0b\x32\x1e.process.ProcessEvent.EndEventH\x00R\x03\x65nd\x12?\n\tkeepalive\x18\x04 \x01(\x0b\x32\x1f.process.ProcessEvent.KeepAliveH\x00R\tkeepalive\x1a\x1e\n\nStartEvent\x12\x10\n\x03pid\x18\x01 \x01(\rR\x03pid\x1a]\n\tDataEvent\x12\x18\n\x06stdout\x18\x01 \x01(\x0cH\x00R\x06stdout\x12\x18\n\x06stderr\x18\x02 \x01(\x0cH\x00R\x06stderr\x12\x12\n\x03pty\x18\x03 \x01(\x0cH\x00R\x03ptyB\x08\n\x06output\x1a|\n\x08\x45ndEvent\x12\x1b\n\texit_code\x18\x01 \x01(\x11R\x08\x65xitCode\x12\x16\n\x06\x65xited\x18\x02 \x01(\x08R\x06\x65xited\x12\x16\n\x06status\x18\x03 \x01(\tR\x06status\x12\x19\n\x05\x65rror\x18\x04 \x01(\tH\x00R\x05\x65rror\x88\x01\x01\x42\x08\n\x06_error\x1a\x0b\n\tKeepAliveB\x07\n\x05\x65vent\"<\n\rStartResponse\x12+\n\x05\x65vent\x18\x01 \x01(\x0b\x32\x15.process.ProcessEventR\x05\x65vent\">\n\x0f\x43onnectResponse\x12+\n\x05\x65vent\x18\x01 \x01(\x0b\x32\x15.process.ProcessEventR\x05\x65vent\"s\n\x10SendInputRequest\x12\x32\n\x07process\x18\x01 \x01(\x0b\x32\x18.process.ProcessSelectorR\x07process\x12+\n\x05input\x18\x02 \x01(\x0b\x32\x15.process.ProcessInputR\x05input\"\x13\n\x11SendInputResponse\"C\n\x0cProcessInput\x12\x16\n\x05stdin\x18\x01 \x01(\x0cH\x00R\x05stdin\x12\x12\n\x03pty\x18\x02 \x01(\x0cH\x00R\x03ptyB\x07\n\x05input\"\xea\x02\n\x12StreamInputRequest\x12>\n\x05start\x18\x01 \x01(\x0b\x32&.process.StreamInputRequest.StartEventH\x00R\x05start\x12;\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32%.process.StreamInputRequest.DataEventH\x00R\x04\x64\x61ta\x12\x45\n\tkeepalive\x18\x03 \x01(\x0b\x32%.process.StreamInputRequest.KeepAliveH\x00R\tkeepalive\x1a@\n\nStartEvent\x12\x32\n\x07process\x18\x01 \x01(\x0b\x32\x18.process.ProcessSelectorR\x07process\x1a\x38\n\tDataEvent\x12+\n\x05input\x18\x02 \x01(\x0b\x32\x15.process.ProcessInputR\x05input\x1a\x0b\n\tKeepAliveB\x07\n\x05\x65vent\"\x15\n\x13StreamInputResponse\"p\n\x11SendSignalRequest\x12\x32\n\x07process\x18\x01 \x01(\x0b\x32\x18.process.ProcessSelectorR\x07process\x12\'\n\x06signal\x18\x02 \x01(\x0e\x32\x0f.process.SignalR\x06signal\"\x14\n\x12SendSignalResponse\"D\n\x0e\x43onnectRequest\x12\x32\n\x07process\x18\x01 \x01(\x0b\x32\x18.process.ProcessSelectorR\x07process\"E\n\x0fProcessSelector\x12\x12\n\x03pid\x18\x01 \x01(\rH\x00R\x03pid\x12\x12\n\x03tag\x18\x02 \x01(\tH\x00R\x03tagB\n\n\x08selector*H\n\x06Signal\x12\x16\n\x12SIGNAL_UNSPECIFIED\x10\x00\x12\x12\n\x0eSIGNAL_SIGTERM\x10\x0f\x12\x12\n\x0eSIGNAL_SIGKILL\x10\t2\xca\x03\n\x07Process\x12\x33\n\x04List\x12\x14.process.ListRequest\x1a\x15.process.ListResponse\x12>\n\x07\x43onnect\x12\x17.process.ConnectRequest\x1a\x18.process.ConnectResponse0\x01\x12\x38\n\x05Start\x12\x15.process.StartRequest\x1a\x16.process.StartResponse0\x01\x12\x39\n\x06Update\x12\x16.process.UpdateRequest\x1a\x17.process.UpdateResponse\x12J\n\x0bStreamInput\x12\x1b.process.StreamInputRequest\x1a\x1c.process.StreamInputResponse(\x01\x12\x42\n\tSendInput\x12\x19.process.SendInputRequest\x1a\x1a.process.SendInputResponse\x12\x45\n\nSendSignal\x12\x1a.process.SendSignalRequest\x1a\x1b.process.SendSignalResponseBW\n\x0b\x63om.processB\x0cProcessProtoP\x01\xa2\x02\x03PXX\xaa\x02\x07Process\xca\x02\x07Process\xe2\x02\x13Process\\GPBMetadata\xea\x02\x07Processb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
+    b'\n\x15process/process.proto\x12\x07process"\\\n\x03PTY\x12%\n\x04size\x18\x01 \x01(\x0b\x32\x11.process.PTY.SizeR\x04size\x1a.\n\x04Size\x12\x12\n\x04\x63ols\x18\x01 \x01(\rR\x04\x63ols\x12\x12\n\x04rows\x18\x02 \x01(\rR\x04rows"\xc3\x01\n\rProcessConfig\x12\x10\n\x03\x63md\x18\x01 \x01(\tR\x03\x63md\x12\x12\n\x04\x61rgs\x18\x02 \x03(\tR\x04\x61rgs\x12\x34\n\x04\x65nvs\x18\x03 \x03(\x0b\x32 .process.ProcessConfig.EnvsEntryR\x04\x65nvs\x12\x15\n\x03\x63wd\x18\x04 \x01(\tH\x00R\x03\x63wd\x88\x01\x01\x1a\x37\n\tEnvsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x06\n\x04_cwd"\r\n\x0bListRequest"n\n\x0bProcessInfo\x12.\n\x06\x63onfig\x18\x01 \x01(\x0b\x32\x16.process.ProcessConfigR\x06\x63onfig\x12\x10\n\x03pid\x18\x02 \x01(\rR\x03pid\x12\x15\n\x03tag\x18\x03 \x01(\tH\x00R\x03tag\x88\x01\x01\x42\x06\n\x04_tag"B\n\x0cListResponse\x12\x32\n\tprocesses\x18\x01 \x03(\x0b\x32\x14.process.ProcessInfoR\tprocesses"\x8c\x01\n\x0cStartRequest\x12\x30\n\x07process\x18\x01 \x01(\x0b\x32\x16.process.ProcessConfigR\x07process\x12#\n\x03pty\x18\x02 \x01(\x0b\x32\x0c.process.PTYH\x00R\x03pty\x88\x01\x01\x12\x15\n\x03tag\x18\x03 \x01(\tH\x01R\x03tag\x88\x01\x01\x42\x06\n\x04_ptyB\x06\n\x04_tag"p\n\rUpdateRequest\x12\x32\n\x07process\x18\x01 \x01(\x0b\x32\x18.process.ProcessSelectorR\x07process\x12#\n\x03pty\x18\x02 \x01(\x0b\x32\x0c.process.PTYH\x00R\x03pty\x88\x01\x01\x42\x06\n\x04_pty"\x10\n\x0eUpdateResponse"\x87\x04\n\x0cProcessEvent\x12\x38\n\x05start\x18\x01 \x01(\x0b\x32 .process.ProcessEvent.StartEventH\x00R\x05start\x12\x35\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x1f.process.ProcessEvent.DataEventH\x00R\x04\x64\x61ta\x12\x32\n\x03\x65nd\x18\x03 \x01(\x0b\x32\x1e.process.ProcessEvent.EndEventH\x00R\x03\x65nd\x12?\n\tkeepalive\x18\x04 \x01(\x0b\x32\x1f.process.ProcessEvent.KeepAliveH\x00R\tkeepalive\x1a\x1e\n\nStartEvent\x12\x10\n\x03pid\x18\x01 \x01(\rR\x03pid\x1a]\n\tDataEvent\x12\x18\n\x06stdout\x18\x01 \x01(\x0cH\x00R\x06stdout\x12\x18\n\x06stderr\x18\x02 \x01(\x0cH\x00R\x06stderr\x12\x12\n\x03pty\x18\x03 \x01(\x0cH\x00R\x03ptyB\x08\n\x06output\x1a|\n\x08\x45ndEvent\x12\x1b\n\texit_code\x18\x01 \x01(\x11R\x08\x65xitCode\x12\x16\n\x06\x65xited\x18\x02 \x01(\x08R\x06\x65xited\x12\x16\n\x06status\x18\x03 \x01(\tR\x06status\x12\x19\n\x05\x65rror\x18\x04 \x01(\tH\x00R\x05\x65rror\x88\x01\x01\x42\x08\n\x06_error\x1a\x0b\n\tKeepAliveB\x07\n\x05\x65vent"<\n\rStartResponse\x12+\n\x05\x65vent\x18\x01 \x01(\x0b\x32\x15.process.ProcessEventR\x05\x65vent">\n\x0f\x43onnectResponse\x12+\n\x05\x65vent\x18\x01 \x01(\x0b\x32\x15.process.ProcessEventR\x05\x65vent"s\n\x10SendInputRequest\x12\x32\n\x07process\x18\x01 \x01(\x0b\x32\x18.process.ProcessSelectorR\x07process\x12+\n\x05input\x18\x02 \x01(\x0b\x32\x15.process.ProcessInputR\x05input"\x13\n\x11SendInputResponse"C\n\x0cProcessInput\x12\x16\n\x05stdin\x18\x01 \x01(\x0cH\x00R\x05stdin\x12\x12\n\x03pty\x18\x02 \x01(\x0cH\x00R\x03ptyB\x07\n\x05input"\xea\x02\n\x12StreamInputRequest\x12>\n\x05start\x18\x01 \x01(\x0b\x32&.process.StreamInputRequest.StartEventH\x00R\x05start\x12;\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32%.process.StreamInputRequest.DataEventH\x00R\x04\x64\x61ta\x12\x45\n\tkeepalive\x18\x03 \x01(\x0b\x32%.process.StreamInputRequest.KeepAliveH\x00R\tkeepalive\x1a@\n\nStartEvent\x12\x32\n\x07process\x18\x01 \x01(\x0b\x32\x18.process.ProcessSelectorR\x07process\x1a\x38\n\tDataEvent\x12+\n\x05input\x18\x02 \x01(\x0b\x32\x15.process.ProcessInputR\x05input\x1a\x0b\n\tKeepAliveB\x07\n\x05\x65vent"\x15\n\x13StreamInputResponse"p\n\x11SendSignalRequest\x12\x32\n\x07process\x18\x01 \x01(\x0b\x32\x18.process.ProcessSelectorR\x07process\x12\'\n\x06signal\x18\x02 \x01(\x0e\x32\x0f.process.SignalR\x06signal"\x14\n\x12SendSignalResponse"D\n\x0e\x43onnectRequest\x12\x32\n\x07process\x18\x01 \x01(\x0b\x32\x18.process.ProcessSelectorR\x07process"E\n\x0fProcessSelector\x12\x12\n\x03pid\x18\x01 \x01(\rH\x00R\x03pid\x12\x12\n\x03tag\x18\x02 \x01(\tH\x00R\x03tagB\n\n\x08selector*H\n\x06Signal\x12\x16\n\x12SIGNAL_UNSPECIFIED\x10\x00\x12\x12\n\x0eSIGNAL_SIGTERM\x10\x0f\x12\x12\n\x0eSIGNAL_SIGKILL\x10\t2\xca\x03\n\x07Process\x12\x33\n\x04List\x12\x14.process.ListRequest\x1a\x15.process.ListResponse\x12>\n\x07\x43onnect\x12\x17.process.ConnectRequest\x1a\x18.process.ConnectResponse0\x01\x12\x38\n\x05Start\x12\x15.process.StartRequest\x1a\x16.process.StartResponse0\x01\x12\x39\n\x06Update\x12\x16.process.UpdateRequest\x1a\x17.process.UpdateResponse\x12J\n\x0bStreamInput\x12\x1b.process.StreamInputRequest\x1a\x1c.process.StreamInputResponse(\x01\x12\x42\n\tSendInput\x12\x19.process.SendInputRequest\x1a\x1a.process.SendInputResponse\x12\x45\n\nSendSignal\x12\x1a.process.SendSignalRequest\x1a\x1b.process.SendSignalResponseBW\n\x0b\x63om.processB\x0cProcessProtoP\x01\xa2\x02\x03PXX\xaa\x02\x07Process\xca\x02\x07Process\xe2\x02\x13Process\\GPBMetadata\xea\x02\x07Processb\x06proto3'
+)
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'process.process_pb2', _globals)
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "process.process_pb2", _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
-  _globals['DESCRIPTOR']._loaded_options = None
-  _globals['DESCRIPTOR']._serialized_options = b'\n\013com.processB\014ProcessProtoP\001\242\002\003PXX\252\002\007Process\312\002\007Process\342\002\023Process\\GPBMetadata\352\002\007Process'
-  _globals['_PROCESSCONFIG_ENVSENTRY']._loaded_options = None
-  _globals['_PROCESSCONFIG_ENVSENTRY']._serialized_options = b'8\001'
-  _globals['_SIGNAL']._serialized_start=2316
-  _globals['_SIGNAL']._serialized_end=2388
-  _globals['_PTY']._serialized_start=34
-  _globals['_PTY']._serialized_end=126
-  _globals['_PTY_SIZE']._serialized_start=80
-  _globals['_PTY_SIZE']._serialized_end=126
-  _globals['_PROCESSCONFIG']._serialized_start=129
-  _globals['_PROCESSCONFIG']._serialized_end=324
-  _globals['_PROCESSCONFIG_ENVSENTRY']._serialized_start=261
-  _globals['_PROCESSCONFIG_ENVSENTRY']._serialized_end=316
-  _globals['_LISTREQUEST']._serialized_start=326
-  _globals['_LISTREQUEST']._serialized_end=339
-  _globals['_PROCESSINFO']._serialized_start=341
-  _globals['_PROCESSINFO']._serialized_end=451
-  _globals['_LISTRESPONSE']._serialized_start=453
-  _globals['_LISTRESPONSE']._serialized_end=519
-  _globals['_STARTREQUEST']._serialized_start=522
-  _globals['_STARTREQUEST']._serialized_end=662
-  _globals['_UPDATEREQUEST']._serialized_start=664
-  _globals['_UPDATEREQUEST']._serialized_end=776
-  _globals['_UPDATERESPONSE']._serialized_start=778
-  _globals['_UPDATERESPONSE']._serialized_end=794
-  _globals['_PROCESSEVENT']._serialized_start=797
-  _globals['_PROCESSEVENT']._serialized_end=1316
-  _globals['_PROCESSEVENT_STARTEVENT']._serialized_start=1043
-  _globals['_PROCESSEVENT_STARTEVENT']._serialized_end=1073
-  _globals['_PROCESSEVENT_DATAEVENT']._serialized_start=1075
-  _globals['_PROCESSEVENT_DATAEVENT']._serialized_end=1168
-  _globals['_PROCESSEVENT_ENDEVENT']._serialized_start=1170
-  _globals['_PROCESSEVENT_ENDEVENT']._serialized_end=1294
-  _globals['_PROCESSEVENT_KEEPALIVE']._serialized_start=1296
-  _globals['_PROCESSEVENT_KEEPALIVE']._serialized_end=1307
-  _globals['_STARTRESPONSE']._serialized_start=1318
-  _globals['_STARTRESPONSE']._serialized_end=1378
-  _globals['_CONNECTRESPONSE']._serialized_start=1380
-  _globals['_CONNECTRESPONSE']._serialized_end=1442
-  _globals['_SENDINPUTREQUEST']._serialized_start=1444
-  _globals['_SENDINPUTREQUEST']._serialized_end=1559
-  _globals['_SENDINPUTRESPONSE']._serialized_start=1561
-  _globals['_SENDINPUTRESPONSE']._serialized_end=1580
-  _globals['_PROCESSINPUT']._serialized_start=1582
-  _globals['_PROCESSINPUT']._serialized_end=1649
-  _globals['_STREAMINPUTREQUEST']._serialized_start=1652
-  _globals['_STREAMINPUTREQUEST']._serialized_end=2014
-  _globals['_STREAMINPUTREQUEST_STARTEVENT']._serialized_start=1870
-  _globals['_STREAMINPUTREQUEST_STARTEVENT']._serialized_end=1934
-  _globals['_STREAMINPUTREQUEST_DATAEVENT']._serialized_start=1936
-  _globals['_STREAMINPUTREQUEST_DATAEVENT']._serialized_end=1992
-  _globals['_STREAMINPUTREQUEST_KEEPALIVE']._serialized_start=1296
-  _globals['_STREAMINPUTREQUEST_KEEPALIVE']._serialized_end=1307
-  _globals['_STREAMINPUTRESPONSE']._serialized_start=2016
-  _globals['_STREAMINPUTRESPONSE']._serialized_end=2037
-  _globals['_SENDSIGNALREQUEST']._serialized_start=2039
-  _globals['_SENDSIGNALREQUEST']._serialized_end=2151
-  _globals['_SENDSIGNALRESPONSE']._serialized_start=2153
-  _globals['_SENDSIGNALRESPONSE']._serialized_end=2173
-  _globals['_CONNECTREQUEST']._serialized_start=2175
-  _globals['_CONNECTREQUEST']._serialized_end=2243
-  _globals['_PROCESSSELECTOR']._serialized_start=2245
-  _globals['_PROCESSSELECTOR']._serialized_end=2314
-  _globals['_PROCESS']._serialized_start=2391
-  _globals['_PROCESS']._serialized_end=2849
+    _globals["DESCRIPTOR"]._loaded_options = None
+    _globals["DESCRIPTOR"]._serialized_options = (
+        b"\n\013com.processB\014ProcessProtoP\001\242\002\003PXX\252\002\007Process\312\002\007Process\342\002\023Process\\GPBMetadata\352\002\007Process"
+    )
+    _globals["_PROCESSCONFIG_ENVSENTRY"]._loaded_options = None
+    _globals["_PROCESSCONFIG_ENVSENTRY"]._serialized_options = b"8\001"
+    _globals["_SIGNAL"]._serialized_start = 2316
+    _globals["_SIGNAL"]._serialized_end = 2388
+    _globals["_PTY"]._serialized_start = 34
+    _globals["_PTY"]._serialized_end = 126
+    _globals["_PTY_SIZE"]._serialized_start = 80
+    _globals["_PTY_SIZE"]._serialized_end = 126
+    _globals["_PROCESSCONFIG"]._serialized_start = 129
+    _globals["_PROCESSCONFIG"]._serialized_end = 324
+    _globals["_PROCESSCONFIG_ENVSENTRY"]._serialized_start = 261
+    _globals["_PROCESSCONFIG_ENVSENTRY"]._serialized_end = 316
+    _globals["_LISTREQUEST"]._serialized_start = 326
+    _globals["_LISTREQUEST"]._serialized_end = 339
+    _globals["_PROCESSINFO"]._serialized_start = 341
+    _globals["_PROCESSINFO"]._serialized_end = 451
+    _globals["_LISTRESPONSE"]._serialized_start = 453
+    _globals["_LISTRESPONSE"]._serialized_end = 519
+    _globals["_STARTREQUEST"]._serialized_start = 522
+    _globals["_STARTREQUEST"]._serialized_end = 662
+    _globals["_UPDATEREQUEST"]._serialized_start = 664
+    _globals["_UPDATEREQUEST"]._serialized_end = 776
+    _globals["_UPDATERESPONSE"]._serialized_start = 778
+    _globals["_UPDATERESPONSE"]._serialized_end = 794
+    _globals["_PROCESSEVENT"]._serialized_start = 797
+    _globals["_PROCESSEVENT"]._serialized_end = 1316
+    _globals["_PROCESSEVENT_STARTEVENT"]._serialized_start = 1043
+    _globals["_PROCESSEVENT_STARTEVENT"]._serialized_end = 1073
+    _globals["_PROCESSEVENT_DATAEVENT"]._serialized_start = 1075
+    _globals["_PROCESSEVENT_DATAEVENT"]._serialized_end = 1168
+    _globals["_PROCESSEVENT_ENDEVENT"]._serialized_start = 1170
+    _globals["_PROCESSEVENT_ENDEVENT"]._serialized_end = 1294
+    _globals["_PROCESSEVENT_KEEPALIVE"]._serialized_start = 1296
+    _globals["_PROCESSEVENT_KEEPALIVE"]._serialized_end = 1307
+    _globals["_STARTRESPONSE"]._serialized_start = 1318
+    _globals["_STARTRESPONSE"]._serialized_end = 1378
+    _globals["_CONNECTRESPONSE"]._serialized_start = 1380
+    _globals["_CONNECTRESPONSE"]._serialized_end = 1442
+    _globals["_SENDINPUTREQUEST"]._serialized_start = 1444
+    _globals["_SENDINPUTREQUEST"]._serialized_end = 1559
+    _globals["_SENDINPUTRESPONSE"]._serialized_start = 1561
+    _globals["_SENDINPUTRESPONSE"]._serialized_end = 1580
+    _globals["_PROCESSINPUT"]._serialized_start = 1582
+    _globals["_PROCESSINPUT"]._serialized_end = 1649
+    _globals["_STREAMINPUTREQUEST"]._serialized_start = 1652
+    _globals["_STREAMINPUTREQUEST"]._serialized_end = 2014
+    _globals["_STREAMINPUTREQUEST_STARTEVENT"]._serialized_start = 1870
+    _globals["_STREAMINPUTREQUEST_STARTEVENT"]._serialized_end = 1934
+    _globals["_STREAMINPUTREQUEST_DATAEVENT"]._serialized_start = 1936
+    _globals["_STREAMINPUTREQUEST_DATAEVENT"]._serialized_end = 1992
+    _globals["_STREAMINPUTREQUEST_KEEPALIVE"]._serialized_start = 1296
+    _globals["_STREAMINPUTREQUEST_KEEPALIVE"]._serialized_end = 1307
+    _globals["_STREAMINPUTRESPONSE"]._serialized_start = 2016
+    _globals["_STREAMINPUTRESPONSE"]._serialized_end = 2037
+    _globals["_SENDSIGNALREQUEST"]._serialized_start = 2039
+    _globals["_SENDSIGNALREQUEST"]._serialized_end = 2151
+    _globals["_SENDSIGNALRESPONSE"]._serialized_start = 2153
+    _globals["_SENDSIGNALRESPONSE"]._serialized_end = 2173
+    _globals["_CONNECTREQUEST"]._serialized_start = 2175
+    _globals["_CONNECTREQUEST"]._serialized_end = 2243
+    _globals["_PROCESSSELECTOR"]._serialized_start = 2245
+    _globals["_PROCESSSELECTOR"]._serialized_end = 2314
+    _globals["_PROCESS"]._serialized_start = 2391
+    _globals["_PROCESS"]._serialized_end = 2849
 # @@protoc_insertion_point(module_scope)

--- a/packages/python-sdk/e2b/envd/process/process_pb2.pyi
+++ b/packages/python-sdk/e2b/envd/process/process_pb2.pyi
@@ -2,7 +2,13 @@ from google.protobuf.internal import containers as _containers
 from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
-from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+from typing import (
+    ClassVar as _ClassVar,
+    Iterable as _Iterable,
+    Mapping as _Mapping,
+    Optional as _Optional,
+    Union as _Union,
+)
 
 DESCRIPTOR: _descriptor.FileDescriptor
 
@@ -11,32 +17,39 @@ class Signal(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     SIGNAL_UNSPECIFIED: _ClassVar[Signal]
     SIGNAL_SIGTERM: _ClassVar[Signal]
     SIGNAL_SIGKILL: _ClassVar[Signal]
+
 SIGNAL_UNSPECIFIED: Signal
 SIGNAL_SIGTERM: Signal
 SIGNAL_SIGKILL: Signal
 
 class PTY(_message.Message):
     __slots__ = ("size",)
+
     class Size(_message.Message):
         __slots__ = ("cols", "rows")
         COLS_FIELD_NUMBER: _ClassVar[int]
         ROWS_FIELD_NUMBER: _ClassVar[int]
         cols: int
         rows: int
-        def __init__(self, cols: _Optional[int] = ..., rows: _Optional[int] = ...) -> None: ...
+        def __init__(
+            self, cols: _Optional[int] = ..., rows: _Optional[int] = ...
+        ) -> None: ...
     SIZE_FIELD_NUMBER: _ClassVar[int]
     size: PTY.Size
     def __init__(self, size: _Optional[_Union[PTY.Size, _Mapping]] = ...) -> None: ...
 
 class ProcessConfig(_message.Message):
     __slots__ = ("cmd", "args", "envs", "cwd")
+
     class EnvsEntry(_message.Message):
         __slots__ = ("key", "value")
         KEY_FIELD_NUMBER: _ClassVar[int]
         VALUE_FIELD_NUMBER: _ClassVar[int]
         key: str
         value: str
-        def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+        def __init__(
+            self, key: _Optional[str] = ..., value: _Optional[str] = ...
+        ) -> None: ...
     CMD_FIELD_NUMBER: _ClassVar[int]
     ARGS_FIELD_NUMBER: _ClassVar[int]
     ENVS_FIELD_NUMBER: _ClassVar[int]
@@ -45,7 +58,13 @@ class ProcessConfig(_message.Message):
     args: _containers.RepeatedScalarFieldContainer[str]
     envs: _containers.ScalarMap[str, str]
     cwd: str
-    def __init__(self, cmd: _Optional[str] = ..., args: _Optional[_Iterable[str]] = ..., envs: _Optional[_Mapping[str, str]] = ..., cwd: _Optional[str] = ...) -> None: ...
+    def __init__(
+        self,
+        cmd: _Optional[str] = ...,
+        args: _Optional[_Iterable[str]] = ...,
+        envs: _Optional[_Mapping[str, str]] = ...,
+        cwd: _Optional[str] = ...,
+    ) -> None: ...
 
 class ListRequest(_message.Message):
     __slots__ = ()
@@ -59,13 +78,20 @@ class ProcessInfo(_message.Message):
     config: ProcessConfig
     pid: int
     tag: str
-    def __init__(self, config: _Optional[_Union[ProcessConfig, _Mapping]] = ..., pid: _Optional[int] = ..., tag: _Optional[str] = ...) -> None: ...
+    def __init__(
+        self,
+        config: _Optional[_Union[ProcessConfig, _Mapping]] = ...,
+        pid: _Optional[int] = ...,
+        tag: _Optional[str] = ...,
+    ) -> None: ...
 
 class ListResponse(_message.Message):
     __slots__ = ("processes",)
     PROCESSES_FIELD_NUMBER: _ClassVar[int]
     processes: _containers.RepeatedCompositeFieldContainer[ProcessInfo]
-    def __init__(self, processes: _Optional[_Iterable[_Union[ProcessInfo, _Mapping]]] = ...) -> None: ...
+    def __init__(
+        self, processes: _Optional[_Iterable[_Union[ProcessInfo, _Mapping]]] = ...
+    ) -> None: ...
 
 class StartRequest(_message.Message):
     __slots__ = ("process", "pty", "tag")
@@ -75,7 +101,12 @@ class StartRequest(_message.Message):
     process: ProcessConfig
     pty: PTY
     tag: str
-    def __init__(self, process: _Optional[_Union[ProcessConfig, _Mapping]] = ..., pty: _Optional[_Union[PTY, _Mapping]] = ..., tag: _Optional[str] = ...) -> None: ...
+    def __init__(
+        self,
+        process: _Optional[_Union[ProcessConfig, _Mapping]] = ...,
+        pty: _Optional[_Union[PTY, _Mapping]] = ...,
+        tag: _Optional[str] = ...,
+    ) -> None: ...
 
 class UpdateRequest(_message.Message):
     __slots__ = ("process", "pty")
@@ -83,7 +114,11 @@ class UpdateRequest(_message.Message):
     PTY_FIELD_NUMBER: _ClassVar[int]
     process: ProcessSelector
     pty: PTY
-    def __init__(self, process: _Optional[_Union[ProcessSelector, _Mapping]] = ..., pty: _Optional[_Union[PTY, _Mapping]] = ...) -> None: ...
+    def __init__(
+        self,
+        process: _Optional[_Union[ProcessSelector, _Mapping]] = ...,
+        pty: _Optional[_Union[PTY, _Mapping]] = ...,
+    ) -> None: ...
 
 class UpdateResponse(_message.Message):
     __slots__ = ()
@@ -91,11 +126,13 @@ class UpdateResponse(_message.Message):
 
 class ProcessEvent(_message.Message):
     __slots__ = ("start", "data", "end", "keepalive")
+
     class StartEvent(_message.Message):
         __slots__ = ("pid",)
         PID_FIELD_NUMBER: _ClassVar[int]
         pid: int
         def __init__(self, pid: _Optional[int] = ...) -> None: ...
+
     class DataEvent(_message.Message):
         __slots__ = ("stdout", "stderr", "pty")
         STDOUT_FIELD_NUMBER: _ClassVar[int]
@@ -104,7 +141,13 @@ class ProcessEvent(_message.Message):
         stdout: bytes
         stderr: bytes
         pty: bytes
-        def __init__(self, stdout: _Optional[bytes] = ..., stderr: _Optional[bytes] = ..., pty: _Optional[bytes] = ...) -> None: ...
+        def __init__(
+            self,
+            stdout: _Optional[bytes] = ...,
+            stderr: _Optional[bytes] = ...,
+            pty: _Optional[bytes] = ...,
+        ) -> None: ...
+
     class EndEvent(_message.Message):
         __slots__ = ("exit_code", "exited", "status", "error")
         EXIT_CODE_FIELD_NUMBER: _ClassVar[int]
@@ -115,7 +158,14 @@ class ProcessEvent(_message.Message):
         exited: bool
         status: str
         error: str
-        def __init__(self, exit_code: _Optional[int] = ..., exited: bool = ..., status: _Optional[str] = ..., error: _Optional[str] = ...) -> None: ...
+        def __init__(
+            self,
+            exit_code: _Optional[int] = ...,
+            exited: bool = ...,
+            status: _Optional[str] = ...,
+            error: _Optional[str] = ...,
+        ) -> None: ...
+
     class KeepAlive(_message.Message):
         __slots__ = ()
         def __init__(self) -> None: ...
@@ -127,19 +177,29 @@ class ProcessEvent(_message.Message):
     data: ProcessEvent.DataEvent
     end: ProcessEvent.EndEvent
     keepalive: ProcessEvent.KeepAlive
-    def __init__(self, start: _Optional[_Union[ProcessEvent.StartEvent, _Mapping]] = ..., data: _Optional[_Union[ProcessEvent.DataEvent, _Mapping]] = ..., end: _Optional[_Union[ProcessEvent.EndEvent, _Mapping]] = ..., keepalive: _Optional[_Union[ProcessEvent.KeepAlive, _Mapping]] = ...) -> None: ...
+    def __init__(
+        self,
+        start: _Optional[_Union[ProcessEvent.StartEvent, _Mapping]] = ...,
+        data: _Optional[_Union[ProcessEvent.DataEvent, _Mapping]] = ...,
+        end: _Optional[_Union[ProcessEvent.EndEvent, _Mapping]] = ...,
+        keepalive: _Optional[_Union[ProcessEvent.KeepAlive, _Mapping]] = ...,
+    ) -> None: ...
 
 class StartResponse(_message.Message):
     __slots__ = ("event",)
     EVENT_FIELD_NUMBER: _ClassVar[int]
     event: ProcessEvent
-    def __init__(self, event: _Optional[_Union[ProcessEvent, _Mapping]] = ...) -> None: ...
+    def __init__(
+        self, event: _Optional[_Union[ProcessEvent, _Mapping]] = ...
+    ) -> None: ...
 
 class ConnectResponse(_message.Message):
     __slots__ = ("event",)
     EVENT_FIELD_NUMBER: _ClassVar[int]
     event: ProcessEvent
-    def __init__(self, event: _Optional[_Union[ProcessEvent, _Mapping]] = ...) -> None: ...
+    def __init__(
+        self, event: _Optional[_Union[ProcessEvent, _Mapping]] = ...
+    ) -> None: ...
 
 class SendInputRequest(_message.Message):
     __slots__ = ("process", "input")
@@ -147,7 +207,11 @@ class SendInputRequest(_message.Message):
     INPUT_FIELD_NUMBER: _ClassVar[int]
     process: ProcessSelector
     input: ProcessInput
-    def __init__(self, process: _Optional[_Union[ProcessSelector, _Mapping]] = ..., input: _Optional[_Union[ProcessInput, _Mapping]] = ...) -> None: ...
+    def __init__(
+        self,
+        process: _Optional[_Union[ProcessSelector, _Mapping]] = ...,
+        input: _Optional[_Union[ProcessInput, _Mapping]] = ...,
+    ) -> None: ...
 
 class SendInputResponse(_message.Message):
     __slots__ = ()
@@ -159,20 +223,29 @@ class ProcessInput(_message.Message):
     PTY_FIELD_NUMBER: _ClassVar[int]
     stdin: bytes
     pty: bytes
-    def __init__(self, stdin: _Optional[bytes] = ..., pty: _Optional[bytes] = ...) -> None: ...
+    def __init__(
+        self, stdin: _Optional[bytes] = ..., pty: _Optional[bytes] = ...
+    ) -> None: ...
 
 class StreamInputRequest(_message.Message):
     __slots__ = ("start", "data", "keepalive")
+
     class StartEvent(_message.Message):
         __slots__ = ("process",)
         PROCESS_FIELD_NUMBER: _ClassVar[int]
         process: ProcessSelector
-        def __init__(self, process: _Optional[_Union[ProcessSelector, _Mapping]] = ...) -> None: ...
+        def __init__(
+            self, process: _Optional[_Union[ProcessSelector, _Mapping]] = ...
+        ) -> None: ...
+
     class DataEvent(_message.Message):
         __slots__ = ("input",)
         INPUT_FIELD_NUMBER: _ClassVar[int]
         input: ProcessInput
-        def __init__(self, input: _Optional[_Union[ProcessInput, _Mapping]] = ...) -> None: ...
+        def __init__(
+            self, input: _Optional[_Union[ProcessInput, _Mapping]] = ...
+        ) -> None: ...
+
     class KeepAlive(_message.Message):
         __slots__ = ()
         def __init__(self) -> None: ...
@@ -182,7 +255,12 @@ class StreamInputRequest(_message.Message):
     start: StreamInputRequest.StartEvent
     data: StreamInputRequest.DataEvent
     keepalive: StreamInputRequest.KeepAlive
-    def __init__(self, start: _Optional[_Union[StreamInputRequest.StartEvent, _Mapping]] = ..., data: _Optional[_Union[StreamInputRequest.DataEvent, _Mapping]] = ..., keepalive: _Optional[_Union[StreamInputRequest.KeepAlive, _Mapping]] = ...) -> None: ...
+    def __init__(
+        self,
+        start: _Optional[_Union[StreamInputRequest.StartEvent, _Mapping]] = ...,
+        data: _Optional[_Union[StreamInputRequest.DataEvent, _Mapping]] = ...,
+        keepalive: _Optional[_Union[StreamInputRequest.KeepAlive, _Mapping]] = ...,
+    ) -> None: ...
 
 class StreamInputResponse(_message.Message):
     __slots__ = ()
@@ -194,7 +272,11 @@ class SendSignalRequest(_message.Message):
     SIGNAL_FIELD_NUMBER: _ClassVar[int]
     process: ProcessSelector
     signal: Signal
-    def __init__(self, process: _Optional[_Union[ProcessSelector, _Mapping]] = ..., signal: _Optional[_Union[Signal, str]] = ...) -> None: ...
+    def __init__(
+        self,
+        process: _Optional[_Union[ProcessSelector, _Mapping]] = ...,
+        signal: _Optional[_Union[Signal, str]] = ...,
+    ) -> None: ...
 
 class SendSignalResponse(_message.Message):
     __slots__ = ()
@@ -204,7 +286,9 @@ class ConnectRequest(_message.Message):
     __slots__ = ("process",)
     PROCESS_FIELD_NUMBER: _ClassVar[int]
     process: ProcessSelector
-    def __init__(self, process: _Optional[_Union[ProcessSelector, _Mapping]] = ...) -> None: ...
+    def __init__(
+        self, process: _Optional[_Union[ProcessSelector, _Mapping]] = ...
+    ) -> None: ...
 
 class ProcessSelector(_message.Message):
     __slots__ = ("pid", "tag")
@@ -212,4 +296,6 @@ class ProcessSelector(_message.Message):
     TAG_FIELD_NUMBER: _ClassVar[int]
     pid: int
     tag: str
-    def __init__(self, pid: _Optional[int] = ..., tag: _Optional[str] = ...) -> None: ...
+    def __init__(
+        self, pid: _Optional[int] = ..., tag: _Optional[str] = ...
+    ) -> None: ...

--- a/packages/python-sdk/e2b/sandbox/process/process_handle.py
+++ b/packages/python-sdk/e2b/sandbox/process/process_handle.py
@@ -37,4 +37,4 @@ class ProcessExitException(SandboxException, ProcessResult):
     """
 
     def __str__(self):
-        return f"Process exited with code {self.exit_code} and error: {self.error}\n{self.stderr}"
+        return f"Process exited with code {self.exit_code} and error:\n{self.stderr}"

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
@@ -302,7 +302,7 @@ class Filesystem:
                     return False
             raise handle_rpc_exception(e)
 
-    async def watch(
+    async def watch_dir(
         self,
         path: str,
         on_event: OutputHandler[FilesystemEvent],

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/watch_handle.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/watch_handle.py
@@ -26,7 +26,7 @@ class AsyncWatchHandle:
 
         self._wait = asyncio.create_task(self._handle_events())
 
-    async def close(self):
+    async def stop(self):
         """
         Stop watching the directory.
         """

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -298,7 +298,7 @@ class Filesystem:
                     return False
             raise handle_rpc_exception(e)
 
-    def watch(
+    def watch_dir(
         self,
         path: str,
         user: Username = "user",

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -13,7 +13,6 @@ from e2b.connection_config import (
 from e2b.envd.api import ENVD_API_FILES_ROUTE, handle_envd_api_exception
 from e2b.envd.filesystem import filesystem_connect, filesystem_pb2
 from e2b.envd.rpc import authentication_header, handle_rpc_exception
-from e2b.exceptions import SandboxException
 from e2b.sandbox.filesystem.filesystem import EntryInfo, map_file_type
 from e2b.sandbox_sync.filesystem.watch_handle import WatchHandle
 
@@ -316,26 +315,19 @@ class Filesystem:
         :param timeout: Timeout for the watch, after which the watch will be closed
         :return: Watcher handle
         """
-        events = self._rpc.watch_dir(
-            filesystem_pb2.WatchDirRequest(path=path),
-            request_timeout=self._connection_config.get_request_timeout(
-                request_timeout
-            ),
-            timeout=timeout,
-            headers={
-                **authentication_header(user),
-                KEEPALIVE_PING_HEADER: str(KEEPALIVE_PING_INTERVAL_SEC),
-            },
-        )
-
         try:
-            start_event = events.__next__()
-
-            if not start_event.HasField("start"):
-                raise SandboxException(
-                    f"Failed to start watch: expected start event, got {start_event}",
-                )
-
-            return WatchHandle(events=events)
+            r = self._rpc.watch_dir_start(
+                filesystem_pb2.WatchDirRequest(path=path),
+                request_timeout=self._connection_config.get_request_timeout(
+                    request_timeout
+                ),
+                timeout=timeout,
+                headers={
+                    **authentication_header(user),
+                    KEEPALIVE_PING_HEADER: str(KEEPALIVE_PING_INTERVAL_SEC),
+                },
+            )
         except Exception as e:
             raise handle_rpc_exception(e)
+
+        return WatchHandle(self._rpc, r.watcherId)

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -303,16 +303,14 @@ class Filesystem:
         path: str,
         user: Username = "user",
         request_timeout: Optional[float] = None,
-        timeout: Optional[float] = 60,
     ) -> WatchHandle:
         """
-        Watches directory for filesystem events. The watch will be closed after the timeout.
-        To get the events, you need to iterate over the returned WatchHandle.
+        Watches directory for filesystem events.
+        To get events, use the `get_new_events` method on the returned handle.
 
         :param path: Path to a directory that will be watched
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request
-        :param timeout: Timeout for the watch, after which the watch will be closed
         :return: Watcher handle
         """
         try:
@@ -321,7 +319,6 @@ class Filesystem:
                 request_timeout=self._connection_config.get_request_timeout(
                     request_timeout
                 ),
-                timeout=timeout,
                 headers={
                     **authentication_header(user),
                     KEEPALIVE_PING_HEADER: str(KEEPALIVE_PING_INTERVAL_SEC),

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -330,4 +330,4 @@ class Filesystem:
         except Exception as e:
             raise handle_rpc_exception(e)
 
-        return WatchHandle(self._rpc, r.watcherId)
+        return WatchHandle(self._rpc, r.watcher_id)

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/watch_handle.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/watch_handle.py
@@ -23,7 +23,7 @@ class WatchHandle:
 
     def stop(self):
         """
-        Stop watching the directory. After you close the watcher you won't be able to get the events anymore.
+        Stop watching the directory. After you stop the watcher you won't be able to get the events anymore.
         """
         try:
             self._rpc.watch_dir_stop(WatchDirStopRequest(watcher_id=self._watcher_id))
@@ -37,7 +37,7 @@ class WatchHandle:
         Get the latest events that have occurred in the watched directory since the last call, or from the beginning of the watching, up to now.
         """
         if self._closed:
-            raise SandboxException("The watcher is already closed")
+            raise SandboxException("The watcher is already stopped")
 
         try:
             r = self._rpc.watch_dir_get(WatchDirGetRequest(watcher_id=self._watcher_id))

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/watch_handle.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/watch_handle.py
@@ -2,7 +2,7 @@ from typing import List
 
 from e2b import SandboxException
 from e2b.envd.filesystem import filesystem_connect
-from e2b.envd.filesystem.filesystem_pb2 import WatchDirStopRequest, WatchDirPollRequest
+from e2b.envd.filesystem.filesystem_pb2 import WatchDirStopRequest, WatchDirGetRequest
 from e2b.envd.rpc import handle_rpc_exception
 from e2b.sandbox.filesystem.watch_handle import FilesystemEvent, map_event_type
 
@@ -32,7 +32,7 @@ class WatchHandle:
 
         self._closed = True
 
-    def get_events(self, offset: int = 0) -> List[FilesystemEvent]:
+    def get(self, offset: int = 0) -> List[FilesystemEvent]:
         """
         Get the events that occurred in the watched directory till now.
         If you are calling it multiple times, you can pass the offset to get the new events only.
@@ -41,9 +41,9 @@ class WatchHandle:
             raise SandboxException("The watcher is already closed")
 
         try:
-            r = self._rpc.watch_dir_poll(
-                WatchDirPollRequest(
-                    watcherId=self._watcher_id,
+            r = self._rpc.watch_dir_get(
+                WatchDirGetRequest(
+                    watcher_id=self._watcher_id,
                     offset=offset,
                 )
             )

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/watch_handle.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/watch_handle.py
@@ -21,7 +21,7 @@ class WatchHandle:
         self._watcher_id = watcher_id
         self._closed = False
 
-    def close(self):
+    def stop(self):
         """
         Stop watching the directory. After you close the watcher you won't be able to get the events anymore.
         """

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/watch_handle.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/watch_handle.py
@@ -1,7 +1,9 @@
-from typing import Any, Generator
+from typing import List
 
+from e2b import SandboxException
+from e2b.envd.filesystem import filesystem_connect
+from e2b.envd.filesystem.filesystem_pb2 import WatchDirStopRequest, WatchDirPollRequest
 from e2b.envd.rpc import handle_rpc_exception
-from e2b.envd.filesystem.filesystem_pb2 import EventType, WatchDirResponse
 from e2b.sandbox.filesystem.watch_handle import FilesystemEvent, map_event_type
 
 
@@ -12,31 +14,51 @@ class WatchHandle:
 
     def __init__(
         self,
-        events: Generator[WatchDirResponse, Any, None],
+        rpc: filesystem_connect.FilesystemClient,
+        watcher_id: str,
     ):
-        self._events = events
-
-    def __iter__(self):
-        return self._handle_events()
+        self._rpc = rpc
+        self._watcher_id = watcher_id
+        self._closed = False
 
     def close(self):
         """
-        Stop watching the directory.
-
-        Warning:
-            You won't get any event if you don't iterate over the handle before closing it.
+        Stop watching the directory. After you close the watcher you won't be able to get the events anymore.
         """
-        self._events.close()
-
-    def _handle_events(self):
         try:
-            for event in self._events:
-                if event.HasField("filesystem"):
-                    event_type = map_event_type(event.filesystem.type)
-                    if event_type:
-                        yield FilesystemEvent(
-                            name=event.filesystem.name,
-                            type=event_type,
-                        )
+            self._rpc.watch_dir_stop(WatchDirStopRequest(watcherId=self._watcher_id))
         except Exception as e:
             raise handle_rpc_exception(e)
+
+        self._closed = True
+
+    def get_events(self, offset: int = 0) -> List[FilesystemEvent]:
+        """
+        Get the events that occurred in the watched directory till now.
+        If you are calling it multiple times, you can pass the offset to get the new events only.
+        """
+        if self._closed:
+            raise SandboxException("The watcher is already closed")
+
+        try:
+            r = self._rpc.watch_dir_poll(
+                WatchDirPollRequest(
+                    watcherId=self._watcher_id,
+                    offset=offset,
+                )
+            )
+        except Exception as e:
+            raise handle_rpc_exception(e)
+
+        events = []
+        for event in r.events:
+            event_type = map_event_type(event.type)
+            if event_type:
+                events.append(
+                    FilesystemEvent(
+                        name=event.name,
+                        type=event_type,
+                    )
+                )
+
+        return events

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/watch_handle.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/watch_handle.py
@@ -26,27 +26,21 @@ class WatchHandle:
         Stop watching the directory. After you close the watcher you won't be able to get the events anymore.
         """
         try:
-            self._rpc.watch_dir_stop(WatchDirStopRequest(watcherId=self._watcher_id))
+            self._rpc.watch_dir_stop(WatchDirStopRequest(watcher_id=self._watcher_id))
         except Exception as e:
             raise handle_rpc_exception(e)
 
         self._closed = True
 
-    def get(self, offset: int = 0) -> List[FilesystemEvent]:
+    def get_new_events(self) -> List[FilesystemEvent]:
         """
-        Get the events that occurred in the watched directory till now.
-        If you are calling it multiple times, you can pass the offset to get the new events only.
+        Get the latest events that have occurred in the watched directory since the last call, or from the beginning of the watching, up to now.
         """
         if self._closed:
             raise SandboxException("The watcher is already closed")
 
         try:
-            r = self._rpc.watch_dir_get(
-                WatchDirGetRequest(
-                    watcher_id=self._watcher_id,
-                    offset=offset,
-                )
-            )
+            r = self._rpc.watch_dir_get(WatchDirGetRequest(watcher_id=self._watcher_id))
         except Exception as e:
             raise handle_rpc_exception(e)
 

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -235,7 +235,8 @@ class Sandbox(SandboxSetup, SandboxApi):
         self.kill()
 
     @overload
-    def kill(self, request_timeout: Optional[float] = None) -> bool: ...
+    def kill(self, request_timeout: Optional[float] = None) -> bool:
+        ...
 
     @overload
     @staticmethod
@@ -245,7 +246,8 @@ class Sandbox(SandboxSetup, SandboxApi):
         domain: Optional[str] = None,
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
-    ) -> bool: ...
+    ) -> bool:
+        ...
 
     @class_method_variant("_cls_kill")
     def kill(self, request_timeout: Optional[float] = None) -> bool:  # type: ignore
@@ -272,7 +274,9 @@ class Sandbox(SandboxSetup, SandboxApi):
         self,
         timeout: int,
         request_timeout: Optional[float] = None,
-    ) -> None: ...
+    ) -> None:
+        ...
+
     @overload
     @staticmethod
     def set_timeout(
@@ -282,7 +286,9 @@ class Sandbox(SandboxSetup, SandboxApi):
         domain: Optional[str] = None,
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
-    ) -> None: ...
+    ) -> None:
+        ...
+
     @class_method_variant("_cls_set_timeout")
     def set_timeout(  # type: ignore
         self,

--- a/packages/python-sdk/e2b/sandbox_sync/process/process.py
+++ b/packages/python-sdk/e2b/sandbox_sync/process/process.py
@@ -132,7 +132,8 @@ class Process:
         on_stderr: Optional[Callable[[str], None]] = None,
         timeout: Optional[float] = 60,
         request_timeout: Optional[float] = None,
-    ) -> ProcessResult: ...
+    ) -> ProcessResult:
+        ...
 
     @overload
     def run(
@@ -146,7 +147,8 @@ class Process:
         on_stderr: None = None,
         timeout: Optional[float] = 60,
         request_timeout: Optional[float] = None,
-    ) -> ProcessHandle: ...
+    ) -> ProcessHandle:
+        ...
 
     def run(
         self,

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_watch.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_watch.py
@@ -2,7 +2,13 @@ import pytest
 
 from asyncio import Event
 
-from e2b import NotFoundException, AsyncSandbox, FilesystemEvent, FilesystemEventType
+from e2b import (
+    NotFoundException,
+    AsyncSandbox,
+    FilesystemEvent,
+    FilesystemEventType,
+    SandboxException,
+)
 
 
 async def test_watch_directory_changes(async_sandbox: AsyncSandbox):
@@ -26,7 +32,7 @@ async def test_watch_directory_changes(async_sandbox: AsyncSandbox):
 
     await event_triggered.wait()
 
-    await handle.close()
+    await handle.stop()
 
 
 async def test_watch_non_existing_directory(async_sandbox: AsyncSandbox):
@@ -36,4 +42,9 @@ async def test_watch_non_existing_directory(async_sandbox: AsyncSandbox):
         await async_sandbox.files.watch(dirname, on_event=lambda e: None)
 
 
-# TODO: Add test for nonexistent file
+async def test_watch_file(async_sandbox: AsyncSandbox):
+    filename = "test_watch.txt"
+    await async_sandbox.files.write(filename, "This file will be watched.")
+
+    with pytest.raises(SandboxException):
+        await async_sandbox.files.watch(filename, on_event=lambda e: None)

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_watch.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_watch.py
@@ -26,7 +26,7 @@ async def test_watch_directory_changes(async_sandbox: AsyncSandbox):
         if e.type == FilesystemEventType.WRITE and e.name == filename:
             event_triggered.set()
 
-    handle = await async_sandbox.files.watch(dirname, on_event=handle_event)
+    handle = await async_sandbox.files.watch_dir(dirname, on_event=handle_event)
 
     await async_sandbox.files.write(f"{dirname}/{filename}", new_content)
 
@@ -39,7 +39,7 @@ async def test_watch_non_existing_directory(async_sandbox: AsyncSandbox):
     dirname = "non_existing_watch_dir"
 
     with pytest.raises(NotFoundException):
-        await async_sandbox.files.watch(dirname, on_event=lambda e: None)
+        await async_sandbox.files.watch_dir(dirname, on_event=lambda e: None)
 
 
 async def test_watch_file(async_sandbox: AsyncSandbox):
@@ -47,4 +47,4 @@ async def test_watch_file(async_sandbox: AsyncSandbox):
     await async_sandbox.files.write(filename, "This file will be watched.")
 
     with pytest.raises(SandboxException):
-        await async_sandbox.files.watch(filename, on_event=lambda e: None)
+        await async_sandbox.files.watch_dir(filename, on_event=lambda e: None)

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_watch.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_watch.py
@@ -9,7 +9,7 @@ def test_watch_directory_changes(sandbox: Sandbox):
     content = "This file will be watched."
 
     sandbox.files.make_dir(dirname)
-    handle = sandbox.files.watch(dirname)
+    handle = sandbox.files.watch_dir(dirname)
     sandbox.files.write(f"{dirname}/{filename}", content)
 
     events = handle.get_new_events()
@@ -31,7 +31,7 @@ def test_watch_iterated(sandbox: Sandbox):
     new_content = "This file has been modified."
 
     sandbox.files.make_dir(dirname)
-    handle = sandbox.files.watch(dirname)
+    handle = sandbox.files.watch_dir(dirname)
     sandbox.files.write(f"{dirname}/{filename}", content)
 
     events = handle.get_new_events()
@@ -50,7 +50,7 @@ def test_watch_non_existing_directory(sandbox: Sandbox):
     dirname = "non_existing_watch_dir"
 
     with pytest.raises(NotFoundException):
-        sandbox.files.watch(dirname)
+        sandbox.files.watch_dir(dirname)
 
 
 def test_watch_file(sandbox: Sandbox):
@@ -58,4 +58,4 @@ def test_watch_file(sandbox: Sandbox):
     sandbox.files.write(filename, "This file will be watched.")
 
     with pytest.raises(SandboxException):
-        sandbox.files.watch(filename)
+        sandbox.files.watch_dir(filename)

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_watch.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_watch.py
@@ -1,6 +1,6 @@
 import pytest
 
-from e2b import NotFoundException, FilesystemEventType, Sandbox
+from e2b import NotFoundException, FilesystemEventType, Sandbox, SandboxException
 
 
 def test_watch_directory_changes(sandbox: Sandbox):
@@ -16,18 +16,24 @@ def test_watch_directory_changes(sandbox: Sandbox):
 
     sandbox.files.write(f"{dirname}/{filename}", new_content)
 
-    for event in handle:
+    events = handle.get()
+    for event in events:
         if event.type == FilesystemEventType.WRITE and event.name == filename:
             break
 
-    handle.close()
+    handle.stop()
 
 
-def test_watch_non_existing_directory(sandbox):
+def test_watch_non_existing_directory(sandbox: Sandbox):
     dirname = "non_existing_watch_dir"
 
     with pytest.raises(NotFoundException):
         sandbox.files.watch(dirname)
 
 
-# TODO: Add test for nonexistent file
+def test_watch_file(sandbox: Sandbox):
+    filename = "test_watch.txt"
+    sandbox.files.write(filename, "This file will be watched.")
+
+    with pytest.raises(SandboxException):
+        sandbox.files.watch(filename)

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_watch.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_watch.py
@@ -7,16 +7,38 @@ def test_watch_directory_changes(sandbox: Sandbox):
     dirname = "test_watch_dir"
     filename = "test_watch.txt"
     content = "This file will be watched."
+
+    sandbox.files.make_dir(dirname)
+    handle = sandbox.files.watch(dirname)
+    sandbox.files.write(f"{dirname}/{filename}", content)
+
+    events = handle.get_new_events()
+    assert len(events) == 3
+    assert events[0].type == FilesystemEventType.CREATE
+    assert events[0].name == filename
+    assert events[1].type == FilesystemEventType.CHMOD
+    assert events[1].name == filename
+    assert events[2].type == FilesystemEventType.WRITE
+    assert events[2].name == filename
+
+    handle.stop()
+
+
+def test_watch_iterated(sandbox: Sandbox):
+    dirname = "test_watch_dir"
+    filename = "test_watch.txt"
+    content = "This file will be watched."
     new_content = "This file has been modified."
 
     sandbox.files.make_dir(dirname)
+    handle = sandbox.files.watch(dirname)
     sandbox.files.write(f"{dirname}/{filename}", content)
 
-    handle = sandbox.files.watch(dirname)
+    events = handle.get_new_events()
+    assert len(events) == 3
 
     sandbox.files.write(f"{dirname}/{filename}", new_content)
-
-    events = handle.get()
+    events = handle.get_new_events()
     for event in events:
         if event.type == FilesystemEventType.WRITE and event.name == filename:
             break

--- a/spec/envd/filesystem/filesystem.proto
+++ b/spec/envd/filesystem/filesystem.proto
@@ -90,12 +90,11 @@ message WatchDirResponse {
 }
 
 message WatchDirStartResponse {
-    string watcherId = 1;
+    string watcher_id = 1;
 }
 
 message WatchDirGetRequest {
     string watcher_id = 1;
-    uint32 offset = 2;
 }
 
 message WatchDirGetResponse {
@@ -103,7 +102,7 @@ message WatchDirGetResponse {
 }
 
 message WatchDirStopRequest {
-      string watcherId = 1;
+      string watcher_id = 1;
 }
 
 message WatchDirStopResponse {}

--- a/spec/envd/filesystem/filesystem.proto
+++ b/spec/envd/filesystem/filesystem.proto
@@ -7,8 +7,14 @@ service Filesystem {
     rpc MakeDir(MakeDirRequest) returns (MakeDirResponse);
     rpc Move(MoveRequest) returns (MoveResponse);
     rpc ListDir(ListDirRequest) returns (ListDirResponse);
-    rpc WatchDir(WatchDirRequest) returns (stream WatchDirResponse);
     rpc Remove(RemoveRequest) returns (RemoveResponse);
+
+    rpc WatchDir(WatchDirRequest) returns (stream WatchDirResponse);
+
+    // Non-streaming versions of WatchDir
+    rpc WatchDirStart(WatchDirRequest) returns (WatchDirStartResponse);
+    rpc WatchDirPoll(WatchDirPollRequest) returns (WatchDirPollResponse);
+    rpc WatchDirStop(WatchDirStopRequest) returns (WatchDirStopResponse);
 }
 
 message MoveRequest {
@@ -66,6 +72,11 @@ message WatchDirRequest {
     string path = 1;
 }
 
+message FilesystemEvent {
+    string name = 1;
+    EventType type = 2;
+}
+
 message WatchDirResponse {
     oneof event {
         StartEvent start = 1;
@@ -75,13 +86,27 @@ message WatchDirResponse {
 
     message StartEvent {}
 
-    message FilesystemEvent {
-        string name = 1;
-        EventType type = 2;
-    }
-
     message KeepAlive {}
 }
+
+message WatchDirStartResponse {
+    string watcherId = 1;
+}
+
+message WatchDirPollRequest {
+    string watcherId = 1;
+    uint32 offset = 2;
+}
+
+message WatchDirPollResponse {
+    repeated FilesystemEvent events = 1;
+}
+
+message WatchDirStopRequest {
+      string watcherId = 1;
+}
+
+message WatchDirStopResponse {}
 
 enum EventType {
     EVENT_TYPE_UNSPECIFIED = 0;

--- a/spec/envd/filesystem/filesystem.proto
+++ b/spec/envd/filesystem/filesystem.proto
@@ -13,7 +13,7 @@ service Filesystem {
 
     // Non-streaming versions of WatchDir
     rpc WatchDirStart(WatchDirRequest) returns (WatchDirStartResponse);
-    rpc WatchDirPoll(WatchDirPollRequest) returns (WatchDirPollResponse);
+    rpc WatchDirGet(WatchDirGetRequest) returns (WatchDirGetResponse);
     rpc WatchDirStop(WatchDirStopRequest) returns (WatchDirStopResponse);
 }
 
@@ -93,12 +93,12 @@ message WatchDirStartResponse {
     string watcherId = 1;
 }
 
-message WatchDirPollRequest {
-    string watcherId = 1;
+message WatchDirGetRequest {
+    string watcher_id = 1;
     uint32 offset = 2;
 }
 
-message WatchDirPollResponse {
+message WatchDirGetResponse {
     repeated FilesystemEvent events = 1;
 }
 


### PR DESCRIPTION
# Description

Current solution didn't work well with in sync Python. If you're unsure whether a file has been created, you might end up waiting for a timeout to exit the loop. 

New implementation uses polling, you can ask for events whenever you want and it will request envd to send all events (or only new ones). This should make it much better for users with sync Python SDK

Example of a problematic usage before and after:
## Before
```python
sbx = Sandbox()
watcher = sbx.files.watch("/home/user")
sbx.files.make_dir("test")
for event in watcher:
    print(event)
     # !!! if you don't exit, you would be stuck for the rest of the timeout (default 60 seconds)
    break
watcher.close()
```
## After
```python
sbx = Sandbox()
watcher = sbx.files.watch("/home/user")
sbx.files.make_dir("test")
events = watcher.get_new_events()
watcher.stop()
for event in events:
    print(event)
```

Even worse case was if you don't know if anything will happen:
## Before
```python
sbx = Sandbox()
watcher = sbx.files.watch("/home/user")
if random.random() > 0.5:
    sbx.files.make_dir("test")
# There's 50% chance you will get stuck. The only workaround is to run in in separate thread and you kill it after a while (you aren't really sure when it's safe)
for event in watcher:
    print(event)
    #  !!! if you don't exit, you would be stuck for the rest of the timeout (default 60 seconds)
    break
watcher.close()
```
## After
```python
sbx = Sandbox()
watcher = sbx.files.watch("/home/user")
if random.random() > 0.5:
    sbx.files.make_dir("test")
events = watcher.get_new_events()
watcher.stop()
for event in events:
    print(event)
```

