### PR TITLE
Assert that the returned sandbox info objects are sorted by start time

### DIFF
--- a/packages/js-sdk/tests/api/list.test.ts
+++ b/packages/js-sdk/tests/api/list.test.ts
@@ -14,8 +14,8 @@ sandboxTest.skipIf(isDebug)('list sandboxes', async ({ sandbox }) => {
   // Check that sandboxes are sorted by startedAt in descending order (newest first)
   for (let i = 0; i < sandboxes.length - 1; i++) {
     assert.isAtLeast(
-      new Date(sandboxes[i].startedAt).getTime(),
       new Date(sandboxes[i + 1].startedAt).getTime(),
+      new Date(sandboxes[i].startedAt).getTime(),
       'Sandboxes should be sorted by startedAt in descending order'
     )
   }

--- a/packages/js-sdk/tests/api/list.test.ts
+++ b/packages/js-sdk/tests/api/list.test.ts
@@ -1,10 +1,22 @@
 import { assert } from 'vitest'
 
 import { Sandbox } from '../../src'
-import { sandboxTest, isDebug } from '../setup.js'
+import { isDebug, sandboxTest } from '../setup.js'
 
 sandboxTest.skipIf(isDebug)('list sandboxes', async ({ sandbox }) => {
   const sandboxes = await Sandbox.list()
   assert.isAtLeast(sandboxes.length, 1)
-  assert.include(sandboxes.map((s) => s.sandboxId), sandbox.sandboxId)
+  assert.include(
+    sandboxes.map((s) => s.sandboxId),
+    sandbox.sandboxId
+  )
+
+  // Check that sandboxes are sorted by startedAt in descending order (newest first)
+  for (let i = 0; i < sandboxes.length - 1; i++) {
+    assert.isAtLeast(
+      new Date(sandboxes[i].startedAt).getTime(),
+      new Date(sandboxes[i + 1].startedAt).getTime(),
+      'Sandboxes should be sorted by startedAt in descending order'
+    )
+  }
 })


### PR DESCRIPTION
# Description
This PR is meant to test the changes found in `APIStore.GetSandboxes` https://github.com/e2b-dev/infra/pull/211