### PR TITLE
Display the new changelog page

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -55,14 +55,6 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
     url.hostname = blogFramerHostname
   }
 
-  // if (url.pathname === '/changelog' || url.pathname === '/changelog/') {
-  //   url.pathname = '/'
-  //   url.hostname = changelogFramerHostname
-  // }
-  // if (url.pathname.startsWith('/changelog')) {
-  //   url.hostname = changelogFramerHostname
-  // }
-
   const res = await fetch(url.toString(), { ...req })
 
   const htmlBody = await res.text()

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -4,7 +4,6 @@ import {
   landingPageHostname,
   landingPageFramerHostname,
   blogFramerHostname,
-  changelogFramerHostname,
 } from '@/app/hostnames'
 
 export async function middleware(req: NextRequest): Promise<NextResponse> {
@@ -39,6 +38,10 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
     url.hostname = landingPageHostname
   }
 
+  if (url.pathname.startsWith('/changelog')) {
+    url.hostname = landingPageHostname
+  }
+
   // TODO: Not on the new landing page hosting yet
   if (url.pathname.startsWith('/ai-agents')) {
     url.hostname = landingPageFramerHostname
@@ -52,13 +55,13 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
     url.hostname = blogFramerHostname
   }
 
-  if (url.pathname === '/changelog' || url.pathname === '/changelog/') {
-    url.pathname = '/'
-    url.hostname = changelogFramerHostname
-  }
-  if (url.pathname.startsWith('/changelog')) {
-    url.hostname = changelogFramerHostname
-  }
+  // if (url.pathname === '/changelog' || url.pathname === '/changelog/') {
+  //   url.pathname = '/'
+  //   url.hostname = changelogFramerHostname
+  // }
+  // if (url.pathname.startsWith('/changelog')) {
+  //   url.hostname = changelogFramerHostname
+  // }
 
   const res = await fetch(url.toString(), { ...req })
 

--- a/apps/web/src/utils/replaceUrls.ts
+++ b/apps/web/src/utils/replaceUrls.ts
@@ -2,7 +2,6 @@ import {
   landingPageHostname,
   landingPageFramerHostname,
   blogFramerHostname,
-  changelogFramerHostname,
 } from '@/app/hostnames'
 
 export function replaceUrls(text: string, urlPathName: string, prefix: string = '', suffix: string = ''): string {
@@ -26,14 +25,6 @@ export function replaceUrls(text: string, urlPathName: string, prefix: string = 
       // so we need to handle this explicitly.
       urlPathName === '/'
         ? `${prefix}https://e2b.dev/blog`
-        : `${prefix}https://e2b.dev`
-    )
-    .replaceAll(
-      `${prefix}${changelogFramerHostname}`,
-      // The default url on framer does not have /changelog in the path but the custom domain does,
-      // so we need to handle this explicitly.
-      urlPathName === '/'
-        ? `${prefix}https://e2b.dev/changelog`
         : `${prefix}https://e2b.dev`
     )
 }


### PR DESCRIPTION
This PR updates the middleware rules so it fetches the new changelog page hosted on Webflow when user goes to `https://e2b.dev/changelog`.