### PR TITLE
Hide metrics in sidebar

### DIFF
--- a/apps/web/src/components/Navigation/routes.tsx
+++ b/apps/web/src/components/Navigation/routes.tsx
@@ -280,11 +280,11 @@ export const docRoutes: NavGroup[] = [
         tag: Tag.New,
         href: '/docs/sandbox/persistence',
       },
-      {
-        title: 'Metrics',
-        tag: Tag.New,
-        href: '/docs/sandbox/metrics',
-      },
+      // {
+      //   title: 'Metrics',
+      //   tag: Tag.New,
+      //   href: '/docs/sandbox/metrics',
+      // },
       {
         title: 'Metadata',
         href: '/docs/sandbox/metadata',


### PR DESCRIPTION
Hide metrics route in the docs sidebar until the feature is fully released