### PR TITLE
Show badge for legacy documentation search results

### DIFF
--- a/apps/web/src/components/Search.tsx
+++ b/apps/web/src/components/Search.tsx
@@ -253,6 +253,13 @@ function SearchResult({
           <HighlightQuery text={contextPreview} query={query} />
         </div>
       )}
+      {result.badge === 'Legacy' && (
+        <div className="absolute top-3 right-4">
+          <span className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 px-2 py-1">
+            {result.badge}
+          </span>
+        </div>
+      )}
     </li>
   )
 }

--- a/apps/web/src/components/Search.tsx
+++ b/apps/web/src/components/Search.tsx
@@ -83,7 +83,12 @@ function useAutocomplete({ close }: { close: () => void }) {
             {
               sourceId: 'documentation',
               getItems() {
-                return search(query, { limit: 5 })
+                const results = search(query, { limit: 5 })
+                return results.sort((a, b) => {
+                  if (a.badge === 'Legacy' && b.badge !== 'Legacy') return 1
+                  if (a.badge !== 'Legacy' && b.badge === 'Legacy') return -1
+                  return 0
+                })
               },
               getItemUrl({ item }) {
                 return item.url
@@ -210,7 +215,7 @@ function SearchResult({
   return (
     <li
       className={clsx(
-        'group block cursor-default px-4 py-3 aria-selected:bg-zinc-50 dark:aria-selected:bg-zinc-800/50',
+        'group block relative cursor-default px-4 py-3 aria-selected:bg-zinc-50 dark:aria-selected:bg-zinc-800/50',
         resultIndex > 0 && 'border-t border-zinc-100 dark:border-zinc-800'
       )}
       aria-labelledby={`${id}-hierarchy ${id}-title`}
@@ -255,7 +260,7 @@ function SearchResult({
       )}
       {result.badge === 'Legacy' && (
         <div className="absolute top-3 right-4">
-          <span className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 px-2 py-1">
+          <span className="rounded-full text-xs bg-zinc-900 py-1 px-3 text-white hover:bg-zinc-700 dark:bg-brand-400/10 dark:text-brand-400 dark:ring-1 dark:ring-inset dark:ring-brand-400/20 dark:hover:bg-brand-400/10 dark:hover:text-brand-300 dark:hover:ring-brand-300">
             {result.badge}
           </span>
         </div>

--- a/apps/web/src/mdx/search.mjs
+++ b/apps/web/src/mdx/search.mjs
@@ -96,7 +96,7 @@ export default function (nextConfig = {}) {
                 document: {
                   id: 'url',
                   index: 'content',
-                  store: ['title', 'pageTitle', 'preview'],
+                  store: ['title', 'pageTitle', 'preview', 'badge'],
                 },
                 context: {
                   resolution: 9,
@@ -114,6 +114,8 @@ export default function (nextConfig = {}) {
                   continue
                 }
 
+                const isLegacy = url.includes('docs/legacy')
+
                 for (let [title, hash, content] of sections) {
                   sectionIndex.add({
                     url: url + (hash ? ('#' + hash) : ''),
@@ -121,6 +123,7 @@ export default function (nextConfig = {}) {
                     content: [title, ...content].join('\\n'),
                     pageTitle: hash ? sections[0][0] : undefined,
                     preview: content.join('\\n'),
+                    badge: isLegacy ? 'Legacy' : undefined,
                   })
                 }
               }
@@ -138,6 +141,7 @@ export default function (nextConfig = {}) {
                   title: item.doc.title,
                   pageTitle: item.doc.pageTitle,
                   preview: item.doc.preview,
+                  badge: item.doc.badge,
                 }))
               }
             `

--- a/apps/web/types.d.ts
+++ b/apps/web/types.d.ts
@@ -6,6 +6,7 @@ declare module '@/mdx/search.mjs' {
     title: string
     pageTitle?: string
     preview?: string
+    badge?: 'Legacy'
   }
 
   export function search(query: string, options?: SearchOptions): Array<Result>


### PR DESCRIPTION
This pr adds a `badge` attribute to documentation indices, which can represent a string literal for certain badge types defined in the `Result` type. 

Possible types at the time of writing: `"Legacy" | undefined`

On each documentation query, we sort all search results containing a badge value of `Legacy` at last and render a badge containing the string value in each search result item.