### PR TITLE
Added security.txt under well-known

### DIFF
--- a/apps/web/public/.well-known/security.txt
+++ b/apps/web/public/.well-known/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:security@e2b.dev
+Preferred-Languages: en
+Canonical: https://e2b.dev/.well-known/security.txt


### PR DESCRIPTION
Added file under `/.well-known/security.txt` to match security standards for security or abuse reports.

More details why this is well known address by search engines or security researchers can be found here:
https://www.rfc-editor.org/rfc/rfc9116