### PR TITLE
Fix: path validation for metadata tags resolution

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -10,67 +10,28 @@ import { Layout } from '@/components/Layout'
 import { headers } from 'next/headers'
 
 async function isValidPath(pathname: string) {
-  const startTime = Date.now()
-  console.log('🔍 [isValidPath] Starting validation for:', pathname)
-  console.log('🌍 [isValidPath] Environment:', {
-    VERCEL_ENV: process.env.VERCEL_ENV,
-    VERCEL_URL: process.env.VERCEL_URL,
-    NODE_ENV: process.env.NODE_ENV,
-  })
-
   try {
     const baseUrl = process.env.VERCEL_URL
       ? `https://${process.env.VERCEL_URL}`
       : 'https://e2b.dev'
     const sitemapUrl = `${baseUrl}/sitemap.xml`
 
-    console.log('🗺️ [isValidPath] Fetching sitemap:', sitemapUrl)
-
     const response = await fetch(sitemapUrl, {
-      next: { revalidate: 300 },
+      next: { revalidate: 900 },
     })
 
     if (!response.ok) {
-      console.warn('⚠️ [isValidPath] Sitemap fetch failed:', {
-        status: response.status,
-        statusText: response.statusText,
-      })
+      console.error('Sitemap fetch failed:', response.statusText)
       return false
     }
 
     const sitemapXml = await response.text()
-    console.log('📄 [isValidPath] Sitemap fetched:', {
-      length: sitemapXml.length,
-      contentType: response.headers.get('content-type'),
-    })
-
     const targetUrl = `https://e2b.dev${pathname}`
     const isValid = sitemapXml.includes(`<loc>${targetUrl}</loc>`)
 
-    const duration = Date.now() - startTime
-    console.log('✅ [isValidPath] Validation complete:', {
-      pathname,
-      targetUrl,
-      isValid,
-      duration: `${duration}ms`,
-      method: 'sitemap',
-    })
-
     return isValid
   } catch (error) {
-    const duration = Date.now() - startTime
-    console.error('❌ [isValidPath] Error during validation:', {
-      pathname,
-      duration: `${duration}ms`,
-      error:
-        error instanceof Error
-          ? {
-              name: error.name,
-              message: error.message,
-              stack: error.stack,
-            }
-          : error,
-    })
+    console.error('Error validating path in isValidPath:', error)
     return false
   }
 }
