### PR TITLE
Clone remote desktop & code-interpreter SDK refs into E2B sdk refs folder during publish 

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -79,6 +79,26 @@ jobs:
         id: sdk-ref
         run: pnpm run --recursive generate-ref
 
+      - name: Clone Remote Code Interpreter SDK reference
+        run: |
+          git clone --depth 1 --filter=blob:none --sparse https://github.com/e2b-dev/code-interpreter -b generate-api-reference-for-code-interpreter-sdk-e2b-1235
+          cd code-interpreter
+          # This command configures git sparse-checkout to only fetch/checkout the 'sdk-reference' directory
+          # from the cloned repository, saving bandwidth and disk space by not downloading other directories
+          git sparse-checkout set sdk-reference
+          cp -r sdk-reference/* ../apps/web/src/app/\(docs\)/docs/sdk-reference/
+          cd ..
+          rm -rf code-interpreter
+
+      - name: Clone Remote Desktop SDK reference
+        run: |
+          git clone --depth 1 --filter=blob:none --sparse https://github.com/e2b-dev/desktop -b generate-api-reference-for-desktop-sdk-e2b-1236
+          cd desktop
+          git sparse-checkout set sdk-reference
+          cp -r sdk-reference/* ../apps/web/src/app/\(docs\)/docs/sdk-reference/
+          cd ..
+          rm -rf desktop
+
       - name: Show docs file structure
         run: |
           if [ -d "./sdk-reference" ]; then

--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -83,8 +83,6 @@ jobs:
         run: |
           git clone --depth 1 --filter=blob:none --sparse https://github.com/e2b-dev/code-interpreter -b generate-api-reference-for-code-interpreter-sdk-e2b-1235
           cd code-interpreter
-          # This command configures git sparse-checkout to only fetch/checkout the 'sdk-reference' directory
-          # from the cloned repository, saving bandwidth and disk space by not downloading other directories
           git sparse-checkout set sdk-reference
           cp -r sdk-reference/* ../apps/web/src/app/\(docs\)/docs/sdk-reference/
           cd ..


### PR DESCRIPTION
### Description 

This was initially performed in [the legacy workflow](https://github.com/e2b-dev/E2B/blob/d27f81c5d3a85e2791258e388eb7ebd5f2e5eaa9/.github/workflows/generate_sdk_ref.yml#L101-L117) but has since been removed, adding it back to have latest [desktop & code-interpreter SDK references](https://e2b.dev/docs/sdk-reference) on our docs

### Test
<img width="234" alt="Screenshot 2025-04-15 at 1 47 16 PM" src="https://github.com/user-attachments/assets/b00347d9-794d-41f1-98db-c4704c59f50d" />


#### should become:

- [ ] desktop:
  - [ ] js-sdk `v1.7.01@latest`
  - [ ] python-sdk `v1.6.1@latest`
- [ ] code-interpreter
  - [ ] js-sdk `v1.1.1@latest`
  - [ ] python-sdk `v1.2.0@latest`


