### PR TITLE
Change the default generated code for e2b.Dockerfile when initializing custom template

### DIFF
--- a/.changeset/thick-trains-lick.md
+++ b/.changeset/thick-trains-lick.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': minor
+---
+
+Change the default generated code for e2b.Dockerfile when initializing custom template

--- a/e2b.Dockerfile
+++ b/e2b.Dockerfile
@@ -1,4 +1,0 @@
-# You can use most Debian-based base images
-FROM ubuntu:22.04
-
-# Install dependencies and customize sandbox

--- a/e2b.Dockerfile
+++ b/e2b.Dockerfile
@@ -1,0 +1,4 @@
+# You can use most Debian-based base images
+FROM ubuntu:22.04
+
+# Install dependencies and customize sandbox

--- a/packages/cli/src/docker/constants.ts
+++ b/packages/cli/src/docker/constants.ts
@@ -2,7 +2,7 @@ export const defaultDockerfileName = 'e2b.Dockerfile'
 export const fallbackDockerfileName = 'Dockerfile'
 
 export const basicDockerfile = `# You can use most Debian-based base images
-FROM ubuntu:22.04
+FROM e2bdev/code-interpreter:latest
 
 # Install dependencies and customize sandbox
 `


### PR DESCRIPTION
Everywhere in docs, we direct users to be using our code interpreter package. However when you run `e2b template init`, we still generate the `e2b.Dockerfile` with 
```
FROM ubuntu:22.04
```
which won't work with the code interpreter package.

This PR changes the generated code to
```
FROM e2bdev/code-interpreter:latest
```