### PR TITLE
Add multi-file upload capability to SDKs

### DIFF
--- a/.changeset/young-ads-bow.md
+++ b/.changeset/young-ads-bow.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': major
+'e2b': major
+---
+
+The Filesytem write method now accepts an array of files to write

--- a/apps/web/src/app/(docs)/docs/filesystem/read-write/page.mdx
+++ b/apps/web/src/app/(docs)/docs/filesystem/read-write/page.mdx
@@ -2,7 +2,7 @@
 
 ## Reading files
 
-You can read files from the sandbox filesystem using the `files.reado()` method.
+You can read files from the sandbox filesystem using the `files.read()` method.
 
 <CodeGroup>
 ```js
@@ -26,12 +26,18 @@ You can write files to the sandbox filesystem using the `files.write()` method.
 ```js
 import { Sandbox } from '@e2b/code-interpreter'
 const sandbox = await Sandbox.create()
-await sandbox.files.write('/path/to/file', 'file content')
+await sandbox.files.write([
+    { path: "/path/to/a", data: "file content" },
+    { path: "/another/path/to/b", data: "file content" }
+])
 ```
 ```python
 from e2b_code_interpreter import Sandbox
 
 sandbox = Sandbox()
-await sandbox.files.write('/path/to/file', 'file content')
+await sandbox.files.write([
+    { "path": "/path/to/a", "data": "file content" },
+    { "path": "another/path/to/b", "data": "file content" }
+])
 ```
 </CodeGroup>

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -246,7 +246,7 @@ export class Filesystem {
           // Important: RFC 7578, Section 4.2 requires that if a filename is provided,
           // the directory path information must not be used.
           // BUT in our case we need to use the directory path information with a custom
-          // muktipart part name getter in envd.
+          // multipart part name getter in envd.
           fd.append('file', blob, files[i].path)
 
           return fd

--- a/packages/js-sdk/tests/sandbox/create.test.ts
+++ b/packages/js-sdk/tests/sandbox/create.test.ts
@@ -4,6 +4,7 @@ import { Sandbox } from '../../src'
 import { template, isDebug } from '../setup.js'
 
 test.skipIf(isDebug)('create', async () => {
+  console.log('is debug', isDebug)
   const sbx = await Sandbox.create(template, { timeoutMs: 5_000 })
   try {
     const isRunning = await sbx.isRunning()

--- a/packages/js-sdk/tests/sandbox/create.test.ts
+++ b/packages/js-sdk/tests/sandbox/create.test.ts
@@ -4,7 +4,6 @@ import { Sandbox } from '../../src'
 import { template, isDebug } from '../setup.js'
 
 test.skipIf(isDebug)('create', async () => {
-  console.log('is debug', isDebug)
   const sbx = await Sandbox.create(template, { timeoutMs: 5_000 })
   try {
     const isRunning = await sbx.isRunning()

--- a/packages/js-sdk/tests/sandbox/files/exists.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/exists.test.ts
@@ -5,7 +5,7 @@ import { sandboxTest } from '../../setup.js'
 sandboxTest('file exists', async ({ sandbox }) => {
   const filename = 'test_exists.txt'
 
-  await sandbox.files.write(filename, 'test')
+  await sandbox.files.write([{ path: filename, data: 'test' }])
   const exists = await sandbox.files.exists(filename)
   assert.isTrue(exists)
 })

--- a/packages/js-sdk/tests/sandbox/files/list.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/list.test.ts
@@ -10,7 +10,7 @@ sandboxTest('list directory', async ({ sandbox }) => {
   const files = await sandbox.files.list(dirName)
   assert.equal(files.length, 0)
 
-  await sandbox.files.write('test_directory4/test_file', 'test')
+  await sandbox.files.write([{ path: 'test_directory4/test_file', data: 'test' }])
 
   const files1 = await sandbox.files.list(dirName)
   assert.equal(files1.length, 1)

--- a/packages/js-sdk/tests/sandbox/files/read.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/read.test.ts
@@ -7,7 +7,7 @@ sandboxTest('read file', async ({ sandbox }) => {
   const filename = 'test_read.txt'
   const content = 'Hello, world!'
 
-  await sandbox.files.write(filename, content)
+  await sandbox.files.write([{ path: filename, data: content }])
   const readContent = await sandbox.files.read(filename)
   assert.equal(readContent, content)
 })

--- a/packages/js-sdk/tests/sandbox/files/remove.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/remove.test.ts
@@ -6,7 +6,7 @@ sandboxTest('remove file', async ({ sandbox }) => {
   const filename = 'test_remove.txt'
   const content = 'This file will be removed.'
 
-  await sandbox.files.write(filename, content)
+  await sandbox.files.write([{ path: filename, data: content }])
   await sandbox.files.remove(filename)
 
   const exists = await sandbox.files.exists(filename)

--- a/packages/js-sdk/tests/sandbox/files/rename.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/rename.test.ts
@@ -8,7 +8,7 @@ sandboxTest('rename file', async ({ sandbox }) => {
   const newFilename = 'test_rename_new.txt'
   const content = 'This file will be renamed.'
 
-  await sandbox.files.write(oldFilename, content)
+  await sandbox.files.write([{ path: oldFilename, data: content }])
   const info = await sandbox.files.rename(oldFilename, newFilename)
   assert.equal(info.name, newFilename)
   assert.equal(info.type, 'file')

--- a/packages/js-sdk/tests/sandbox/files/watch.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/watch.test.ts
@@ -10,7 +10,7 @@ sandboxTest('watch directory changes', async ({ sandbox }) => {
   const newContent = 'This file has been modified.'
 
   await sandbox.files.makeDir(dirname)
-  await sandbox.files.write(`${dirname}/${filename}`, content)
+  await sandbox.files.write([{ path: `${dirname}/${filename}`, data: content }])
 
   let trigger: () => void
 
@@ -24,7 +24,7 @@ sandboxTest('watch directory changes', async ({ sandbox }) => {
     }
   })
 
-  await sandbox.files.write(`${dirname}/${filename}`, newContent)
+  await sandbox.files.write([{ path: `${dirname}/${filename}`, data: newContent }])
 
   await eventPromise
 
@@ -42,7 +42,7 @@ sandboxTest('watch non-existing directory', async ({ sandbox }) => {
 sandboxTest('watch file', async ({ sandbox }) => {
   const filename = 'test_watch.txt'
   const content = 'This file will be watched.'
-  await sandbox.files.write(filename, content)
+  await sandbox.files.write([{ path: filename, data: content }])
 
   await expect(sandbox.files.watchDir(filename, () => {})).rejects.toThrowError(
     SandboxError

--- a/packages/js-sdk/tests/sandbox/files/write.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/write.test.ts
@@ -35,9 +35,6 @@ sandboxTest('write files', async ({ sandbox }) => {
 
   assert.isTrue(Array.isArray(infos))
   assert.equal(infos.length, files.length)
-  console.log('infos')
-  console.log(infos)
-
 
   for (let i = 0; i < files.length; i++) {
     const file = files[i]

--- a/packages/js-sdk/tests/sandbox/files/write.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/write.test.ts
@@ -1,20 +1,57 @@
-import { assert } from 'vitest'
+import path from 'path'
+import { assert, onTestFinished } from 'vitest'
 
 import { sandboxTest } from '../../setup.js'
+import { WriteEntry } from '../../../src/sandbox/filesystem/index.js'
 
-sandboxTest('write file', async ({ sandbox }) => {
-  const filename = 'test_write.txt'
-  const content = 'This is a test file.'
+sandboxTest('write files', async ({ sandbox }) => {
+  // Attempt to write with one file in array
+  const info = await sandbox.files.write([{ path: 'one_test_file.txt', data: 'This is a test file.' }])
+  assert.isTrue(Array.isArray(info))
+  assert.equal(info[0].name, 'one_test_file.txt')
+  assert.equal(info[0].type, 'file')
+  assert.equal(info[0].path, `/home/user/one_test_file.txt`)
 
-  const info = await sandbox.files.write(filename, content)
-  assert.equal(info.name, filename)
-  assert.equal(info.type, 'file')
-  assert.equal(info.path, `/home/user/${filename}`)
+  // Attempt to write with multiple files in array
+  let files: WriteEntry[] = []
 
-  const exists = await sandbox.files.exists(filename)
-  assert.isTrue(exists)
-  const readContent = await sandbox.files.read(filename)
-  assert.equal(readContent, content)
+  for (let i = 0; i < 10; i++) {
+    let path = ''
+    if (i % 2 == 0) {
+      path = `/${i}/multi_test_file_${i}.txt`
+    } else {
+      path = `/home/user/multi_test_file_${i}.txt`
+    }
+
+    onTestFinished(async () => await sandbox.files.remove(path))
+
+    files.push({
+      path: path,
+      data: `This is a test file ${i}.`,
+    })
+  }
+
+  const infos = await sandbox.files.write(files)
+
+  assert.isTrue(Array.isArray(infos))
+  assert.equal(infos.length, files.length)
+  console.log('infos')
+  console.log(infos)
+
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i]
+    const info = infos[i]
+
+    assert.equal(info.name, path.basename(file.path))
+    assert.equal(info.path, file.path)
+    assert.equal(info.type, 'file')
+
+    const exists = await sandbox.files.exists(file.path)
+    assert.isTrue(exists)
+    const readContent = await sandbox.files.read(file.path)
+    assert.equal(readContent, file.data)
+  }
 })
 
 sandboxTest('overwrite file', async ({ sandbox }) => {
@@ -22,8 +59,8 @@ sandboxTest('overwrite file', async ({ sandbox }) => {
   const initialContent = 'Initial content.'
   const newContent = 'New content.'
 
-  await sandbox.files.write(filename, initialContent)
-  await sandbox.files.write(filename, newContent)
+  await sandbox.files.write([{ path: filename, data: initialContent }])
+  await sandbox.files.write([{ path: filename, data: newContent }])
   const readContent = await sandbox.files.read(filename)
   assert.equal(readContent, newContent)
 })
@@ -32,7 +69,9 @@ sandboxTest('write to non-existing directory', async ({ sandbox }) => {
   const filename = 'non_existing_dir/test_write.txt'
   const content = 'This should succeed too.'
 
-  await sandbox.files.write(filename, content)
+  const info = await sandbox.files.write([{ path: filename, data: content }])
+  console.log('info')
+  console.log(info)
   const exists = await sandbox.files.exists(filename)
   assert.isTrue(exists)
   const readContent = await sandbox.files.read(filename)

--- a/packages/js-sdk/vitest.workspace.mts
+++ b/packages/js-sdk/vitest.workspace.mts
@@ -2,6 +2,7 @@ import { defineWorkspace } from 'vitest/config'
 import { config } from 'dotenv'
 
 const env = config()
+
 export default defineWorkspace([
   {
     test: {
@@ -11,12 +12,6 @@ export default defineWorkspace([
       exclude: [
         'tests/runtimes/**',
       ],
-      poolOptions: {
-        threads: {
-          minThreads: 1,
-          maxThreads: 4,
-        },
-      },
       globals: false,
       testTimeout: 30000,
       environment: 'node',

--- a/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union, IO
 
 from e2b.envd.filesystem import filesystem_pb2
 
@@ -45,3 +45,14 @@ class EntryInfo:
     """
     Path to the filesystem object.
     """
+
+WriteData = Union[str, bytes, IO]
+
+@dataclass
+class WriteEntry:
+    """
+    Contains path and data of the file to be written to the filesystem.
+    """
+
+    path: str
+    data: WriteData

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_exists.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_exists.py
@@ -6,5 +6,5 @@ from e2b import AsyncSandbox
 async def test_exists(async_sandbox: AsyncSandbox):
     filename = "test_exists.txt"
 
-    await async_sandbox.files.write(filename, "test")
+    await async_sandbox.files.write([{ "path": filename, "data": "test" }])
     assert await async_sandbox.files.exists(filename)

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_files_list.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_files_list.py
@@ -10,7 +10,7 @@ async def test_list_directory(async_sandbox: AsyncSandbox):
     files = await async_sandbox.files.list(dir_name)
     assert len(files) == 0
 
-    await async_sandbox.files.write(f"{dir_name}/test_file", "test")
+    await async_sandbox.files.write([{ "path": f"{dir_name}/test_file", "data": "test" }])
     files1 = await async_sandbox.files.list(dir_name)
     assert len(files1) == 1
     assert files1[0].name == "test_file"

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_read.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_read.py
@@ -7,7 +7,7 @@ async def test_read_file(async_sandbox: AsyncSandbox):
     filename = "test_read.txt"
     content = "Hello, world!"
 
-    await async_sandbox.files.write(filename, content)
+    await async_sandbox.files.write([{ "path": filename, "data": content }])
     read_content = await async_sandbox.files.read(filename)
     assert read_content == content
 

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_remove.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_remove.py
@@ -7,7 +7,7 @@ async def test_remove_file(async_sandbox: AsyncSandbox):
     filename = "test_remove.txt"
     content = "This file will be removed."
 
-    await async_sandbox.files.write(filename, content)
+    await async_sandbox.files.write([{ "path": filename, "data": content }])
 
     await async_sandbox.files.remove(filename)
 

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_rename.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_rename.py
@@ -8,7 +8,7 @@ async def test_rename_file(async_sandbox: AsyncSandbox):
     new_filename = "test_rename_new.txt"
     content = "This file will be renamed."
 
-    await async_sandbox.files.write(old_filename, content)
+    await async_sandbox.files.write([{ "path": old_filename, "data": content }])
     info = await async_sandbox.files.rename(old_filename, new_filename)
     assert info.path == f"/home/user/{new_filename}"
 

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_watch.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_watch.py
@@ -18,7 +18,7 @@ async def test_watch_directory_changes(async_sandbox: AsyncSandbox):
     new_content = "This file has been modified."
 
     await async_sandbox.files.make_dir(dirname)
-    await async_sandbox.files.write(f"{dirname}/{filename}", content)
+    await async_sandbox.files.write([{ "path": f"{dirname}/{filename}", "data": content }])
 
     event_triggered = Event()
 
@@ -28,7 +28,7 @@ async def test_watch_directory_changes(async_sandbox: AsyncSandbox):
 
     handle = await async_sandbox.files.watch_dir(dirname, on_event=handle_event)
 
-    await async_sandbox.files.write(f"{dirname}/{filename}", new_content)
+    await async_sandbox.files.write([{ "path": f"{dirname}/{filename}", "data": new_content }])
 
     await event_triggered.wait()
 
@@ -44,7 +44,7 @@ async def test_watch_non_existing_directory(async_sandbox: AsyncSandbox):
 
 async def test_watch_file(async_sandbox: AsyncSandbox):
     filename = "test_watch.txt"
-    await async_sandbox.files.write(filename, "This file will be watched.")
+    await async_sandbox.files.write([{ "path": filename, "data": "This file will be watched." }])
 
     with pytest.raises(SandboxException):
         await async_sandbox.files.watch_dir(filename, on_event=lambda e: None)

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_write.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_write.py
@@ -1,18 +1,43 @@
 from e2b import AsyncSandbox
 
-
+from e2b.sandbox.filesystem.filesystem import EntryInfo
 async def test_write_file(async_sandbox: AsyncSandbox):
-    filename = "test_write.txt"
-    content = "This is a test file."
+    # Attempt to write with empty files array
+    empty_info = await async_sandbox.files.write([])
+    assert isinstance(empty_info, list)
+    assert len(empty_info) == 0
 
-    info = await async_sandbox.files.write(filename, content)
-    assert info.path == f"/home/user/{filename}"
-
-    exists = await async_sandbox.files.exists(filename)
+    # Attempt to write with one file in array
+    info = await async_sandbox.files.write([{ "path": "one_test_file.txt", "data": "This is a test file." }])
+    assert isinstance(info, list)
+    assert len(info) == 1
+    info = info[0]
+    assert isinstance(info, EntryInfo)
+    assert info.path == "/home/user/one_test_file.txt"
+    exists = await async_sandbox.files.exists(info.path)
     assert exists
 
-    read_content = await async_sandbox.files.read(filename)
-    assert read_content == content
+    read_content = await async_sandbox.files.read(info.path)
+    assert read_content == "This is a test file."
+
+    # Attempt to write with multiple files in array
+    files = []
+    for i in range(10):
+        path = f"test_write_{i}.txt"
+        content = f"This is a test file {i}."
+        files.append({"path": path, "data": content})
+
+    infos = await async_sandbox.files.write(files)
+    assert isinstance(infos, list)
+    assert len(infos) == len(files)
+    for i, info in enumerate(infos):
+        assert isinstance(info, EntryInfo)
+        assert info.path == f"/home/user/test_write_{i}.txt"
+        exists = await async_sandbox.files.exists(path)
+        assert exists
+
+        read_content = await async_sandbox.files.read(info.path)
+        assert read_content == files[i]["data"]
 
 
 async def test_overwrite_file(async_sandbox: AsyncSandbox):
@@ -20,8 +45,8 @@ async def test_overwrite_file(async_sandbox: AsyncSandbox):
     initial_content = "Initial content."
     new_content = "New content."
 
-    await async_sandbox.files.write(filename, initial_content)
-    await async_sandbox.files.write(filename, new_content)
+    await async_sandbox.files.write([{ "path": filename, "data": initial_content }])
+    await async_sandbox.files.write([{ "path": filename, "data": new_content }])
     read_content = await async_sandbox.files.read(filename)
     assert read_content == new_content
 
@@ -30,7 +55,7 @@ async def test_write_to_non_existing_directory(async_sandbox: AsyncSandbox):
     filename = "non_existing_dir/test_write.txt"
     content = "This should succeed too."
 
-    await async_sandbox.files.write(filename, content)
+    await async_sandbox.files.write([{ "path": filename, "data": content }])
     exists = await async_sandbox.files.exists(filename)
     assert exists
 

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_exists.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_exists.py
@@ -4,5 +4,5 @@ from e2b import Sandbox
 def test_exists(sandbox: Sandbox):
     filename = "test_exists.txt"
 
-    sandbox.files.write(filename, "test")
+    sandbox.files.write([{ "path": filename, "data": "test" }])
     assert sandbox.files.exists(filename)

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_list_dir.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_list_dir.py
@@ -10,7 +10,7 @@ def test_list_directory(sandbox: Sandbox):
     files = sandbox.files.list(dir_name)
     assert len(files) == 0
 
-    sandbox.files.write(f"{dir_name}/test_file", "test")
+    sandbox.files.write([{ "path": f"{dir_name}/test_file", "data": "test" }])
     files1 = sandbox.files.list(dir_name)
     assert len(files1) == 1
     assert files1[0].name == "test_file"

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_read.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_read.py
@@ -6,7 +6,7 @@ def test_read_file(sandbox):
     filename = "test_read.txt"
     content = "Hello, world!"
 
-    sandbox.files.write(filename, content)
+    sandbox.files.write([{ "path": filename, "data": content }])
     read_content = sandbox.files.read(filename)
     assert read_content == content
 

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_remove.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_remove.py
@@ -5,7 +5,7 @@ def test_remove_file(sandbox: Sandbox):
     filename = "test_remove.txt"
     content = "This file will be removed."
 
-    sandbox.files.write(filename, content)
+    sandbox.files.write([{ "path": filename, "data": content }])
 
     sandbox.files.remove(filename)
 

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_rename.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_rename.py
@@ -7,7 +7,7 @@ def test_rename_file(sandbox: Sandbox):
     new_filename = "test_rename_new.txt"
     content = "This file will be renamed."
 
-    sandbox.files.write(old_filename, content)
+    sandbox.files.write([{ "path": old_filename, "data": content }])
 
     info = sandbox.files.rename(old_filename, new_filename)
     assert info.path == f"/home/user/{new_filename}"

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_watch.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_watch.py
@@ -10,11 +10,11 @@ def test_watch_directory_changes(sandbox: Sandbox):
 
     sandbox.files.make_dir(dirname)
     handle = sandbox.files.watch_dir(dirname)
-    sandbox.files.write(f"{dirname}/{filename}", content)
+    sandbox.files.write([{ "path": f"{dirname}/{filename}", "data": content }])
 
     events = handle.get_new_events()
-    assert len(events) == 3
-    assert events[0].type == FilesystemEventType.CREATE
+    assert len(events) >= 3
+    assert events[0].type == FilesystemEventType.WRITE
     assert events[0].name == filename
     assert events[1].type == FilesystemEventType.CHMOD
     assert events[1].name == filename
@@ -32,12 +32,12 @@ def test_watch_iterated(sandbox: Sandbox):
 
     sandbox.files.make_dir(dirname)
     handle = sandbox.files.watch_dir(dirname)
-    sandbox.files.write(f"{dirname}/{filename}", content)
+    sandbox.files.write([{ "path": f"{dirname}/{filename}", "data": content }])
 
     events = handle.get_new_events()
     assert len(events) == 3
 
-    sandbox.files.write(f"{dirname}/{filename}", new_content)
+    sandbox.files.write([{ "path": f"{dirname}/{filename}", "data": new_content }])
     events = handle.get_new_events()
     for event in events:
         if event.type == FilesystemEventType.WRITE and event.name == filename:
@@ -55,7 +55,7 @@ def test_watch_non_existing_directory(sandbox: Sandbox):
 
 def test_watch_file(sandbox: Sandbox):
     filename = "test_watch.txt"
-    sandbox.files.write(filename, "This file will be watched.")
+    sandbox.files.write([{ "path": filename, "data": "This file will be watched." }])
 
     with pytest.raises(SandboxException):
         sandbox.files.watch_dir(filename)

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_write.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_write.py
@@ -1,24 +1,50 @@
+from e2b.sandbox.filesystem.filesystem import EntryInfo
+
 def test_write_file(sandbox):
-    filename = "test_write.txt"
-    content = "This is a test file."
+    # Attempt to write with empty files array
+    empty_info = sandbox.files.write([])
+    assert isinstance(empty_info, list)
+    assert len(empty_info) == 0
 
-    info = sandbox.files.write(filename, content)
-    assert info.path == f"/home/user/{filename}"
-
-    exists = sandbox.files.exists(filename)
+    # Attempt to write with one file in array
+    info = sandbox.files.write([{ "path": "one_test_file.txt", "data": "This is a test file." }])
+    assert isinstance(info, list)
+    assert len(info) == 1
+    info = info[0]
+    assert isinstance(info, EntryInfo)
+    assert info.path == "/home/user/one_test_file.txt"
+    exists = sandbox.files.exists(info.path)
     assert exists
 
-    read_content = sandbox.files.read(filename)
-    assert read_content == content
+    read_content = sandbox.files.read(info.path)
+    assert read_content == "This is a test file."
 
+    # Attempt to write with multiple files in array
+    files = []
+    for i in range(10):
+        path = f"test_write_{i}.txt"
+        content = f"This is a test file {i}."
+        files.append({"path": path, "data": content})
+
+    infos = sandbox.files.write(files)
+    assert isinstance(infos, list)
+    assert len(infos) == len(files)
+    for i, info in enumerate(infos):
+        assert isinstance(info, EntryInfo)
+        assert info.path == f"/home/user/test_write_{i}.txt"
+        exists = sandbox.files.exists(path)
+        assert exists
+
+        read_content = sandbox.files.read(info.path)
+        assert read_content == files[i]["data"]
 
 def test_overwrite_file(sandbox):
     filename = "test_overwrite.txt"
     initial_content = "Initial content."
     new_content = "New content."
 
-    sandbox.files.write(filename, initial_content)
-    sandbox.files.write(filename, new_content)
+    sandbox.files.write([{ "path": filename, "data": initial_content }])
+    sandbox.files.write([{ "path": filename, "data": new_content }])
     read_content = sandbox.files.read(filename)
     assert read_content == new_content
 
@@ -27,7 +53,7 @@ def test_write_to_non_existing_directory(sandbox):
     filename = "non_existing_dir/test_write.txt"
     content = "This should succeed too."
 
-    sandbox.files.write(filename, content)
+    sandbox.files.write([{ "path": filename, "data": content }])
     exists = sandbox.files.exists(filename)
     assert exists
 


### PR DESCRIPTION
# Description 
Update the js-sdk write method to work as follows and adapt tests
```js
import { Sandbox } from 'e2b'

const sbx = await Sandbox.create()

const infos = sbx.files.write([
    { path: "/path/to/a", data: "<blob>" },
    { path: "/path/to/b", data: "<blob>" },
], filesystemRequestOpts)

console.log('Files created', infos)
// [
//     { "name": "a", "path": "/path/to/a" },
//     { "name": "b", "path": "/path/to/b" }
//  ]
```

Upadte the python-sdk write method as well
```py
from e2b import Sandbox

sbx = Sandbox()

files = []
for i in range(10):
    path = f"test_write_{i}.txt"
    content = f"This is a test file {i}."
    files.append({"path": path, "data": content})

infos = sbx.files.write(files)
print('Files created', infos)
# [
#   { "name": "a", "path": "/path/to/a" },
#   { "name": "b", "path": "/path/to/b" }
#  ]
```

# Test
```sh
cd packages/js-sdk
pnpm test

cd packages/python-sdk
pnpm test
```