### PR TITLE
fix: Typing mismatch in filesystem write method

### DIFF
--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -193,7 +193,7 @@ class Filesystem:
                 )
             path, write_files, user, request_timeout = (
                 path_or_files,
-                [{"path": path_or_files, "data": data_or_user}],
+                [WriteEntry(path=path_or_files, data=data_or_user)],
                 user_or_request_timeout or "user",
                 request_timeout_or_none,
             )
@@ -210,7 +210,7 @@ class Filesystem:
         # Prepare the files for the multipart/form-data request
         httpx_files = []
         for file in write_files:
-            file_path, file_data = file["path"], file["data"]
+            file_path, file_data = file.path, file.data
             if isinstance(file_data, str) or isinstance(file_data, bytes):
                 httpx_files.append(("file", (file_path, file_data)))
             elif isinstance(file_data, IOBase):


### PR DESCRIPTION
The function signature here is:

```python
    def write(
        self,
        path_or_files: Union[str, List[WriteEntry]],
        data_or_user: Union[str, bytes, IO, Username] = "user",
        user_or_request_timeout: Optional[Union[float, Username]] = None,
        request_timeout_or_none: Optional[float] = None,
    ) -> Union[EntryInfo, List[EntryInfo]]:
```

Notice that `path_or_files` is `str` or a list of `WriteEntry` objects. But further down, if it is a `str`, we're turning it into a `list` of `dict`s, instead of into a `list` of `WriteEntry` objects. We also then proceed to _use_ it like a `dict`. But this means if we pass a `list[WriteEntry]`, as the type hint suggests, we get the following error:

```
  File ".../spike.py", line 49, in write_files
    box.files.write(
          ~~~~~~~~~~~~~~~^
        [
        ^
    ...<2 lines>...
        ],
        ^^
    )
    ^
  File ".../.venv/lib/python3.13/site-packages/e2b/sandbox_sync/filesystem/filesystem.py", line 213, in write
    file_path, file_data = file["path"], file["data"]
                           ~~~~^^^^^^^^
TypeError: 'WriteEntry' object is not subscriptable
```

This PR fixes this, by instead only creating/assuming `WriteEntry` objects in the `list`, as the type hint suggests.
