### PR TITLE
Support `E2B_SANDBOX_DOMAIN` env variable for sandbox traffic routing 

### DIFF
--- a/.changeset/bright-owls-compare.md
+++ b/.changeset/bright-owls-compare.md
@@ -1,0 +1,7 @@
+---
+'@e2b/python-sdk': minor
+'e2b': minor
+'@e2b/cli': minor
+---
+
+Support of different domain for sandbox traffic routing

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -29,6 +29,12 @@ export interface ConnectionOpts {
    */
   domain?: string
   /**
+   * Domain to use for the sandbox traffic.
+   *
+   * @default E2B_SANDBOX_DOMAIN // environment variable or fallback domain from `domain` option
+   */
+  sandboxDomain?: string
+  /**
    * If true the SDK starts in the debug mode and connects to the local envd API server.
    * @internal
    * @default E2B_DEBUG // environment variable or `false`
@@ -57,6 +63,7 @@ export interface ConnectionOpts {
 export class ConnectionConfig {
   readonly debug: boolean
   readonly domain: string
+  readonly sandboxDomain: string
   readonly apiUrl: string
   readonly logger?: Logger
 
@@ -71,6 +78,7 @@ export class ConnectionConfig {
     this.apiKey = opts?.apiKey || ConnectionConfig.apiKey
     this.debug = opts?.debug || ConnectionConfig.debug
     this.domain = opts?.domain || ConnectionConfig.domain
+    this.sandboxDomain = opts?.sandboxDomain || ConnectionConfig.sandboxDomain
     this.accessToken = opts?.accessToken || ConnectionConfig.accessToken
     this.requestTimeoutMs = opts?.requestTimeoutMs ?? REQUEST_TIMEOUT_MS
     this.logger = opts?.logger
@@ -83,6 +91,10 @@ export class ConnectionConfig {
 
   private static get domain() {
     return getEnvVar('E2B_DOMAIN') || 'e2b.app'
+  }
+
+  private static get sandboxDomain() {
+    return getEnvVar('E2B_SANDBOX_DOMAIN') || ConnectionConfig.domain
   }
 
   private static get debug() {

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -315,7 +315,7 @@ export class Sandbox extends SandboxApi {
       return `localhost:${port}`
     }
 
-    return `${port}-${this.sandboxId}.${this.connectionConfig.domain}`
+    return `${port}-${this.sandboxId}.${this.connectionConfig.sandboxDomain}`
   }
 
   /**

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -19,6 +19,10 @@ class ConnectionConfig:
         return os.getenv("E2B_DOMAIN", "e2b.app")
 
     @staticmethod
+    def _sandbox_domain():
+        return os.getenv("E2B_SANDBOX_DOMAIN", os.getenv("E2B_DOMAIN", "e2b.app"))
+
+    @staticmethod
     def _debug():
         return os.getenv("E2B_DEBUG", "false").lower() == "true"
 
@@ -39,8 +43,11 @@ class ConnectionConfig:
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
         proxy: Optional[ProxyTypes] = None,
+        sandbox_domain: Optional[str] = None,
     ):
         self.domain = domain or ConnectionConfig._domain()
+        self.sandbox_domain = sandbox_domain or ConnectionConfig._sandbox_domain()
+
         self.debug = debug or ConnectionConfig._debug()
         self.api_key = api_key or ConnectionConfig._api_key()
         self.access_token = access_token or ConnectionConfig._access_token()

--- a/packages/python-sdk/e2b/sandbox/main.py
+++ b/packages/python-sdk/e2b/sandbox/main.py
@@ -112,4 +112,4 @@ class SandboxSetup(ABC):
         if self.connection_config.debug:
             return f"localhost:{port}"
 
-        return f"{port}-{self.sandbox_id}.{self.connection_config.domain}"
+        return f"{port}-{self.sandbox_id}.{self.connection_config.sandbox_domain}"

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -359,6 +359,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         config_dict = self.connection_config.__dict__
         config_dict.pop("access_token", None)
         config_dict.pop("api_url", None)
+        config_dict.pop("sandbox_domain", None)
 
         if request_timeout:
             config_dict["request_timeout"] = request_timeout
@@ -420,6 +421,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         config_dict = self.connection_config.__dict__
         config_dict.pop("access_token", None)
         config_dict.pop("api_url", None)
+        config_dict.pop("sandbox_domain", None)
 
         if request_timeout:
             config_dict["request_timeout"] = request_timeout
@@ -443,6 +445,7 @@ class AsyncSandbox(SandboxSetup, SandboxApi):
         config_dict = self.connection_config.__dict__
         config_dict.pop("access_token", None)
         config_dict.pop("api_url", None)
+        config_dict.pop("sandbox_domain", None)
 
         if request_timeout:
             config_dict["request_timeout"] = request_timeout

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -336,6 +336,7 @@ class Sandbox(SandboxSetup, SandboxApi):
         config_dict = self.connection_config.__dict__
         config_dict.pop("access_token", None)
         config_dict.pop("api_url", None)
+        config_dict.pop("sandbox_domain", None)
 
         if request_timeout:
             config_dict["request_timeout"] = request_timeout
@@ -398,6 +399,7 @@ class Sandbox(SandboxSetup, SandboxApi):
         config_dict = self.connection_config.__dict__
         config_dict.pop("access_token", None)
         config_dict.pop("api_url", None)
+        config_dict.pop("sandbox_domain", None)
 
         if request_timeout:
             config_dict["request_timeout"] = request_timeout
@@ -420,6 +422,7 @@ class Sandbox(SandboxSetup, SandboxApi):
         config_dict = self.connection_config.__dict__
         config_dict.pop("access_token", None)
         config_dict.pop("api_url", None)
+        config_dict.pop("sandbox_domain", None)
 
         if request_timeout:
             config_dict["request_timeout"] = request_timeout


### PR DESCRIPTION
Introduce a new environment variable E2B_SANDBOX_DOMAIN that can override E2B_DOMAIN (or the default e2b.app) so sandbox traffic is routed to a different domain.