### PR TITLE
watchDir remove redundant "timeout" option in JS SDK

### DIFF
--- a/.changeset/twenty-pears-kick.md
+++ b/.changeset/twenty-pears-kick.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+removed timeout option from watchDir JS SDK

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -517,7 +517,6 @@ export class Filesystem {
     path: string,
     onEvent: (event: FilesystemEvent) => void | Promise<void>,
     opts?: WatchOpts & {
-      timeout?: number
       onExit?: (err?: Error) => void | Promise<void>
     }
   ): Promise<WatchHandle> {


### PR DESCRIPTION
- removes redundant "timeout" option for watchDir method in the JS SDK (we're using timeoutMs already)