### PR TITLE
Allow for short sandbox id in `e2b sbx connect`

### DIFF
--- a/.changeset/tidy-meals-develop.md
+++ b/.changeset/tidy-meals-develop.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Allow connect command to use short sandbox ID

--- a/packages/cli/src/commands/sandbox/connect.ts
+++ b/packages/cli/src/commands/sandbox/connect.ts
@@ -35,6 +35,10 @@ async function connectToSandbox({
   apiKey: string
   sandboxID: string
 }) {
+  if (sandboxID.split('-').length == 1) {
+    sandboxID = `${sandboxID}-00000000`
+  }
+
   const sandbox = await e2b.Sandbox.connect(sandboxID, { apiKey })
 
   console.log(


### PR DESCRIPTION
# Description

Allow for short sandbox ID in CLI when using `e2b sandbox connect <sandbox-id>` 