### PR TITLE
Explicitly mention Docker commands when building template

### DIFF
--- a/.changeset/warm-grapes-applaud.md
+++ b/.changeset/warm-grapes-applaud.md
@@ -2,4 +2,4 @@
 '@e2b/cli': minor
 ---
 
-Explicitly mention Docker commands when building template"
+Explicitly mention Docker commands when building template

--- a/.changeset/warm-grapes-applaud.md
+++ b/.changeset/warm-grapes-applaud.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': minor
+---
+
+Explicitly mention Docker commands when building template"


### PR DESCRIPTION
This PR improves CLI messaging when building sandbox templates. Now, the used Docker commands are explicitly logged to the user like this:

```
Building docker image with the following command:
docker build . \ # <--- This log is new
   -f e2b.Dockerfile \
   --pull --platform linux/amd64 \
   -t docker.e2b.dev/e2b/custom-envs/vqwjjtzwfi59d1cwww1k:ec8a819a-9666-45df-997b-e181b9fe4224 

[+] Building 0.7s (5/5) FINISHED                                                                              docker:desktop-linux
 => [internal] load build definition from e2b.Dockerfile                                                                      0.0s
 => => transferring dockerfile: 149B                                                                                          0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04 
```
and
```
Pushing docker image with the following command:
docker push docker.e2b.dev/e2b/custom-envs/vqwjjtzwfi59d1cwww1k:ec8a819a-9666-45df-997b-e181b9fe4224 # <--- This log is new

The push refers to repository [docker.e2b.dev/e2b/custom-envs/vqwjjtzwfi59d1cwww1k]
```

so the user can potentially debug some issues on their own.