### PR TITLE
Fix minor issue in python filesystem SDK

### DIFF
--- a/.changeset/selfish-cars-relax.md
+++ b/.changeset/selfish-cars-relax.md
@@ -1,0 +1,5 @@
+---
+'@e2b/python-sdk': patch
+---
+
+Fix minor issue in python filesystem SDK (type-safety)

--- a/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
@@ -47,9 +47,7 @@ class EntryInfo:
     """
 
 
-dataclass
-
-
+@dataclass
 class WriteEntry:
     """
     Contains path and data of the file to be written to the filesystem.


### PR DESCRIPTION
One should now be able to use sb.filesystem.write(WriteEntry[]) in a typesafe way.