### PR TITLE
Improve envd version handling

### DIFF
--- a/packages/js-sdk/src/envd/api.ts
+++ b/packages/js-sdk/src/envd/api.ts
@@ -95,7 +95,7 @@ export async function handleWatchDirStartEvent(
 
 class EnvdApiClient {
   readonly api: ReturnType<typeof createClient<paths>>
-  readonly version: string | undefined
+  readonly version: string
 
   constructor(
     config: Pick<ConnectionConfig, 'apiUrl' | 'logger' | 'accessToken'> & {
@@ -103,7 +103,7 @@ class EnvdApiClient {
       headers?: Record<string, string>
     },
     metadata: {
-      version?: string
+      version: string
     }
   ) {
     this.api = createClient({

--- a/packages/js-sdk/src/envd/versions.ts
+++ b/packages/js-sdk/src/envd/versions.ts
@@ -1,1 +1,2 @@
 export const ENVD_VERSION_RECURSIVE_WATCH = '0.1.4'
+export const ENVD_DEBUG_FALLBACK = '99.99.99'

--- a/packages/js-sdk/src/sandbox/commands/index.ts
+++ b/packages/js-sdk/src/sandbox/commands/index.ts
@@ -119,12 +119,17 @@ export class Commands {
   protected readonly rpc: Client<typeof ProcessService>
 
   private readonly defaultProcessConnectionTimeout = 60_000 // 60 seconds
+  private readonly envdVersion: string
 
   constructor(
     transport: Transport,
-    private readonly connectionConfig: ConnectionConfig
+    private readonly connectionConfig: ConnectionConfig,
+    metadata: {
+      version: string
+    }
   ) {
     this.rpc = createClient(ProcessService, transport)
+    this.envdVersion = metadata.version
   }
 
   /**

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -23,6 +23,7 @@ import {
 import { getSignature } from './signature'
 import { compareVersions } from 'compare-versions'
 import { SandboxError } from '../errors'
+import { ENVD_DEBUG_FALLBACK } from '../envd/versions'
 
 /**
  * Options for sandbox upload/download URL generation.
@@ -107,7 +108,7 @@ export class Sandbox extends SandboxApi {
     opts: SandboxConnectOpts & {
       sandboxId: string
       sandboxDomain?: string
-      envdVersion?: string
+      envdVersion: string
       envdAccessToken?: string
     }
   ) {
@@ -162,7 +163,7 @@ export class Sandbox extends SandboxApi {
           : {},
       },
       {
-        version: opts?.envdVersion,
+        version: opts.envdVersion,
       }
     )
     this.files = new Filesystem(
@@ -170,7 +171,9 @@ export class Sandbox extends SandboxApi {
       this.envdApi,
       this.connectionConfig
     )
-    this.commands = new Commands(rpcTransport, this.connectionConfig)
+    this.commands = new Commands(rpcTransport, this.connectionConfig, {
+      version: opts.envdVersion,
+    })
     this.pty = new Pty(rpcTransport, this.connectionConfig)
   }
 
@@ -236,6 +239,7 @@ export class Sandbox extends SandboxApi {
     if (config.debug) {
       return new this({
         sandboxId: 'debug_sandbox_id',
+        envdVersion: ENVD_DEBUG_FALLBACK,
         ...config,
       }) as InstanceType<S>
     }
@@ -304,6 +308,7 @@ export class Sandbox extends SandboxApi {
     if (config.debug) {
       return new this({
         sandboxId: 'debug_sandbox_id',
+        envdVersion: ENVD_DEBUG_FALLBACK,
         ...config,
       }) as InstanceType<S>
     }

--- a/packages/python-sdk/e2b/envd/versions.py
+++ b/packages/python-sdk/e2b/envd/versions.py
@@ -1,3 +1,4 @@
 from packaging.version import Version
 
 ENVD_VERSION_RECURSIVE_WATCH = Version("0.1.4")
+ENVD_DEBUG_FALLBACK = Version("99.99.99")

--- a/packages/python-sdk/e2b/sandbox/main.py
+++ b/packages/python-sdk/e2b/sandbox/main.py
@@ -12,7 +12,7 @@ from httpx import Limits
 class SandboxOpts(TypedDict):
     sandbox_id: str
     sandbox_domain: Optional[str]
-    envd_version: Optional[str]
+    envd_version: Version
     envd_access_token: Optional[str]
     connection_config: ConnectionConfig
 

--- a/packages/python-sdk/e2b/sandbox/main.py
+++ b/packages/python-sdk/e2b/sandbox/main.py
@@ -1,4 +1,5 @@
 import urllib.parse
+from packaging.version import Version
 
 from typing import Optional, TypedDict
 
@@ -31,7 +32,7 @@ class SandboxBase:
     def __init__(
         self,
         sandbox_id: str,
-        envd_version: Optional[str],
+        envd_version: Version,
         envd_access_token: Optional[str],
         sandbox_domain: Optional[str],
         connection_config: ConnectionConfig,
@@ -53,7 +54,7 @@ class SandboxBase:
         return self.__connection_config
 
     @property
-    def _envd_version(self) -> Optional[str]:
+    def _envd_version(self) -> Version:
         return self.__envd_version
 
     @property

--- a/packages/python-sdk/e2b/sandbox_async/commands/command.py
+++ b/packages/python-sdk/e2b/sandbox_async/commands/command.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Literal, Optional, Union, overload
 
 import e2b_connect
 import httpcore
+from packaging.version import Version
 from e2b.connection_config import (
     ConnectionConfig,
     Username,
@@ -27,8 +28,10 @@ class Commands:
         envd_api_url: str,
         connection_config: ConnectionConfig,
         pool: httpcore.AsyncConnectionPool,
+        envd_version: Version,
     ) -> None:
         self._connection_config = connection_config
+        self._envd_version = envd_version
         self._rpc = process_connect.ProcessClient(
             envd_api_url,
             # TODO: Fix and enable compression again — the headers compression is not solved for streaming.

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
@@ -34,7 +34,7 @@ class Filesystem:
     def __init__(
         self,
         envd_api_url: str,
-        envd_version: Optional[str],
+        envd_version: Version,
         connection_config: ConnectionConfig,
         pool: httpcore.AsyncConnectionPool,
         envd_api: httpx.AsyncClient,
@@ -485,11 +485,7 @@ class Filesystem:
 
         :return: `AsyncWatchHandle` object for stopping watching directory
         """
-        if (
-            recursive
-            and self._envd_version is not None
-            and Version(self._envd_version) < ENVD_VERSION_RECURSIVE_WATCH
-        ):
+        if recursive and self._envd_version < ENVD_VERSION_RECURSIVE_WATCH:
             raise TemplateException(
                 "You need to update the template to use recursive watching. "
                 "You can do this by running `e2b template build` in the directory with the template."

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -10,6 +10,7 @@ from typing_extensions import Unpack, Self
 from e2b.api.client.types import Unset
 from e2b.connection_config import ConnectionConfig, ApiParams
 from e2b.envd.api import ENVD_API_HEALTH_ROUTE, ahandle_envd_api_exception
+from e2b.envd.versions import ENVD_DEBUG_FALLBACK
 from e2b.exceptions import format_request_timeout_error, SandboxException
 from e2b.sandbox.main import SandboxOpts
 from e2b.sandbox.sandbox_api import SandboxMetrics
@@ -107,6 +108,7 @@ class AsyncSandbox(SandboxApi):
             self.envd_api_url,
             self.connection_config,
             self._transport.pool,
+            self._envd_version,
         )
         self._pty = Pty(
             self.envd_api_url,
@@ -473,16 +475,15 @@ class AsyncSandbox(SandboxApi):
 
         :return: List of sandbox metrics containing CPU, memory and disk usage information
         """
-        if self._envd_version:
-            if Version(self._envd_version) < Version("0.1.5"):
-                raise SandboxException(
-                    "Metrics are not supported in this version of the sandbox, please rebuild your template."
-                )
+        if self._envd_version < Version("0.1.5"):
+            raise SandboxException(
+                "Metrics are not supported in this version of the sandbox, please rebuild your template."
+            )
 
-            if Version(self._envd_version) < Version("0.2.4"):
-                logger.warning(
-                    "Disk metrics are not supported in this version of the sandbox, please rebuild the template to get disk metrics."
-                )
+        if self._envd_version < Version("0.2.4"):
+            logger.warning(
+                "Disk metrics are not supported in this version of the sandbox, please rebuild the template to get disk metrics."
+            )
 
         return await SandboxApi._cls_get_metrics(
             sandbox_id=self.sandbox_id,
@@ -634,7 +635,7 @@ class AsyncSandbox(SandboxApi):
         if debug:
             sandbox_id = "debug_sandbox_id"
             sandbox_domain = None
-            envd_version = None
+            envd_version = ENVD_DEBUG_FALLBACK
             envd_access_token = None
         else:
             response = await SandboxApi._create_sandbox(
@@ -650,7 +651,7 @@ class AsyncSandbox(SandboxApi):
 
             sandbox_id = response.sandbox_id
             sandbox_domain = response.sandbox_domain
-            envd_version = response.envd_version
+            envd_version = Version(response.envd_version)
             envd_access_token = response.envd_access_token
 
             if envd_access_token is not None and not isinstance(

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -612,7 +612,7 @@ class AsyncSandbox(SandboxApi):
         return cls(
             sandbox_id=response.sandbox_id,
             sandbox_domain=response.sandbox_domain,
-            envd_version=response.envd_version,
+            envd_version=Version(response.envd_version),
             envd_access_token=envd_access_token,
             connection_config=connection_config,
         )

--- a/packages/python-sdk/e2b/sandbox_sync/commands/command.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/command.py
@@ -2,6 +2,7 @@ from typing import Callable, Dict, List, Literal, Optional, Union, overload
 
 import e2b_connect
 import httpcore
+from packaging.version import Version
 from e2b.connection_config import (
     ConnectionConfig,
     Username,
@@ -26,8 +27,10 @@ class Commands:
         envd_api_url: str,
         connection_config: ConnectionConfig,
         pool: httpcore.ConnectionPool,
+        envd_version: Version,
     ) -> None:
         self._connection_config = connection_config
+        self._envd_version = envd_version
         self._rpc = process_connect.ProcessClient(
             envd_api_url,
             # TODO: Fix and enable compression again — the headers compression is not solved for streaming.

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -35,7 +35,7 @@ class Filesystem:
     def __init__(
         self,
         envd_api_url: str,
-        envd_version: Optional[str],
+        envd_version: Version,
         connection_config: ConnectionConfig,
         pool: httpcore.ConnectionPool,
         envd_api: httpx.Client,
@@ -480,11 +480,7 @@ class Filesystem:
 
         :return: `WatchHandle` object for stopping watching directory
         """
-        if (
-            recursive
-            and self._envd_version is not None
-            and Version(self._envd_version) < ENVD_VERSION_RECURSIVE_WATCH
-        ):
+        if recursive and self._envd_version < ENVD_VERSION_RECURSIVE_WATCH:
             raise TemplateException(
                 "You need to update the template to use recursive watching. "
                 "You can do this by running `e2b template build` in the directory with the template."

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -611,7 +611,7 @@ class Sandbox(SandboxApi):
             sandbox_id=sandbox_id,
             sandbox_domain=response.sandbox_domain,
             connection_config=connection_config,
-            envd_version=response.envd_version,
+            envd_version=Version(response.envd_version),
             envd_access_token=envd_access_token,
         )
 


### PR DESCRIPTION
The envd is always present, so we can simplify the handling + pass it to filesystem module as a preparation for stdin