### PR TITLE
Update Ubuntu base image to 22.04

### DIFF
--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: ./packages/cli
     name: Build CLI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/js_sdk_tests.yml
+++ b/.github/workflows/js_sdk_tests.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: ./packages/js-sdk
     name: Build and test SDK
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   test:
     name: Build and test SDK
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/python_sdk_tests.yml
+++ b/.github/workflows/python_sdk_tests.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: ./packages/python-sdk
     name: Build and test SDK
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: ./templates/base
 
     name: Build and Push Images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

There is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
