### PR TITLE
Fix Socket closed build error

### DIFF
--- a/.changeset/sweet-pots-pull.md
+++ b/.changeset/sweet-pots-pull.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Fix socket closed error


### PR DESCRIPTION
# Description

If the build and push takes more than 10 minutes the connection gets automatically closed by load balancer and the request fails with UND_ERR_SOCKET error. In this case we just need to retry the request.