### PR TITLE
Add temporary docs redirects 

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -82,6 +82,20 @@ const nextConfig = {
       ],
     }
   },
+  async redirects() {
+    return [
+      {
+        source: '/docs/sandbox-templates/overview',
+        destination: '/docs/sandbox-template',
+        permanent: true,
+      },
+      {
+        source: '/docs/sandbox-templates',
+        destination: '/docs/sandbox-template',
+        permanent: true,
+      },
+    ]
+  },
 }
 
 export default withSearch(


### PR DESCRIPTION
on our landing page & documentation we have references to outdated urls. for an upcoming event, redirects should be in place to avoid broken links. the redirects should only be temporary and the broken references should be fixed when resources are available to do so