### PR TITLE
Show resolvable url in error message

### DIFF
--- a/.changeset/sweet-geese-yell.md
+++ b/.changeset/sweet-geese-yell.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Before the urls in our error messages pointed to a doc page that doesn't exist. This change updates the urls with links that resolve to dashboard

--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,3 @@
+# Releasing e2b cli 
+
+to create a changeset run `npx changeset`

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -18,7 +18,7 @@ const authErrorBox = (keyName: string) => {
         )} environment variable.
     Visit ${asPrimary(
           'https://e2b.dev/dashboard?tab=keys'
-        )} to get the access token.`,
+        )} to get the API key.`,
         {
           width: 70,
           float: 'center',

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -8,48 +8,38 @@ export let apiKey = process.env.E2B_API_KEY
 export let accessToken = process.env.E2B_ACCESS_TOKEN
 
 const authErrorBox = (keyName: string) => {
+  let link
+  let msg
   switch (keyName) {
     case 'E2B_API_KEY':
-      return boxen.default(
-        `You must be logged in to use this command. Run ${asBold('e2b auth login')}.
-    
-    If you are seeing this message in CI/CD you may need to set the ${asBold(
-          `${keyName}`
-        )} environment variable.
-    Visit ${asPrimary(
-          'https://e2b.dev/dashboard?tab=keys'
-        )} to get the API key.`,
-        {
-          width: 70,
-          float: 'center',
-          padding: 0.5,
-          margin: 1,
-          borderStyle: 'round',
-          borderColor: 'redBright',
-        }
-      )
+      link = 'https://e2b.dev/dashboard?tab=keys'
+      msg = 'API key'
+
     case 'E2B_ACCESS_TOKEN':
-      return boxen.default(
-        `You must be logged in to use this command. Run ${asBold('e2b auth login')}.
-    
-    If you are seeing this message in CI/CD you may need to set the ${asBold(
-          `${keyName}`
-        )} environment variable.
-    Visit ${asPrimary(
-          'https://e2b.dev/dashboard?tab=personal'
-        )} to get the access token.`,
-        {
-          width: 70,
-          float: 'center',
-          padding: 0.5,
-          margin: 1,
-          borderStyle: 'round',
-          borderColor: 'redBright',
-        }
-      )
-    default:
-      throw new Error(`Unknown key name: ${keyName}`)
+      link = 'https://e2b.dev/dashboard?tab=personal'
+      msg = 'access token'
   }
+  // throwing error in default in switch statement results in unreachable code,
+  // so we need to check if link and msg are defined here instead
+  if (!link || !msg) {
+    throw new Error(`Unknown key name: ${keyName}`)
+  }
+  return boxen.default(
+    `You must be logged in to use this command. Run ${asBold('e2b auth login')}.
+
+If you are seeing this message in CI/CD you may need to set the ${asBold(
+      `${keyName}`
+    )} environment variable.
+Visit ${asPrimary(link)} to get the ${msg}.`,
+    {
+      width: 70,
+      float: 'center',
+      padding: 0.5,
+      margin: 1,
+      borderStyle: 'round',
+      borderColor: 'redBright',
+    }
+  )
 }
 
 export function ensureAPIKey() {

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -7,24 +7,50 @@ import { asBold, asPrimary } from './utils/format'
 export let apiKey = process.env.E2B_API_KEY
 export let accessToken = process.env.E2B_ACCESS_TOKEN
 
-const authErrorBox =(keyName: string) => boxen.default(
-  `You must be logged in to use this command. Run ${asBold('e2b auth login')}.
-
-If you are seeing this message in CI/CD you may need to set the ${asBold(
-    `${keyName}`
-  )} environment variable.
-Visit ${asPrimary(
-    'https://e2b.dev/docs/getting-started/api-key'
-  )} to get the access token.`,
-  {
-    width: 70,
-    float: 'center',
-    padding: 0.5,
-    margin: 1,
-    borderStyle: 'round',
-    borderColor: 'redBright',
+const authErrorBox = (keyName: string) => {
+  switch (keyName) {
+    case 'E2B_API_KEY':
+      return boxen.default(
+        `You must be logged in to use this command. Run ${asBold('e2b auth login')}.
+    
+    If you are seeing this message in CI/CD you may need to set the ${asBold(
+          `${keyName}`
+        )} environment variable.
+    Visit ${asPrimary(
+          'https://e2b.dev/dashboard?tab=keys'
+        )} to get the access token.`,
+        {
+          width: 70,
+          float: 'center',
+          padding: 0.5,
+          margin: 1,
+          borderStyle: 'round',
+          borderColor: 'redBright',
+        }
+      )
+    case 'E2B_ACCESS_TOKEN':
+      return boxen.default(
+        `You must be logged in to use this command. Run ${asBold('e2b auth login')}.
+    
+    If you are seeing this message in CI/CD you may need to set the ${asBold(
+          `${keyName}`
+        )} environment variable.
+    Visit ${asPrimary(
+          'https://e2b.dev/dashboard?tab=personal'
+        )} to get the access token.`,
+        {
+          width: 70,
+          float: 'center',
+          padding: 0.5,
+          margin: 1,
+          borderStyle: 'round',
+          borderColor: 'redBright',
+        }
+      )
+    default:
+      throw new Error(`Unknown key name: ${keyName}`)
   }
-)
+}
 
 export function ensureAPIKey() {
   // If apiKey is not already set (either from env var or from user config), try to get it from config file


### PR DESCRIPTION
Before the urls in our error messages pointed to a doc page that doesn't exist. This change updates the urls with links that resolve to dashboard

also adds note on how to create changesets