### PR TITLE
Update metrics docs beta note to be public 

### DIFF
--- a/apps/web/src/app/(docs)/docs/sandbox/metrics/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox/metrics/page.mdx
@@ -1,7 +1,10 @@
 # Sandbox metrics
 
 <Note>
-This feature is in a private beta.
+Sandbox metrics are currently in public beta:
+1. You'll need to install the [beta version of the SDKs](/docs/sandbox/installing-beta-sdks).
+2. Consider [some limitations](#limitations-while-in-beta).
+3. The persistence is free for all users during the beta.
 </Note>
 
 The sandbox metrics allows you to get information about the sandbox's CPU and memory usage.

--- a/apps/web/src/app/(docs)/docs/sandbox/metrics/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox/metrics/page.mdx
@@ -4,7 +4,7 @@
 Sandbox metrics are currently in public beta:
 1. You'll need to install the [beta version of the SDKs](/docs/sandbox/installing-beta-sdks).
 2. Consider [some limitations](#limitations-while-in-beta).
-3. The persistence is free for all users during the beta.
+3. The metrics is free for all users during the beta.
 </Note>
 
 The sandbox metrics allows you to get information about the sandbox's CPU and memory usage.


### PR DESCRIPTION
The metrics command is not in private beta as it does not require a special cluster. 