### PR TITLE
Improve legacy banner visibility in /docs

### DIFF
--- a/apps/web/src/components/LegacyBanner.tsx
+++ b/apps/web/src/components/LegacyBanner.tsx
@@ -13,8 +13,8 @@ export default function LegacyBanner() {
   return (
     <>
       <div className="sticky top-[5rem] inset-x-0 z-10">
-        <div className="flex items-center gap-2 max-w-6xl mx-auto w-fit px-4 py-3 rounded-2xl bg-gradient-to-b from-zinc-800 to-zinc-900 text-zinc-400 ring-1 ring-inset ring-zinc-700">
-          <AlertCircle className="h-4 w-4 text-brand-400/80" />
+        <div className="flex items-center gap-2 max-w-6xl mx-auto w-fit px-4 py-3 rounded-2xl bg-brand-400/10 backdrop-blur-sm text-brand-400/80 ring-1 ring-inset ring-brand-400/20">
+          <AlertCircle className="h-4 w-4 " />
           <span>
             You are reading a{' '}
             <span className="text-brand-400/90">legacy (pre v1.0)</span>{' '}

--- a/apps/web/src/components/Navigation/routes.tsx
+++ b/apps/web/src/components/Navigation/routes.tsx
@@ -484,7 +484,7 @@ const sdkRefNameMap = {
 }
 
 export const sdkRefRoutes: VersionedNavGroup[] = (
-  sdkRefRoutesJson as VersionedNavGroup[]
+  sdkRefRoutesJson as unknown as VersionedNavGroup[]
 )
   .sort((a, b) => {
     const order = {


### PR DESCRIPTION
This pr improves the legacy banner visibility in legacy documentation pages by utilizing the brand color (dark orange) on border, text and background.