### PR TITLE
Feat(cli): Add Bun-based binary release workflow

### DIFF
--- a/.github/workflows/cli_build_binaries.yml
+++ b/.github/workflows/cli_build_binaries.yml
@@ -1,0 +1,52 @@
+# .github/workflows/cli_build_binaries.yml
+name: Build and Release CLI Binaries
+
+on:
+  push:
+    tags:
+      # Match the specific tag format for the CLI package
+      - '@e2b/cli@[0-9]+.[0-9]+.[0-9]+'
+      # We might also want to handle tags with pre-release identifiers like -beta.0
+      # - '@e2b/cli@[0-9]+.[0-9]+.[0-9]+-**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build Standalone CLI Binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Set up Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build CLI binaries and Generate Checksums
+        run: pnpm --filter @e2b/cli run build:compile
+
+      - name: Upload Binaries and Checksum to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: packages/cli/release/*
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cli_build_binaries.yml
+++ b/.github/workflows/cli_build_binaries.yml
@@ -33,6 +33,7 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
 
+      # required to build the binaries
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
 
@@ -40,7 +41,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build CLI binaries and Generate Checksums
-        run: pnpm --filter @e2b/cli run build:compile
+        run: pnpm run --filter @e2b/cli build:compile
+
+      - name: Test Native Binary
+        run: pnpm run --filter @e2b/cli test:binary
 
       - name: Upload Binaries and Checksum to GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/cli_release_binaries.yml
+++ b/.github/workflows/cli_release_binaries.yml
@@ -6,9 +6,7 @@ on:
     tags:
       # Match the specific tag format for the CLI package
       - '@e2b/cli@[0-9]+.[0-9]+.[0-9]+'
-      # We might also want to handle tags with pre-release identifiers like -beta.0
-      # - '@e2b/cli@[0-9]+.[0-9]+.[0-9]+-**'
-  workflow_dispatch:
+      # - '@e2b/cli@[0-9]+.[0-9]+.[0-9]+-**' # Optional: for pre-releases
 
 permissions:
   contents: write
@@ -46,7 +44,9 @@ jobs:
       - name: Test Native Binary
         run: pnpm run --filter @e2b/cli test:binary
 
-      - name: Upload Binaries and Checksum to GitHub Release
+      - name: Upload to Tagged Release
+        id: upload_tagged
+        if: startsWith(github.ref, 'refs/tags/@e2b/cli@')
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 
 # generate output
 dist
+release
 
 # compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "build:compile": "./scripts/build-binaries.sh",
     "dev": "tsup --watch",
     "test": "pnpm build && cd testground/demo-basic && ../../dist/index.js template build",
+    "test:binary": "./scripts/test-binary.sh",
     "check-deps": "knip",
     "update-deps": "ncu -u && pnpm i",
     "generate-ref": "./scripts/generate_sdk_ref.sh"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "prepublishOnly": "pnpm build",
     "build": "tsc --noEmit --skipLibCheck && tsup --minify",
+    "build:compile": "./scripts/build-binaries.sh",
     "dev": "tsup --watch",
     "test": "pnpm build && cd testground/demo-basic && ../../dist/index.js template build",
     "check-deps": "knip",

--- a/packages/cli/scripts/build-binaries.sh
+++ b/packages/cli/scripts/build-binaries.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Navigate to the package root directory (one level up from scripts)
+cd "$(dirname "$0")/.."
+
+# --- Configuration ---
+ENTRY_POINT="./src/index.ts"
+OUTPUT_DIR="./release"
+PACKAGE_JSON="./package.json"
+
+# --- Get Version ---
+if [ ! -f "$PACKAGE_JSON" ]; then
+  echo "Error: package.json not found at $PACKAGE_JSON!"
+  exit 1
+fi
+VERSION=$(node -p "require('$PACKAGE_JSON').version")
+if [ -z "$VERSION" ]; then
+  echo "Error: Could not extract version from $PACKAGE_JSON!"
+  exit 1
+fi
+echo "Building binaries for version: $VERSION"
+
+# --- Prepare Output Directory ---
+echo "Preparing output directory: $OUTPUT_DIR"
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+# --- Define Targets ---
+# Format: "<desired_os>_<desired_arch>:<bun_target>:<outfile_extension>"
+TARGETS=(
+  "linux_x64:bun-linux-x64:"
+  "darwin_x64:bun-darwin-x64:"
+  "darwin_arm64:bun-darwin-arm64:"
+  "windows_x64:bun-windows-x64:.exe"
+)
+
+# --- Build Logic ---
+echo "Starting Bun compilation..."
+for target_info in "${TARGETS[@]}"; do
+  IFS=':' read -r os_arch bun_target extension <<< "$target_info"
+  outfile="${OUTPUT_DIR}/cli_${VERSION}_${os_arch}${extension}"
+
+  echo "  Compiling for ${os_arch} -> ${outfile}"
+  bun build "$ENTRY_POINT" --compile --target "$bun_target" --outfile "$outfile"
+  if [ $? -ne 0 ]; then
+    echo "Error: Bun build failed for target ${bun_target}!"
+    exit 1
+  fi
+done
+
+echo "Build complete. Binaries generated."
+
+# --- Generate Checksums ---
+CHECKSUM_FILE="${OUTPUT_DIR}/cli_${VERSION}_checksums.txt"
+echo "Generating checksums -> ${CHECKSUM_FILE}"
+# Navigate into the output directory to generate relative paths in the checksum file
+cd "$OUTPUT_DIR"
+# Use sha256sum to generate checksums for all files EXCEPT the checksum file itself
+# The output format matches the example (hash<space><space>filename)
+sha256sum * > "$(basename "$CHECKSUM_FILE")"
+# Go back to the package root
+cd ..
+
+echo "Checksums generated:"
+cat "$CHECKSUM_FILE"
+
+echo "Build script finished successfully."

--- a/packages/cli/scripts/build-binaries.sh
+++ b/packages/cli/scripts/build-binaries.sh
@@ -33,6 +33,7 @@ TARGETS=(
   "darwin_x64:bun-darwin-x64:"
   "darwin_arm64:bun-darwin-arm64:"
   "windows_x64:bun-windows-x64:.exe"
+  "linux_arm64:bun-linux-arm64:"
 )
 
 # --- Build Logic ---

--- a/packages/cli/scripts/test-binary.sh
+++ b/packages/cli/scripts/test-binary.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Navigate to the package root directory (one level up from scripts)
+cd "$(dirname "$0")/.."
+
+# --- Configuration ---
+OUTPUT_DIR="./release"
+PACKAGE_JSON="./package.json"
+
+# --- Get Version ---
+if [ ! -f "$PACKAGE_JSON" ]; then
+  echo "Error: package.json not found at $PACKAGE_JSON!"
+  exit 1
+fi
+VERSION=$(node -p "require('$PACKAGE_JSON').version")
+if [ -z "$VERSION" ]; then
+  echo "Error: Could not extract version from $PACKAGE_JSON!"
+  exit 1
+fi
+
+# --- Determine Native OS and Arch ---
+OS_LOWER=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH_RAW=$(uname -m)
+ARCH_LOWER=""
+
+case "$ARCH_RAW" in
+  x86_64) ARCH_LOWER="x64" ;;
+  arm64|aarch64) ARCH_LOWER="arm64" ;;
+  *) echo "Error: Unsupported architecture for testing: $ARCH_RAW"; exit 1 ;;
+esac
+
+# Construct OS/Arch suffix for filename (only Linux supported by this script for now)
+if [ "$OS_LOWER" == "linux" ]; then
+  OS_ARCH_SUFFIX="linux_${ARCH_LOWER}"
+  EXTENSION=""
+elif [ "$OS_LOWER" == "darwin" ]; then
+  OS_ARCH_SUFFIX="darwin_${ARCH_LOWER}"
+  EXTENSION=""
+else
+  echo "Error: Script currently only supports testing on Linux or Darwin, not $OS_LOWER"
+  exit 1
+fi
+
+echo "Attempting to test binary for native platform: ${OS_ARCH_SUFFIX}"
+
+# --- Find and Test Binary ---
+NATIVE_BINARY="${OUTPUT_DIR}/cli_${VERSION}_${OS_ARCH_SUFFIX}${EXTENSION}"
+
+echo "Checking if binary exists: $NATIVE_BINARY"
+if [ ! -f "$NATIVE_BINARY" ]; then
+  echo "Error: Native binary not found at $NATIVE_BINARY!"
+  ls -la "$OUTPUT_DIR" # List contents for debugging
+  exit 1
+fi
+
+echo "Making binary executable..."
+chmod +x "$NATIVE_BINARY"
+
+echo "Running: $NATIVE_BINARY --version"
+OUTPUT=$("$NATIVE_BINARY" --version)
+EXIT_CODE=$?
+
+echo "Output: $OUTPUT"
+echo "Exit Code: $EXIT_CODE"
+
+if [ $EXIT_CODE -ne 0 ]; then
+  echo "Error: Binary execution failed with exit code $EXIT_CODE!"
+  exit 1
+fi
+
+echo "Checking output for version string '$VERSION'..."
+if ! echo "$OUTPUT" | grep -q "$VERSION"; then
+  echo "Error: Version string '$VERSION' not found in output!"
+  exit 1
+fi
+
+echo "Native binary test passed for ${OS_ARCH_SUFFIX}!"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,7 +392,7 @@ importers:
         version: 3.1.1(@types/node@18.18.6)(@vitest/browser@3.1.1)(jiti@2.4.2)(msw@2.7.0(@types/node@18.18.6)(typescript@5.5.3))(terser@5.39.0)(yaml@2.5.1)
       vitest-browser-react:
         specifier: ^0.1.1
-        version: 0.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(@vitest/browser@3.1.1(bufferutil@4.0.8)(msw@2.7.0(@types/node@18.18.6)(typescript@5.5.3))(playwright@1.48.0)(utf-8-validate@6.0.3)(vite@6.2.5(@types/node@18.18.6)(jiti@2.4.2)(terser@5.39.0)(yaml@2.5.1))(vitest@3.1.1))(react-dom@18.2.0(react@18.3.1))(react@18.3.1)(vitest@3.1.1(@types/node@18.18.6)(@vitest/browser@3.1.1)(jiti@2.4.2)(msw@2.7.0(@types/node@18.18.6)(typescript@5.5.3))(terser@5.39.0)(yaml@2.5.1))
+        version: 0.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(@vitest/browser@3.1.1)(react-dom@18.2.0(react@18.3.1))(react@18.3.1)(vitest@3.1.1)
 
   packages/python-sdk: {}
 
@@ -11614,7 +11614,7 @@ snapshots:
       debug: 4.4.0(supports-color@9.4.0)
       enhanced-resolve: 5.18.1
       eslint: 8.57.1
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0)(eslint@8.57.1)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.0)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.0
@@ -11626,7 +11626,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11647,7 +11647,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0)(eslint@8.57.1)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -12149,8 +12149,8 @@ snapshots:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.1
-      ignore: 5.2.4
+      fast-glob: 3.3.3
+      ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
 
@@ -15426,7 +15426,7 @@ snapshots:
       terser: 5.39.0
       yaml: 2.5.1
 
-  vitest-browser-react@0.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(@vitest/browser@3.1.1(bufferutil@4.0.8)(msw@2.7.0(@types/node@18.18.6)(typescript@5.5.3))(playwright@1.48.0)(utf-8-validate@6.0.3)(vite@6.2.5(@types/node@18.18.6)(jiti@2.4.2)(terser@5.39.0)(yaml@2.5.1))(vitest@3.1.1))(react-dom@18.2.0(react@18.3.1))(react@18.3.1)(vitest@3.1.1(@types/node@18.18.6)(@vitest/browser@3.1.1)(jiti@2.4.2)(msw@2.7.0(@types/node@18.18.6)(typescript@5.5.3))(terser@5.39.0)(yaml@2.5.1)):
+  vitest-browser-react@0.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(@vitest/browser@3.1.1)(react-dom@18.2.0(react@18.3.1))(react@18.3.1)(vitest@3.1.1):
     dependencies:
       '@vitest/browser': 3.1.1(bufferutil@4.0.8)(msw@2.7.0(@types/node@18.18.6)(typescript@5.5.3))(playwright@1.48.0)(utf-8-validate@6.0.3)(vite@6.2.5(@types/node@18.18.6)(jiti@2.4.2)(terser@5.39.0)(yaml@2.5.1))(vitest@3.1.1)
       react: 18.3.1


### PR DESCRIPTION
This PR introduces a new workflow for building and releasing standalone CLI binaries using Bun.

**Key changes:**

*   `bun build --compile` for creating binaries (faster builds, potentially smaller size).
*   Added a build script `packages/cli/scripts/build-binaries.sh` to:
    *   Compile binaries for Linux (x64), macOS (x64, arm64), and Windows (x64).
    *   Embed the version in the output filename (`cli_VERSION_os_arch`).
    *   Generate a corresponding `cli_VERSION_checksums.txt` file.
*   Added a testing script `packages/cli/scripts/test-binary.sh` to:
    *   Detect the native OS (Linux/Darwin) and architecture (x64/arm64) where the script is run.
    *   Locate the corresponding built binary.
    *   Perform a smoke test by running the binary with `--version`.
    *   Verify the exit code and check if the output contains the correct version.
*   Created a new workflow `.github/workflows/cli_release_binaries.yml`:
    *   Triggers when tags matching `@e2b/cli@<version>` are pushed.
    *   Installs dependencies using `pnpm install --frozen-lockfile`.
    *   Runs the `build-binaries.sh` script via `pnpm run`.
    *   Runs the `test-binary.sh` script via `pnpm run` to test the binary built for the runner's native architecture.
    *   Uploads the generated binaries and checksum file to the corresponding GitHub Release.
    *   Includes logic to optionally upload binaries to the latest existing CLI release if triggered manually (requires `gh` CLI).
*   Updated `package.json` scripts.
*   Set execute permission for `build-binaries.sh` & `test-binary.sh`.


**Build Script Output**
<img width="233" alt="Screenshot 2025-05-03 at 3 59 41 PM" src="https://github.com/user-attachments/assets/ae173e1d-746c-4da8-9fb5-a18871332e2c" />

**CLI Release Content**
<img width="1268" alt="Screenshot 2025-05-04 at 1 45 37 PM" src="https://github.com/user-attachments/assets/2e5b8f39-2104-4a68-9708-96535ad2c637" />
