### PR TITLE
Add option for a template ready check

### DIFF
--- a/.changeset/four-numbers-drive.md
+++ b/.changeset/four-numbers-drive.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': minor
+---
+
+Add ready command for template build

--- a/apps/web/src/app/(docs)/docs/legacy/sandbox/custom/page.mdx
+++ b/apps/web/src/app/(docs)/docs/legacy/sandbox/custom/page.mdx
@@ -20,7 +20,7 @@ Once you build your custom sandbox template, you can spawn multiple isolated san
 
       // Create new sandbox
       const sandbox = await Sandbox.create({
-        template: '<sandbox-template-id>', // You get sandbox template ID from the CLI after you run `$ e2b build`
+        template: '<sandbox-template-id>', // You get sandbox template ID from the CLI after you run `$ e2b template build`
       })
 
       // Close sandbox once done
@@ -32,7 +32,7 @@ Once you build your custom sandbox template, you can spawn multiple isolated san
 
       # Create new sandbox
       sandbox = Sandbox(
-        template="<sandbox-template>", # You get sandbox template from the CLI after you run `$ e2b build`
+        template="<sandbox-template>", # You get sandbox template from the CLI after you run `$ e2b template build`
       )
 
       # Close sandbox once done

--- a/apps/web/src/app/(docs)/docs/legacy/sandbox/templates/overview/page.mdx
+++ b/apps/web/src/app/(docs)/docs/legacy/sandbox/templates/overview/page.mdx
@@ -32,7 +32,7 @@ Follow our [guide](/docs/guide/custom-sandbox) on how to create a custom sandbox
 
       // Create new sandbox
       const sandbox = await Sandbox.create({
-        // You get sandbox template from the CLI after you run `$ e2b build`
+        // You get sandbox template from the CLI after you run `$ e2b template build`
         template: '<sandbox-template>',  // $HighlightLine
       })
 
@@ -45,7 +45,7 @@ Follow our [guide](/docs/guide/custom-sandbox) on how to create a custom sandbox
 
       # Create new sandbox
       sandbox = Sandbox(
-        # You get sandbox template from the CLI after you run `$ e2b build`
+        # You get sandbox template from the CLI after you run `$ e2b template build`
         template="<sandbox-template>", # $HighlightLine
       )
 

