### PR TITLE
(Workers) Patch connect-es fetch transport to always use redirect: follow

### DIFF
--- a/.changeset/lemon-maps-sleep.md
+++ b/.changeset/lemon-maps-sleep.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+patch connect-es fetch transport to always use redirect: follow

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -114,6 +114,17 @@ export class Sandbox extends SandboxApi {
       baseUrl: this.envdApiUrl,
       useBinaryFormat: false,
       interceptors: opts?.logger ? [createRpcLogger(opts.logger)] : undefined,
+      fetch: (url, options) => {
+        // Patch fetch to always use redirect: "follow"
+        // connect-web doesn't allow to configure redirect option - https://github.com/connectrpc/connect-es/pull/1082
+        // connect-web package uses redirect: "error" which is not supported in edge runtimes
+        // E2B endpoints should be safe to use with redirect: "follow" https://github.com/e2b-dev/E2B/issues/531#issuecomment-2779492867
+        options = {
+          ...(options ?? {}),
+          redirect: 'follow',
+        }
+        return fetch(url, options)
+      },
     })
 
     this.envdApi = new EnvdApiClient(


### PR DESCRIPTION
backports the changes from beta branch (#669)