### PR TITLE
Remove table borders in CLI

### DIFF
--- a/packages/cli/src/commands/sandbox/list.ts
+++ b/packages/cli/src/commands/sandbox/list.ts
@@ -19,7 +19,12 @@ export const listCommand = new commander.Command('list')
           title: 'Running sandboxes',
           columns: [
             { name: 'sandboxID', alignment: 'left', title: 'Sandbox ID' },
-            { name: 'templateID', alignment: 'left', title: 'Template ID' },
+            {
+              name: 'templateID',
+              alignment: 'left',
+              title: 'Template ID',
+              maxLen: 20,
+            },
             { name: 'alias', alignment: 'left', title: 'Alias' },
             { name: 'startedAt', alignment: 'left', title: 'Started at' },
             { name: 'endAt', alignment: 'left', title: 'End at' },

--- a/packages/cli/src/commands/sandbox/list.ts
+++ b/packages/cli/src/commands/sandbox/list.ts
@@ -41,6 +41,27 @@ export const listCommand = new commander.Command('list')
                 a.startedAt.localeCompare(b.startedAt) ||
                 a.sandboxID.localeCompare(b.sandboxID)
             ),
+          style: {
+            headerTop: {
+              left: '',
+              right: '',
+              mid: '',
+              other: '',
+            },
+            headerBottom: {
+              left: '',
+              right: '',
+              mid: '',
+              other: '',
+            },
+            tableBottom: {
+              left: '',
+              right: '',
+              mid: '',
+              other: '',
+            },
+            vertical: '',
+          },
           colorMap: {
             orange: '\x1b[38;5;216m',
           },

--- a/packages/cli/src/commands/template/list.ts
+++ b/packages/cli/src/commands/template/list.ts
@@ -47,6 +47,27 @@ export const listCommand = new commander.Command('list')
             ...template,
             aliases: listAliases(template.aliases),
           })),
+          style: {
+            headerTop: {
+              left: '',
+              right: '',
+              mid: '',
+              other: '',
+            },
+            headerBottom: {
+              left: '',
+              right: '',
+              mid: '',
+              other: '',
+            },
+            tableBottom: {
+              left: '',
+              right: '',
+              mid: '',
+              other: '',
+            },
+            vertical: '',
+          },
           colorMap: {
             orange: '\x1b[38;5;216m',
           },
@@ -62,7 +83,7 @@ export const listCommand = new commander.Command('list')
   })
 
 export async function listSandboxTemplates({
-  teamID
+  teamID,
 }: {
   teamID?: string
 }): Promise<e2b.components['schemas']['Template'][]> {

--- a/packages/cli/src/commands/template/list.ts
+++ b/packages/cli/src/commands/template/list.ts
@@ -38,6 +38,7 @@ export const listCommand = new commander.Command('list')
               alignment: 'left',
               title: 'Template Name',
               color: 'orange',
+              maxLen: 20,
             },
             { name: 'cpuCount', alignment: 'right', title: 'vCPUs' },
             { name: 'memoryMB', alignment: 'right', title: 'RAM MiB' },

--- a/packages/cli/src/utils/format.ts
+++ b/packages/cli/src/utils/format.ts
@@ -100,7 +100,7 @@ export function withUnderline(content: string) {
 
 export function listAliases(aliases: string[] | undefined) {
   if (!aliases) return undefined
-  return aliases.join(' | ')
+  return aliases.join(', ')
 }
 
 export function asTypescript(code: string) {


### PR DESCRIPTION
Before:

<img width="519" alt="Screenshot 2024-11-29 at 15 37 04" src="https://github.com/user-attachments/assets/5e76deae-1a42-4781-9e0a-627e5f3085d7">

After:

<img width="476" alt="Screenshot 2024-11-29 at 15 36 54" src="https://github.com/user-attachments/assets/569f2f19-213f-40ed-9c53-0cc3951c43fe">