--- a/apps/web/src/app/(docs)/docs/sandbox-template/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/page.mdx
@@ -106,17 +106,20 @@ print(execution.stdout)
 ```
 </CodeGroup>
 
+## How it works
+Every time you are building a sandbox template, we create a container based on the [`e2b.Dockerfile`](/docs/sandbox-template#3-customize-e2b-dockerfile) file you create in the process.
+We extract the container's filesystem, do provisioning and configuration (e.g. installing required dependencies), and start a sandbox.
+We call this sandbox a _sandbox template_.
+
+Then, these steps happen:
+
+    1. We take the running sandbox template.
+    2. (Only if you specified the [start command](/docs/sandbox-template/start-cmd), otherwise this step is skipped) **Execute the start command and wait for readiness (by default 20 seconds)**. Readiness check can be configured using [ready command](/docs/sandbox-template/ready-cmd).
+    3. Snapshot the sandbox and make it ready for you to spawn it with the SDK.
 
 
+<Note title="Sandbox Snapshot">
+  Snapshots are saved running sandboxes. We serialize and save the whole sandbox's filesystem together with all the running processes in a way that can be loaded later.
 
-
-
-
-
-
-
-
-
-
-
-
+  This allows us to load the sandbox in a few hundred milliseconds any time later with all the processes already running and the filesystem exactly as it was.
+</Note>

--- a/apps/web/src/app/(docs)/docs/sandbox-template/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/page.mdx
@@ -109,15 +109,15 @@ print(execution.stdout)
 ## How it works
 Every time you are building a sandbox template, we create a container based on the [`e2b.Dockerfile`](/docs/sandbox-template#3-customize-e2b-dockerfile) file you create in the process.
 We extract the container's filesystem, do provisioning and configuration (e.g. installing required dependencies), and start a sandbox.
-We call this sandbox a _sandbox template_.
 
 Then, these steps happen:
 
-    1. We take the running sandbox template.
+    1. We take the running sandbox.
     2. (Only if you specified the [start command](/docs/sandbox-template/start-cmd), otherwise this step is skipped) Execute the start command.
     3. Wait for readiness (by default 20 seconds if start command is specified, otherwise immediately ready). Readiness check can be configured using [ready command](/docs/sandbox-template/ready-cmd).
     4. Snapshot the sandbox and make it ready for you to spawn it with the SDK.
 
+We call this sandbox snapshot a _sandbox template_.
 
 <Note title="Sandbox Snapshot">
   Snapshots are saved running sandboxes. We serialize and save the whole sandbox's filesystem together with all the running processes in a way that can be loaded later.

--- a/apps/web/src/app/(docs)/docs/sandbox-template/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/page.mdx
@@ -114,8 +114,9 @@ We call this sandbox a _sandbox template_.
 Then, these steps happen:
 
     1. We take the running sandbox template.
-    2. (Only if you specified the [start command](/docs/sandbox-template/start-cmd), otherwise this step is skipped) **Execute the start command and wait for readiness (by default 20 seconds)**. Readiness check can be configured using [ready command](/docs/sandbox-template/ready-cmd).
-    3. Snapshot the sandbox and make it ready for you to spawn it with the SDK.
+    2. (Only if you specified the [start command](/docs/sandbox-template/start-cmd), otherwise this step is skipped) Execute the start command.
+    3. Wait for readiness (by default 20 seconds if start command is specified, otherwise immediately ready). Readiness check can be configured using [ready command](/docs/sandbox-template/ready-cmd).
+    4. Snapshot the sandbox and make it ready for you to spawn it with the SDK.
 
 
 <Note title="Sandbox Snapshot">

--- a/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
@@ -6,7 +6,7 @@ This way you can control how long should we wait for the start command or any sy
 
 ## How to add ready command
 
-You can specify the ready command inside the `e2b.toml` in the same directory where you run `e2b build`.
+You can specify the ready command inside the `e2b.toml` in the same directory where you run `e2b template build`.
 <CodeGroup isFileName title="e2b.toml" isRunnable={false}>
   ```toml
   # This is a config for E2B sandbox template

--- a/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
@@ -1,5 +1,5 @@
 # Ready Command
