### PR TITLE
Fix dataclass declaration for `WriteEntry`

### DIFF
--- a/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
@@ -47,7 +47,7 @@ class EntryInfo:
     """
 
 
-dataclass
+@dataclass
 class WriteEntry:
     """
     Contains path and data of the file to be written to the filesystem.


### PR DESCRIPTION
There was a type in dataclass declaration that caused the WriteEntry to behave incorrectly.