### PR TITLE
Fix CLI build issue

### DIFF
--- a/.changeset/stale-owls-own.md
+++ b/.changeset/stale-owls-own.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Fix ESM import for older node versions

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,5 @@
 #!/usr/bin/env -S node --enable-source-maps
 
-import * as updateNotifier from 'update-notifier'
-
 import * as commander from 'commander'
 import * as packageJSON from '../package.json'
 import { program } from './commands'
@@ -9,12 +7,18 @@ import { commands2md } from './utils/commands2md'
 
 export const pkg = packageJSON
 
-updateNotifier
-  .default({
-    pkg,
-    updateCheckInterval: 1000 * 60 * 60 * 8, // 8 hours
-  })
-  .notify()
+async function loadUpdateNotifier() {
+    const updateNotifier = await import('update-notifier');
+    return updateNotifier.default;
+}
+
+loadUpdateNotifier().then(updateNotifier => {
+    updateNotifier({
+        pkg,
+        updateCheckInterval:1000 * 60 * 60 * 8, // 8 hours
+    })
+        .notify()
+})
 
 const prog = program.version(
   packageJSON.version,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S node --enable-source-maps
 
+import updateNotifier from 'update-notifier'
 import * as commander from 'commander'
 import * as packageJSON from '../package.json'
 import { program } from './commands'
@@ -7,18 +8,11 @@ import { commands2md } from './utils/commands2md'
 
 export const pkg = packageJSON
 
-async function loadUpdateNotifier() {
-    const updateNotifier = await import('update-notifier');
-    return updateNotifier.default;
-}
-
-loadUpdateNotifier().then(updateNotifier => {
-    updateNotifier({
-        pkg,
-        updateCheckInterval:1000 * 60 * 60 * 8, // 8 hours
-    })
-        .notify()
+updateNotifier({
+  pkg,
+  updateCheckInterval:1000 * 60 * 60 * 8, // 8 hours
 })
+  .notify()
 
 const prog = program.version(
   packageJSON.version,

--- a/packages/cli/tsup.config.js
+++ b/packages/cli/tsup.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 import * as packageJSON from './package.json'
 
-const excludedPackages = ['update-notifier', 'inquirer']
+const excludedPackages = ['inquirer']
 
 export default defineConfig({
   entry: ['src/index.ts'],


### PR DESCRIPTION
Load update notifier dynamically

We needed update the package because of vulnerabilities

If we don't load it asynchronously there's following error.
```
packages/cli generate-ref: /home/runner/work/E2B/E2B/packages/cli/dist/index.js:55406
packages/cli generate-ref: var updateNotifier = __toESM(require("update-notifier"));
packages/cli generate-ref:                              ^
packages/cli generate-ref: Error [ERR_REQUIRE_ESM]: require() of ES Module /home/runner/work/E2B/E2B/node_modules/.pnpm/update-notifier@6.0.2/node_modules/update-notifier/index.js from /home/runner/work/E2B/E2B/packages/cli/dist/index.js not supported.
packages/cli generate-ref: Instead change the require of /home/runner/work/E2B/E2B/node_modules/.pnpm/update-notifier@6.0.2/node
```