### PR TITLE
Client ID part removal from SDKs

### DIFF
--- a/.changeset/green-roses-know.md
+++ b/.changeset/green-roses-know.md
@@ -1,4 +1,5 @@
 ---
+'@e2b/cli': minor
 '@e2b/python-sdk': minor
 'e2b': minor
 ---

--- a/.changeset/green-roses-know.md
+++ b/.changeset/green-roses-know.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': minor
+'e2b': minor
+---
+
+Sandbox IDs are no longer using client part that is deprecated

--- a/packages/cli/src/commands/sandbox/connect.ts
+++ b/packages/cli/src/commands/sandbox/connect.ts
@@ -35,10 +35,6 @@ async function connectToSandbox({
   apiKey: string
   sandboxID: string
 }) {
-  if (sandboxID.split('-').length == 1) {
-    sandboxID = `${sandboxID}-00000000`
-  }
-
   const sandbox = await e2b.Sandbox.connect(sandboxID, { apiKey })
 
   console.log(

--- a/packages/cli/src/commands/sandbox/list.ts
+++ b/packages/cli/src/commands/sandbox/list.ts
@@ -36,7 +36,7 @@ export const listCommand = new commander.Command('list')
           rows: sandboxes
             .map((sandbox) => ({
               ...sandbox,
-              sandboxID: `${sandbox.sandboxID}-${sandbox.clientID}`,
+              sandboxID: sandbox.sandboxID,
               startedAt: new Date(sandbox.startedAt).toLocaleString(),
               endAt: new Date(sandbox.endAt).toLocaleString(),
               metadata: JSON.stringify(sandbox.metadata),

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -197,7 +197,7 @@ export class SandboxApi {
 
     return (
       res.data?.map((sandbox: components['schemas']['ListedSandbox']) => ({
-        sandboxId: this.getSandboxId({ sandboxId: sandbox.sandboxID, clientId: sandbox.clientID }),
+        sandboxId:  sandbox.sandboxID,
         templateId: sandbox.templateID,
         clientId: sandbox.clientID,
         state: sandbox.state,
@@ -245,10 +245,7 @@ export class SandboxApi {
     }
 
     return {
-      sandboxId: this.getSandboxId({
-        sandboxId: res.data.sandboxID,
-        clientId: res.data.clientID,
-      }),
+      sandboxId: res.data.sandboxID,
       templateId: res.data.templateID,
       ...(res.data.alias && { name: res.data.alias }),
       metadata: res.data.metadata ?? {},
@@ -331,13 +328,7 @@ export class SandboxApi {
     }
 
     if (compareVersions(res.data!.envdVersion, '0.1.0') < 0) {
-      await this.kill(
-        this.getSandboxId({
-          sandboxId: res.data!.sandboxID,
-          clientId: res.data!.clientID,
-        }),
-        opts
-      )
+      await this.kill(res.data!.sandboxID, opts)
       throw new TemplateError(
         'You need to update the template to use the new SDK. ' +
           'You can do this by running `e2b template build` in the directory with the template.'
@@ -345,10 +336,7 @@ export class SandboxApi {
     }
 
     return {
-      sandboxId: this.getSandboxId({
-        sandboxId: res.data!.sandboxID,
-        clientId: res.data!.clientID,
-      }),
+      sandboxId: res.data!.sandboxID,
       envdVersion: res.data!.envdVersion,
       envdAccessToken: res.data!.envdAccessToken
     }
@@ -356,15 +344,5 @@ export class SandboxApi {
 
   private static timeoutToSeconds(timeout: number): number {
     return Math.ceil(timeout / 1000)
-  }
-
-  private static getSandboxId({
-    sandboxId,
-    clientId,
-  }: {
-    sandboxId: string
-    clientId: string
-  }): string {
-    return `${sandboxId}-${clientId}`
   }
 }

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -65,7 +65,3 @@ class SandboxApiBase(ABC):
         max_connections=20,
         keepalive_expiry=20,
     )
-
-    @staticmethod
-    def _get_sandbox_id(sandbox_id: str, client_id: str) -> str:
-        return f"{sandbox_id}-{client_id}"

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -80,10 +80,7 @@ class SandboxApi(SandboxApiBase):
 
         return [
             ListedSandbox(
-                sandbox_id=SandboxApi._get_sandbox_id(
-                    sandbox.sandbox_id,
-                    sandbox.client_id,
-                ),
+                sandbox_id=sandbox.sandbox_id,
                 template_id=sandbox.template_id,
                 name=sandbox.alias if isinstance(sandbox.alias, str) else None,
                 metadata=(
@@ -146,10 +143,7 @@ class SandboxApi(SandboxApiBase):
                 raise Exception("Body of the request is None")
 
             return SandboxInfo(
-                sandbox_id=SandboxApi._get_sandbox_id(
-                    res.parsed.sandbox_id,
-                    res.parsed.client_id,
-                ),
+                sandbox_id=res.parsed.sandbox_id,
                 template_id=res.parsed.template_id,
                 name=res.parsed.alias if isinstance(res.parsed.alias, str) else None,
                 metadata=(
@@ -286,22 +280,14 @@ class SandboxApi(SandboxApiBase):
                 raise Exception("Body of the request is None")
 
             if Version(res.parsed.envd_version) < Version("0.1.0"):
-                await SandboxApi._cls_kill(
-                    SandboxApi._get_sandbox_id(
-                        res.parsed.sandbox_id,
-                        res.parsed.client_id,
-                    )
-                )
+                await SandboxApi._cls_kill(res.parsed.sandbox_id)
                 raise TemplateException(
                     "You need to update the template to use the new SDK. "
                     "You can do this by running `e2b template build` in the directory with the template."
                 )
 
             return SandboxCreateResponse(
-                sandbox_id=SandboxApi._get_sandbox_id(
-                    res.parsed.sandbox_id,
-                    res.parsed.client_id,
-                ),
+                sandbox_id=res.parsed.sandbox_id,
                 envd_version=res.parsed.envd_version,
                 envd_access_token=res.parsed.envd_access_token,
             )

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -76,10 +76,7 @@ class SandboxApi(SandboxApiBase):
 
             return [
                 ListedSandbox(
-                    sandbox_id=SandboxApi._get_sandbox_id(
-                        sandbox.sandbox_id,
-                        sandbox.client_id,
-                    ),
+                    sandbox_id=sandbox.sandbox_id,
                     template_id=sandbox.template_id,
                     name=sandbox.alias if isinstance(sandbox.alias, str) else None,
                     metadata=(
@@ -141,10 +138,7 @@ class SandboxApi(SandboxApiBase):
                 raise Exception("Body of the request is None")
 
             return SandboxInfo(
-                sandbox_id=SandboxApi._get_sandbox_id(
-                    res.parsed.sandbox_id,
-                    res.parsed.client_id,
-                ),
+                sandbox_id=res.parsed.sandbox_id,
                 template_id=res.parsed.template_id,
                 name=res.parsed.alias if isinstance(res.parsed.alias, str) else None,
                 metadata=(
@@ -278,22 +272,14 @@ class SandboxApi(SandboxApiBase):
                 raise Exception("Body of the request is None")
 
             if Version(res.parsed.envd_version) < Version("0.1.0"):
-                SandboxApi._cls_kill(
-                    SandboxApi._get_sandbox_id(
-                        res.parsed.sandbox_id,
-                        res.parsed.client_id,
-                    )
-                )
+                SandboxApi._cls_kill(res.parsed.sandbox_id)
                 raise TemplateException(
                     "You need to update the template to use the new SDK. "
                     "You can do this by running `e2b template build` in the directory with the template."
                 )
 
             return SandboxCreateResponse(
-                sandbox_id=SandboxApi._get_sandbox_id(
-                    res.parsed.sandbox_id,
-                    res.parsed.client_id,
-                ),
+                sandbox_id=res.parsed.sandbox_id,
                 envd_version=res.parsed.envd_version,
                 envd_access_token=res.parsed.envd_access_token,
             )


### PR DESCRIPTION
- CLI spawn, connect, and logs work with and without the client part provided
- JavaScript and Python SDKs are no longer returning IDs with client part