@@ -79,10 +40,6 @@ export async function generateMetadata() {
   const headerList = headers()
   const pathname = headerList.get('x-middleware-pathname')
   const shouldIndex = headerList.get('x-e2b-should-index')
-
-  console.log('LAYOUT METADATA HEADERS', Array.from(headerList.entries()))
-  console.log('LAYOUT METADATA PATHNAME', pathname)
-  console.log('LAYOUT METADATA SHOULD INDEX', shouldIndex)
 
   let isValid = false
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,14 +8,25 @@ import glob from 'fast-glob'
 import { Section } from '@/components/SectionProvider'
 import { Layout } from '@/components/Layout'
 import { headers } from 'next/headers'
+import path from 'path'
 
 async function isValidPath(pathname: string) {
   try {
+    const rootAppDirPath = path.join(
+      process.env.NODE_ENV === 'production'
+        ? path.join('.', 'src', 'app')
+        : path.join(process.cwd(), 'src', 'app')
+    )
+
+    console.log('LAYOUT METADATA ROOT APP DIR PATH', rootAppDirPath)
+
     const docsDirectory = await glob('**/*.mdx', {
-      cwd: `src/app/(docs)${pathname}`,
+      cwd: `${rootAppDirPath}/(docs)${pathname}`,
     })
 
-    return docsDirectory.length > 0
+    console.log('LAYOUT METADATA DOCS DIRECTORY', docsDirectory)
+
+    return docsDirectory.length > 0 && docsDirectory.includes('page.mdx')
   } catch (error) {
     console.error('Error validating path in generateMetadata:', error)
     return false
@@ -26,6 +37,10 @@ export async function generateMetadata() {
   const headerList = headers()
   const pathname = headerList.get('x-middleware-pathname')
   const shouldIndex = headerList.get('x-e2b-should-index')
+
+  console.log('LAYOUT METADATA HEADERS', Array.from(headerList.entries()))
+  console.log('LAYOUT METADATA PATHNAME', pathname)
+  console.log('LAYOUT METADATA SHOULD INDEX', shouldIndex)
 
   let isValid = false
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -16,6 +16,7 @@ async function isValidPath(pathname: string) {
       : 'https://e2b.dev'
     const sitemapUrl = `${baseUrl}/sitemap.xml`
 
+    // NOTE: Expects all valid paths to be in one sitemap.xml file
     const response = await fetch(sitemapUrl, {
       cache: 'force-cache',
     })

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -17,7 +17,7 @@ async function isValidPath(pathname: string) {
     const sitemapUrl = `${baseUrl}/sitemap.xml`
 
     const response = await fetch(sitemapUrl, {
-      next: { revalidate: 900 },
+      cache: 'force-cache',
     })
 
     if (!response.ok) {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -10,7 +10,7 @@ import { Layout } from '@/components/Layout'
 import { headers } from 'next/headers'
 import path from 'path'
 
-async function isValidPath(pathname: string) {
+function isValidPath(pathname: string) {
   const startTime = Date.now()
   console.log('🔍 [isValidPath] Starting validation for:', pathname)
   console.log('🌍 [isValidPath] Environment:', {
@@ -18,6 +18,10 @@ async function isValidPath(pathname: string) {
     NODE_ENV: process.env.NODE_ENV,
     LAMBDA_RUNTIME_DIR: process.env.LAMBDA_RUNTIME_DIR,
     cwd: process.cwd(),
+  })
+  console.log('📂 [isValidPath] Directory structure:', {
+    cwd: process.cwd(),
+    files: glob.sync('**/*', { cwd: process.cwd(), dot: true }),
   })
 
   try {
@@ -65,7 +69,7 @@ async function isValidPath(pathname: string) {
       cwd: globCwd,
     })
 
-    const docsDirectory = await glob(globPattern, {
+    const docsDirectory = glob.sync(globPattern, {
       cwd: globCwd,
     })
 
@@ -117,7 +121,7 @@ export async function generateMetadata() {
   let isValid = false
 
   if (pathname?.startsWith('/docs')) {
-    isValid = await isValidPath(pathname)
+    isValid = isValidPath(pathname)
   }
 
   return {

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -4,6 +4,8 @@ import { getPageForSitemap } from '@/utils/sitemap'
 
 export const dynamic = 'force-static'
 
+// NOTE: Sitemap should not be split into multiple files.
+// This would break path validation in [app/layout.tsx]
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const docsDirectory = path.join(
     process.env.NODE_ENV === 'production'

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -4,15 +4,8 @@ import type { NextRequest } from 'next/server'
 export function middleware(request: NextRequest) {
   const path = request.nextUrl.pathname
 
-  console.log('MIDDLEWARE HEADERS', Array.from(request.headers.entries()))
-
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-middleware-pathname', path)
-
-  // Ensure the header is forwarded
-  if (request.headers.get('x-e2b-should-index') === '1') {
-    requestHeaders.set('x-e2b-should-index', 'true')
-  }
 
   return NextResponse.next({
     request: {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -4,8 +4,15 @@ import type { NextRequest } from 'next/server'
 export function middleware(request: NextRequest) {
   const path = request.nextUrl.pathname
 
+  console.log('MIDDLEWARE HEADERS', Array.from(request.headers.entries()))
+
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-middleware-pathname', path)
+
+  // Ensure the header is forwarded
+  if (request.headers.get('x-e2b-should-index') === '1') {
+    requestHeaders.set('x-e2b-should-index', 'true')
+  }
 
   return NextResponse.next({
     request: {


### PR DESCRIPTION
This pr fixes validating pathnames for SEO metadata tag generation, by checking against already built time cached sitemap instead of doing request time glob resolution. path resolutions in vercels request-time are hard to optimize for & test, since the environment differs quite a bit from what could be tested locally + this should be faster since the fetch & sitemap are cached for the build.