### PR TITLE
Redirect to localhost instead of e2b.dev after sign in with oauth in dev environment

### DIFF
--- a/apps/web/src/components/AuthForm.tsx
+++ b/apps/web/src/components/AuthForm.tsx
@@ -72,8 +72,8 @@ function AuthForm({ view }: Props) {
           }}
           redirectTo={
             view === 'forgotten_password'
-              ? `${process.env.NEXT_PUBLIC_BASE_URL}/auth/update-password`
-              : `${process.env.NEXT_PUBLIC_BASE_URL}/dashboard`
+              ? `${document.location.origin}/auth/update-password`
+              : `${document.location.origin}/dashboard`
           }
         />
       </div>

--- a/apps/web/src/components/AuthForm.tsx
+++ b/apps/web/src/components/AuthForm.tsx
@@ -72,8 +72,8 @@ function AuthForm({ view }: Props) {
           }}
           redirectTo={
             view === 'forgotten_password'
-              ? 'https://e2b.dev/auth/update-password'
-              : 'https://e2b.dev/dashboard'
+              ? `${process.env.NEXT_PUBLIC_BASE_URL}/auth/update-password`
+              : `${process.env.NEXT_PUBLIC_BASE_URL}/dashboard`
           }
         />
       </div>


### PR DESCRIPTION
this pr fixes the following in a local development environment:

- supabase auth redirect after oauth sign in
- forgot password flow


this is accomplished by using `document.location.origin`, to always use the url on which the auth flow was started. this makes sense if different developers use different ports for their app development and when authenticating on vercel preview urls.
