### PR TITLE
Fix CLI migrate copy target

### DIFF
--- a/.changeset/thirty-birds-serve.md
+++ b/.changeset/thirty-birds-serve.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+fix template migrate copy target path

--- a/packages/cli/src/commands/template/generators/handlebars.ts
+++ b/packages/cli/src/commands/template/generators/handlebars.ts
@@ -72,7 +72,7 @@ export async function transformTemplateData(
       case 'COPY': {
         if (step.args.length >= 2) {
           const src = step.args[0]
-          let dest = step.args[step.args.length - 1]
+          let dest = step.args[1]
           if (!dest || dest === '') {
             dest = '.'
           }


### PR DESCRIPTION
Fix CLI migrate copy target path. The Copy args can be longer than 2, but the second argument should be always the path (not the last one).