### PR TITLE
Clarify how filtering works with multiple key-value pairs

### DIFF
--- a/apps/web/src/app/(docs)/docs/sandbox/list/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox/list/page.mdx
@@ -64,11 +64,11 @@ Running sandbox template id: 3e4rngfa34txe0gxc1zf
 
 ## Filtering sandboxes
 <Note>
-    This feature is in private beta.
+This feature is in a private beta.
 </Note>
 
-You can filter sandboxes by:
-- <Link href="/docs/sandbox/metadata">Metadata</Link> key value pairs
+You can filter sandboxes by specifying <Link href="/docs/sandbox/metadata">Metadata</Link> key value pairs.
+Specifying multiple key value pairs will return sandboxes that match all of them.
 
 This can be useful when you have a large number of sandboxes and want to find only specific ones. The filtering is performed on the server side.
 
@@ -85,7 +85,7 @@ const sandbox = await Sandbox.create({
   },
 })
 
-// List running sandboxes filtered by metadata.
+// List running sandboxes that has `userId` key with value `123` and `env` key with value `dev`.
 const runningSandboxes = await Sandbox.list({
     filters: { userId: '123', env: 'dev' } // $HighlightLine
 })
@@ -102,7 +102,7 @@ sandbox = Sandbox(
     },
 )
 
-# List running sandboxes filtered by metadata.
+# List running sandboxes that has `userId` key with value `123` and `env` key with value `dev`.
 running_sandboxes = Sandbox.list(filters={
     "userId": "123", "env": "dev" # $HighlightLine
 })

--- a/apps/web/src/app/(docs)/docs/sandbox/list/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox/list/page.mdx
@@ -70,7 +70,7 @@ This feature is in a private beta.
 You can filter sandboxes by specifying <Link href="/docs/sandbox/metadata">Metadata</Link> key value pairs.
 Specifying multiple key value pairs will return sandboxes that match all of them.
 
-This can be useful when you have a large number of sandboxes and want to find only specific ones. The filtering is performed on the server side.
+This can be useful when you have a large number of sandboxes and want to find only specific ones. The filtering is performed on the server.
 
 <CodeGroup>
 ```js


### PR DESCRIPTION
Update docs to make it clear how sandbox filtering works with multiple key-value metadata pairs.