### PR TITLE
Adds ability to pause Sandbox using Sandbox.pause() static class method

### DIFF
--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -107,8 +107,9 @@ export class Sandbox extends SandboxApi {
 
     this.sandboxId = opts.sandboxId
     this.connectionConfig = new ConnectionConfig(opts)
-    this.envdApiUrl = `${this.connectionConfig.debug ? 'http' : 'https'
-      }://${this.getHost(this.envdPort)}`
+    this.envdApiUrl = `${
+      this.connectionConfig.debug ? 'http' : 'https'
+    }://${this.getHost(this.envdPort)}`
 
     const rpcTransport = createConnectTransport({
       baseUrl: this.envdApiUrl,
@@ -254,9 +255,29 @@ export class Sandbox extends SandboxApi {
     sandboxId: string,
     opts?: Omit<SandboxOpts, 'metadata' | 'envs'>
   ): Promise<InstanceType<S>> {
-    await Sandbox.resumeSandbox(sandboxId, opts?.timeoutMs ?? this.defaultSandboxTimeoutMs, opts)
+    await Sandbox.resumeSandbox(
+      sandboxId,
+      opts?.timeoutMs ?? this.defaultSandboxTimeoutMs,
+      opts
+    )
 
     return await this.connect(sandboxId, opts)
+  }
+
+  /**
+   * Pause a sandbox by its ID.
+   *
+   * @param sandboxId sandbox ID.
+   * @param opts connection options.
+   *
+   * @returns sandbox ID that can be used to resume the sandbox.
+   */
+  static async pause(
+    sandboxId: string,
+    opts?: Omit<SandboxOpts, 'metadata' | 'envs' | 'timeoutMs'>
+  ): Promise<string> {
+    await Sandbox.pauseSandbox(sandboxId, opts)
+    return sandboxId
   }
 
   /**
@@ -391,7 +412,10 @@ export class Sandbox extends SandboxApi {
    * @returns sandbox ID that can be used to resume the sandbox.
    */
   async pause(opts?: Pick<SandboxOpts, 'requestTimeoutMs'>): Promise<string> {
-    await Sandbox.pauseSandbox(this.sandboxId, { ...this.connectionConfig, ...opts })
+    await Sandbox.pauseSandbox(this.sandboxId, {
+      ...this.connectionConfig,
+      ...opts,
+    })
 
     return this.sandboxId
   }

--- a/packages/js-sdk/tests/api/snapshot.test.ts
+++ b/packages/js-sdk/tests/api/snapshot.test.ts
@@ -1,13 +1,13 @@
 import { assert } from 'vitest'
 import { Sandbox } from '../../src'
-import { sandboxTest } from '../setup'
+import { sandboxTest, isDebug } from '../setup'
 
-sandboxTest('pause a sandbox', async ({ sandbox }) => {
+sandboxTest.skipIf(isDebug)('pause a sandbox', async ({ sandbox }) => {
   await Sandbox.pause(sandbox.sandboxId)
-  assert.isTrue(await sandbox.isRunning())
+  assert.isFalse(await sandbox.isRunning())
 })
 
-sandboxTest('resume a sandbox', async ({ sandbox }) => {
+sandboxTest.skipIf(isDebug)('resume a sandbox', async ({ sandbox }) => {
   // pause
   await Sandbox.pause(sandbox.sandboxId)
   assert.isFalse(await sandbox.isRunning())

--- a/packages/js-sdk/tests/api/snapshot.test.ts
+++ b/packages/js-sdk/tests/api/snapshot.test.ts
@@ -1,0 +1,20 @@
+import { assert } from 'vitest'
+import { Sandbox } from '../../src'
+import { sandboxTest } from '../setup'
+
+sandboxTest('pause a sandbox', async ({ sandbox }) => {
+  const sandboxId = sandbox.sandboxId
+  await Sandbox.pause(sandboxId)
+  assert.isTrue(await sandbox.isRunning())
+})
+
+sandboxTest('resume a sandbox', async ({ sandbox }) => {
+  // pause
+  const sandboxId = sandbox.sandboxId
+  await Sandbox.pause(sandboxId)
+  assert.isFalse(await sandbox.isRunning())
+
+  // resume
+  await Sandbox.resume(sandboxId)
+  assert.isTrue(await sandbox.isRunning())
+})

--- a/packages/js-sdk/tests/api/snapshot.test.ts
+++ b/packages/js-sdk/tests/api/snapshot.test.ts
@@ -3,18 +3,16 @@ import { Sandbox } from '../../src'
 import { sandboxTest } from '../setup'
 
 sandboxTest('pause a sandbox', async ({ sandbox }) => {
-  const sandboxId = sandbox.sandboxId
-  await Sandbox.pause(sandboxId)
+  await Sandbox.pause(sandbox.sandboxId)
   assert.isTrue(await sandbox.isRunning())
 })
 
 sandboxTest('resume a sandbox', async ({ sandbox }) => {
   // pause
-  const sandboxId = sandbox.sandboxId
-  await Sandbox.pause(sandboxId)
+  await Sandbox.pause(sandbox.sandboxId)
   assert.isFalse(await sandbox.isRunning())
 
   // resume
-  await Sandbox.resume(sandboxId)
+  await Sandbox.resume(sandbox.sandboxId)
   assert.isTrue(await sandbox.isRunning())
 })

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -416,9 +416,23 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
             debug=debug,
         )
 
-    @classmethod
+    @overload
     async def pause(
-        cls,
+        self,
+        request_timeout: Optional[float] = None,
+    ) -> str:
+        """
+        Pause the sandbox.
+
+        :param request_timeout: Timeout for the request in **seconds**
+
+        :return: sandbox ID that can be used to resume the sandbox
+        """
+        ...
+
+    @overload
+    @staticmethod
+    async def pause(
         sandbox_id: str,
         api_key: Optional[str] = None,
         domain: Optional[str] = None,
@@ -426,26 +440,18 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         request_timeout: Optional[float] = None,
     ) -> str:
         """
-        Pause a sandbox by its ID.
+        Pause the sandbox specified by sandbox ID.
 
         :param sandbox_id: Sandbox ID
-        :param api_key: E2B API Key to use for authentication
-        :param domain: Domain of the sandbox server
-        :param debug: Enable debug mode
+        :param api_key: E2B API Key to use for authentication, defaults to `E2B_API_KEY` environment variable
         :param request_timeout: Timeout for the request in **seconds**
 
         :return: sandbox ID that can be used to resume the sandbox
         """
-        await SandboxApi._cls_pause(
-            sandbox_id=sandbox_id,
-            api_key=api_key,
-            domain=domain,
-            debug=debug,
-            request_timeout=request_timeout,
-        )
-        return sandbox_id
+        ...
 
-    async def pause(
+    @class_method_variant("_cls_pause")
+    async def pause(  # type: ignore
         self,
         request_timeout: Optional[float] = None,
     ) -> str:

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -416,6 +416,35 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
             debug=debug,
         )
 
+    @classmethod
+    async def pause(
+        cls,
+        sandbox_id: str,
+        api_key: Optional[str] = None,
+        domain: Optional[str] = None,
+        debug: Optional[bool] = None,
+        request_timeout: Optional[float] = None,
+    ) -> str:
+        """
+        Pause a sandbox by its ID.
+
+        :param sandbox_id: Sandbox ID
+        :param api_key: E2B API Key to use for authentication
+        :param domain: Domain of the sandbox server
+        :param debug: Enable debug mode
+        :param request_timeout: Timeout for the request in **seconds**
+
+        :return: sandbox ID that can be used to resume the sandbox
+        """
+        await SandboxApi._cls_pause(
+            sandbox_id=sandbox_id,
+            api_key=api_key,
+            domain=domain,
+            debug=debug,
+            request_timeout=request_timeout,
+        )
+        return sandbox_id
+
     async def pause(
         self,
         request_timeout: Optional[float] = None,

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -299,7 +299,7 @@ class Sandbox(SandboxSetup, SandboxApi):
 
         SandboxApi._cls_kill(
             sandbox_id=self.sandbox_id,
-            **self.connection_config.__dict__
+            **self.connection_config.__dict__,
         )
 
     @overload
@@ -462,6 +462,7 @@ class Sandbox(SandboxSetup, SandboxApi):
             debug=self.connection_config.debug,
             request_timeout=request_timeout,
         )
+
         return self.sandbox_id
 
     @overload

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -290,16 +290,9 @@ class Sandbox(SandboxSetup, SandboxApi):
         :param request_timeout: Timeout for the request
         :return: `True` if the sandbox was killed, `False` if the sandbox was not found
         """
-        config_dict = self.connection_config.__dict__
-        config_dict.pop("access_token", None)
-        config_dict.pop("api_url", None)
-
-        if request_timeout:
-            config_dict["request_timeout"] = request_timeout
-
         SandboxApi._cls_kill(
             sandbox_id=self.sandbox_id,
-            **self.connection_config.__dict__,
+            request_timeout=request_timeout,
         )
 
     @overload
@@ -350,17 +343,10 @@ class Sandbox(SandboxSetup, SandboxApi):
         timeout: int,
         request_timeout: Optional[float] = None,
     ) -> None:
-        config_dict = self.connection_config.__dict__
-        config_dict.pop("access_token", None)
-        config_dict.pop("api_url", None)
-
-        if request_timeout:
-            config_dict["request_timeout"] = request_timeout
-
         SandboxApi._cls_set_timeout(
             sandbox_id=self.sandbox_id,
             timeout=timeout,
-            **self.connection_config.__dict__,
+            request_timeout=request_timeout,
         )
 
     @classmethod
@@ -407,9 +393,23 @@ class Sandbox(SandboxSetup, SandboxApi):
             debug=debug,
         )
 
-    @classmethod
+    @overload
     def pause(
-        cls,
+        self,
+        request_timeout: Optional[float] = None,
+    ) -> str:
+        """
+        Pause the sandbox.
+
+        :param request_timeout: Timeout for the request in **seconds**
+
+        :return: sandbox ID that can be used to resume the sandbox
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def pause(
         sandbox_id: str,
         api_key: Optional[str] = None,
         domain: Optional[str] = None,
@@ -427,16 +427,10 @@ class Sandbox(SandboxSetup, SandboxApi):
 
         :return: sandbox ID that can be used to resume the sandbox
         """
-        SandboxApi._cls_pause(
-            sandbox_id=sandbox_id,
-            api_key=api_key,
-            domain=domain,
-            debug=debug,
-            request_timeout=request_timeout,
-        )
-        return sandbox_id
+        ...
 
-    def pause(
+    @class_method_variant("_cls_pause")
+    def pause( # type: ignore
         self,
         request_timeout: Optional[float] = None,
     ) -> str:
@@ -447,7 +441,6 @@ class Sandbox(SandboxSetup, SandboxApi):
 
         :return: sandbox ID that can be used to resume the sandbox
         """
-
         SandboxApi._cls_pause(
             sandbox_id=self.sandbox_id,
             api_key=self.connection_config.api_key,
@@ -455,7 +448,6 @@ class Sandbox(SandboxSetup, SandboxApi):
             debug=self.connection_config.debug,
             request_timeout=request_timeout,
         )
-
         return self.sandbox_id
 
     @overload

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -350,10 +350,17 @@ class Sandbox(SandboxSetup, SandboxApi):
         timeout: int,
         request_timeout: Optional[float] = None,
     ) -> None:
+        config_dict = self.connection_config.__dict__
+        config_dict.pop("access_token", None)
+        config_dict.pop("api_url", None)
+
+        if request_timeout:
+            config_dict["request_timeout"] = request_timeout
+
         SandboxApi._cls_set_timeout(
             sandbox_id=self.sandbox_id,
             timeout=timeout,
-            request_timeout=request_timeout,
+            **self.connection_config.__dict__,
         )
 
     @classmethod

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -299,7 +299,7 @@ class Sandbox(SandboxSetup, SandboxApi):
 
         SandboxApi._cls_kill(
             sandbox_id=self.sandbox_id,
-            **config_dict,
+            **self.connection_config.__dict__
         )
 
     @overload

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -407,6 +407,35 @@ class Sandbox(SandboxSetup, SandboxApi):
             debug=debug,
         )
 
+    @classmethod
+    def pause(
+        cls,
+        sandbox_id: str,
+        api_key: Optional[str] = None,
+        domain: Optional[str] = None,
+        debug: Optional[bool] = None,
+        request_timeout: Optional[float] = None,
+    ) -> str:
+        """
+        Pause a sandbox by its ID.
+
+        :param sandbox_id: Sandbox ID
+        :param api_key: E2B API Key to use for authentication
+        :param domain: Domain of the sandbox server
+        :param debug: Enable debug mode
+        :param request_timeout: Timeout for the request in **seconds**
+
+        :return: sandbox ID that can be used to resume the sandbox
+        """
+        SandboxApi._cls_pause(
+            sandbox_id=sandbox_id,
+            api_key=api_key,
+            domain=domain,
+            debug=debug,
+            request_timeout=request_timeout,
+        )
+        return sandbox_id
+
     def pause(
         self,
         request_timeout: Optional[float] = None,

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -290,9 +290,16 @@ class Sandbox(SandboxSetup, SandboxApi):
         :param request_timeout: Timeout for the request
         :return: `True` if the sandbox was killed, `False` if the sandbox was not found
         """
+        config_dict = self.connection_config.__dict__
+        config_dict.pop("access_token", None)
+        config_dict.pop("api_url", None)
+
+        if request_timeout:
+            config_dict["request_timeout"] = request_timeout
+
         SandboxApi._cls_kill(
             sandbox_id=self.sandbox_id,
-            request_timeout=request_timeout,
+            **config_dict,
         )
 
     @overload

--- a/packages/python-sdk/tests/async/api_async/test_sbx_snapshot.py
+++ b/packages/python-sdk/tests/async/api_async/test_sbx_snapshot.py
@@ -1,0 +1,21 @@
+import pytest
+from e2b import AsyncSandbox
+
+
+@pytest.mark.skip_debug()
+async def test_pause_sandbox(async_sandbox: AsyncSandbox):
+    sandbox_id = async_sandbox.sandbox_id
+    await AsyncSandbox.pause(sandbox_id)
+    assert not await async_sandbox.is_running()
+
+
+@pytest.mark.skip_debug()
+async def test_resume_sandbox(async_sandbox: AsyncSandbox):
+    # pause
+    sandbox_id = async_sandbox.sandbox_id
+    await AsyncSandbox.pause(sandbox_id)
+    assert not await async_sandbox.is_running()
+
+    # resume
+    await AsyncSandbox.resume(sandbox_id)
+    assert await async_sandbox.is_running()

--- a/packages/python-sdk/tests/async/api_async/test_sbx_snapshot.py
+++ b/packages/python-sdk/tests/async/api_async/test_sbx_snapshot.py
@@ -4,18 +4,16 @@ from e2b import AsyncSandbox
 
 @pytest.mark.skip_debug()
 async def test_pause_sandbox(async_sandbox: AsyncSandbox):
-    sandbox_id = async_sandbox.sandbox_id
-    await AsyncSandbox.pause(sandbox_id)
+    await AsyncSandbox.pause(async_sandbox.sandbox_id)
     assert not await async_sandbox.is_running()
 
 
 @pytest.mark.skip_debug()
 async def test_resume_sandbox(async_sandbox: AsyncSandbox):
     # pause
-    sandbox_id = async_sandbox.sandbox_id
-    await AsyncSandbox.pause(sandbox_id)
+    await AsyncSandbox.pause(async_sandbox.sandbox_id)
     assert not await async_sandbox.is_running()
 
     # resume
-    await AsyncSandbox.resume(sandbox_id)
+    await AsyncSandbox.resume(async_sandbox.sandbox_id)
     assert await async_sandbox.is_running()

--- a/packages/python-sdk/tests/sync/api_sync/test_sbx_snapshot.py
+++ b/packages/python-sdk/tests/sync/api_sync/test_sbx_snapshot.py
@@ -1,0 +1,21 @@
+import pytest
+from e2b import Sandbox
+
+
+@pytest.mark.skip_debug()
+def test_pause_sandbox(sandbox: Sandbox):
+    sandbox_id = sandbox.sandbox_id
+    Sandbox.pause(sandbox_id)
+    assert not sandbox.is_running()
+
+
+@pytest.mark.skip_debug()
+def test_resume_sandbox(sandbox: Sandbox):
+    # pause
+    sandbox_id = sandbox.sandbox_id
+    Sandbox.pause(sandbox_id)
+    assert not sandbox.is_running()
+
+    # resume
+    Sandbox.resume(sandbox_id)
+    assert sandbox.is_running()

--- a/packages/python-sdk/tests/sync/api_sync/test_sbx_snapshot.py
+++ b/packages/python-sdk/tests/sync/api_sync/test_sbx_snapshot.py
@@ -4,18 +4,16 @@ from e2b import Sandbox
 
 @pytest.mark.skip_debug()
 def test_pause_sandbox(sandbox: Sandbox):
-    sandbox_id = sandbox.sandbox_id
-    Sandbox.pause(sandbox_id)
+    Sandbox.pause(sandbox.sandbox_id)
     assert not sandbox.is_running()
 
 
 @pytest.mark.skip_debug()
 def test_resume_sandbox(sandbox: Sandbox):
     # pause
-    sandbox_id = sandbox.sandbox_id
-    Sandbox.pause(sandbox_id)
+    Sandbox.pause(sandbox.sandbox_id)
     assert not sandbox.is_running()
 
     # resume
-    Sandbox.resume(sandbox_id)
+    Sandbox.resume(sandbox.sandbox_id)
     assert sandbox.is_running()


### PR DESCRIPTION
- Added Sandbox.pause static method in JavaScript, Python BETA SDKs
- Added tests for the above

**Example**

JS

```ts
const sbx = await Sandbox.create()
await Sandbox.pause(sbx.sandboxId) // can be used in a background job for example
await Sandbox.resume(sbx.sandboxId)
```

Python

```py
sbx = Sandbox()
Sandbox.pause(sbx.sandbox_id)
Sandbox.resume(sbx.sandbox_id)
```