### PR TITLE
Fix typo in docs

### DIFF
--- a/apps/web/src/app/(docs)/docs/page.mdx
+++ b/apps/web/src/app/(docs)/docs/page.mdx
@@ -22,7 +22,7 @@ pip install e2b-code-interpreter
 </CodeGroup>
 
 ## What is E2B?
-E2B is an [open-source](https://github.com/e2b-dev) infrastructure that allows you run to AI-generated code in secure isolated sandboxes in the cloud.
+E2B is an [open-source](https://github.com/e2b-dev) infrastructure that allows you to run AI-generated code in secure isolated sandboxes in the cloud.
 To start and control sandboxes, use our [Python SDK](https://pypi.org/project/e2b/) or [JavaScript SDK](https://www.npmjs.com/package/e2b). {{ className: 'lead' }}
 
 Some of the typical use cases for E2B are AI data analysis or visualization, running AI-generated code of various languages, playground for coding agents, environment for codegen evals, or running full AI-generated apps like in [Fragments](https://github.com/e2b-dev/fragments).


### PR DESCRIPTION
run to => to run

🙂