-The ready command allows you to specify a command that will determine **template sandbox** readiness.
+The ready command allows you to specify a command that will determine **template sandbox** readiness before a [snapshot](/docs/sandbox-template#how-it-works) is created.
 It is executed in an infinite loop until it returns a successful **exit code&nbsp;0**.
 This way you can control how long should we wait for the [start command](/docs/sandbox-template/start-cmd) or any system state.
 

--- a/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
@@ -1,7 +1,7 @@
 # Ready Command
 The ready command allows you to specify a command that will determine **template sandbox** readiness before creating the snapshot.
 The ready command is executed in an infinite loop until it returns a successful **exit code&nbsp;0**.
-This way you can control how long should we wait for the start command or any system state.
+This way you can control how long should we wait for the [start command](/docs/sandbox-template/start-cmd) or any system state.
 
 
 ## How to add ready command

--- a/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
@@ -1,0 +1,22 @@
+# Ready Command
+The ready command allows you to specify a command that will determine **template sandbox** readiness before creating the snapshot.
+The ready command is executed in an infinite loop until it returns a successful **exit code&nbsp;0**.
+This way you can control how long should we wait for the start command or any system state.
+
+
+## How to add ready command
+
+You can specify the ready command inside the `e2b.toml` in the same directory where you run `e2b build`.
+<CodeGroup isFileName title="e2b.toml" isRunnable={false}>
+  ```toml
+  # This is a config for E2B sandbox template
+  template_id = "1wdqsf9le9gk21ztb4mo"
+  dockerfile = "e2b.Dockerfile"
+  template_name = "my-agent-sandbox"
+  ready_cmd = "<your-ready-command>"  # $HighlightLine
+  ```
+</CodeGroup>
+
+## Default values
+By default, the ready command is set to `sleep 0`, which means the template sandbox will be ready immediatelly.
+If the [start command](/docs/sandbox-template/start-cmd) is defined, the default is set to `sleep 20`, which means that the template sandbox will wait for 20 seconds before taking the snapshot.

--- a/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
@@ -33,7 +33,7 @@ Here are some examples of the ready command you can use.
 
 ### Wait for URL to return 200 status code
 ```bash
-ready_cmd = 'curl -s -o /dev/null -w "%{http_code}" https://myurl.com | grep -q "200"'
+ready_cmd = 'curl -s -o /dev/null -w "%{http_code}" http://localhost:3000 | grep -q "200"'
 ```
 
 ### Wait for a specific process to start

--- a/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
@@ -27,3 +27,21 @@ You can specify the ready command inside the `e2b.toml` in the same directory wh
 ## Default values
 By default, the ready command is set to `sleep 0`, which means the sandbox template will be ready immediatelly.
 If the [start command](/docs/sandbox-template/start-cmd) is defined, the default is set to `sleep 20`, which means that the template sandbox will wait for 20 seconds before taking the snapshot.
+
+## Examples
+Here are some examples of the ready command you can use.
+
+### Wait for URL to return 200 status code
+```bash
+ready_cmd = 'curl -s -o /dev/null -w "%{http_code}" https://myurl.com | grep -q "200"'
+```
+
+### Wait for a specific process to start
+```bash
+ready_cmd = 'pgrep my-process-name > /dev/null'
+```
+
+### Wait for a file to exist
+```bash
+ready_cmd = '[ -f /tmp/ready.flag ]'
+```

--- a/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/ready-cmd/page.mdx
@@ -1,11 +1,18 @@
 # Ready Command
-The ready command allows you to specify a command that will determine **template sandbox** readiness before creating the snapshot.
-The ready command is executed in an infinite loop until it returns a successful **exit code&nbsp;0**.
+The ready command allows you to specify a command that will determine **template sandbox** readiness.
+It is executed in an infinite loop until it returns a successful **exit code&nbsp;0**.
 This way you can control how long should we wait for the [start command](/docs/sandbox-template/start-cmd) or any system state.
 
 
 ## How to add ready command
 
+When you are building a sandbox template you can specify the ready command by using the [`--ready-cmd`](/docs/sdk-reference/cli/v1.5.0/template#e2b-template-build) option:
+
+```bash
+e2b template build --ready-cmd "<your-ready-command>"
+```
+
+### Sandbox template config
 You can specify the ready command inside the `e2b.toml` in the same directory where you run `e2b template build`.
 <CodeGroup isFileName title="e2b.toml" isRunnable={false}>
   ```toml
@@ -18,5 +25,5 @@ You can specify the ready command inside the `e2b.toml` in the same directory wh
 </CodeGroup>
 
 ## Default values
-By default, the ready command is set to `sleep 0`, which means the template sandbox will be ready immediatelly.
+By default, the ready command is set to `sleep 0`, which means the sandbox template will be ready immediatelly.
 If the [start command](/docs/sandbox-template/start-cmd) is defined, the default is set to `sleep 20`, which means that the template sandbox will wait for 20 seconds before taking the snapshot.

--- a/apps/web/src/app/(docs)/docs/sandbox-template/start-cmd/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/start-cmd/page.mdx
@@ -27,24 +27,6 @@ You can specify the start command also inside the `e2b.toml` in the same directo
   ```
 </CodeGroup>
 
-## How it works
-Every time you are building a [custom sandbox](/docs/sandbox-template), we create a container based on the [`e2b.Dockerfile`](/docs/sandbox-template#3-customize-e2b-dockerfile) file you create in the process.
-We extract the container's filesystem, do provisioning and configuration (e.g. installing required dependencies), and start a sandbox.
-We call this sandbox a _template sandbox_.
-
-Then, these steps happen:
-
-    1. We take the running template sandbox.
-    2. (Only if you specified the start command, otherwise this step is skipped) **Execute the start command and wait for readiness (by default 20 seconds)**. Readiness check can be configured using [ready command](/docs/sandbox-template/ready-cmd).
-    3. Snapshot the sandbox and make it ready for you to spawn it with the SDK.
-
-
-<Note title="Sandbox Snapshot">
-Snapshots are saved running sandboxes. We serialize and save the whole sandbox's filesystem together with all the running processes in a way that can be loaded later.
-
-This allows us to load the sandbox in a few hundred milliseconds any time later with all the processes already running and the filesystem exactly as it was.
-</Note>
-
 
 ## Logs
 You can retrieve the start command's logs using the SDK during runtime.

--- a/apps/web/src/app/(docs)/docs/sandbox-template/start-cmd/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/start-cmd/page.mdx
@@ -15,16 +15,27 @@ e2b build -c "<your-start-command>"
 
 When you spawn the custom sandbox you built, the start command will be already running if there was no error when we tried to execute it.
 
+### Sandbox template config
+You can specify the start command also inside the `e2b.toml` in the same directory where you run `e2b build`.
+<CodeGroup isFileName title="e2b.toml" isRunnable={false}>
+  ```toml
+  # This is a config for E2B sandbox template
+  template_id = "1wdqsf9le9gk21ztb4mo"
+  dockerfile = "e2b.Dockerfile"
+  template_name = "my-agent-sandbox"
+  start_cmd = "<your-start-command>"  # $HighlightLine
+  ```
+</CodeGroup>
 
 ## How it works
 Every time you are building a [custom sandbox](/docs/sandbox-template), we create a container based on the [`e2b.Dockerfile`](/docs/sandbox-template#3-customize-e2b-dockerfile) file you create in the process.
-We extract the container's filesystem and start a sandbox with this extracted filesystem.
+We extract the container's filesystem, do provisioning and configuration (e.g. installing required dependencies), and start a sandbox.
 We call this sandbox a _template sandbox_.
 
 Then, these steps happen:
 
     1. We take the running template sandbox.
-    2. (Only if you specified the start command, otherwise this step is skipped) **Execute the start command and wait 15 seconds**.
+    2. (Only if you specified the start command, otherwise this step is skipped) **Execute the start command and wait for readiness (by default 20 seconds)**. Readiness check can be configured using [ready command](/docs/sandbox-template/ready-cmd).
     3. Snapshot the sandbox and make it ready for you to spawn it with the SDK.
 
 
@@ -33,10 +44,6 @@ Snapshots are saved running sandboxes. We serialize and save the whole sandbox's
 
 This allows us to load the sandbox in a few hundred milliseconds any time later with all the processes already running and the filesystem exactly as it was.
 </Note>
-
-
-## Limits
-- We wait 15 seconds after we execute the start command before we snapshot the sandbox.
 
 
 ## Logs
@@ -85,17 +92,5 @@ Or you can use the CLI:
 <CodeGroup isTerminalCommand>
 ```bash {{ language: 'bash' }}
 e2b sandbox logs <sandbox-id>
-```
-</CodeGroup>
-
-## Sandbox template config
-The start command is specified inside the `e2b.toml` in the same directory where you ran `e2b build -c "<your-start-command>"`.
-<CodeGroup isFileName title="e2b.toml" isRunnable={false}>
-```toml
-# This is a config for E2B sandbox template
-template_id = "1wdqsf9le9gk21ztb4mo"
-dockerfile = "e2b.Dockerfile"
-template_name = "my-agent-sandbox"
-start_cmd = "<your-start-command>"  # $HighlightLine
 ```
 </CodeGroup>

--- a/apps/web/src/app/(docs)/docs/sandbox-template/start-cmd/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/start-cmd/page.mdx
@@ -10,13 +10,13 @@ The idea behind the start command feature is to lower the wait times for your us
 When you are building a sandbox template you can specify the start command by using the [`-c`](/docs/sdk-reference/cli/v1.0.9/template#e2b-template-build) option:
 
 ```bash
-e2b build -c "<your-start-command>"
+e2b template build -c "<your-start-command>"
 ```
 
 When you spawn the custom sandbox you built, the start command will be already running if there was no error when we tried to execute it.
 
 ### Sandbox template config
-You can specify the start command also inside the `e2b.toml` in the same directory where you run `e2b build`.
+You can specify the start command also inside the `e2b.toml` in the same directory where you run `e2b template build`.
 <CodeGroup isFileName title="e2b.toml" isRunnable={false}>
   ```toml
   # This is a config for E2B sandbox template

--- a/apps/web/src/app/(docs)/docs/sandbox-template/start-cmd/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox-template/start-cmd/page.mdx
@@ -4,6 +4,7 @@ This way, you can for example have running servers or seeded databases inside th
 
 The idea behind the start command feature is to lower the wait times for your users and have everything ready for your users when you spawn your sandbox.
 
+You can see how it works [here](/docs/sandbox-template#how-it-works).
 
 ## How to add start command
 

--- a/apps/web/src/components/Navigation/routes.tsx
+++ b/apps/web/src/components/Navigation/routes.tsx
@@ -343,6 +343,10 @@ export const docRoutes: NavGroup[] = [
         href: '/docs/sandbox-template/start-cmd',
       },
       {
+        title: 'Ready command',
+        href: '/docs/sandbox-template/ready-cmd',
+      },
+      {
         title: 'Customize CPU & RAM',
         href: '/docs/sandbox-template/customize-cpu-ram',
       },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,7 +30,7 @@ e2b auth login
 > To authenticate without the ability to open the browser, provide
 > `E2B_ACCESS_TOKEN` as an environment variable. Get your `E2B_ACCESS_TOKEN`
 > from the Personal tab at [e2b.dev/dashboard](https://e2b.dev/dashboard). Then use the CLI like this:
-> `E2B_ACCESS_TOKEN=sk_e2b_... e2b build`.
+> `E2B_ACCESS_TOKEN=sk_e2b_... e2b template build`.
 
 > [!IMPORTANT]  
 > Note the distinction between `E2B_ACCESS_TOKEN` and `E2B_API_KEY`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,6 +49,7 @@
     "@types/inquirer": "^9.0.7",
     "@types/json2md": "^1.5.4",
     "@types/node": "^18.18.6",
+    "@types/statuses": "^2.0.5",
     "@types/update-notifier": "6.0.5",
     "json2md": "^2.0.1",
     "knip": "^5.43.6",
@@ -77,6 +78,7 @@
     "e2b": "^1.2.1",
     "inquirer": "^9.2.12",
     "open": "^9.1.0",
+    "statuses": "^2.0.1",
     "strip-ansi": "^7.1.0",
     "update-notifier": "^6.0.2",
     "yup": "^1.3.2"

--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -131,7 +131,7 @@ export const buildCommand = new commander.Command('build')
     '[template]',
     `specify ${asBold(
       '[template]'
-    )} to rebuild it. If you don's specify ${asBold(
+    )} to rebuild it. If you dont's specify ${asBold(
       '[template]'
     )} and there is no ${asLocal(
       'e2b.toml'
@@ -221,6 +221,8 @@ export const buildCommand = new commander.Command('build')
         let cpuCount = opts.cpuCount
         let memoryMB = opts.memoryMb
         let teamID = opts.team
+        let readyCmd: string | undefined
+        let readyTimeout: number | undefined
 
         const root = getRoot(opts.path)
         const configPath = getConfigPath(root, opts.config)
@@ -249,6 +251,8 @@ export const buildCommand = new commander.Command('build')
           cpuCount = opts.cpuCount || config.cpu_count
           memoryMB = opts.memoryMb || config.memory_mb
           teamID = opts.team || config.team_id
+          readyCmd = config.ready_cmd
+          readyTimeout = config.ready_timeout
         }
 
         const userConfig = getUserConfig()
@@ -295,6 +299,8 @@ export const buildCommand = new commander.Command('build')
           memoryMB: memoryMB,
           dockerfile: dockerfileContent,
           teamID: teamID,
+          readyCmd: readyCmd,
+          readyTimeout: readyTimeout,
         }
 
         if (opts.memoryMb) {
@@ -327,6 +333,8 @@ export const buildCommand = new commander.Command('build')
             cpu_count: cpuCount,
             memory_mb: memoryMB,
             team_id: teamID,
+            ready_cmd: readyCmd,
+            ready_timeout: readyTimeout,
           },
           true
         )

