### PR TITLE
Update documentation title for file and directory metadata

### DIFF
--- a/apps/web/src/components/Navigation/routes.tsx
+++ b/apps/web/src/components/Navigation/routes.tsx
@@ -360,7 +360,7 @@ export const docRoutes: NavGroup[] = [
         href: '/docs/filesystem/read-write',
       },
       {
-        title: 'Get info about a file or directory',
+        title: 'File & directory metadata',
         href: '/docs/filesystem/info',
       },
       {


### PR DESCRIPTION
This pull request updates the title of a navigation route in the `docRoutes` configuration to improve clarity and consistency.

From:
<img width="342" height="288" alt="image" src="https://github.com/user-attachments/assets/be4f237f-d329-468e-b5fc-098704eb1ae8" />

To:
<img width="381" height="254" alt="image" src="https://github.com/user-attachments/assets/73d0cadb-3dd1-45f1-a94e-c050556bb4c6" />
