### PR TITLE
Fix authErrorBox switch breaking

### DIFF
--- a/.changeset/tasty-lemons-grow.md
+++ b/.changeset/tasty-lemons-grow.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': minor
+---
+
+fix determining the correct auth error message

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -14,10 +14,11 @@ const authErrorBox = (keyName: string) => {
     case 'E2B_API_KEY':
       link = 'https://e2b.dev/dashboard?tab=keys'
       msg = 'API key'
-
+      break
     case 'E2B_ACCESS_TOKEN':
       link = 'https://e2b.dev/dashboard?tab=personal'
       msg = 'access token'
+      break
   }
   // throwing error in default in switch statement results in unreachable code,
   // so we need to check if link and msg are defined here instead


### PR DESCRIPTION
To show the correct error message in our cli, we need to break the switch cases. Currently always the last case will be applied, no matter the input.