--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -152,6 +152,10 @@ export const buildCommand = new commander.Command('build')
     '-c, --cmd <start-command>',
     'specify command that will be executed when the sandbox is started.'
   )
+  .option(
+    '--ready-cmd <ready-command>',
+    'specify command that will need to exit 0 for the template to be ready.'
+  )
   .addOption(teamOption)
   .addOption(configOption)
   .option(
@@ -178,6 +182,7 @@ export const buildCommand = new commander.Command('build')
         dockerfile?: string
         name?: string
         cmd?: string
+        readyCmd?: string
         team?: string
         config?: string
         cpuCount?: number
@@ -218,11 +223,10 @@ export const buildCommand = new commander.Command('build')
 
         let dockerfile = opts.dockerfile
         let startCmd = opts.cmd
+        let readyCmd=  opts.readyCmd
         let cpuCount = opts.cpuCount
         let memoryMB = opts.memoryMb
         let teamID = opts.team
-        let readyCmd: string | undefined
-        let readyTimeout: number | undefined
 
         const root = getRoot(opts.path)
         const configPath = getConfigPath(root, opts.config)
@@ -248,10 +252,10 @@ export const buildCommand = new commander.Command('build')
           templateID = config.template_id
           dockerfile = opts.dockerfile || config.dockerfile
           startCmd = opts.cmd || config.start_cmd
+          readyCmd = opts.readyCmd ||config.ready_cmd
           cpuCount = opts.cpuCount || config.cpu_count
           memoryMB = opts.memoryMb || config.memory_mb
           teamID = opts.team || config.team_id
-          readyCmd = config.ready_cmd
         }
 
         const userConfig = getUserConfig()
