### PR TITLE
Show SDK ref dir only when it exists

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: '3.9'
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
@@ -78,10 +78,15 @@ jobs:
       - name: Generate SDK reference
         id: sdk-ref
         run: pnpm run --recursive generate-ref
-              
+
       - name: Show docs file structure
-        run: tree ./sdk-reference
-  
+        run: |
+          if [ -d "./sdk-reference" ]; then
+            tree ./sdk-reference
+          else
+            echo "sdk-reference directory does not exist"
+          fi
+
       - name: Update lock file
         run: pnpm i --no-link --no-frozen-lockfile
 


### PR DESCRIPTION
# Description 
To avoid errors like [these](https://github.com/e2b-dev/E2B/actions/runs/14200197836/job/39785152642) where we publish without any sdk ref changes. 