### PR TITLE
Fix cli build

### DIFF
--- a/.changeset/great-starfishes-teach.md
+++ b/.changeset/great-starfishes-teach.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/cli': patch
+---
+
+fix build pipeline

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -269,23 +269,23 @@ export class Filesystem {
     const { path, writeOpts, writeFiles } =
       typeof pathOrFiles === 'string'
         ? {
-            path: pathOrFiles,
-            writeOpts: opts as FilesystemRequestOpts,
-            writeFiles: [
-              {
-                data: dataOrOpts as
-                  | string
-                  | ArrayBuffer
-                  | Blob
-                  | ReadableStream,
-              },
-            ],
-          }
+          path: pathOrFiles,
+          writeOpts: opts as FilesystemRequestOpts,
+          writeFiles: [
+            {
+              data: dataOrOpts as
+                | string
+                | ArrayBuffer
+                | Blob
+                | ReadableStream,
+            },
+          ],
+        }
         : {
-            path: undefined,
-            writeOpts: dataOrOpts as FilesystemRequestOpts,
-            writeFiles: pathOrFiles as WriteEntry[],
-          }
+          path: undefined,
+          writeOpts: dataOrOpts as FilesystemRequestOpts,
+          writeFiles: pathOrFiles as WriteEntry[],
+        }
 
     if (writeFiles.length === 0) return [] as EntryInfo[]
 
@@ -508,13 +508,12 @@ export class Filesystem {
     }
   ): Promise<WatchHandle> {
     if (
-      opts?.recursive &&
       this.envdApi.version &&
       compareVersions(this.envdApi.version, ENVD_VERSION_RECURSIVE_WATCH) < 0
     ) {
       throw new TemplateError(
         'You need to update the template to use recursive watching. ' +
-          'You can do this by running `e2b template build` in the directory with the template.'
+        'You can do this by running `e2b template build` in the directory with the template.'
       )
     }
 
@@ -525,14 +524,14 @@ export class Filesystem {
 
     const reqTimeout = requestTimeoutMs
       ? setTimeout(() => {
-          controller.abort()
-        }, requestTimeoutMs)
+        controller.abort()
+      }, requestTimeoutMs)
       : undefined
 
     const events = this.rpc.watchDir(
       {
         path,
-        recursive: opts?.recursive ?? this.defaultWatchRecursive,
+        recursive: this.defaultWatchRecursive,
       },
       {
         headers: {
@@ -540,7 +539,7 @@ export class Filesystem {
           [KEEPALIVE_PING_HEADER]: KEEPALIVE_PING_INTERVAL_SEC.toString(),
         },
         signal: controller.signal,
-        timeoutMs: opts?.timeoutMs ?? this.defaultWatchTimeout,
+        timeoutMs: this.defaultWatchTimeout,
       }
     )
 


### PR DESCRIPTION
https://github.com/e2b-dev/E2B/actions/runs/13958203528/job/39074272842

```
➜  cli git:(main) ✗ pnpm run build                                                                                                                            ~/E2B/packages/cli

> @e2b/cli@1.2.2 build /Users/f/E2B/packages/cli
> tsc --noEmit --skipLibCheck && tsup --minify

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.3.6
CLI Using tsup config: /Users/f/E2B/packages/cli/tsup.config.js
CLI Target: node18
CLI Cleaning output folder
CJS Build start
CJS dist/index.js     1.82 MB
CJS dist/index.js.map 5.05 MB
CJS ⚡️ Build success in 256ms
➜  cli git:(main) ✗ git switch -c fix-cli-build                                                                                                               ~/E2B/packages/cli
Switched to a new branch 'fix-cli-build'
➜  cli git:(fix-cli-build) ✗
```