### PR TITLE
Do not use user config team id for template build command 

### DIFF
--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -262,9 +262,6 @@ export const buildCommand = new commander.Command('build')
         }
 
         const userConfig = getUserConfig()
-        if (userConfig) {
-          teamID = teamID || userConfig.teamId
-        }
 
         if (config && templateID && config.template_id !== templateID) {
           // error: you can't specify different ID than the one in config


### PR DESCRIPTION
# Description
The team ID is derived from the provided access token for this specific command, this PR lets you still explicitly specify the team id via opts but does not take it from the user config to avoid unwanted team does not exist errors when specifying access tokens for different clusters.

# Test
```sh
$ [E2B/packages/cli] pnpm build

# test while being logged in
$ [E2B/templates/base] e2b auth login # in prod
$ E2B/templates/base] E2B_DOMAIN=<your_dev_domain> E2B_ACCESS_TOKEN=<your_access_token> ../../packages/cli/dist/index.js template build

# test while being logged out 
$ [E2B/templates/base] e2b auth logout
$ E2B/templates/base] E2B_DOMAIN=<your_dev_domain> E2B_ACCESS_TOKEN=<your_access_token> ../../packages/cli/dist/index.js template build
```
