### PR TITLE
Update persistence docs

### DIFF
--- a/apps/web/src/app/(docs)/docs/sandbox/persistence/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox/persistence/page.mdx
@@ -1,8 +1,7 @@
 # Sandbox persistence
 
 <Note>
-Sandbox persistence is currently in beta:
-1. [Reach out to us](/docs/support) with your use case to get access to the beta.
+Sandbox persistence is currently in public beta:
 1. You'll need to install the [beta version of the SDKs](#installing-the-beta-version-of-the-sdks).
 1. Consider [some limitations](#limitations-while-in-beta).
 1. The persistence is free for all users during the beta.


### PR DESCRIPTION
This PR removes a requirement for reaching to get access to persistence as persistence is now in public beta.