### PR TITLE
Fixes the label in template section and toast opacity

### DIFF
--- a/apps/web/src/components/Dashboard/Templates.tsx
+++ b/apps/web/src/components/Dashboard/Templates.tsx
@@ -176,7 +176,7 @@ export function TemplatesContent({
                       <Lock className="w-4 h-4" />
                     )}
                     <span className="text-xs">
-                      {template.public ? 'Visible' : 'Private'}
+                      {template.public ? 'Public' : 'Private'}
                     </span>
                   </div>
                 </TableCell>

--- a/apps/web/src/components/Dashboard/Templates.tsx
+++ b/apps/web/src/components/Dashboard/Templates.tsx
@@ -145,7 +145,7 @@ export function TemplatesContent({
       <Table>
         <TableHeader>
           <TableRow className="hover:bg-orange-500/10 dark:hover:bg-orange-500/10 border-b border-white/5">
-            <TableHead>Visibility</TableHead>
+            <TableHead>Access</TableHead>
             <TableHead>Template ID</TableHead>
             <TableHead>Template Name</TableHead>
             <TableHead>vCPUs</TableHead>
@@ -207,7 +207,7 @@ export function TemplatesContent({
                         ) : (
                           <LockOpen className="w-4 h-4 mr-2" />
                         )}
-                        {template.public ? 'Make private' : 'Make public'}
+                        {template.public ? 'Unpublish' : 'Publish'}
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         className="text-red-500"

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -29,7 +29,7 @@ const toastVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-orange-500/50 border border-white/20 text-foreground',
+        default: 'bg-orange-500 border border-white/20 text-foreground',
         destructive:
           'destructive group border-destructive bg-destructive text-destructive-foreground',
       },
@@ -43,7 +43,7 @@ const toastVariants = cva(
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
-  VariantProps<typeof toastVariants>
+    VariantProps<typeof toastVariants>
 >(({ className, variant, ...props }, ref) => {
   return (
     <ToastPrimitives.Root


### PR DESCRIPTION
Fixes: Visible > Public
Toast opacity to 100:

<img width="428" alt="Screenshot 2024-12-10 at 10 12 50" src="https://github.com/user-attachments/assets/b6f303ad-c2d0-4fae-a9ff-d142b47493ca">