### PR TITLE
Add `/cookbook` page 

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -35,7 +35,7 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
     url.hostname = landingPageHostname
   }
 
-  if (url.pathname.startsWith('/cookbooks')) {
+  if (url.pathname.startsWith('/cookbook')) {
     url.hostname = landingPageHostname
   }
 
@@ -85,7 +85,7 @@ export const config = {
     '/privacy/:path*',
     '/terms/:path*',
     '/pricing/:path*',
-    '/cookbooks/:path*',
+    '/cookbook/:path*',
   ],
 }
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -84,7 +84,8 @@ export const config = {
     '/ai-agents/:path*',
     '/privacy/:path*',
     '/terms/:path*',
-    '/pricing/:path*'
+    '/pricing/:path*',
+    '/cookbooks/:path*',
   ],
 }
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -35,6 +35,10 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
     url.hostname = landingPageHostname
   }
 
+  if (url.pathname.startsWith('/cookbooks')) {
+    url.hostname = landingPageHostname
+  }
+
   // TODO: Not on the new landing page hosting yet
   if (url.pathname.startsWith('/ai-agents')) {
     url.hostname = landingPageFramerHostname


### PR DESCRIPTION
This PR makes sure that the `https://e2b.dev/cookbook` route correctly displays the content of the cookbook page that's part of our landing page on our Webflow.