### PR TITLE
Improve assetPrefix configuration for proxy / development setup

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -49,11 +49,9 @@ const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
   basePath: '',
   assetPrefix:
-    process.env.NODE_ENV === 'production'
+    process.env.VERCEL_ENV === 'production'
       ? `https://${
-          process.env.VERCEL_ENV === 'production'
-            ? process.env.VERCEL_PROJECT_PRODUCTION_URL
-            : ( process.env.VERCEL_BRANCH_URL ?? process.env.VERCEL_URL )
+             process.env.VERCEL_PROJECT_PRODUCTION_URL
         }`
       : undefined,
   headers: async () => [

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -47,13 +47,13 @@ const codeSnippetsDir = path.resolve('./src/code')
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
-  basePath: '',
+/*   basePath: '',
   assetPrefix:
     process.env.NODE_ENV === 'production'
       ? `https://${
           process.env.DASHBOARD_PROXY_DOMAIN ?? process.env.VERCEL_URL
         }`
-      : undefined,
+      : undefined, */
   headers: async () => [
     {
       source: '/:path*',

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -51,7 +51,9 @@ const nextConfig = {
   assetPrefix:
     process.env.NODE_ENV === 'production'
       ? `https://${
-          process.env.DASHBOARD_PROXY_DOMAIN ?? process.env.VERCEL_URL
+          process.env.VERCEL_ENV === 'production'
+            ? process.env.VERCEL_PROJECT_PRODUCTION_URL
+            : ( process.env.VERCEL_BRANCH_URL ?? process.env.VERCEL_URL )
         }`
       : undefined,
   headers: async () => [

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -47,13 +47,13 @@ const codeSnippetsDir = path.resolve('./src/code')
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
-/*   basePath: '',
+  basePath: '',
   assetPrefix:
     process.env.NODE_ENV === 'production'
       ? `https://${
           process.env.DASHBOARD_PROXY_DOMAIN ?? process.env.VERCEL_URL
         }`
-      : undefined, */
+      : undefined,
   headers: async () => [
     {
       source: '/:path*',

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -49,10 +49,10 @@ const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
   basePath: '',
   assetPrefix:
+    // our production next app is proxied by our dashboard next app.
+    // to make assets load correctly after proxying, we need to specify the proxied domain here.
     process.env.VERCEL_ENV === 'production'
-      ? `https://${
-             process.env.VERCEL_PROJECT_PRODUCTION_URL
-        }`
+      ? `https://e2b-docs.vercel.app`
       : undefined,
   headers: async () => [
     {


### PR DESCRIPTION
Because our docs nextjs app is being proxied by our dashboard nextjs app, we need to ensure the docs nextjs app uses absolute urls to handle it's assets. Because when it is proxied by another nextjs app, the proxy tries to reference the docs nextjs apps assets relatively, which results in assets not being found. 

Before this pr, we set an assetPrefix for every node production deployment, which caused issues on preview deployments, since these can consist of multiple assigned domains and depending on which one was opened, the asset prefixing failed. 

These changes ensure that only the production deployment of the docs application has an assetPrefix. Here we can be certain on which domain it will live. We hardcode the domain here to ensure 100% consistency with `e2b-dev/dashboard`s proxy domain config, without relying on the vercel projects assigned domain setup.