### PR TITLE
Allow writing BufferedReader

### DIFF
--- a/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
@@ -1,6 +1,6 @@
 import httpcore
 import httpx
-from io import TextIOBase
+from io import TextIOBase, BufferedReader
 from packaging.version import Version
 from typing import AsyncIterator, IO, List, Literal, Optional, overload, Union
 from e2b.sandbox.filesystem.filesystem import WriteEntry
@@ -206,7 +206,7 @@ class Filesystem:
             file_path, file_data = file['path'], file['data']
             if isinstance(file_data, str) or isinstance(file_data, bytes):
                 httpx_files.append(('file', (file_path, file_data)))
-            elif isinstance(file_data, TextIOBase):
+            elif isinstance(file_data, TextIOBase) or isinstance(file_data, BufferedReader):
                 httpx_files.append(('file', (file_path, file_data.read())))
             else:
                 raise ValueError(f"Unsupported data type for file {file_path}")

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -1,4 +1,4 @@
-from io import TextIOBase
+from io import TextIOBase, BufferedReader
 from typing import IO, Iterator, List, Literal, Optional, overload, Union
 from e2b.sandbox.filesystem.filesystem import WriteEntry
 
@@ -202,7 +202,7 @@ class Filesystem:
             file_path, file_data = file['path'], file['data']
             if isinstance(file_data, str) or isinstance(file_data, bytes):
                 httpx_files.append(('file', (file_path, file_data)))
-            elif isinstance(file_data, TextIOBase):
+            elif isinstance(file_data, TextIOBase) or isinstance(file_data, BufferedReader):
                 httpx_files.append(('file', (file_path, file_data.read())))
             else:
                 raise ValueError(f"Unsupported data type for file {file_path}")

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_write.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_write.py
@@ -1,7 +1,9 @@
+import io
+
 from e2b import AsyncSandbox
 from e2b.sandbox_async.filesystem.filesystem import EntryInfo
 
-async def test_write_file(async_sandbox: AsyncSandbox):
+async def test_write_text_file(async_sandbox: AsyncSandbox):
     filename = "test_write.txt"
     content = "This is a test file."
 
@@ -19,6 +21,21 @@ async def test_write_file(async_sandbox: AsyncSandbox):
 
     read_content = await async_sandbox.files.read(filename)
     assert read_content == content
+
+async def test_write_binary_file(async_sandbox: AsyncSandbox):
+    filename = "test_write.txt"
+    text = "This is a test binary file."
+    # equivalent to `open("path/to/local/file", "rb")`
+    content = io.BufferedReader(io.BytesIO(text.encode("utf-8")))
+
+    info = await async_sandbox.files.write(filename, content)
+    assert info.path == f"/home/user/{filename}"
+
+    exists = await async_sandbox.files.exists(filename)
+    assert exists
+
+    read_content = await async_sandbox.files.read(filename)
+    assert read_content == text
 
 async def test_write_multiple_files(async_sandbox: AsyncSandbox):
     # Attempt to write with empty files array

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_write.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_write.py
@@ -1,6 +1,8 @@
+import io
+
 from e2b.sandbox.filesystem.filesystem import EntryInfo
 
-def test_write_file(sandbox):
+def test_write_text_file(sandbox):
     filename = "test_write.txt"
     content = "This is a test file."
 
@@ -18,6 +20,21 @@ def test_write_file(sandbox):
 
     read_content = sandbox.files.read(filename)
     assert read_content == content
+
+def test_write_binary_file(sandbox):
+    filename = "test_write.txt"
+    text = "This is a test binary file."
+    # equivalent to `open("path/to/local/file", "rb")`
+    content = io.BufferedReader(io.BytesIO(text.encode("utf-8")))
+
+    info = sandbox.files.write(filename, content)
+    assert info.path == f"/home/user/{filename}"
+
+    exists = sandbox.files.exists(filename)
+    assert exists
+
+    read_content = sandbox.files.read(filename)
+    assert read_content == text
 
 def test_write_multiple_files(sandbox):
     # Attempt to write with empty files array


### PR DESCRIPTION
- [x] update `write` method in sync & async python SDKs to allow `io.BufferedReader` files
- [x] update tests 