### PR TITLE
Remove backslashes from the docker build command (Windows)

### DIFF
--- a/.changeset/tasty-candles-leave.md
+++ b/.changeset/tasty-candles-leave.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+fixes an issue building templates on Windows

--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -91,23 +91,23 @@ async function triggerTemplateBuild(templateID: string, buildID: string) {
   const maxRetries = 3
   for (let i = 0; i < maxRetries; i++) {
     try {
-      res = await client.api.POST(
-        '/templates/{templateID}/builds/{buildID}',
-        {
-          params: {
-            path: {
-              templateID,
-              buildID,
-            },
+      res = await client.api.POST('/templates/{templateID}/builds/{buildID}', {
+        params: {
+          path: {
+            templateID,
+            buildID,
           },
-        }
-      )
+        },
+      })
 
       break
     } catch (e) {
       // If the build and push takes more than 10 minutes the connection gets automatically closed by load balancer
       // and the request fails with UND_ERR_SOCKET error. In this case we just need to retry the request.
-      if ((e instanceof TypeError) && (((e as TypeError).cause) as any)?.code !== 'UND_ERR_SOCKET') {
+      if (
+        e instanceof TypeError &&
+        ((e as TypeError).cause as any)?.code !== 'UND_ERR_SOCKET'
+      ) {
         console.error(e)
         console.log('Retrying...')
       }
@@ -350,15 +350,22 @@ export const buildCommand = new commander.Command('build')
         }
         process.stdout.write('\n')
 
-        const cmd = `docker build . \\
-   -f ${dockerfileRelativePath} \\
-   --pull --platform linux/amd64 \\
-   -t docker.${connectionConfig.domain}/e2b/custom-envs/${templateID}:${template.buildID} ${Object.entries(
-          dockerBuildArgs
+        const buildArgs = Object.entries(dockerBuildArgs)
+          .map(([key, value]) => `--build-arg "${key}=${value}"`)
+          .join(' ')
+
+        const cmd = [
+          'docker build',
+          `-f ${dockerfileRelativePath}`,
+          '--pull --platform linux/amd64',
+          `-t docker.${connectionConfig.domain}/e2b/custom-envs/${templateID}:${template.buildID}`,
+          buildArgs,
+          '.',
+        ].join(' ')
+
+        console.log(
+          `Building docker image with the following command:\n${asBold(cmd)}\n`
         )
-            .map(([key, value]) => `--build-arg "${key}=${value}"`)
-            .join(' \\ \n   ')}`
-        console.log(`Building docker image with the following command:\n${asBold(cmd)}\n`)
 
         child_process.execSync(cmd, {
           stdio: 'inherit',
@@ -371,15 +378,16 @@ export const buildCommand = new commander.Command('build')
         console.log('> Docker image built.\n')
 
         const pushCmd = `docker push docker.${connectionConfig.domain}/e2b/custom-envs/${templateID}:${template.buildID}`
-        console.log(`Pushing docker image with the following command:\n${asBold(pushCmd)}\n`)
+        console.log(
+          `Pushing docker image with the following command:\n${asBold(
+            pushCmd
+          )}\n`
+        )
         try {
-          child_process.execSync(
-            pushCmd,
-            {
-              stdio: 'inherit',
-              cwd: root,
-            }
-          )
+          child_process.execSync(pushCmd, {
+            stdio: 'inherit',
+            cwd: root,
+          })
         } catch (err: any) {
           await buildWithProxy(
             userConfig,
@@ -446,14 +454,16 @@ async function waitForBuildFinish(
 sandbox = Sandbox("${aliases?.length ? aliases[0] : template.templateID}")
 
 # Create async sandbox
-sandbox = await AsyncSandbox.create("${aliases?.length ? aliases[0] : template.templateID
-          }")`)
+sandbox = await AsyncSandbox.create("${
+          aliases?.length ? aliases[0] : template.templateID
+        }")`)
 
         const typescriptExample = asTypescript(`import { Sandbox } from 'e2b'
 
 // Create sandbox
-const sandbox = await Sandbox.create('${aliases?.length ? aliases[0] : template.templateID
-          }')`)
+const sandbox = await Sandbox.create('${
+          aliases?.length ? aliases[0] : template.templateID
+        }')`)
 
         const examplesMessage = `You can now use the template to create custom sandboxes.\nLearn more on ${asPrimary(
           'https://e2b.dev/docs'


### PR DESCRIPTION
- Fixing #650, on Windows commands cannot separate arguments by backslash (\).