### PR TITLE
Refactor Sandbox object in Python

### DIFF
--- a/packages/js-sdk/src/api/schema.gen.ts
+++ b/packages/js-sdk/src/api/schema.gen.ts
@@ -916,7 +916,6 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         BuildLogEntry: {
-            /** @description Log level of the entry */
             level: components["schemas"]["LogLevel"];
             /** @description Log message content */
             message: string;
@@ -971,6 +970,13 @@ export interface components {
             /** @description Name of the API key */
             name: string;
         };
+        /**
+         * Format: int32
+         * @description Disk size for the sandbox in MiB
+         */
+        DiskSizeMB: number;
+        /** @description Version of the envd running in the sandbox */
+        EnvdVersion: string;
         EnvVars: {
             [key: string]: string;
         };
@@ -1002,11 +1008,13 @@ export interface components {
              */
             clientID: string;
             cpuCount: components["schemas"]["CPUCount"];
+            diskSizeMB: components["schemas"]["DiskSizeMB"];
             /**
              * Format: date-time
              * @description Time when the sandbox will expire
              */
             endAt: string;
+            envdVersion: components["schemas"]["EnvdVersion"];
             memoryMB: components["schemas"]["MemoryMB"];
             metadata?: components["schemas"]["SandboxMetadata"];
             /** @description Identifier of the sandbox */
@@ -1027,7 +1035,7 @@ export interface components {
         LogLevel: "debug" | "info" | "warn" | "error";
         /**
          * Format: int32
-         * @description Memory for the sandbox in MB
+         * @description Memory for the sandbox in MiB
          */
         MemoryMB: number;
         NewAccessToken: {
@@ -1174,6 +1182,7 @@ export interface components {
              */
             clientID: string;
             cpuCount: components["schemas"]["CPUCount"];
+            diskSizeMB: components["schemas"]["DiskSizeMB"];
             /** @description Base domain where the sandbox traffic is accessible */
             domain?: string | null;
             /**
@@ -1184,7 +1193,7 @@ export interface components {
             /** @description Access token used for envd communication */
             envdAccessToken?: string;
             /** @description Version of the envd running in the sandbox */
-            envdVersion?: string;
+            envdVersion: string;
             memoryMB: components["schemas"]["MemoryMB"];
             metadata?: components["schemas"]["SandboxMetadata"];
             /** @description Identifier of the sandbox */
@@ -1213,7 +1222,22 @@ export interface components {
              */
             timestamp: string;
         };
+        SandboxLogEntry: {
+            fields: {
+                [key: string]: string;
+            };
+            level: components["schemas"]["LogLevel"];
+            /** @description Log message content */
+            message: string;
+            /**
+             * Format: date-time
+             * @description Timestamp of the log entry
+             */
+            timestamp: string;
+        };
         SandboxLogs: {
+            /** @description Structured logs of the sandbox */
+            logEntries: components["schemas"]["SandboxLogEntry"][];
             /** @description Logs of the sandbox */
             logs: components["schemas"]["SandboxLog"][];
         };
@@ -1320,6 +1344,8 @@ export interface components {
              */
             createdAt: string;
             createdBy: components["schemas"]["TeamUser"] | null;
+            diskSizeMB: components["schemas"]["DiskSizeMB"];
+            envdVersion: components["schemas"]["EnvdVersion"];
             /**
              * Format: date-time
              * @description Time when the template was last used
@@ -1399,7 +1425,9 @@ export interface components {
              */
             force: boolean;
             /** @description Image to use as a base for the template build */
-            fromImage: string;
+            fromImage?: string;
+            /** @description Template to use as a base for the template build */
+            fromTemplate?: string;
             /** @description Ready check command to execute in the template after the build */
             readyCmd?: string;
             /** @description Start command to execute in the template after the build */

--- a/packages/python-sdk/e2b/api/client/models/__init__.py
+++ b/packages/python-sdk/e2b/api/client/models/__init__.py
@@ -22,6 +22,8 @@ from .resumed_sandbox import ResumedSandbox
 from .sandbox import Sandbox
 from .sandbox_detail import SandboxDetail
 from .sandbox_log import SandboxLog
+from .sandbox_log_entry import SandboxLogEntry
+from .sandbox_log_entry_fields import SandboxLogEntryFields
 from .sandbox_logs import SandboxLogs
 from .sandbox_metric import SandboxMetric
 from .sandbox_state import SandboxState
@@ -62,6 +64,8 @@ __all__ = (
     "SandboxDetail",
     "SandboxesWithMetrics",
     "SandboxLog",
+    "SandboxLogEntry",
+    "SandboxLogEntryFields",
     "SandboxLogs",
     "SandboxMetric",
     "SandboxState",

--- a/packages/python-sdk/e2b/api/client/models/listed_sandbox.py
+++ b/packages/python-sdk/e2b/api/client/models/listed_sandbox.py
@@ -18,8 +18,10 @@ class ListedSandbox:
     Attributes:
         client_id (str): Identifier of the client
         cpu_count (int): CPU cores for the sandbox
+        disk_size_mb (int): Disk size for the sandbox in MiB
         end_at (datetime.datetime): Time when the sandbox will expire
-        memory_mb (int): Memory for the sandbox in MB
+        envd_version (str): Version of the envd running in the sandbox
+        memory_mb (int): Memory for the sandbox in MiB
         sandbox_id (str): Identifier of the sandbox
         started_at (datetime.datetime): Time when the sandbox was started
         state (SandboxState): State of the sandbox
@@ -30,7 +32,9 @@ class ListedSandbox:
 
     client_id: str
     cpu_count: int
+    disk_size_mb: int
     end_at: datetime.datetime
+    envd_version: str
     memory_mb: int
     sandbox_id: str
     started_at: datetime.datetime
@@ -45,7 +49,11 @@ class ListedSandbox:
 
         cpu_count = self.cpu_count
 
+        disk_size_mb = self.disk_size_mb
+
         end_at = self.end_at.isoformat()
+
+        envd_version = self.envd_version
 
         memory_mb = self.memory_mb
 
@@ -67,7 +75,9 @@ class ListedSandbox:
             {
                 "clientID": client_id,
                 "cpuCount": cpu_count,
+                "diskSizeMB": disk_size_mb,
                 "endAt": end_at,
+                "envdVersion": envd_version,
                 "memoryMB": memory_mb,
                 "sandboxID": sandbox_id,
                 "startedAt": started_at,
@@ -89,7 +99,11 @@ class ListedSandbox:
 
         cpu_count = d.pop("cpuCount")
 
+        disk_size_mb = d.pop("diskSizeMB")
+
         end_at = isoparse(d.pop("endAt"))
+
+        envd_version = d.pop("envdVersion")
 
         memory_mb = d.pop("memoryMB")
 
@@ -108,7 +122,9 @@ class ListedSandbox:
         listed_sandbox = cls(
             client_id=client_id,
             cpu_count=cpu_count,
+            disk_size_mb=disk_size_mb,
             end_at=end_at,
+            envd_version=envd_version,
             memory_mb=memory_mb,
             sandbox_id=sandbox_id,
             started_at=started_at,

--- a/packages/python-sdk/e2b/api/client/models/sandbox_detail.py
+++ b/packages/python-sdk/e2b/api/client/models/sandbox_detail.py
@@ -18,8 +18,10 @@ class SandboxDetail:
     Attributes:
         client_id (str): Identifier of the client
         cpu_count (int): CPU cores for the sandbox
+        disk_size_mb (int): Disk size for the sandbox in MiB
         end_at (datetime.datetime): Time when the sandbox will expire
-        memory_mb (int): Memory for the sandbox in MB
+        envd_version (str): Version of the envd running in the sandbox
+        memory_mb (int): Memory for the sandbox in MiB
         sandbox_id (str): Identifier of the sandbox
         started_at (datetime.datetime): Time when the sandbox was started
         state (SandboxState): State of the sandbox
@@ -27,13 +29,14 @@ class SandboxDetail:
         alias (Union[Unset, str]): Alias of the template
         domain (Union[None, Unset, str]): Base domain where the sandbox traffic is accessible
         envd_access_token (Union[Unset, str]): Access token used for envd communication
-        envd_version (Union[Unset, str]): Version of the envd running in the sandbox
         metadata (Union[Unset, Any]):
     """
 
     client_id: str
     cpu_count: int
+    disk_size_mb: int
     end_at: datetime.datetime
+    envd_version: str
     memory_mb: int
     sandbox_id: str
     started_at: datetime.datetime
@@ -42,7 +45,6 @@ class SandboxDetail:
     alias: Union[Unset, str] = UNSET
     domain: Union[None, Unset, str] = UNSET
     envd_access_token: Union[Unset, str] = UNSET
-    envd_version: Union[Unset, str] = UNSET
     metadata: Union[Unset, Any] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -51,7 +53,11 @@ class SandboxDetail:
 
         cpu_count = self.cpu_count
 
+        disk_size_mb = self.disk_size_mb
+
         end_at = self.end_at.isoformat()
+
+        envd_version = self.envd_version
 
         memory_mb = self.memory_mb
 
@@ -73,8 +79,6 @@ class SandboxDetail:
 
         envd_access_token = self.envd_access_token
 
-        envd_version = self.envd_version
-
         metadata = self.metadata
 
         field_dict: dict[str, Any] = {}
@@ -83,7 +87,9 @@ class SandboxDetail:
             {
                 "clientID": client_id,
                 "cpuCount": cpu_count,
+                "diskSizeMB": disk_size_mb,
                 "endAt": end_at,
+                "envdVersion": envd_version,
                 "memoryMB": memory_mb,
                 "sandboxID": sandbox_id,
                 "startedAt": started_at,
@@ -97,8 +103,6 @@ class SandboxDetail:
             field_dict["domain"] = domain
         if envd_access_token is not UNSET:
             field_dict["envdAccessToken"] = envd_access_token
-        if envd_version is not UNSET:
-            field_dict["envdVersion"] = envd_version
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
 
@@ -111,7 +115,11 @@ class SandboxDetail:
 
         cpu_count = d.pop("cpuCount")
 
+        disk_size_mb = d.pop("diskSizeMB")
+
         end_at = isoparse(d.pop("endAt"))
+
+        envd_version = d.pop("envdVersion")
 
         memory_mb = d.pop("memoryMB")
 
@@ -136,14 +144,14 @@ class SandboxDetail:
 
         envd_access_token = d.pop("envdAccessToken", UNSET)
 
-        envd_version = d.pop("envdVersion", UNSET)
-
         metadata = d.pop("metadata", UNSET)
 
         sandbox_detail = cls(
             client_id=client_id,
             cpu_count=cpu_count,
+            disk_size_mb=disk_size_mb,
             end_at=end_at,
+            envd_version=envd_version,
             memory_mb=memory_mb,
             sandbox_id=sandbox_id,
             started_at=started_at,
@@ -152,7 +160,6 @@ class SandboxDetail:
             alias=alias,
             domain=domain,
             envd_access_token=envd_access_token,
-            envd_version=envd_version,
             metadata=metadata,
         )
 

--- a/packages/python-sdk/e2b/api/client/models/sandbox_logs.py
+++ b/packages/python-sdk/e2b/api/client/models/sandbox_logs.py
@@ -6,6 +6,7 @@ from attrs import field as _attrs_field
 
 if TYPE_CHECKING:
     from ..models.sandbox_log import SandboxLog
+    from ..models.sandbox_log_entry import SandboxLogEntry
 
 
 T = TypeVar("T", bound="SandboxLogs")
@@ -15,13 +16,20 @@ T = TypeVar("T", bound="SandboxLogs")
 class SandboxLogs:
     """
     Attributes:
+        log_entries (list['SandboxLogEntry']): Structured logs of the sandbox
         logs (list['SandboxLog']): Logs of the sandbox
     """
 
+    log_entries: list["SandboxLogEntry"]
     logs: list["SandboxLog"]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        log_entries = []
+        for log_entries_item_data in self.log_entries:
+            log_entries_item = log_entries_item_data.to_dict()
+            log_entries.append(log_entries_item)
+
         logs = []
         for logs_item_data in self.logs:
             logs_item = logs_item_data.to_dict()
@@ -31,6 +39,7 @@ class SandboxLogs:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "logEntries": log_entries,
                 "logs": logs,
             }
         )
@@ -40,8 +49,16 @@ class SandboxLogs:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.sandbox_log import SandboxLog
+        from ..models.sandbox_log_entry import SandboxLogEntry
 
         d = dict(src_dict)
+        log_entries = []
+        _log_entries = d.pop("logEntries")
+        for log_entries_item_data in _log_entries:
+            log_entries_item = SandboxLogEntry.from_dict(log_entries_item_data)
+
+            log_entries.append(log_entries_item)
+
         logs = []
         _logs = d.pop("logs")
         for logs_item_data in _logs:
@@ -50,6 +67,7 @@ class SandboxLogs:
             logs.append(logs_item)
 
         sandbox_logs = cls(
+            log_entries=log_entries,
             logs=logs,
         )
 

--- a/packages/python-sdk/e2b/api/client/models/template.py
+++ b/packages/python-sdk/e2b/api/client/models/template.py
@@ -24,8 +24,10 @@ class Template:
         cpu_count (int): CPU cores for the sandbox
         created_at (datetime.datetime): Time when the template was created
         created_by (Union['TeamUser', None]):
+        disk_size_mb (int): Disk size for the sandbox in MiB
+        envd_version (str): Version of the envd running in the sandbox
         last_spawned_at (datetime.datetime): Time when the template was last used
-        memory_mb (int): Memory for the sandbox in MB
+        memory_mb (int): Memory for the sandbox in MiB
         public (bool): Whether the template is public or only accessible by the team
         spawn_count (int): Number of times the template was used
         template_id (str): Identifier of the template
@@ -38,6 +40,8 @@ class Template:
     cpu_count: int
     created_at: datetime.datetime
     created_by: Union["TeamUser", None]
+    disk_size_mb: int
+    envd_version: str
     last_spawned_at: datetime.datetime
     memory_mb: int
     public: bool
@@ -64,6 +68,10 @@ class Template:
         else:
             created_by = self.created_by
 
+        disk_size_mb = self.disk_size_mb
+
+        envd_version = self.envd_version
+
         last_spawned_at = self.last_spawned_at.isoformat()
 
         memory_mb = self.memory_mb
@@ -89,6 +97,8 @@ class Template:
                 "cpuCount": cpu_count,
                 "createdAt": created_at,
                 "createdBy": created_by,
+                "diskSizeMB": disk_size_mb,
+                "envdVersion": envd_version,
                 "lastSpawnedAt": last_spawned_at,
                 "memoryMB": memory_mb,
                 "public": public,
@@ -130,6 +140,10 @@ class Template:
 
         created_by = _parse_created_by(d.pop("createdBy"))
 
+        disk_size_mb = d.pop("diskSizeMB")
+
+        envd_version = d.pop("envdVersion")
+
         last_spawned_at = isoparse(d.pop("lastSpawnedAt"))
 
         memory_mb = d.pop("memoryMB")
@@ -150,6 +164,8 @@ class Template:
             cpu_count=cpu_count,
             created_at=created_at,
             created_by=created_by,
+            disk_size_mb=disk_size_mb,
+            envd_version=envd_version,
             last_spawned_at=last_spawned_at,
             memory_mb=memory_mb,
             public=public,

--- a/packages/python-sdk/e2b/api/client/models/template_build_request.py
+++ b/packages/python-sdk/e2b/api/client/models/template_build_request.py
@@ -16,7 +16,7 @@ class TemplateBuildRequest:
         dockerfile (str): Dockerfile for the template
         alias (Union[Unset, str]): Alias of the template
         cpu_count (Union[Unset, int]): CPU cores for the sandbox
-        memory_mb (Union[Unset, int]): Memory for the sandbox in MB
+        memory_mb (Union[Unset, int]): Memory for the sandbox in MiB
         ready_cmd (Union[Unset, str]): Ready check command to execute in the template after the build
         start_cmd (Union[Unset, str]): Start command to execute in the template after the build
         team_id (Union[Unset, str]): Identifier of the team

--- a/packages/python-sdk/e2b/api/client/models/template_build_request_v2.py
+++ b/packages/python-sdk/e2b/api/client/models/template_build_request_v2.py
@@ -15,7 +15,7 @@ class TemplateBuildRequestV2:
     Attributes:
         alias (str): Alias of the template
         cpu_count (Union[Unset, int]): CPU cores for the sandbox
-        memory_mb (Union[Unset, int]): Memory for the sandbox in MB
+        memory_mb (Union[Unset, int]): Memory for the sandbox in MiB
         team_id (Union[Unset, str]): Identifier of the team
     """
 

--- a/packages/python-sdk/e2b/api/client/models/template_build_start_v2.py
+++ b/packages/python-sdk/e2b/api/client/models/template_build_start_v2.py
@@ -17,25 +17,29 @@ T = TypeVar("T", bound="TemplateBuildStartV2")
 class TemplateBuildStartV2:
     """
     Attributes:
-        from_image (str): Image to use as a base for the template build
         force (Union[Unset, bool]): Whether the whole build should be forced to run regardless of the cache Default:
             False.
+        from_image (Union[Unset, str]): Image to use as a base for the template build
+        from_template (Union[Unset, str]): Template to use as a base for the template build
         ready_cmd (Union[Unset, str]): Ready check command to execute in the template after the build
         start_cmd (Union[Unset, str]): Start command to execute in the template after the build
         steps (Union[Unset, list['TemplateStep']]): List of steps to execute in the template build
     """
 
-    from_image: str
     force: Union[Unset, bool] = False
+    from_image: Union[Unset, str] = UNSET
+    from_template: Union[Unset, str] = UNSET
     ready_cmd: Union[Unset, str] = UNSET
     start_cmd: Union[Unset, str] = UNSET
     steps: Union[Unset, list["TemplateStep"]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        force = self.force
+
         from_image = self.from_image
 
-        force = self.force
+        from_template = self.from_template
 
         ready_cmd = self.ready_cmd
 
@@ -50,13 +54,13 @@ class TemplateBuildStartV2:
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "fromImage": from_image,
-            }
-        )
+        field_dict.update({})
         if force is not UNSET:
             field_dict["force"] = force
+        if from_image is not UNSET:
+            field_dict["fromImage"] = from_image
+        if from_template is not UNSET:
+            field_dict["fromTemplate"] = from_template
         if ready_cmd is not UNSET:
             field_dict["readyCmd"] = ready_cmd
         if start_cmd is not UNSET:
@@ -71,9 +75,11 @@ class TemplateBuildStartV2:
         from ..models.template_step import TemplateStep
 
         d = dict(src_dict)
-        from_image = d.pop("fromImage")
-
         force = d.pop("force", UNSET)
+
+        from_image = d.pop("fromImage", UNSET)
+
+        from_template = d.pop("fromTemplate", UNSET)
 
         ready_cmd = d.pop("readyCmd", UNSET)
 
@@ -87,8 +93,9 @@ class TemplateBuildStartV2:
             steps.append(steps_item)
 
         template_build_start_v2 = cls(
-            from_image=from_image,
             force=force,
+            from_image=from_image,
+            from_template=from_template,
             ready_cmd=ready_cmd,
             start_cmd=start_cmd,
             steps=steps,

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
-from typing import Optional, Dict
+from typing import Optional, Dict, Union
 from datetime import datetime
 
-from e2b.api.client.models import SandboxState
+from e2b.api.client.models import SandboxState, SandboxDetail, ListedSandbox
 
 
 @dataclass
@@ -23,33 +23,58 @@ class SandboxInfo:
     """Sandbox start time."""
     end_at: datetime
     """Sandbox expiration date."""
-    envd_version: Optional[str]
-    """Envd version."""
-    _envd_access_token: Optional[str]
-    """Envd access token."""
-
-
-@dataclass
-class ListedSandbox:
-    """Information about a sandbox."""
-
-    sandbox_id: str
-    """Sandbox ID."""
-    template_id: str
-    """Template ID."""
-    name: Optional[str]
-    """Template Alias."""
     state: SandboxState
     """Sandbox state."""
     cpu_count: int
     """Sandbox CPU count."""
     memory_mb: int
-    """Sandbox Memory size in MB."""
-    metadata: Dict[str, str]
-    """Saved sandbox metadata."""
-    started_at: datetime
-    """Sandbox start time."""
-    end_at: datetime
+    """Sandbox Memory size in MiB."""
+    envd_version: str
+    """Envd version."""
+    _envd_access_token: Optional[str]
+    """Envd access token."""
+
+    @classmethod
+    def _from_sandbox_data(
+        cls,
+        sandbox: Union[ListedSandbox, SandboxDetail],
+        envd_access_token: Optional[str] = None,
+        sandbox_domain: Optional[str] = None,
+    ):
+        return cls(
+            sandbox_domain=sandbox_domain,
+            sandbox_id=sandbox.sandbox_id,
+            template_id=sandbox.template_id,
+            name=(sandbox.alias if isinstance(sandbox.alias, str) else None),
+            metadata=(sandbox.metadata if isinstance(sandbox.metadata, dict) else {}),
+            started_at=sandbox.started_at,
+            end_at=sandbox.end_at,
+            state=sandbox.state,
+            cpu_count=sandbox.cpu_count,
+            memory_mb=sandbox.memory_mb,
+            envd_version=sandbox.envd_version,
+            _envd_access_token=envd_access_token,
+        )
+
+    @classmethod
+    def _from_listed_sandbox(cls, listed_sandbox: ListedSandbox):
+        return cls._from_sandbox_data(listed_sandbox)
+
+    @classmethod
+    def _from_sandbox_detail(cls, sandbox_detail: SandboxDetail):
+        return cls._from_sandbox_data(
+            sandbox_detail,
+            (
+                sandbox_detail.envd_access_token
+                if isinstance(sandbox_detail.envd_access_token, str)
+                else None
+            ),
+            sandbox_domain=(
+                sandbox_detail.domain
+                if isinstance(sandbox_detail.domain, str)
+                else None
+            ),
+        )
 
 
 @dataclass

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -72,22 +72,10 @@ class SandboxApi(SandboxBase):
         if res.parsed is None:
             return []
 
-        return [
-            ListedSandbox(
-                sandbox_id=sandbox.sandbox_id,
-                template_id=sandbox.template_id,
-                name=sandbox.alias if isinstance(sandbox.alias, str) else None,
-                metadata=(
-                    sandbox.metadata if isinstance(sandbox.metadata, dict) else {}
-                ),
-                state=sandbox.state,
-                cpu_count=sandbox.cpu_count,
-                memory_mb=sandbox.memory_mb,
-                started_at=sandbox.started_at,
-                end_at=sandbox.end_at,
-            )
-            for sandbox in res.parsed
-        ]
+        if isinstance(res.parsed, Error):
+            raise SandboxException(f"{res.parsed.message}: Request failed")
+
+        return [SandboxInfo._from_listed_sandbox(sandbox) for sandbox in res.parsed]
 
     @classmethod
     async def _cls_get_info(
@@ -118,19 +106,10 @@ class SandboxApi(SandboxBase):
             if res.parsed is None:
                 raise Exception("Body of the request is None")
 
-            return SandboxInfo(
-                sandbox_id=res.parsed.sandbox_id,
-                sandbox_domain=res.parsed.domain,
-                template_id=res.parsed.template_id,
-                name=res.parsed.alias if isinstance(res.parsed.alias, str) else None,
-                metadata=(
-                    res.parsed.metadata if isinstance(res.parsed.metadata, dict) else {}
-                ),
-                started_at=res.parsed.started_at,
-                end_at=res.parsed.end_at,
-                envd_version=res.parsed.envd_version,
-                _envd_access_token=res.parsed.envd_access_token,
-            )
+            if isinstance(res.parsed, Error):
+                raise SandboxException(f"{res.parsed.message}: Request failed")
+
+            return SandboxInfo._from_sandbox_detail(res.parsed)
 
     @classmethod
     async def _cls_kill(

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -69,22 +69,10 @@ class SandboxApi(SandboxBase):
             if res.parsed is None:
                 return []
 
-            return [
-                ListedSandbox(
-                    sandbox_id=sandbox.sandbox_id,
-                    template_id=sandbox.template_id,
-                    name=sandbox.alias if isinstance(sandbox.alias, str) else None,
-                    metadata=(
-                        sandbox.metadata if isinstance(sandbox.metadata, dict) else {}
-                    ),
-                    state=sandbox.state,
-                    cpu_count=sandbox.cpu_count,
-                    memory_mb=sandbox.memory_mb,
-                    started_at=sandbox.started_at,
-                    end_at=sandbox.end_at,
-                )
-                for sandbox in res.parsed
-            ]
+            if isinstance(res.parsed, Error):
+                raise SandboxException(f"{res.parsed.message}: Request failed")
+
+            return [SandboxInfo._from_listed_sandbox(sandbox) for sandbox in res.parsed]
 
     @classmethod
     def _cls_get_info(
@@ -115,19 +103,7 @@ class SandboxApi(SandboxBase):
             if res.parsed is None:
                 raise Exception("Body of the request is None")
 
-            return SandboxInfo(
-                sandbox_id=res.parsed.sandbox_id,
-                sandbox_domain=res.parsed.domain,
-                template_id=res.parsed.template_id,
-                name=res.parsed.alias if isinstance(res.parsed.alias, str) else None,
-                metadata=(
-                    res.parsed.metadata if isinstance(res.parsed.metadata, dict) else {}
-                ),
-                started_at=res.parsed.started_at,
-                end_at=res.parsed.end_at,
-                envd_version=res.parsed.envd_version,
-                _envd_access_token=res.parsed.envd_access_token,
-            )
+            return SandboxInfo._from_sandbox_detail(res.parsed)
 
     @classmethod
     def _cls_kill(

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -152,7 +152,17 @@ components:
       type: integer
       format: int32
       minimum: 128
-      description: Memory for the sandbox in MB
+      description: Memory for the sandbox in MiB
+
+    DiskSizeMB:
+      type: integer
+      format: int32
+      minimum: 0
+      description: Disk size for the sandbox in MiB
+
+    EnvdVersion:
+      type: string
+      description: Version of the envd running in the sandbox
 
     SandboxMetadata:
       additionalProperties:
@@ -185,15 +195,42 @@ components:
           type: string
           description: Log line content
 
+    SandboxLogEntry:
+      required:
+        - timestamp
+        - level
+        - message
+        - fields
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          description: Timestamp of the log entry
+        message:
+          type: string
+          description: Log message content
+        level:
+          $ref: "#/components/schemas/LogLevel"
+        fields:
+          type: object
+          additionalProperties:
+            type: string
+
     SandboxLogs:
       required:
         - logs
+        - logEntries
       properties:
         logs:
           description: Logs of the sandbox
           type: array
           items:
             $ref: "#/components/schemas/SandboxLog"
+        logEntries:
+          description: Structured logs of the sandbox
+          type: array
+          items:
+            $ref: "#/components/schemas/SandboxLogEntry"
 
     SandboxMetric:
       description: Metric entry with timestamp and line
@@ -274,8 +311,10 @@ components:
         - startedAt
         - cpuCount
         - memoryMB
+        - diskSizeMB
         - endAt
         - state
+        - envdVersion
       properties:
         templateID:
           type: string
@@ -312,6 +351,8 @@ components:
           $ref: "#/components/schemas/CPUCount"
         memoryMB:
           $ref: "#/components/schemas/MemoryMB"
+        diskSizeMB:
+          $ref: "#/components/schemas/DiskSizeMB"
         metadata:
           $ref: "#/components/schemas/SandboxMetadata"
         state:
@@ -325,8 +366,10 @@ components:
         - startedAt
         - cpuCount
         - memoryMB
+        - diskSizeMB
         - endAt
         - state
+        - envdVersion
       properties:
         templateID:
           type: string
@@ -353,10 +396,14 @@ components:
           $ref: "#/components/schemas/CPUCount"
         memoryMB:
           $ref: "#/components/schemas/MemoryMB"
+        diskSizeMB:
+          $ref: "#/components/schemas/DiskSizeMB"
         metadata:
           $ref: "#/components/schemas/SandboxMetadata"
         state:
           $ref: "#/components/schemas/SandboxState"
+        envdVersion:
+          $ref: "#/components/schemas/EnvdVersion"
 
     SandboxesWithMetrics:
       required:
@@ -413,6 +460,7 @@ components:
         - buildID
         - cpuCount
         - memoryMB
+        - diskSizeMB
         - public
         - createdAt
         - updatedAt
@@ -420,6 +468,7 @@ components:
         - lastSpawnedAt
         - spawnCount
         - buildCount
+        - envdVersion
       properties:
         templateID:
           type: string
@@ -431,6 +480,8 @@ components:
           $ref: "#/components/schemas/CPUCount"
         memoryMB:
           $ref: "#/components/schemas/MemoryMB"
+        diskSizeMB:
+          $ref: "#/components/schemas/DiskSizeMB"
         public:
           type: boolean
           description: Whether the template is public or only accessible by the team
@@ -463,6 +514,8 @@ components:
           type: integer
           format: int32
           description: Number of times the template was built
+        envdVersion:
+          $ref: "#/components/schemas/EnvdVersion"
 
     TemplateBuildRequest:
       required:
@@ -526,12 +579,14 @@ components:
           $ref: "#/components/schemas/MemoryMB"
 
     TemplateBuildStartV2:
-      required:
-        - fromImage
+      type: object
       properties:
         fromImage:
           type: string
           description: Image to use as a base for the template build
+        fromTemplate:
+          type: string
+          description: Template to use as a base for the template build
         force:
           default: false
           type: boolean
@@ -583,7 +638,6 @@ components:
           type: string
           description: Log message content
         level:
-          description: Log level of the entry
           $ref: "#/components/schemas/LogLevel"
 
     TemplateBuild:
@@ -1325,69 +1379,6 @@ paths:
       description: Create a new template
       tags: [templates]
       security:
-        - AccessTokenAuth: []
-        - ApiKeyAuth: []
-        - Supabase1TokenAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/TemplateBuildRequestV2"
-
-      responses:
-        "202":
-          description: The build was requested successfully
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Template"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
-
-  /templates/{templateID}/files/{hash}:
-    get:
-      description: Get an upload link for a tar file containing build layer files
-      tags: [templates]
-      security:
-        - AccessTokenAuth: []
-        - ApiKeyAuth: []
-        - Supabase1TokenAuth: []
-      parameters:
-        - $ref: "#/components/parameters/templateID"
-        - in: path
-          name: hash
-          required: true
-          schema:
-            type: string
-            description: Hash of the files
-
-      responses:
-        "201":
-          description: The upload link where to upload the tar file
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TemplateBuildFileUpload"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
-
-  /v2/templates:
-    post:
-      description: Create a new template
-      tags: [templates]
-      security:
-        - AccessTokenAuth: []
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
       requestBody:
@@ -1588,32 +1579,6 @@ paths:
       description: Start the build
       tags: [templates]
       security:
-        - AccessTokenAuth: []
-        - ApiKeyAuth: []
-        - Supabase1TokenAuth: []
-      parameters:
-        - $ref: "#/components/parameters/templateID"
-        - $ref: "#/components/parameters/buildID"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/TemplateBuildStartV2"
-      responses:
-        "202":
-          description: The build has started
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
-
-  /v2/templates/{templateID}/builds/{buildID}:
-    post:
-      description: Start the build
-      tags: [templates]
-      security:
-        - AccessTokenAuth: []
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
       parameters:
@@ -1656,7 +1621,6 @@ paths:
           name: level
           schema:
             $ref: "#/components/schemas/LogLevel"
-            default: debug
       responses:
         "200":
           description: Successfully returned the template


### PR DESCRIPTION
# Description

We can simplify typing and return only SandboxInfo in SDKs as the types are very similar (there are some extra fields in detail, which we don't want to expose but we need them e.g. for connect) 