### PR TITLE
Pass debug explicitly to Sandbox in tests

### DIFF
--- a/packages/js-sdk/tests/setup.ts
+++ b/packages/js-sdk/tests/setup.ts
@@ -10,7 +10,7 @@ export const sandboxTest = base.extend<SandboxFixture>({
   sandbox: [
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
-      const sandbox = await Sandbox.create(template)
+      const sandbox = await Sandbox.create(template, { debug: isDebug })
       try {
         await use(sandbox)
       } finally {

--- a/packages/python-sdk/tests/conftest.py
+++ b/packages/python-sdk/tests/conftest.py
@@ -22,7 +22,7 @@ def template():
 
 @pytest.fixture()
 def sandbox(template, debug):
-    sandbox = Sandbox(template)
+    sandbox = Sandbox(template, debug=debug)
 
     try:
         yield sandbox
@@ -38,7 +38,7 @@ def sandbox(template, debug):
 
 @pytest_asyncio.fixture
 async def async_sandbox(template, debug):
-    sandbox = await AsyncSandbox.create(template)
+    sandbox = await AsyncSandbox.create(template, debug=debug)
 
     try:
         yield sandbox


### PR DESCRIPTION
- I don't know why, but I couldn't run Python tests otherwise for some reason