### PR TITLE
Update JS SDK target to es2017

### DIFF
--- a/.changeset/silver-ladybugs-lay.md
+++ b/.changeset/silver-ladybugs-lay.md
@@ -1,0 +1,5 @@
+---
+'e2b': minor
+---
+
+Update JS SDK target to es2017

--- a/packages/js-sdk/tsup.config.js
+++ b/packages/js-sdk/tsup.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   minify: false,
-  target: ['es2015'],
+  target: ['es2017'],
   sourcemap: true,
   dts: true,
   format: ['esm', 'cjs'],


### PR DESCRIPTION
Updates the JS SDK target to es2017 (from es2015). This change improves error logs that include user code. This is happening because before es2017 (e.g. es2015) tsup adds polyfill for async (which we use in the API) obfuscating the code execution path.

(The previously generated code)
```
var __async = (__this, __arguments, generator) => {
  return new Promise((resolve, reject) => {
    var fulfilled = (value) => {
      try {
        step(generator.next(value));
      } catch (e) {
        reject(e);
      }
    };
    var rejected = (value) => {
      try {
        step(generator.throw(value));
      } catch (e) {
        reject(e);
      }
    };
    var step = (x) => x.done ? resolve(x.value) : Promise.resolve(x.value).then(fulfilled, rejected);
    step((generator = generator.apply(__this, __arguments)).next());
  });
};
var __await = function(promise, isYieldStar) {
  this[0] = promise;
  this[1] = isYieldStar;
};
```