### PR TITLE
Add option for proxying SDK requests to API and sandbox

### DIFF
--- a/.changeset/cuddly-buckets-tie.md
+++ b/.changeset/cuddly-buckets-tie.md
@@ -1,0 +1,5 @@
+---
+'@e2b/python-sdk': patch
+---
+
+Add support for passing proxy

--- a/packages/python-sdk/e2b/__init__.py
+++ b/packages/python-sdk/e2b/__init__.py
@@ -31,6 +31,7 @@ from .api import (
 )
 from .connection_config import (
     ConnectionConfig,
+    ProxyTypes,
 )
 from .exceptions import (
     SandboxException,

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -1,9 +1,9 @@
 import json
 import logging
-from dataclasses import dataclass
-
 from typing import Optional
 from httpx import Limits
+from dataclasses import dataclass
+
 
 from e2b.api.client.client import AuthenticatedClient
 from e2b.connection_config import ConnectionConfig
@@ -97,6 +97,7 @@ class ApiClient(AuthenticatedClient):
                     "request": [self._log_request],
                     "response": [self._log_response],
                 },
+                "proxy": config.proxy,
                 "limits": limits,
             },
             headers=headers,

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -2,8 +2,8 @@ import json
 import logging
 from dataclasses import dataclass
 
-from typing import Optional, Union
-from httpx import HTTPTransport, AsyncHTTPTransport
+from typing import Optional
+from httpx import Limits
 
 from e2b.api.client.client import AuthenticatedClient
 from e2b.connection_config import ConnectionConfig
@@ -50,7 +50,7 @@ class ApiClient(AuthenticatedClient):
         config: ConnectionConfig,
         require_api_key: bool = True,
         require_access_token: bool = False,
-        transport: Optional[Union[HTTPTransport, AsyncHTTPTransport]] = None,
+        limits: Optional[Limits] = None,
         *args,
         **kwargs,
     ):
@@ -97,7 +97,7 @@ class ApiClient(AuthenticatedClient):
                     "request": [self._log_request],
                     "response": [self._log_response],
                 },
-                "transport": transport,
+                "limits": limits,
             },
             headers=headers,
             token=token,

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -1,6 +1,7 @@
 import os
 
 from typing import Literal, Optional, Dict
+from httpx._types import ProxyTypes
 
 REQUEST_TIMEOUT: float = 30.0  # 30 seconds
 
@@ -37,12 +38,14 @@ class ConnectionConfig:
         access_token: Optional[str] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
+        proxy: Optional[ProxyTypes] = None,
     ):
         self.domain = domain or ConnectionConfig._domain()
         self.debug = debug or ConnectionConfig._debug()
         self.api_key = api_key or ConnectionConfig._api_key()
         self.access_token = access_token or ConnectionConfig._access_token()
         self.headers = headers
