### PR TITLE
Fix sandbox auto-pause doc syntax

### DIFF
--- a/apps/web/src/app/(docs)/docs/sandbox/persistence/page.mdx
+++ b/apps/web/src/app/(docs)/docs/sandbox/persistence/page.mdx
@@ -230,7 +230,7 @@ Sandboxes can now automatically pause after they time out. When a sandbox is pau
 ```js
 import { Sandbox } from '@e2b/code-interpreter'
 
-// Create sandbox with auto-pause enabled
+// Create sandbox with auto-pause enabled (Beta)
 const sandbox = await Sandbox.betaCreate({
     autoPause: true, // Auto-pause after the sandbox times out
     timeoutMs: 10 * 60 * 1000 // Optional: change the default timeout (10 minutes)


### PR DESCRIPTION
This PR includes the changes from https://github.com/e2b-dev/E2B/pull/913, as the workflows there are not properly configured to handle external PRs without any change.