@@ -294,12 +298,11 @@ export const buildCommand = new commander.Command('build')
         const body = {
           alias: name,
           startCmd: startCmd,
+          readyCmd: readyCmd,
           cpuCount: cpuCount,
           memoryMB: memoryMB,
           dockerfile: dockerfileContent,
           teamID: teamID,
-          readyCmd: readyCmd,
-          readyTimeout: readyTimeout,
         }
 
         if (opts.memoryMb) {
@@ -329,10 +332,10 @@ export const buildCommand = new commander.Command('build')
             dockerfile: dockerfileRelativePath,
             template_name: name,
             start_cmd: startCmd,
+            ready_cmd: readyCmd,
             cpu_count: cpuCount,
             memory_mb: memoryMB,
             team_id: teamID,
-            ready_cmd: readyCmd,
           },
           true
         )

--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -252,7 +252,6 @@ export const buildCommand = new commander.Command('build')
           memoryMB = opts.memoryMb || config.memory_mb
           teamID = opts.team || config.team_id
           readyCmd = config.ready_cmd
-          readyTimeout = config.ready_timeout
         }
 
         const userConfig = getUserConfig()
@@ -334,7 +333,6 @@ export const buildCommand = new commander.Command('build')
             memory_mb: memoryMB,
             team_id: teamID,
             ready_cmd: readyCmd,
