### PR TITLE
Set default domain even if the env variable is an empty string

### DIFF
--- a/.changeset/happy-pens-fetch.md
+++ b/.changeset/happy-pens-fetch.md
@@ -1,0 +1,5 @@
+---
+'@e2b/python-sdk': patch
+---
+
+Set default domain even if the env variable is an empty string

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -16,7 +16,7 @@ class ConnectionConfig:
 
     @staticmethod
     def _domain():
-        return os.getenv("E2B_DOMAIN", "e2b.app")
+        return os.getenv("E2B_DOMAIN") or "e2b.app"
 
     @staticmethod
     def _debug():
@@ -77,6 +77,7 @@ class ConnectionConfig:
 
     def get_request_timeout(self, request_timeout: Optional[float] = None):
         return self._get_request_timeout(self.request_timeout, request_timeout)
+
 
 Username = Literal["root", "user"]
 """


### PR DESCRIPTION
# Description

os.getenv doesn't use the default value, if the variable is empty string