### PR TITLE
Use TextEncoder for crypto/signed URLs

### DIFF
--- a/.changeset/many-boats-knock.md
+++ b/.changeset/many-boats-knock.md
@@ -1,5 +1,5 @@
 ---
-'e2b': patch
+'e2b': minor
 ---
 
 use TextEncoder/TextDecoder instead of node:crypto

--- a/.changeset/many-boats-knock.md
+++ b/.changeset/many-boats-knock.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+use TextEncoder/TextDecoder instead of node:crypto

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -3,7 +3,8 @@ import { createConnectTransport } from '@connectrpc/connect-web'
 import {
   ConnectionConfig,
   ConnectionOpts,
-  defaultUsername, Username,
+  defaultUsername,
+  Username,
 } from '../connectionConfig'
 import { EnvdApiClient, handleEnvdApiError } from '../envd/api'
 import { createRpcLogger } from '../logs'
@@ -59,7 +60,7 @@ export interface SandboxUrlOpts {
    *
    * @default false
    */
-  useSignature?: true,
+  useSignature?: true
 
   /**
    * Use signature expiration for the URL.
@@ -144,7 +145,9 @@ export class Sandbox extends SandboxApi {
     this.connectionConfig = new ConnectionConfig(opts)
 
     this.envdAccessToken = opts.envdAccessToken
-    this.envdApiUrl = `${this.connectionConfig.debug ? 'http' : 'https'}://${this.getHost(this.envdPort)}`
+    this.envdApiUrl = `${
+      this.connectionConfig.debug ? 'http' : 'https'
+    }://${this.getHost(this.envdPort)}`
 
     const rpcTransport = createConnectTransport({
       baseUrl: this.envdApiUrl,
@@ -176,7 +179,9 @@ export class Sandbox extends SandboxApi {
         apiUrl: this.envdApiUrl,
         logger: opts?.logger,
         accessToken: this.envdAccessToken,
-        headers: this.envdAccessToken ? { 'X-Access-Token': this.envdAccessToken } : { },
+        headers: this.envdAccessToken
+          ? { 'X-Access-Token': this.envdAccessToken }
+          : {},
       },
       {
         version: opts?.envdVersion,
@@ -280,9 +285,12 @@ export class Sandbox extends SandboxApi {
     const config = new ConnectionConfig(opts)
     const info = await this.getInfo(sandboxId, opts)
 
-    return new this(
-        { sandboxId, envdAccessToken: info.envdAccessToken, envdVersion: info.envdVersion, ...config }
-    ) as InstanceType<S>
+    return new this({
+      sandboxId,
+      envdAccessToken: info.envdAccessToken,
+      envdVersion: info.envdVersion,
+      ...config,
+    }) as InstanceType<S>
   }
 
   /**
@@ -398,12 +406,19 @@ export class Sandbox extends SandboxApi {
   uploadUrl(path?: string, opts?: SandboxUrlOpts) {
     opts = opts ?? {}
 
-    if (!this.envdAccessToken && (opts.useSignature || opts.useSignatureExpiration != undefined)) {
-      throw new Error('Signature can be used only when sandbox is spawned with secure option.')
+    if (
+      !this.envdAccessToken &&
+      (opts.useSignature || opts.useSignatureExpiration != undefined)
+    ) {
+      throw new Error(
+        'Signature can be used only when sandbox is spawned with secure option.'
+      )
     }
 
     if (!opts.useSignature && opts.useSignatureExpiration != undefined) {
-      throw new Error('Signature expiration can be used only when signature is set to true.')
+      throw new Error(
+        'Signature expiration can be used only when signature is set to true.'
+      )
     }
 
     const username = opts.user ?? defaultUsername
@@ -412,9 +427,13 @@ export class Sandbox extends SandboxApi {
 
     if (opts.useSignature) {
       const url = new URL(fileUrl)
-      const sig = getSignature(
-          { path: filePath, operation: 'write', user: username, expirationInSeconds: opts.useSignatureExpiration, envdAccessToken: this.envdAccessToken}
-      )
+      const sig = getSignature({
+        path: filePath,
+        operation: 'write',
+        user: username,
+        expirationInSeconds: opts.useSignatureExpiration,
+        envdAccessToken: this.envdAccessToken,
+      })
 
       url.searchParams.set('signature', sig.signature)
       if (sig.expiration) {
@@ -436,15 +455,23 @@ export class Sandbox extends SandboxApi {
    *
    * @returns URL for downloading file.
    */
-  downloadUrl(path: string, opts?: SandboxUrlOpts) { //path: string, useSignature?: boolean, signatureExpirationInSeconds?: number) {
+  downloadUrl(path: string, opts?: SandboxUrlOpts) {
+    //path: string, useSignature?: boolean, signatureExpirationInSeconds?: number) {
     opts = opts ?? {}
 
-    if (!this.envdAccessToken && (opts.useSignature || opts.useSignatureExpiration != undefined)) {
-      throw new Error('Signature can be used only when sandbox is spawned with secure option.')
+    if (
+      !this.envdAccessToken &&
+      (opts.useSignature || opts.useSignatureExpiration != undefined)
+    ) {
+      throw new Error(
+        'Signature can be used only when sandbox is spawned with secure option.'
+      )
     }
 
     if (!opts.useSignature && opts.useSignatureExpiration != undefined) {
-      throw new Error('Signature expiration can be used only when signature is set to true.')
+      throw new Error(
+        'Signature expiration can be used only when signature is set to true.'
+      )
     }
 
     const username = opts.user ?? defaultUsername
@@ -452,9 +479,13 @@ export class Sandbox extends SandboxApi {
 
     if (opts.useSignature) {
       const url = new URL(fileUrl)
-      const sig = getSignature(
-          { path, operation: 'read', user: username, expirationInSeconds: opts.useSignatureExpiration, envdAccessToken: this.envdAccessToken}
-      )
+      const sig = getSignature({
+        path,
+        operation: 'read',
+        user: username,
+        expirationInSeconds: opts.useSignatureExpiration,
+        envdAccessToken: this.envdAccessToken,
+      })
 
       url.searchParams.set('signature', sig.signature)
       if (sig.expiration) {
@@ -466,7 +497,6 @@ export class Sandbox extends SandboxApi {
 
     return fileUrl
   }
-
 
   /**
    * Get sandbox information like sandbox ID, template, metadata, started at/end at date.
@@ -482,8 +512,7 @@ export class Sandbox extends SandboxApi {
     })
   }
 
-
-  private fileUrl(path?: string, username?:  string) {
+  private fileUrl(path?: string, username?: string) {
     const url = new URL('/files', this.envdApiUrl)
 
     url.searchParams.set('username', username ?? defaultUsername)

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -403,7 +403,7 @@ export class Sandbox extends SandboxApi {
    *
    * @returns URL for uploading file.
    */
-  uploadUrl(path?: string, opts?: SandboxUrlOpts) {
+  async uploadUrl(path?: string, opts?: SandboxUrlOpts) {
     opts = opts ?? {}
 
     if (
@@ -427,7 +427,7 @@ export class Sandbox extends SandboxApi {
 
     if (opts.useSignature) {
       const url = new URL(fileUrl)
-      const sig = getSignature({
+      const sig = await getSignature({
         path: filePath,
         operation: 'write',
         user: username,
@@ -455,7 +455,7 @@ export class Sandbox extends SandboxApi {
    *
    * @returns URL for downloading file.
    */
-  downloadUrl(path: string, opts?: SandboxUrlOpts) {
+  async downloadUrl(path: string, opts?: SandboxUrlOpts) {
     //path: string, useSignature?: boolean, signatureExpirationInSeconds?: number) {
     opts = opts ?? {}
 
@@ -479,7 +479,7 @@ export class Sandbox extends SandboxApi {
 
     if (opts.useSignature) {
       const url = new URL(fileUrl)
-      const sig = getSignature({
+      const sig = await getSignature({
         path,
         operation: 'read',
         user: username,

--- a/packages/js-sdk/src/sandbox/signature.ts
+++ b/packages/js-sdk/src/sandbox/signature.ts
@@ -1,3 +1,5 @@
+import { sha256 } from '../utils'
+
 /**
  * Get the URL signature for the specified path, operation and user.
  *
@@ -16,24 +18,6 @@ interface SignatureOpts {
   user: string
   expirationInSeconds?: number
   envdAccessToken?: string
-}
-
-// Cross-platform crypto implementation
-async function sha256(data: string): Promise<string> {
-  // Use Node.js crypto if WebCrypto is not available
-  if (typeof crypto === 'undefined') {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { createHash } = require('node:crypto')
-    const hash = createHash('sha256').update(data, 'utf8').digest()
-    return hash.toString('base64')
-  }
-
-  // Use WebCrypto API if available
-  const encoder = new TextEncoder()
-  const dataBuffer = encoder.encode(data)
-  const hashBuffer = await crypto.subtle.digest('SHA-256', dataBuffer)
-  const hashArray = new Uint8Array(hashBuffer)
-  return btoa(String.fromCharCode(...hashArray))
 }
 
 export async function getSignature({

--- a/packages/js-sdk/src/sandbox/signature.ts
+++ b/packages/js-sdk/src/sandbox/signature.ts
@@ -1,5 +1,3 @@
-import crypto from 'node:crypto'
-
 /**
  * Get the URL signature for the specified path, operation and user.
  *
@@ -12,36 +10,53 @@ import crypto from 'node:crypto'
  * @param expirationInSeconds Optional signature expiration time in seconds.
  */
 
-
 interface SignatureOpts {
-    path: string
-    operation: 'read' | 'write'
-    user: string
-    expirationInSeconds?: number
-    envdAccessToken?: string
+  path: string
+  operation: 'read' | 'write'
+  user: string
+  expirationInSeconds?: number
+  envdAccessToken?: string
 }
 
-export function getSignature({ path, operation, user, expirationInSeconds, envdAccessToken }: SignatureOpts): { signature: string; expiration: number | null } {
-    if (!envdAccessToken) {
-        throw new Error('Access token is not set and signature cannot be generated!')
-    }
+export async function getSignature({
+  path,
+  operation,
+  user,
+  expirationInSeconds,
+  envdAccessToken,
+}: SignatureOpts): Promise<{ signature: string; expiration: number | null }> {
+  if (!envdAccessToken) {
+    throw new Error(
+      'Access token is not set and signature cannot be generated!'
+    )
+  }
 
-    // expiration is unix timestamp
-    const signatureExpiration = expirationInSeconds ? Math.floor(Date.now() / 1000) + expirationInSeconds : null
-    let signatureRaw: string
+  // expiration is unix timestamp
+  const signatureExpiration = expirationInSeconds
+    ? Math.floor(Date.now() / 1000) + expirationInSeconds
+    : null
+  let signatureRaw: string
 
-    if (signatureExpiration === null) {
-        signatureRaw = `${path}:${operation}:${user}:${envdAccessToken}`
-    } else {
-        signatureRaw = `${path}:${operation}:${user}:${envdAccessToken}:${signatureExpiration.toString()}`
-    }
+  if (signatureExpiration === null) {
+    signatureRaw = `${path}:${operation}:${user}:${envdAccessToken}`
+  } else {
+    signatureRaw = `${path}:${operation}:${user}:${envdAccessToken}:${signatureExpiration.toString()}`
+  }
 
-    const buff = Buffer.from(signatureRaw, 'utf8')
-    const hash = crypto.createHash('sha256').update(buff).digest()
-    const signature =  'v1_' + hash.toString('base64').replace(/=+$/, '')
+  // Use TextEncoder to convert string to Uint8Array
+  const encoder = new TextEncoder()
+  const data = encoder.encode(signatureRaw)
 
-    return {
-        signature: signature,
-        expiration: signatureExpiration
-    }
+  // Use WebCrypto to create SHA-256 hash
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+
+  // Convert ArrayBuffer to base64 string
+  const hashArray = new Uint8Array(hashBuffer)
+  const hashBase64 = btoa(String.fromCharCode(...hashArray))
+  const signature = 'v1_' + hashBase64.replace(/=+$/, '')
+
+  return {
+    signature: signature,
+    expiration: signatureExpiration,
+  }
 }

--- a/packages/js-sdk/src/sandbox/signature.ts
+++ b/packages/js-sdk/src/sandbox/signature.ts
@@ -21,7 +21,8 @@ interface SignatureOpts {
 // Cross-platform crypto implementation
 async function sha256(data: string): Promise<string> {
   // Use Node.js crypto if WebCrypto is not available
-  if (!crypto) {
+  if (typeof crypto === 'undefined') {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { createHash } = require('node:crypto')
     const hash = createHash('sha256').update(data, 'utf8').digest()
     return hash.toString('base64')

--- a/packages/js-sdk/src/utils.ts
+++ b/packages/js-sdk/src/utils.ts
@@ -1,0 +1,16 @@
+export async function sha256(data: string): Promise<string> {
+  // Use WebCrypto API if available
+  if (typeof crypto !== 'undefined') {
+    const encoder = new TextEncoder()
+    const dataBuffer = encoder.encode(data)
+    const hashBuffer = await crypto.subtle.digest('SHA-256', dataBuffer)
+    const hashArray = new Uint8Array(hashBuffer)
+    return btoa(String.fromCharCode(...hashArray))
+  }
+
+  // Use Node.js crypto if WebCrypto is not available
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { createHash } = require('node:crypto')
+  const hash = createHash('sha256').update(data, 'utf8').digest()
+  return hash.toString('base64')
+}

--- a/packages/js-sdk/tests/sandbox/files/signing.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/signing.test.ts
@@ -12,7 +12,7 @@ test.skipIf(isDebug)('test access file with expired signing', async () => {
   })
   await sbx.files.write('hello.txt', 'hello world')
 
-  const fileUrlWithSigning = sbx.downloadUrl('hello.txt', {
+  const fileUrlWithSigning = await sbx.downloadUrl('hello.txt', {
     useSignature: true,
     useSignatureExpiration: -10_000,
   })
@@ -37,7 +37,7 @@ test.skipIf(isDebug)('test access file with valid signing', async () => {
   })
   await sbx.files.write('hello.txt', 'hello world')
 
-  const fileUrlWithSigning = sbx.downloadUrl('hello.txt', {
+  const fileUrlWithSigning = await sbx.downloadUrl('hello.txt', {
     useSignature: true,
     useSignatureExpiration: 10_000,
   })
@@ -52,35 +52,38 @@ test.skipIf(isDebug)('test access file with valid signing', async () => {
   await sbx.kill()
 })
 
-test.skipIf(isDebug)('test access file with valid signing as root', async () => {
-  const sbx = await Sandbox.create(template, {
-    timeoutMs: timeout,
-    secure: true,
-  })
-  await sbx.files.write('hello.txt', 'hello world', { user: 'root' })
+test.skipIf(isDebug)(
+  'test access file with valid signing as root',
+  async () => {
+    const sbx = await Sandbox.create(template, {
+      timeoutMs: timeout,
+      secure: true,
+    })
+    await sbx.files.write('hello.txt', 'hello world', { user: 'root' })
 
-  const fileUrlWithSigning = sbx.downloadUrl('hello.txt', {
-    user: 'root',
-    useSignature: true,
-    useSignatureExpiration: 10_000,
-  })
+    const fileUrlWithSigning = await sbx.downloadUrl('hello.txt', {
+      user: 'root',
+      useSignature: true,
+      useSignatureExpiration: 10_000,
+    })
 
-  const res = await fetch(fileUrlWithSigning)
-  const resBody = await res.text()
-  const resStatus = res.status
+    const res = await fetch(fileUrlWithSigning)
+    const resBody = await res.text()
+    const resStatus = res.status
 
-  assert.equal(resStatus, 200)
-  assert.equal(resBody, 'hello world')
+    assert.equal(resStatus, 200)
+    assert.equal(resBody, 'hello world')
 
-  await sbx.kill()
-})
+    await sbx.kill()
+  }
+)
 
 test.skipIf(isDebug)('test upload file with valid signing', async () => {
   const sbx = await Sandbox.create(template, {
     timeoutMs: timeout,
     secure: true,
   })
-  const fileUrlWithSigning = sbx.uploadUrl('hello.txt', {
+  const fileUrlWithSigning = await sbx.uploadUrl('hello.txt', {
     useSignature: true,
     useSignatureExpiration: 10_000,
   })
@@ -100,39 +103,42 @@ test.skipIf(isDebug)('test upload file with valid signing', async () => {
   await sbx.kill()
 })
 
-test.skipIf(isDebug)('test upload file with valid signing as root user', async () => {
-  const sbx = await Sandbox.create(template, {
-    timeoutMs: timeout,
-    secure: true,
-  })
+test.skipIf(isDebug)(
+  'test upload file with valid signing as root user',
+  async () => {
+    const sbx = await Sandbox.create(template, {
+      timeoutMs: timeout,
+      secure: true,
+    })
 
-  const fileUrlWithSigning = sbx.uploadUrl('hello.txt', {
-    user: 'root',
-    useSignature: true,
-    useSignatureExpiration: 10_000,
-  })
+    const fileUrlWithSigning = await sbx.uploadUrl('hello.txt', {
+      user: 'root',
+      useSignature: true,
+      useSignatureExpiration: 10_000,
+    })
 
-  const form = new FormData()
-  form.append('file', 'file content')
+    const form = new FormData()
+    form.append('file', 'file content')
 
-  const res = await fetch(fileUrlWithSigning, { method: 'POST', body: form })
-  const resBody = await res.text()
-  const resStatus = res.status
+    const res = await fetch(fileUrlWithSigning, { method: 'POST', body: form })
+    const resBody = await res.text()
+    const resStatus = res.status
 
-  assert.equal(resStatus, 200)
-  assert.deepEqual(JSON.parse(resBody), [
-    { name: 'hello.txt', path: '/root/hello.txt', type: 'file' },
-  ])
+    assert.equal(resStatus, 200)
+    assert.deepEqual(JSON.parse(resBody), [
+      { name: 'hello.txt', path: '/root/hello.txt', type: 'file' },
+    ])
 
-  await sbx.kill()
-})
+    await sbx.kill()
+  }
+)
 
 test.skipIf(isDebug)('test upload file with invalid signing', async () => {
   const sbx = await Sandbox.create(template, {
     timeoutMs: timeout,
     secure: true,
   })
-  const fileUrlWithSigning = sbx.uploadUrl('hello.txt', {
+  const fileUrlWithSigning = await sbx.uploadUrl('hello.txt', {
     useSignature: true,
     useSignatureExpiration: -10_000,
   })
@@ -158,7 +164,7 @@ test.skipIf(isDebug)('test upload file with missing signing', async () => {
     timeoutMs: timeout,
     secure: true,
   })
-  const fileUrlWithSigning = sbx.uploadUrl('hello.txt')
+  const fileUrlWithSigning = await sbx.uploadUrl('hello.txt')
 
   const form = new FormData()
   form.append('file', 'file content')

--- a/packages/js-sdk/tests/sandbox/secure.test.ts
+++ b/packages/js-sdk/tests/sandbox/secure.test.ts
@@ -12,7 +12,7 @@ test.skipIf(isDebug)('test access file without signing', async () => {
   })
   await sbx.files.write('hello.txt', 'hello world')
 
-  const fileUrlWithoutSigning = sbx.downloadUrl('hello.txt')
+  const fileUrlWithoutSigning = await sbx.downloadUrl('hello.txt')
 
   const res = await fetch(fileUrlWithoutSigning)
   const resBody = await res.text()
@@ -34,7 +34,7 @@ test.skipIf(isDebug)('test access file with signing', async () => {
   })
   await sbx.files.write('hello.txt', 'hello world')
 
-  const fileUrlWithSigning = sbx.downloadUrl('hello.txt', {
+  const fileUrlWithSigning = await sbx.downloadUrl('hello.txt', {
     useSignature: true,
   })
 
@@ -76,7 +76,7 @@ test.skipIf(isDebug)('signing generation', async () => {
     expiration: null,
   }
 
-  const readSignatureReceived = getSignature({
+  const readSignatureReceived = await getSignature({
     path,
     operation,
     user,
@@ -107,7 +107,7 @@ test.skipIf(isDebug)('signing generation with expiration', async () => {
     expiration: signatureExpiration,
   }
 
-  const readSignatureReceived = getSignature({
+  const readSignatureReceived = await getSignature({
     path,
     operation,
     user,
@@ -124,7 +124,7 @@ test.skipIf(isDebug)('static signing key comparison', async () => {
   const user = 'user'
   const envdAccessToken = '0tQG31xiMp0IOQfaz9dcwi72L1CPo8e0'
 
-  const signatureReceived = getSignature({
+  const signatureReceived = await getSignature({
     path,
     operation,
     user,


### PR DESCRIPTION
- Replaces node:crypto with cross-runtime TextEncoder/TextDecoder API
- The uploadUrl/downloadUrl methods are now async