### PR TITLE
Add image URI mask option for template build to allow custom image repository

### DIFF
--- a/.changeset/clever-pets-complain.md
+++ b/.changeset/clever-pets-complain.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': minor
+---
+
+Add image mask attribute for template build

--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -29,6 +29,7 @@ import { buildWithProxy } from './buildWithProxy'
 
 const templateCheckInterval = 500 // 0.5 sec
 
+// Custom image URI is used for Bring Your Own Compute with self-hosted Docker registry
 export const imageUriMask = process.env.E2B_IMAGE_URI_MASK
 
 async function getTemplateBuildLogs({


### PR DESCRIPTION
This will allow customers who are not using our Docker repository to fall back to their own during template build.