### PR TITLE
E2B-1546: add google tag manager capibilites for /docs

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -29,15 +29,6 @@ export const metadata: Metadata = {
   },
 }
 
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    interface IntrinsicElements {
-      'chatlio-widget': any
-    }
-  }
-}
-
 export default async function RootLayout({ children }) {
   const pages = await glob('**/*.mdx', { cwd: 'src/app/(docs)/docs' })
   const allSectionsEntries = (await Promise.all(

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next'
 import { Analytics } from '@vercel/analytics/react'
+import Script from 'next/script'
 
 import { Providers } from '@/app/providers'
 
@@ -32,7 +33,7 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      'chatlio-widget': any;
+      'chatlio-widget': any
     }
   }
 }
@@ -40,23 +41,40 @@ declare global {
 export default async function RootLayout({ children }) {
   const pages = await glob('**/*.mdx', { cwd: 'src/app/(docs)/docs' })
   const allSectionsEntries = (await Promise.all(
-    pages.map(async filename => [
+    pages.map(async (filename) => [
       '/docs/' + filename.replace(/\(docs\)\/?|(^|\/)page\.mdx$/, ''),
       (await import(`./(docs)/docs/${filename}`)).sections,
-    ]),
+    ])
   )) as Array<[string, Array<Section>]>
   const allSections = Object.fromEntries(allSectionsEntries)
 
   return (
-    <html
-      lang="en"
-      className="h-full"
-      suppressHydrationWarning
-    >
+    <html lang="en" className="h-full" suppressHydrationWarning>
       <head>
+        {process.env.NODE_ENV === 'production' && (
+          <Script id="google-tag-manager" strategy="afterInteractive">
+            {`
+              (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+              })(window,document,'script','dataLayer','GTM-K2W3LVD2');
+            `}
+          </Script>
+        )}
         <Canonical />
       </head>
       <body className="flex min-h-full antialiased bg-zinc-900">
+        {process.env.NODE_ENV === 'production' && (
+          <noscript>
+            <iframe
+              src="https://www.googletagmanager.com/ns.html?id=GTM-K2W3LVD2"
+              height="0"
+              width="0"
+              style={{ display: 'none', visibility: 'hidden' }}
+            />
+          </noscript>
+        )}
         <Providers>
           <Layout allSections={allSections}>
             <Header />


### PR DESCRIPTION
This PR adds necessary Google Tag Manager identification tags to our next.js app. Primary focus for the GTM here lies on `/dashboard `& `/docs` 