+        self.proxy = proxy
 
         self.request_timeout = ConnectionConfig._get_request_timeout(
             REQUEST_TIMEOUT,

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -4,7 +4,7 @@ import httpx
 from typing import Dict, Optional, TypedDict, overload
 from typing_extensions import Unpack
 
-from e2b.connection_config import ConnectionConfig
+from e2b.connection_config import ConnectionConfig, ProxyTypes
 from e2b.envd.api import ENVD_API_HEALTH_ROUTE, ahandle_envd_api_exception
 from e2b.exceptions import format_request_timeout_error
 from e2b.sandbox.main import SandboxSetup
@@ -106,7 +106,9 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         self._envd_api_url = f"{'http' if self.connection_config.debug else 'https'}://{self.get_host(self.envd_port)}"
         self._envd_version = opts["envd_version"]
 
-        self._transport = AsyncTransportWithLogger(limits=self._limits)
+        self._transport = AsyncTransportWithLogger(
+            limits=self._limits, proxy=self._connection_config.proxy
+        )
         self._envd_api = httpx.AsyncClient(
             base_url=self.envd_api_url,
             transport=self._transport,
@@ -177,6 +179,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         domain: Optional[str] = None,
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
+        proxy: Optional[ProxyTypes] = None,
     ):
         """
         Create a new sandbox.
@@ -189,6 +192,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         :param envs: Custom environment variables for the sandbox
         :param api_key: E2B API Key to use for authentication, defaults to `E2B_API_KEY` environment variable
         :param request_timeout: Timeout for the request in **seconds**
+        :param proxy: Proxy to use for the request and for the **requests made to the returned sandbox**
 
         :return: sandbox instance for the new sandbox
 
@@ -199,6 +203,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
             domain=domain,
             debug=debug,
             request_timeout=request_timeout,
+            proxy=proxy,
         )
 
         if connection_config.debug:
@@ -214,6 +219,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
                 debug=debug,
                 request_timeout=request_timeout,
                 env_vars=envs,
+                proxy=proxy,
             )
             sandbox_id = response.sandbox_id
             envd_version = response.envd_version
@@ -231,6 +237,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         api_key: Optional[str] = None,
         domain: Optional[str] = None,
         debug: Optional[bool] = None,
+        proxy: Optional[ProxyTypes] = None,
     ):
         """
         Connect to an existing sandbox.
@@ -238,6 +245,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
 
         :param sandbox_id: Sandbox ID
         :param api_key: E2B API Key to use for authentication, defaults to `E2B_API_KEY` environment variable
+        :param proxy: Proxy to use for the request and for the **requests made to the returned sandbox**
 
         :return: sandbox instance for the existing sandbox
 
@@ -253,6 +261,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
             api_key=api_key,
             domain=domain,
             debug=debug,
+            proxy=proxy,
         )
 
         return cls(
@@ -286,6 +295,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         domain: Optional[str] = None,
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> bool:
         """
         Kill the sandbox specified by sandbox ID.
@@ -293,13 +303,17 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         :param sandbox_id: Sandbox ID
         :param api_key: E2B API Key to use for authentication, defaults to `E2B_API_KEY` environment variable
         :param request_timeout: Timeout for the request in **seconds**
+        :param proxy: Proxy to use for the request
 
         :return: `True` if the sandbox was killed, `False` if the sandbox was not found
         """
         ...
 
     @class_method_variant("_cls_kill")
-    async def kill(self, request_timeout: Optional[float] = None) -> bool:  # type: ignore
+    async def kill(
+        self,
+        request_timeout: Optional[float] = None,
+    ) -> bool:  # type: ignore
         config_dict = self.connection_config.__dict__
         config_dict.pop("access_token", None)
         config_dict.pop("api_url", None)
@@ -309,7 +323,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
 
         await SandboxApi._cls_kill(
             sandbox_id=self.sandbox_id,
-            **self.connection_config.__dict__,
+            **config_dict,
         )
 
     @overload
@@ -339,6 +353,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         domain: Optional[str] = None,
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> None:
         """
         Set the timeout of the specified sandbox.
@@ -350,6 +365,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         :param sandbox_id: Sandbox ID
         :param timeout: Timeout for the sandbox in **seconds**
         :param request_timeout: Timeout for the request in **seconds**
+        :param proxy: Proxy to use for the request
         """
         ...
 
@@ -369,7 +385,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         await SandboxApi._cls_set_timeout(
             sandbox_id=self.sandbox_id,
             timeout=timeout,
-            **self.connection_config.__dict__,
+            **config_dict,
         )
 
     async def get_info(  # type: ignore

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -407,5 +407,5 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
 
         return await SandboxApi.get_info(
             sandbox_id=self.sandbox_id,
-            **self.connection_config.__dict__,
+            **config_dict,
         )

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -268,7 +268,3 @@ class SandboxApi(SandboxApiBase):
                 ),
                 envd_version=res.parsed.envd_version,
             )
-
-    @staticmethod
-    def _get_sandbox_id(sandbox_id: str, client_id: str) -> str:
-        return f"{sandbox_id}-{client_id}"

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -1,6 +1,8 @@
 import urllib.parse
+
 from typing import Optional, Dict, List
 from packaging.version import Version
+
 
 from e2b.sandbox.sandbox_api import SandboxInfo, SandboxApiBase, SandboxQuery
 from e2b.exceptions import TemplateException
@@ -13,7 +15,7 @@ from e2b.api.client.api.sandboxes import (
     delete_sandboxes_sandbox_id,
     post_sandboxes,
 )