-            ready_timeout: readyTimeout,
           },
           true
         )

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -31,7 +31,6 @@ export const configSchema = yup.object({
   dockerfile: yup.string().required(),
   start_cmd: yup.string().optional(),
   ready_cmd: yup.string().optional(),
-  ready_timeout: yup.number().integer().min(1).optional(),
   cpu_count: yup.number().integer().min(1).optional(),
   memory_mb: yup.number().integer().min(128).optional(),
   team_id: yup.string().optional(),

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -30,6 +30,8 @@ export const configSchema = yup.object({
   template_name: yup.string().optional(),
   dockerfile: yup.string().required(),
   start_cmd: yup.string().optional(),
+  ready_cmd: yup.string().optional(),
+  ready_timeout: yup.number().integer().min(1).optional(),
   cpu_count: yup.number().integer().min(1).optional(),
   memory_mb: yup.number().integer().min(128).optional(),
   team_id: yup.string().optional(),

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -1,3 +1,5 @@
+import status from 'statuses'
+
 /**
  * Thrown when a request to E2B API occurs.
  */
@@ -16,7 +18,7 @@ export function handleE2BRequestError<T>(
     return
   }
 
-  let message = 'unknown error'
+  let message: string
   const code = res.error?.code ?? 0
   switch (code) {
     case 400:
@@ -33,6 +35,9 @@ export function handleE2BRequestError<T>(
       break
     case 500:
       message = 'internal server error'
+      break
+    default:
+      message = status(code) || 'unknown error'
       break
   }
 

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -28,7 +28,7 @@
     "dev": "tsup --watch",
     "example": "tsx example.mts",
     "test": "vitest run",
-    "generate": "python ./../../spec/remove_extra_tags.py sandboxes templates && openapi-typescript ../../spec/openapi_generated.yml -x api_key --array-length --alphabetize --output src/api/schema.gen.ts",
+    "generate": "python ./../../spec/remove_extra_tags.py sandboxes templates auth && openapi-typescript ../../spec/openapi_generated.yml -x api_key --array-length --alphabetize --output src/api/schema.gen.ts",
     "generate-envd-api": "openapi-typescript ../../spec/envd/envd.yaml -x api_key --array-length --alphabetize --output src/envd/schema.gen.ts",
     "generate-ref": "./scripts/generate_sdk_ref.sh",
     "check-deps": "knip",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,6 +271,9 @@ importers:
       open:
         specifier: ^9.1.0
         version: 9.1.0
+      statuses:
+        specifier: ^2.0.1
+        version: 2.0.1
       strip-ansi:
         specifier: ^7.1.0
         version: 7.1.0
@@ -293,6 +296,9 @@ importers:
       '@types/node':
         specifier: ^18.18.6
         version: 18.18.6
+      '@types/statuses':
+        specifier: ^2.0.5
+        version: 2.0.5
       '@types/update-notifier':
         specifier: 6.0.5
         version: 6.0.5
@@ -9809,8 +9815,7 @@ snapshots:
 
   '@types/shimmer@1.2.0': {}
 
-  '@types/statuses@2.0.5':
-    optional: true
+  '@types/statuses@2.0.5': {}
 
   '@types/tedious@4.0.14':
     dependencies:
@@ -11271,7 +11276,7 @@ snapshots:
       debug: 4.4.0(supports-color@9.4.0)
       enhanced-resolve: 5.18.1
       eslint: 8.57.1
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0)(eslint@8.57.1)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.0)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.0
@@ -11283,7 +11288,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11304,7 +11309,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0)(eslint@8.57.1)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -14329,8 +14334,7 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
-  statuses@2.0.1:
-    optional: true
+  statuses@2.0.1: {}
 
   std-env@3.9.0: {}
 


### PR DESCRIPTION
## Description
Add option for a template ready check. You can specify `ready_cmd` which will be run until it exits with code 0. Max timeout is 5 minutes. After exit code 0, the template will be marked as ready.

If no ready command is defined, `sleep 20` is assumed when the start command is present, and `sleep 0` when none is defined. It is also possible to define ready command without any start command. This might be helpful if the filesystem contains self-booted services (e.g. using systemd).

```
ready_cmd = "echo 'Starting ready check'; sleep 40; echo 'Template is ready'"
```

This adds possibility to configure the default 20 seconds wait time for a start command.

New documentation can be found at `/docs/sandbox-template/ready-cmd`.

## Checklist
- [x] Make sure the https://github.com/e2b-dev/infra/pull/719 is deployed
