### PR TITLE
Fix Webflow proxying with www-prefixed hostname and proper request handling

### DIFF
--- a/apps/web/src/app/hostnames.ts
+++ b/apps/web/src/app/hostnames.ts
@@ -1,5 +1,5 @@
 // We are in the process of migrating to the new landing page hosting.
-export const landingPageHostname = 'e2b-landing-page.com'
+export const landingPageHostname = 'www.e2b-landing-page.com'
 export const landingPageFramerHostname = 'e2b-landing-page.framer.website'
 export const blogFramerHostname = 'e2b-blog.framer.website'
 export const changelogFramerHostname = 'e2b-changelog.framer.website'


### PR DESCRIPTION
This PR resolves the Cloudflare IP blocking issue by:

1. Adding www prefix to landing page hostname
2. Properly handling request headers with new Headers object
3. Adding redirect handling to follow redirects
4. Refactoring middleware response handling for proper URL rewriting

These changes prevent Cloudflare from identifying our requests as suspicious automated traffic while maintaining the functionality of our proxy middleware.