### PR TITLE
Fixes incorrect error message in Python SDK

### DIFF
--- a/packages/python-sdk/e2b/envd/rpc.py
+++ b/packages/python-sdk/e2b/envd/rpc.py
@@ -26,11 +26,11 @@ def handle_rpc_exception(e: Exception):
             return format_sandbox_timeout_exception(e.message)
         elif e.status == Code.canceled:
             return TimeoutException(
-                f"{e.message}: This error is likely due to exceeding 'requestTimeoutMs'. You can pass the request timeout value as an option when making the request."
+                f"{e.message}: This error is likely due to exceeding 'request_timeout'. You can pass the request timeout value as an option when making the request."
             )
         elif e.status == Code.deadline_exceeded:
             return TimeoutException(
-                f"{e.message}: This error is likely due to exceeding 'timeoutMs' — the total time a long running request (like process or directory watch) can be active. It can be modified by passing 'timeoutMs' when making the request. Use '0' to disable the timeout."
+                f"{e.message}: This error is likely due to exceeding 'timeout' — the total time a long running request (like process or directory watch) can be active. It can be modified by passing 'timeout' when making the request. Use '0' to disable the timeout."
             )
         else:
             return SandboxException(f"{e.status}: {e.message}")


### PR DESCRIPTION
- closes #776
- changes timeout error message in Python SDK, before was same as in the JS SDK which is incorrect.