### PR TITLE
Fix byte shift in sandbox metrics

### DIFF
--- a/.changeset/polite-grapes-destroy.md
+++ b/.changeset/polite-grapes-destroy.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Fix incorect byte shift (manifested for RAM and disk greater than 4 GB)

--- a/packages/cli/src/commands/sandbox/metrics.ts
+++ b/packages/cli/src/commands/sandbox/metrics.ts
@@ -130,17 +130,22 @@ function printMetric(
           .toString()
           .padStart(2)} Core${multipleCores && 's'} | ` +
         asBold('Memory') +
-        `: ${(metric.memUsed >>> 20).toString().padStart(5)} / ${(
-          metric.memTotal >>> 20
+        `: ${toMB(metric.memUsed).toFixed(0).padStart(5)} / ${toMB(
+          metric.memTotal
         )
-          .toString()
+          .toFixed(0)
           .padEnd(5)} MiB | ` +
         asBold('Disk') +
-        `: ${(metric.diskUsed >>> 20).toString().padStart(5)} / ${(
-          metric.diskTotal >>> 20
+        `: ${toMB(metric.diskUsed).toFixed(0).padStart(5)} / ${toMB(
+          metric.diskTotal
         )
-          .toString()
+          .toFixed(0)
           .padEnd(5)} MiB`
     )
   }
+}
+
+// we can't use bite shift here because shift is 32 bit operation and disk sizes can be greater than 2^32
+function toMB(bytes: number): number {
+  return bytes / 1024 / 1024
 }


### PR DESCRIPTION
This pull request addresses a bug in the CLI related to incorrect byte shifting for memory and disk metrics when dealing with sizes greater than 4 GB. 