### PR TITLE
Fixes parsing http errors in connect client

### DIFF
--- a/.changeset/mighty-dragons-shake.md
+++ b/.changeset/mighty-dragons-shake.md
@@ -1,0 +1,5 @@
+---
+'@e2b/python-sdk': patch
+---
+
+fixes http error handling in e2b connect package

--- a/packages/python-sdk/e2b/envd/rpc.py
+++ b/packages/python-sdk/e2b/envd/rpc.py
@@ -10,6 +10,7 @@ from e2b.exceptions import (
     TimeoutException,
     format_sandbox_timeout_exception,
     AuthenticationException,
+    RateLimitException,
 )
 from e2b.connection_config import Username, default_username
 
@@ -24,6 +25,10 @@ def handle_rpc_exception(e: Exception):
             return NotFoundException(e.message)
         elif e.status == Code.unavailable:
             return format_sandbox_timeout_exception(e.message)
+        elif e.status == Code.resource_exhausted:
+            return RateLimitException(
+                f"{e.message}: Rate limit exceeded, please try again later."
+            )
         elif e.status == Code.canceled:
             return TimeoutException(
                 f"{e.message}: This error is likely due to exceeding 'request_timeout'. You can pass the request timeout value as an option when making the request."

--- a/packages/python-sdk/e2b_connect/client.py
+++ b/packages/python-sdk/e2b_connect/client.py
@@ -85,21 +85,11 @@ def error_for_response(http_resp: Response):
         error = json.loads(http_resp.content)
         return make_error(error)
     except (json.decoder.JSONDecodeError, KeyError):
-        if http_resp.status == 429:
-            return ConnectException(
-                Code.resource_exhausted,
-                f"{http_resp.content.decode()} The requests are being rate limited.",
-            )
-        elif http_resp.status == 502:
-            return ConnectException(
-                Code.unavailable,
-                http_resp.content.decode(),
-            )
-        else:
-            return ConnectException(
-                Code.unknown,
-                f"{http_resp.status}: {http_resp.content.decode('utf-8')}",
-            )
+        error = {
+            "code": http_resp.status,
+            "message": http_resp.content.decode('utf-8')
+        }
+        return make_error(error)
 
 def make_error(error):
     status = None

--- a/packages/python-sdk/e2b_connect/client.py
+++ b/packages/python-sdk/e2b_connect/client.py
@@ -94,7 +94,7 @@ def error_for_response(http_resp: Response):
 def make_error(error):
     status = None
     try:
-        code_value = error["code"]
+        code_value = error.get("code")
         # return error code from http status code
         if isinstance(code_value, int):
             status = make_error_from_http_code(code_value)


### PR DESCRIPTION
What was happening is the sandbox was timing out, connect client was not parsing the error correctly (while streaming command) and you got a parsing error instead of sandbox timeout exception

- Fixes https://github.com/e2b-dev/desktop/issues/97 > read response content
- Adds handling for http response status code (such as 502) from the server

Example code:

```py
from e2b import Sandbox
import time

def main():
    sandbox = Sandbox(
        timeout=10,
    )
    info = sandbox.get_info()
    start_time = info.started_at.timestamp()
    while True:
        elapsed_seconds = time.time() - start_time
        sandbox.commands.run("ls -la")
        print(f"Run command at {time.time()}, {elapsed_seconds:.2f} seconds elapsed")

if __name__ == "__main__":
    main()
```

Before:

```
Run command at 1751560744.80317, 0.77 seconds elapsed
Run command at 1751560744.9999402, 1.11 seconds elapsed
Run command at 1751560745.1917272, 1.30 seconds elapsed
Run command at 1751560745.392896, 1.50 seconds elapsed
Run command at 1751560745.590512, 1.70 seconds elapsed
Run command at 1751560745.784769, 1.90 seconds elapsed
Run command at 1751560745.975764, 2.09 seconds elapsed
Run command at 1751560746.166791, 2.28 seconds elapsed
Run command at 1751560746.357606, 2.47 seconds elapsed
Run command at 1751560746.555593, 2.66 seconds elapsed
Run command at 1751560746.752803, 2.86 seconds elapsed
Run command at 1751560746.9508932, 3.06 seconds elapsed
Run command at 1751560747.1478882, 3.26 seconds elapsed
Run command at 1751560747.344202, 3.45 seconds elapsed
Run command at 1751560747.542072, 3.65 seconds elapsed
Run command at 1751560747.7298298, 3.85 seconds elapsed
Run command at 1751560747.924543, 4.03 seconds elapsed
Run command at 1751560748.119057, 4.23 seconds elapsed
Run command at 1751560748.310394, 4.42 seconds elapsed
Run command at 1751560748.501639, 4.61 seconds elapsed
Run command at 1751560748.6946602, 4.81 seconds elapsed
Run command at 1751560748.8846369, 5.00 seconds elapsed
Run command at 1751560749.083088, 5.19 seconds elapsed
Run command at 1751560749.2801611, 5.39 seconds elapsed
Run command at 1751560749.475949, 5.58 seconds elapsed
Run command at 1751560749.6695821, 5.78 seconds elapsed
Run command at 1751560749.862676, 5.97 seconds elapsed
Run command at 1751560750.058424, 6.17 seconds elapsed
Run command at 1751560750.271945, 6.36 seconds elapsed
Run command at 1751560750.4680839, 6.58 seconds elapsed
Run command at 1751560750.668449, 6.77 seconds elapsed
Run command at 1751560750.863143, 6.97 seconds elapsed
Run command at 1751560751.057122, 7.17 seconds elapsed
Run command at 1751560751.2528489, 7.36 seconds elapsed
Run command at 1751560751.442789, 7.56 seconds elapsed
Run command at 1751560751.637415, 7.75 seconds elapsed
Run command at 1751560751.8309681, 7.94 seconds elapsed
Run command at 1751560752.025137, 8.14 seconds elapsed
Run command at 1751560752.218251, 8.33 seconds elapsed
Run command at 1751560752.414166, 8.52 seconds elapsed
Run command at 1751560752.605698, 8.72 seconds elapsed
Run command at 1751560752.799616, 8.91 seconds elapsed
Run command at 1751560752.996634, 9.10 seconds elapsed
Run command at 1751560753.1954508, 9.30 seconds elapsed
Run command at 1751560753.519951, 9.50 seconds elapsed
Run command at 1751560753.713332, 9.82 seconds elapsed
Traceback (most recent call last):
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/example2.py", line 16, in <module>
    main()
    ~~~~^^
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/example2.py", line 12, in main
    sandbox.commands.run("ls -la")
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/e2b/sandbox_sync/commands/command.py", line 201, in run
    proc = self._start(
        cmd,
    ...<4 lines>...
        request_timeout,
    )
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/e2b/sandbox_sync/commands/command.py", line 261, in _start
    raise handle_rpc_exception(e)
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/e2b/sandbox_sync/commands/command.py", line 248, in _start
    start_event = events.__next__()
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/e2b_connect/client.py", line 388, in call_server_stream
    raise error_for_response(http_resp)
          ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/e2b_connect/client.py", line 66, in error_for_response
    error = json.loads(http_resp.content)
                       ^^^^^^^^^^^^^^^^^
  File "/Users/mish/Library/Caches/pypoetry/virtualenvs/e2b-e6GdLxLZ-py3.13/lib/python3.13/site-packages/httpcore/_models.py", line 406, in content
    raise RuntimeError(
    ...<2 lines>...
    )
RuntimeError: Attempted to access 'response.content' on a streaming response. Call 'response.read()' first.
```

After:

```
Run command at 1751560310.672757, 0.32 seconds elapsed
Run command at 1751560310.866078, 0.63 seconds elapsed
Run command at 1751560311.057599, 0.83 seconds elapsed
Run command at 1751560311.251391, 1.02 seconds elapsed
Run command at 1751560311.4458392, 1.21 seconds elapsed
Run command at 1751560311.6396658, 1.41 seconds elapsed
Run command at 1751560311.838529, 1.60 seconds elapsed
Run command at 1751560312.0340521, 1.80 seconds elapsed
Run command at 1751560312.2251031, 1.99 seconds elapsed
Run command at 1751560312.417126, 2.19 seconds elapsed
Run command at 1751560312.612763, 2.38 seconds elapsed
Run command at 1751560312.8064609, 2.57 seconds elapsed
Run command at 1751560312.998018, 2.77 seconds elapsed
Run command at 1751560313.1888058, 2.96 seconds elapsed
Run command at 1751560313.379574, 3.15 seconds elapsed
Run command at 1751560313.574123, 3.34 seconds elapsed
Run command at 1751560313.768694, 3.53 seconds elapsed
Run command at 1751560313.9634502, 3.73 seconds elapsed
Run command at 1751560314.1608572, 3.92 seconds elapsed
Run command at 1751560314.353206, 4.12 seconds elapsed
Run command at 1751560314.5573819, 4.31 seconds elapsed
Run command at 1751560314.75912, 4.52 seconds elapsed
Run command at 1751560314.95167, 4.72 seconds elapsed
Run command at 1751560315.1440582, 4.91 seconds elapsed
Run command at 1751560315.3326652, 5.10 seconds elapsed
Run command at 1751560315.5328388, 5.29 seconds elapsed
Run command at 1751560315.724878, 5.49 seconds elapsed
Run command at 1751560315.922386, 5.69 seconds elapsed
Run command at 1751560316.141522, 5.88 seconds elapsed
Run command at 1751560316.328209, 6.10 seconds elapsed
Run command at 1751560316.520502, 6.29 seconds elapsed
Run command at 1751560316.712369, 6.48 seconds elapsed
Run command at 1751560316.903543, 6.67 seconds elapsed
Run command at 1751560317.097236, 6.86 seconds elapsed
Run command at 1751560317.288552, 7.06 seconds elapsed
Run command at 1751560317.4828632, 7.25 seconds elapsed
Run command at 1751560317.678276, 7.44 seconds elapsed
Run command at 1751560317.879376, 7.64 seconds elapsed
Run command at 1751560318.081203, 7.84 seconds elapsed
Run command at 1751560318.269483, 8.04 seconds elapsed
Run command at 1751560318.589459, 8.23 seconds elapsed
Run command at 1751560318.7822669, 8.55 seconds elapsed
Run command at 1751560318.974462, 8.74 seconds elapsed
Run command at 1751560319.16336, 8.93 seconds elapsed
Run command at 1751560319.425109, 9.12 seconds elapsed
Run command at 1751560319.6169238, 9.39 seconds elapsed
Run command at 1751560319.81015, 9.58 seconds elapsed
Run command at 1751560320.001769, 9.77 seconds elapsed
Traceback (most recent call last):
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/e2b/sandbox_sync/commands/command.py", line 248, in _start
    start_event = events.__next__()
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/e2b_connect/client.py", line 400, in call_server_stream
    raise error_for_response(http_resp)
e2b_connect.client.ConnectException: (<Code.unavailable: 'unavailable'>, 'The sandbox was not found')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/example2.py", line 16, in <module>
    main()
    ~~~~^^
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/example2.py", line 12, in main
    sandbox.commands.run("ls -la")
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/e2b/sandbox_sync/commands/command.py", line 201, in run
    proc = self._start(
        cmd,
    ...<4 lines>...
        request_timeout,
    )
  File "/Users/mish/Documents/Projects/E2B/E2B/packages/python-sdk/e2b/sandbox_sync/commands/command.py", line 261, in _start
    raise handle_rpc_exception(e)
e2b.exceptions.TimeoutException: The sandbox was not found: This error is likely due to sandbox timeout. You can modify the sandbox timeout by passing 'timeout' when starting the sandbox or calling '.set_timeout' on the sandbox with the desired timeout.
```