### PR TITLE
Fix duplicate search analytics event captures

### DIFF
--- a/apps/web/src/components/LegacyBanner.tsx
+++ b/apps/web/src/components/LegacyBanner.tsx
@@ -17,7 +17,7 @@ export default function LegacyBanner() {
           <AlertCircle className="h-4 w-4 text-brand-400/80" />
           <span>
             You are reading a{' '}
-            <span className="text-brand-400/90">legacy (pre v.1.0)</span>{' '}
+            <span className="text-brand-400/90">legacy (pre v1.0)</span>{' '}
             document.
           </span>
         </div>

--- a/apps/web/src/components/Search.tsx
+++ b/apps/web/src/components/Search.tsx
@@ -46,11 +46,16 @@ function useAutocomplete({ close }: { close: () => void }) {
   >({})
 
   const captureSearchEvent = useDebounceCallback(
-    (query: string, results_count: number) =>
+    (query: string, results_count: number) => {
+      // return when length <= one, because this occurs when query is
+      // erased & last event on debounce stack is let through with 1 char
+      if (query.length <= 1) return
+
       posthog.capture('searched docs', {
         query,
         results_count,
-      }),
+      })
+    },
     500
   )
 
@@ -95,7 +100,7 @@ function useAutocomplete({ close }: { close: () => void }) {
       onStateChange({ state }) {
         setAutocompleteState(state)
 
-        if (state.query) {
+        if (state.query && state.status === 'loading') {
           captureSearchEvent(
             state.query,
             state.collections[0]?.items.length || 0


### PR DESCRIPTION
This pr adds the following:
1. prevents unnecessary analytics event captures when user erases query & user navigates through results with arrow keys
2. changes docs page legacy banner prose (v.1.0 -> v1.0)
