### PR TITLE
Update `User-Agent` header in SDKs based on the SDK version

### DIFF
--- a/.changeset/plenty-foxes-press.md
+++ b/.changeset/plenty-foxes-press.md
@@ -1,4 +1,5 @@
 ---
+'e2b': patch
 '@e2b/python-sdk': patch
 ---
 

--- a/.changeset/plenty-foxes-press.md
+++ b/.changeset/plenty-foxes-press.md
@@ -1,0 +1,5 @@
+---
+'@e2b/python-sdk': patch
+---
+
+Update connect header

--- a/packages/js-sdk/src/api/metadata.ts
+++ b/packages/js-sdk/src/api/metadata.ts
@@ -2,7 +2,7 @@ import platform from 'platform'
 
 import { version } from '../../package.json'
 
-export { version } from '../../package.json'
+export { version }
 
 declare let window: any
 

--- a/packages/js-sdk/src/api/metadata.ts
+++ b/packages/js-sdk/src/api/metadata.ts
@@ -2,6 +2,8 @@ import platform from 'platform'
 
 import { version } from '../../package.json'
 
+export { version } from '../../package.json'
+
 declare let window: any
 
 type Runtime = 'node' | 'browser' | 'deno' | 'bun' | 'vercel-edge' | 'cloudflare-worker' | 'unknown'

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -1,5 +1,5 @@
 import { Logger } from './logs'
-import { getEnvVar } from './api/metadata'
+import {getEnvVar, version} from './api/metadata'
 
 const REQUEST_TIMEOUT_MS = 30_000 // 30 seconds
 export const KEEPALIVE_PING_INTERVAL_SEC = 50 // 50 seconds
@@ -74,7 +74,8 @@ export class ConnectionConfig {
     this.accessToken = opts?.accessToken || ConnectionConfig.accessToken
     this.requestTimeoutMs = opts?.requestTimeoutMs ?? REQUEST_TIMEOUT_MS
     this.logger = opts?.logger
-    this.headers = opts?.headers
+    this.headers = opts?.headers || {}
+    this.headers['User-Agent'] = `e2b-js-sdk/${version}`
 
     this.apiUrl = this.debug
       ? 'http://localhost:3000'

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -167,7 +167,11 @@ export class Sandbox extends SandboxApi {
         // connect-web package uses redirect: "error" which is not supported in edge runtimes
         // E2B endpoints should be safe to use with redirect: "follow" https://github.com/e2b-dev/E2B/issues/531#issuecomment-2779492867
 
-        const headers = new Headers(options?.headers)
+        const headers = new Headers(this.connectionConfig.headers)
+        new Headers(options?.headers).forEach(
+          (value, key) => headers.append(key, value)
+        )
+
         if (this.envdAccessToken) {
           headers.append('X-Access-Token', this.envdAccessToken)
         }

--- a/packages/python-sdk/e2b/api/metadata.py
+++ b/packages/python-sdk/e2b/api/metadata.py
@@ -2,6 +2,8 @@ import platform
 
 from importlib import metadata
 
+package_version = metadata.version("e2b")
+
 default_headers = {
     "lang": "python",
     "lang_version": platform.python_version(),

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -3,6 +3,8 @@ import os
 from typing import Literal, Optional, Dict
 from httpx._types import ProxyTypes
 
+from e2b.api.metadata import package_version
+
 REQUEST_TIMEOUT: float = 30.0  # 30 seconds
 
 KEEPALIVE_PING_INTERVAL_SEC = 50  # 50 seconds
@@ -45,6 +47,8 @@ class ConnectionConfig:
         self.api_key = api_key or ConnectionConfig._api_key()
         self.access_token = access_token or ConnectionConfig._access_token()
         self.headers = headers or {}
+        self.headers["User-Agent"] = f"e2b-python-sdk/{package_version}"
+
         self.proxy = proxy
 
         self.request_timeout = ConnectionConfig._get_request_timeout(

--- a/packages/python-sdk/e2b_connect/client.py
+++ b/packages/python-sdk/e2b_connect/client.py
@@ -161,7 +161,7 @@ class Client:
         self._codec = JSONCodec if json else ProtobufCodec
         self._response_type = response_type
         self._compressor = compressor
-        self._headers = {**{"user-agent": "connect-python-v2"}, **headers}
+        self._headers = headers
         self._connection_retries = 3
 
     def _prepare_unary_request(

--- a/packages/python-sdk/e2b_connect/client.py
+++ b/packages/python-sdk/e2b_connect/client.py
@@ -161,7 +161,7 @@ class Client:
         self._codec = JSONCodec if json else ProtobufCodec
         self._response_type = response_type
         self._compressor = compressor
-        self._headers = {**{"user-agent": "connect-python"}, **headers}
+        self._headers = {**{"user-agent": "connect-python-v2"}, **headers}
         self._connection_retries = 3
 
     def _prepare_unary_request(


### PR DESCRIPTION
# Description

The bug where extra fields in envd response caused an exception was fixed in #738. As we're also ignoring new fields in envd (implemented in https://github.com/e2b-dev/infra/pull/847). We now have to update the `user-agent` header.