### PR TITLE
Respect `E2B_DOMAIN` for `e2b auth login` in CLI

### DIFF
--- a/.changeset/spotty-eagles-complain.md
+++ b/.changeset/spotty-eagles-complain.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Use `E2B_DOMAIN` for auth login

--- a/packages/cli/src/user.ts
+++ b/packages/cli/src/user.ts
@@ -14,7 +14,7 @@ export interface UserConfig {
 }
 
 export const USER_CONFIG_PATH = path.join(os.homedir(), '.e2b', 'config.json') // TODO: Keep in Keychain
-export const DOCS_BASE = `https://${process.env.E2B_DOCS_DOMAIN || process.env.E2B_DOMAIN || 'e2b.dev'}/docs`
+export const DOCS_BASE = process.env.E2B_DOCS_BASE || `https://${process.env.E2B_DOMAIN || 'e2b.dev'}/docs`
 
 export function getUserConfig(): UserConfig | null {
   if (!fs.existsSync(USER_CONFIG_PATH)) return null

--- a/packages/cli/src/user.ts
+++ b/packages/cli/src/user.ts
@@ -14,7 +14,7 @@ export interface UserConfig {
 }
 
 export const USER_CONFIG_PATH = path.join(os.homedir(), '.e2b', 'config.json') // TODO: Keep in Keychain
-export const DOCS_BASE = process.env.E2B_DOCS_BASE || 'https://e2b.dev/docs'
+export const DOCS_BASE = `https://${process.env.E2B_DOCS_DOMAIN || process.env.E2B_DOMAIN || 'e2b.dev'}/docs`
 
 export function getUserConfig(): UserConfig | null {
   if (!fs.existsSync(USER_CONFIG_PATH)) return null


### PR DESCRIPTION
# Description

- Respect `E2B_DOMAIN` for `e2b auth login` in CLI
- Keep `E2B_DOCS_BASE` to allow for running dashboard locally or towards potentially different domain