-from e2b.connection_config import ConnectionConfig
+from e2b.connection_config import ConnectionConfig, ProxyTypes
 from e2b.api import handle_api_exception
 
 
@@ -27,6 +29,7 @@ class SandboxApi(SandboxApiBase):
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> List[SandboxInfo]:
         """
         List all running sandboxes.
@@ -37,6 +40,7 @@ class SandboxApi(SandboxApiBase):
         :param debug: Enable debug mode, all requested are then sent to localhost
         :param request_timeout: Timeout for the request in **seconds**
         :param headers: Additional headers to send with the request
+        :param proxy: Proxy to use for the request
 
         :return: List of running sandboxes
         """
@@ -46,6 +50,7 @@ class SandboxApi(SandboxApiBase):
             debug=debug,
             request_timeout=request_timeout,
             headers=headers,
+            proxy=proxy,
         )
 
         # Convert filters to the format expected by the API
@@ -99,6 +104,7 @@ class SandboxApi(SandboxApiBase):
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> SandboxInfo:
         """
         Get the sandbox info.
@@ -108,6 +114,7 @@ class SandboxApi(SandboxApiBase):
         :param debug: Debug mode, defaults to `E2B_DEBUG` environment variable
         :param request_timeout: Timeout for the request in **seconds**
         :param headers: Additional headers to send with the request
+        :param proxy: Proxy to use for the request
 
         :return: Sandbox info
         """
@@ -117,6 +124,7 @@ class SandboxApi(SandboxApiBase):
             debug=debug,
             request_timeout=request_timeout,
             headers=headers,
