### PR TITLE
Remove level field and deduplicate timestamp field 

### DIFF
--- a/packages/cli/src/commands/sandbox/metrics.ts
+++ b/packages/cli/src/commands/sandbox/metrics.ts
@@ -146,13 +146,12 @@ function printMetric(
     console.log(
       JSON.stringify({
         timestamp: new Date(timestamp).toISOString(),
-        level,
         ...metric,
       })
     )
   } else {
     const time = `[${new Date(timestamp).toISOString().replace(/T/, ' ')}]`
-    delete metric['level']
+    delete metric['timestamp']
     console.log(
       `${asTimestamp(time)} ${level} ` +
         util.inspect(metric, {


### PR DESCRIPTION
this addresses theses issues pointed out by @jakubno :

```
No need to return timestamp if it's already in square brackets
[2025-02-04 19:28:08.627Z]  { cpuCount: 2, cpuUsedPct: 3.23, memTotalMiB: 987, memUsedMiB: 55, timestamp: '2025-02-04T19:28:08.62741452Z' }

And if you do json format, there level field
{"timestamp":"2025-02-04T19:28:08.62741452Z","level":"","cpuCount":2,"cpuUsedPct":3.23,"memTotalMiB":987,"memUsedMiB":55}
```