### PR TITLE
Fix docs examples for Python SDK `read` method

### DIFF
--- a/apps/web/src/app/(docs)/docs/filesystem/download/page.mdx
+++ b/apps/web/src/app/(docs)/docs/filesystem/download/page.mdx
@@ -22,7 +22,7 @@ sandbox = Sandbox()
 # Read file from sandbox
 content = sandbox.files.read('/path/in/sandbox')
 # Write file to local filesystem
-with open('/local/path', 'wb') as file:
+with open('/local/path', 'w') as file:
   file.write(content)
 ```
 </CodeGroup>

--- a/apps/web/src/app/(docs)/docs/quickstart/upload-download-files/page.mdx
+++ b/apps/web/src/app/(docs)/docs/quickstart/upload-download-files/page.mdx
@@ -92,7 +92,7 @@ sbx = Sandbox.create()
 # Download file from the sandbox to path '/home/user/my-file'
 content = sbx.files.read('/home/user/my-file')
 # Write file to local path
-with open('/local/file', 'wb') as file:
+with open('/local/file', 'w') as file:
     file.write(content)
 ```
 </CodeGroup>
@@ -126,13 +126,13 @@ sbx = Sandbox.create()
 # Download file A from the sandbox to path '/home/user/my-file-a'
 contentA = sbx.files.read('/home/user/my-file-a')
 # Write file A to local path
-with open('/local/file/a', 'wb') as file:
+with open('/local/file/a', 'w') as file:
     file.write(contentA)
 
 # Download file B from the sandbox to path '/home/user/my-file-b'
 contentB = sbx.files.read('/home/user/my-file-b')
 # Write file B to local path
-with open('/local/file/b', 'wb') as file:
+with open('/local/file/b', 'w') as file:
     file.write(contentB)
 ```
 </CodeGroup>


### PR DESCRIPTION
The Python examples were using read that returned string, but we were using it as bytes in the examples.

Users already opened two issues about this that we had to solve until they mentioned it is wrong in the docs. 