### PR TITLE
Vitest: continue after failing test

### DIFF
--- a/packages/js-sdk/vitest.workspace.mts
+++ b/packages/js-sdk/vitest.workspace.mts
@@ -11,7 +11,7 @@ export default defineWorkspace([
       globals: false,
       testTimeout: 30_000,
       environment: 'node',
-      bail: 1,
+      bail: 0,
       server: {},
       deps: {
         interopDefault: true,
@@ -28,12 +28,12 @@ export default defineWorkspace([
       browser: {
         enabled: true,
         headless: true,
-        instances: [{browser: 'chromium'}],
+        instances: [{ browser: 'chromium' }],
         provider: 'playwright',
         // https://playwright.dev
       },
       provide: {
-        E2B_API_KEY: process.env.E2B_API_KEY || env.parsed.E2B_API_KEY,
+        E2B_API_KEY: process.env.E2B_API_KEY || env.parsed?.E2B_API_KEY,
       },
     },
   },
@@ -53,4 +53,3 @@ export default defineWorkspace([
     },
   },
 ])
-


### PR DESCRIPTION
Like in pytest, we should be running all the tests before reporting test results. Currently, vitest finishes after 1 test has failed, this could cause confusion if your new test should be running after the failing one.