### PR TITLE
Vendor strip-ansi npm module to avoid ESM-related issues

### DIFF
--- a/.changeset/hungry-cups-warn.md
+++ b/.changeset/hungry-cups-warn.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+inline strip-ansi to avoid esm-related errors

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -94,7 +94,6 @@
     "glob": "^11.0.3",
     "openapi-fetch": "^0.9.7",
     "platform": "^1.3.6",
-    "strip-ansi": "^7.1.0",
     "tar": "^7.4.3"
   },
   "engines": {

--- a/packages/js-sdk/src/template/buildApi.ts
+++ b/packages/js-sdk/src/template/buildApi.ts
@@ -2,7 +2,7 @@ import { ApiClient, paths, handleApiError } from '../api'
 import { BuildError, FileUploadError } from './errors'
 import { LogEntry } from './types'
 import { tarFileStreamUpload } from './utils'
-import stripAnsi from 'strip-ansi'
+import { stripAnsi } from '../utils'
 
 type RequestBuildInput = {
   alias: string

--- a/packages/js-sdk/src/template/types.ts
+++ b/packages/js-sdk/src/template/types.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi'
+import { stripAnsi } from '../utils'
 import { ReadyCmd } from './readycmd'
 
 export type Instruction = {

--- a/packages/js-sdk/src/utils.ts
+++ b/packages/js-sdk/src/utils.ts
@@ -84,3 +84,22 @@ export async function dynamicTar(): Promise<typeof import('tar')> {
   // @ts-ignore
   return await import('tar')
 }
+
+// Source: https://github.com/chalk/ansi-regex/blob/main/index.js
+function ansiRegex({ onlyFirst = false } = {}) {
+  // Valid string terminator sequences are BEL, ESC\, and 0x9c
+  const ST = '(?:\\u0007|\\u001B\\u005C|\\u009C)'
+  // OSC sequences only: ESC ] ... ST (non-greedy until the first ST)
+  const osc = `(?:\\u001B\\][\\s\\S]*?${ST})`
+  // CSI and related: ESC/C1, optional intermediates, optional params (supports ; and :) then final byte
+  const csi =
+    '[\\u001B\\u009B][[\\]()#;?]*(?:\\d{1,4}(?:[;:]\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]'
+
+  const pattern = `${osc}|${csi}`
+
+  return new RegExp(pattern, onlyFirst ? undefined : 'g')
+}
+
+export function stripAnsi(text: string): string {
+  return text.replace(ansiRegex(), '')
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,9 +347,6 @@ importers:
       platform:
         specifier: ^1.3.6
         version: 1.3.6
-      strip-ansi:
-        specifier: ^7.1.0
-        version: 7.1.0
       tar:
         specifier: ^7.4.3
         version: 7.4.3
@@ -11171,7 +11168,7 @@ snapshots:
 
   bufferutil@4.0.8:
     dependencies:
-      node-gyp-build: 4.6.1
+      node-gyp-build: 4.8.4
 
   builtins@5.0.1:
     dependencies:
@@ -14136,8 +14133,7 @@ snapshots:
 
   node-gyp-build@4.6.1: {}
 
-  node-gyp-build@4.8.4:
-    optional: true
+  node-gyp-build@4.8.4: {}
 
   node-gyp@9.4.0:
     dependencies:


### PR DESCRIPTION
We bundled `strip-ansi` module but it is ESM-only, it caused a runtime when trying to `require()` ESM-only module from the bundle (on older Node versions).

- Inlined the code from `strip-ansi` into `utils.ts` so it can be correctly bundled.
- Fixes #894