### PR TITLE
build-arg's not working for e2b template build command

### DIFF
--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -356,7 +356,7 @@ export const buildCommand = new commander.Command('build')
    -t docker.${connectionConfig.domain}/e2b/custom-envs/${templateID}:${template.buildID} ${Object.entries(
           dockerBuildArgs
         )
-            .map(([key, value]) => `--build-arg="${key}=${value}"`)
+            .map(([key, value]) => `--build-arg "${key}=${value}"`)
             .join(' \\ \n   ')}`
         console.log(`Building docker image with the following command:\n${asBold(cmd)}\n`)
 


### PR DESCRIPTION
At the moment if you pass in build args it breaks since the commands aren't compatible with the docker build command:

Sample error at the moment when passing the --build-arg to e2b which proxies the command on incorrectly:

```
(base) ➜  web git:(lb) ✗ npm run build-template template-name version

> new-nextjs-app@0.1.0 build-template
> ts-node scripts/build-template.ts template-name template-version sha

ERROR: "docker buildx build" requires exactly 1 argument.
See 'docker buildx build --help'.

Usage:  docker buildx build [OPTIONS] PATH | URL | -

Start a build
/bin/sh: line 4: --build-arg=TEMPLATE_VERSION=0.0.1: command not found
Error: Command failed: docker build . \
   -f e2b.Dockerfile \
   --pull --platform linux/amd64 \
   -t docker.e2b.dev/e2b/custom-envs/17e92ok9u0gimh3oy1qg:be0bdf11-4cf2-4ee0-a932-1ecb6ae50298 --build-arg="TEMPLATE_NAME=lead-magnet" \
   --build-arg="TEMPLATE_VERSION=0.0.1"
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at checkExecSyncError (node:child_process:889:11)
    at Object.execSync (node:child_process:961:15)
    at e.<anonymous> (/opt/homebrew/lib/node_modules/@e2b/cli/src/commands/template/build.ts:363:23) {
  status: 127,
  signal: null,
  output: [ null, null, null ],
  pid: 67925,
  stdout: null,
  stderr: null
}
Failed to build template: Error: Command failed: e2b template build -d "../../sandbox/templates/e2b.Dockerfile" -n template-name sha1 --build-arg TEMPLATE_NAME=template-name --build-arg TEMPLATE_VERSION=0.0.1 -p "../sandbox/templates/"
ERROR: "docker buildx build" requires exactly 1 argument.
See 'docker buildx build --help'.

Usage:  docker buildx build [OPTIONS] PATH | URL | -
```