### PR TITLE
Fix usage in browser

### DIFF
--- a/.changeset/twelve-planets-attend.md
+++ b/.changeset/twelve-planets-attend.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+Fix browser usage

--- a/packages/js-sdk/src/api/metadata.ts
+++ b/packages/js-sdk/src/api/metadata.ts
@@ -52,6 +52,10 @@ export const defaultHeaders = {
 }
 
 export function getEnvVar(name: string) {
+  if (typeof process === 'undefined') {
+    return ''
+  }
+
   if (runtime === 'deno') {
     // @ts-ignore
     return Deno.env.get(name)


### PR DESCRIPTION
Variable `process` isn't present in browser