### PR TITLE
Update template start command limits in docs

### DIFF
--- a/apps/web/src/app/(docs)/docs/sandbox-template/start-cmd/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/start-cmd/page.mdx
@@ -36,7 +36,6 @@ This allows us to load the sandbox in a few hundred milliseconds any time later 
 
 
 ## Limits
-- The network isn't accessible when running the start command during the build phase.
 - We wait 15 seconds after we execute the start command before we snapshot the sandbox.
 
 


### PR DESCRIPTION
Network is now available when running a start command. Remove the network limitation from the documentation.