### PR TITLE
Fix edge runtime issue - use redirect: follow fetch option

### DIFF
--- a/.changeset/serious-rocks-exist.md
+++ b/.changeset/serious-rocks-exist.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+Added support for edge workers on cloudflare

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -114,6 +114,17 @@ export class Sandbox extends SandboxApi {
       baseUrl: this.envdApiUrl,
       useBinaryFormat: false,
       interceptors: opts?.logger ? [createRpcLogger(opts.logger)] : undefined,
+      fetch: (url, options) => {
+        // Patch fetch to always use redirect: "follow"
+        // connect-web doesn't allow to configure redirect option - https://github.com/connectrpc/connect-es/pull/1082
+        // connect-web package uses redirect: "error" which is not supported in edge runtimes
+        // E2B endpoints should be safe to use with redirect: "follow" https://github.com/e2b-dev/E2B/issues/531#issuecomment-2779492867
+        options = {
+          ...(options ?? {}),
+          redirect: 'follow',
+        }
+        return fetch(url, options)
+      },
     })
 
     this.envdApi = new EnvdApiClient(


### PR DESCRIPTION
Works well in my Cloudflare PoC https://github.com/rychlis/e2b-edge-test/blob/main/src/index.ts
PoC is using these APIs work well:
- `Sandbox.create`
- `sandbox.commands.run` with background ture

I use follow as per @ValentaTomas comment here https://github.com/e2b-dev/E2B/issues/531#issuecomment-2779492867

Few notes:
- I use beta release so I based this PR on beta, can do separate PR to main if needed
- Maybe I can only change this behavior based on detected runtime, but I think it might be safe
- Didn't look into E2B testing suite yet. My PoC only tests APIs I listed, maybe there are other edge runtime issues I didn't uncover yet

Should fix https://github.com/e2b-dev/E2B/issues/531