### PR TITLE
Fix: assetPrefix refers to correct domains for production & preview environments

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -50,7 +50,9 @@ const nextConfig = {
   basePath: '',
   assetPrefix:
     process.env.NODE_ENV === 'production'
-      ? `https://${process.env.NEXT_PUBLIC_DOMAIN}`
+      ? `https://${
+          process.env.DASHBOARD_PROXY_DOMAIN ?? process.env.VERCEL_URL
+        }`
       : undefined,
   headers: async () => [
     {

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -50,7 +50,7 @@ const nextConfig = {
   basePath: '',
   assetPrefix:
     process.env.NODE_ENV === 'production'
-      ? `https://${process.env.VERCEL_URL}`
+      ? `https://${process.env.NEXT_PUBLIC_DOMAIN}`
       : undefined,
   headers: async () => [
     {


### PR DESCRIPTION
This pr fixes the following issue for [#569](https://github.com/e2b-dev/E2B/pull/569):

The production vercel environment did not refer assets to the correct production domain through VERCEL_URL. Hence a custom environment variable was added to the production environment to account for that.