### PR TITLE
bump beta versions

### DIFF
--- a/.changeset/fifty-points-cross.md
+++ b/.changeset/fifty-points-cross.md
@@ -1,7 +1,0 @@
----
-'@e2b/python-sdk': minor
-'e2b': minor
-'@e2b/cli': minor
----
-
-improved Sandbox.list method with pagination

--- a/.changeset/serious-rocks-exist.md
+++ b/.changeset/serious-rocks-exist.md
@@ -1,5 +1,0 @@
----
-'e2b': patch
----
-
-Added support for edge workers on cloudflare

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,7 +73,7 @@
     "command-exists": "^1.2.9",
     "commander": "^11.1.0",
     "console-table-printer": "^2.11.2",
-    "e2b": "1.2.0-beta.3",
+    "e2b": "1.2.0-beta.2",
     "inquirer": "^9.2.12",
     "open": "^9.1.0",
     "strip-ansi": "^7.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,7 +73,7 @@
     "command-exists": "^1.2.9",
     "commander": "^11.1.0",
     "console-table-printer": "^2.11.2",
-    "e2b": "1.2.0-beta.2",
+    "e2b": "1.2.0-beta.3",
     "inquirer": "^9.2.12",
     "open": "^9.1.0",
     "strip-ansi": "^7.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2b/cli",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "description": "CLI for managing e2b sandbox templates",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2b",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.3",
   "description": "E2B SDK that give agents cloud environments",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2b",
-  "version": "1.2.0-beta.3",
+  "version": "1.2.0-beta.4",
   "description": "E2B SDK that give agents cloud environments",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "e2b"
-version = "1.2.0b3"
+version = "1.2.0b4"
 description = "E2B SDK that give agents cloud environments"
 authors = ["e2b <hello@e2b.dev>"]
 license = "MIT"

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "e2b"
-version = "1.2.0b2"
+version = "1.2.0b3"
 description = "E2B SDK that give agents cloud environments"
 authors = ["e2b <hello@e2b.dev>"]
 license = "MIT"


### PR DESCRIPTION
- removes outdated change sets
- bumped packages versions
- CLI version was unchanged because the current version is not on NPM
- Python beta SDK was updated few hours ago?