+            proxy=proxy,
         )
 
         async with AsyncApiClient(
@@ -157,6 +165,7 @@ class SandboxApi(SandboxApiBase):
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> bool:
         config = ConnectionConfig(
             api_key=api_key,
@@ -164,6 +173,7 @@ class SandboxApi(SandboxApiBase):
             debug=debug,
             request_timeout=request_timeout,
             headers=headers,
+            proxy=proxy,
         )
 
         if config.debug:
@@ -197,6 +207,7 @@ class SandboxApi(SandboxApiBase):
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> None:
         config = ConnectionConfig(
             api_key=api_key,
@@ -204,6 +215,7 @@ class SandboxApi(SandboxApiBase):
             debug=debug,
             request_timeout=request_timeout,
             headers=headers,
+            proxy=proxy,
         )
 
         if config.debug:
@@ -235,6 +247,7 @@ class SandboxApi(SandboxApiBase):
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(
             api_key=api_key,
@@ -242,6 +255,7 @@ class SandboxApi(SandboxApiBase):
             debug=debug,
             request_timeout=request_timeout,
             headers=headers,
+            proxy=proxy,
         )
 
         async with AsyncApiClient(

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -58,7 +58,10 @@ class SandboxApi(SandboxApiBase):
                 }
                 metadata = urllib.parse.urlencode(quoted_metadata)
 
-        async with AsyncApiClient(config) as api_client:
+        async with AsyncApiClient(
+            config,
+            limits=SandboxApiBase._limits,
+        ) as api_client:
             res = await get_sandboxes.asyncio_detailed(
                 client=api_client,
                 metadata=metadata,
@@ -116,7 +119,10 @@ class SandboxApi(SandboxApiBase):
             headers=headers,
         )
 
-        async with AsyncApiClient(config) as api_client:
+        async with AsyncApiClient(
+            config,
+            limits=SandboxApiBase._limits,
+        ) as api_client:
             res = await get_sandboxes_sandbox_id.asyncio_detailed(
                 sandbox_id,
                 client=api_client,
@@ -164,7 +170,10 @@ class SandboxApi(SandboxApiBase):
             # Skip killing the sandbox in debug mode
             return True
 
-        async with AsyncApiClient(config) as api_client:
+        async with AsyncApiClient(
+            config,
+            limits=SandboxApiBase._limits,
+        ) as api_client:
             res = await delete_sandboxes_sandbox_id.asyncio_detailed(
                 sandbox_id,
                 client=api_client,
@@ -201,7 +210,10 @@ class SandboxApi(SandboxApiBase):
             # Skip setting the timeout in debug mode
             return
 
-        async with AsyncApiClient(config) as api_client:
+        async with AsyncApiClient(
+            config,
+            limits=SandboxApiBase._limits,
+        ) as api_client:
             res = await post_sandboxes_sandbox_id_timeout.asyncio_detailed(
                 sandbox_id,
                 client=api_client,
@@ -232,7 +244,10 @@ class SandboxApi(SandboxApiBase):
             headers=headers,
         )
 
-        async with AsyncApiClient(config) as api_client:
+        async with AsyncApiClient(
+            config,
+            limits=SandboxApiBase._limits,
+        ) as api_client:
             res = await post_sandboxes.asyncio_detailed(
                 body=NewSandbox(
                     template_id=template,

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -277,6 +277,7 @@ class Sandbox(SandboxSetup, SandboxApi):
         domain: Optional[str] = None,
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> bool:
         """
         Kill the sandbox specified by sandbox ID.
@@ -284,6 +285,7 @@ class Sandbox(SandboxSetup, SandboxApi):
         :param sandbox_id: Sandbox ID
         :param api_key: E2B API Key to use for authentication, defaults to `E2B_API_KEY` environment variable
         :param request_timeout: Timeout for the request in **seconds**
+        :param proxy: Proxy to use for the request
 
         :return: `True` if the sandbox was killed, `False` if the sandbox was not found
         """
@@ -336,6 +338,7 @@ class Sandbox(SandboxSetup, SandboxApi):
         domain: Optional[str] = None,
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> None:
         """
         Set the timeout of the sandbox specified by sandbox ID.
@@ -348,6 +351,7 @@ class Sandbox(SandboxSetup, SandboxApi):
         :param timeout: Timeout for the sandbox in **seconds**
         :param api_key: E2B API Key to use for authentication, defaults to `E2B_API_KEY` environment variable
         :param request_timeout: Timeout for the request in **seconds**
+        :param proxy: Proxy to use for the request
         """
         ...
 

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -308,7 +308,7 @@ class Sandbox(SandboxSetup, SandboxApi):
 
         SandboxApi._cls_kill(
             sandbox_id=self.sandbox_id,
-            **self.connection_config.__dict__,
+            **config_dict,
         )
 
     @overload
@@ -371,7 +371,7 @@ class Sandbox(SandboxSetup, SandboxApi):
         SandboxApi._cls_set_timeout(
             sandbox_id=self.sandbox_id,
             timeout=timeout,
-            **self.connection_config.__dict__,
+            **config_dict,
         )
 
     def get_info(  # type: ignore
@@ -392,5 +392,5 @@ class Sandbox(SandboxSetup, SandboxApi):
 
         return SandboxApi.get_info(
             sandbox_id=self.sandbox_id,
-            **self.connection_config.__dict__,
+            **config_dict,
         )

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -61,7 +61,8 @@ class SandboxApi(SandboxApiBase):
                 metadata = urllib.parse.urlencode(quoted_metadata)
 
         with ApiClient(
-            config, transport=HTTPTransport(limits=SandboxApiBase._limits)
+            config,
+            limits=SandboxApiBase._limits,
         ) as api_client:
             res = get_sandboxes.sync_detailed(client=api_client, metadata=metadata)
 
@@ -118,7 +119,8 @@ class SandboxApi(SandboxApiBase):
         )
 
         with ApiClient(
-            config, transport=HTTPTransport(limits=SandboxApiBase._limits)
+            config,
+            limits=SandboxApiBase._limits,
         ) as api_client:
             res = get_sandboxes_sandbox_id.sync_detailed(
                 sandbox_id,
@@ -168,7 +170,8 @@ class SandboxApi(SandboxApiBase):
             return True
 
         with ApiClient(
-            config, transport=HTTPTransport(limits=SandboxApiBase._limits)
+            config,
+            limits=SandboxApiBase._limits,
         ) as api_client:
             res = delete_sandboxes_sandbox_id.sync_detailed(
                 sandbox_id,
@@ -207,7 +210,8 @@ class SandboxApi(SandboxApiBase):
             return
 
         with ApiClient(
-            config, transport=HTTPTransport(limits=SandboxApiBase._limits)
+            config,
+            limits=SandboxApiBase._limits,
         ) as api_client:
             res = post_sandboxes_sandbox_id_timeout.sync_detailed(
                 sandbox_id,
@@ -240,7 +244,8 @@ class SandboxApi(SandboxApiBase):
         )
 
         with ApiClient(
-            config, transport=HTTPTransport(limits=SandboxApiBase._limits)
+            config,
+            limits=SandboxApiBase._limits
         ) as api_client:
             res = post_sandboxes.sync_detailed(
                 body=NewSandbox(

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -1,7 +1,6 @@
 import urllib.parse
 
-from httpx import HTTPTransport
-from typing import Optional, Dict, List, Tuple
+from typing import Optional, Dict, List
 from packaging.version import Version
 
 from e2b.sandbox.sandbox_api import SandboxInfo, SandboxApiBase, SandboxQuery
@@ -15,7 +14,7 @@ from e2b.api.client.api.sandboxes import (
     delete_sandboxes_sandbox_id,
     post_sandboxes,
 )
-from e2b.connection_config import ConnectionConfig
+from e2b.connection_config import ConnectionConfig, ProxyTypes
 from e2b.api import handle_api_exception
 
 
@@ -29,6 +28,7 @@ class SandboxApi(SandboxApiBase):
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> List[SandboxInfo]:
         """
         List all running sandboxes.
@@ -39,6 +39,7 @@ class SandboxApi(SandboxApiBase):
         :param debug: Enable debug mode, all requested are then sent to localhost
         :param request_timeout: Timeout for the request in **seconds**
         :param headers: Additional headers to send with the request
+        :param proxy: Proxy to use for the request
 
         :return: List of running sandboxes
         """
@@ -48,6 +49,7 @@ class SandboxApi(SandboxApiBase):
             debug=debug,
             request_timeout=request_timeout,
             headers=headers,
+            proxy=proxy,
         )
 
         # Convert filters to the format expected by the API
@@ -98,6 +100,7 @@ class SandboxApi(SandboxApiBase):
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> SandboxInfo:
         """
         Get the sandbox info.
@@ -116,6 +119,7 @@ class SandboxApi(SandboxApiBase):
             debug=debug,
             request_timeout=request_timeout,
             headers=headers,
+            proxy=proxy,
         )
 
         with ApiClient(
@@ -156,6 +160,7 @@ class SandboxApi(SandboxApiBase):
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> bool:
         config = ConnectionConfig(
             api_key=api_key,
@@ -163,6 +168,7 @@ class SandboxApi(SandboxApiBase):
             debug=debug,
             request_timeout=request_timeout,
             headers=headers,
+            proxy=proxy,
         )
 
         if config.debug:
@@ -196,6 +202,7 @@ class SandboxApi(SandboxApiBase):
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> None:
         config = ConnectionConfig(
             api_key=api_key,
@@ -203,6 +210,7 @@ class SandboxApi(SandboxApiBase):
             debug=debug,
             request_timeout=request_timeout,
             headers=headers,
+            proxy=proxy,
         )
 
         if config.debug:
@@ -234,6 +242,7 @@ class SandboxApi(SandboxApiBase):
         debug: Optional[bool] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
+        proxy: Optional[ProxyTypes] = None,
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(
             api_key=api_key,
@@ -241,6 +250,7 @@ class SandboxApi(SandboxApiBase):
             debug=debug,
             request_timeout=request_timeout,
             headers=headers,
+            proxy=proxy,
         )
 
         with ApiClient(


### PR DESCRIPTION
PR that allows you to pass `proxy` (of the type ProxyTypes) when calling methods in the SDK that send requests. Also, if you pass `proxy` when creating a sandbox, all the sandbox requests (called on the Sandbox/AsyncSandbox instance) will automatically use the same proxy.

The PR also contains a small bugfix—adding missing passing of limits and passing these directly instead of through transport to be able to pass the proxy parameter properly.

This change should also be compatible with the code interpreter—it uses the client transport, which uses the passed proxy if there is any.