### PR TITLE
Scope template build for typescript and python

### DIFF
--- a/packages/cli/src/templates/python-build-sync.hbs
+++ b/packages/cli/src/templates/python-build-sync.hbs
@@ -2,13 +2,14 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="{{alias}}",
-{{#if cpuCount}}
-    cpu_count={{cpuCount}},
-{{/if}}
-{{#if memoryMB}}
-    memory_mb={{memoryMB}},
-{{/if}}
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="{{alias}}",
+    {{#if cpuCount}}
+        cpu_count={{cpuCount}},
+    {{/if}}
+    {{#if memoryMB}}
+        memory_mb={{memoryMB}},
+    {{/if}}
+    )

--- a/packages/cli/src/templates/typescript-build.hbs
+++ b/packages/cli/src/templates/typescript-build.hbs
@@ -1,12 +1,16 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: '{{alias}}',
-{{#if cpuCount}}
-  cpuCount: {{cpuCount}},
-{{/if}}
-{{#if memoryMB}}
-  memoryMB: {{memoryMB}},
-{{/if}}
-})
+async function main() {
+  await Template.build(template, {
+    alias: '{{alias}}',
+    {{#if cpuCount}}
+    cpuCount: {{cpuCount}},
+    {{/if}}
+    {{#if memoryMB}}
+    memoryMB: {{memoryMB}},
+    {{/if}}
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/complex-python/e2b.toml
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/e2b.toml
@@ -1,3 +1,3 @@
 template_id = "complex-python"
 dockerfile = "e2b.Dockerfile"
-template_name = "Complex Python App"
+template_name = "complex-python-app"

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-async/build_dev.py
@@ -6,7 +6,7 @@ from template import template
 async def main():
     await AsyncTemplate.build(
         template,
-        alias="Complex Python App-dev",
+        alias="complex-python-app-dev",
     )
 
 

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-async/build_prod.py
@@ -6,7 +6,7 @@ from template import template
 async def main():
     await AsyncTemplate.build(
         template,
-        alias="Complex Python App",
+        alias="complex-python-app",
     )
 
 

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-sync/build_dev.py
@@ -2,7 +2,8 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="Complex Python App-dev",
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="complex-python-app-dev",
+    )

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-sync/build_prod.py
@@ -2,7 +2,8 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="Complex Python App",
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="complex-python-app",
+    )

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/typescript/build.dev.ts
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/typescript/build.dev.ts
@@ -1,6 +1,10 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'Complex Python App-dev',
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'complex-python-app-dev',
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/typescript/build.prod.ts
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/typescript/build.prod.ts
@@ -1,6 +1,10 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'Complex Python App',
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'complex-python-app',
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-sync/build_dev.py
@@ -2,7 +2,8 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="copy-test-dev",
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="copy-test-dev",
+    )

--- a/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-sync/build_prod.py
@@ -2,7 +2,8 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="copy-test",
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="copy-test",
+    )

--- a/packages/cli/tests/commands/template/fixtures/copy-variations/expected/typescript/build.dev.ts
+++ b/packages/cli/tests/commands/template/fixtures/copy-variations/expected/typescript/build.dev.ts
@@ -1,6 +1,10 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'copy-test-dev',
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'copy-test-dev',
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/copy-variations/expected/typescript/build.prod.ts
+++ b/packages/cli/tests/commands/template/fixtures/copy-variations/expected/typescript/build.prod.ts
@@ -1,6 +1,10 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'copy-test',
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'copy-test',
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-sync/build_dev.py
@@ -2,7 +2,8 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="custom-app-dev",
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="custom-app-dev",
+    )

--- a/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-sync/build_prod.py
@@ -2,7 +2,8 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="custom-app",
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="custom-app",
+    )

--- a/packages/cli/tests/commands/template/fixtures/custom-commands/expected/typescript/build.dev.ts
+++ b/packages/cli/tests/commands/template/fixtures/custom-commands/expected/typescript/build.dev.ts
@@ -1,6 +1,10 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'custom-app-dev',
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'custom-app-dev',
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/custom-commands/expected/typescript/build.prod.ts
+++ b/packages/cli/tests/commands/template/fixtures/custom-commands/expected/typescript/build.prod.ts
@@ -1,6 +1,10 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'custom-app',
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'custom-app',
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-sync/build_dev.py
@@ -2,7 +2,8 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="minimal-template-dev",
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="minimal-template-dev",
+    )

--- a/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-sync/build_prod.py
@@ -2,7 +2,8 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="minimal-template",
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="minimal-template",
+    )

--- a/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/typescript/build.dev.ts
+++ b/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/typescript/build.dev.ts
@@ -1,6 +1,10 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'minimal-template-dev',
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'minimal-template-dev',
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/typescript/build.prod.ts
+++ b/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/typescript/build.prod.ts
@@ -1,6 +1,10 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'minimal-template',
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'minimal-template',
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-sync/build_dev.py
@@ -2,7 +2,8 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="multi-stage-dev",
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="multi-stage-dev",
+    )

--- a/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-sync/build_prod.py
@@ -2,7 +2,8 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="multi-stage",
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="multi-stage",
+    )

--- a/packages/cli/tests/commands/template/fixtures/multi-stage/expected/typescript/build.dev.ts
+++ b/packages/cli/tests/commands/template/fixtures/multi-stage/expected/typescript/build.dev.ts
@@ -1,6 +1,10 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'multi-stage-dev',
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'multi-stage-dev',
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/multi-stage/expected/typescript/build.prod.ts
+++ b/packages/cli/tests/commands/template/fixtures/multi-stage/expected/typescript/build.prod.ts
@@ -1,6 +1,10 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'multi-stage',
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'multi-stage',
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-sync/build_dev.py
@@ -2,7 +2,8 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="env-test-dev",
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="env-test-dev",
+    )

--- a/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-sync/build_prod.py
@@ -2,7 +2,8 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="env-test",
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="env-test",
+    )

--- a/packages/cli/tests/commands/template/fixtures/multiple-env/expected/typescript/build.dev.ts
+++ b/packages/cli/tests/commands/template/fixtures/multiple-env/expected/typescript/build.dev.ts
@@ -1,6 +1,10 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'env-test-dev',
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'env-test-dev',
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/multiple-env/expected/typescript/build.prod.ts
+++ b/packages/cli/tests/commands/template/fixtures/multiple-env/expected/typescript/build.prod.ts
@@ -1,6 +1,10 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'env-test',
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'env-test',
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-sync/build_dev.py
@@ -2,9 +2,10 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="start-cmd-dev",
-    cpu_count=2,
-    memory_mb=1024,
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="start-cmd-dev",
+        cpu_count=2,
+        memory_mb=1024,
+    )

--- a/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-sync/build_prod.py
@@ -2,9 +2,10 @@ from e2b import Template
 from template import template
 
 
-Template.build(
-    template,
-    alias="start-cmd",
-    cpu_count=2,
-    memory_mb=1024,
-)
+if __name__ == "__main__":
+    Template.build(
+        template,
+        alias="start-cmd",
+        cpu_count=2,
+        memory_mb=1024,
+    )

--- a/packages/cli/tests/commands/template/fixtures/start-cmd/expected/typescript/build.dev.ts
+++ b/packages/cli/tests/commands/template/fixtures/start-cmd/expected/typescript/build.dev.ts
@@ -1,8 +1,12 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'start-cmd-dev',
-  cpuCount: 2,
-  memoryMB: 1024,
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'start-cmd-dev',
+    cpuCount: 2,
+    memoryMB: 1024,
+  });
+}
+
+main().catch(console.error);

--- a/packages/cli/tests/commands/template/fixtures/start-cmd/expected/typescript/build.prod.ts
+++ b/packages/cli/tests/commands/template/fixtures/start-cmd/expected/typescript/build.prod.ts
@@ -1,8 +1,12 @@
 import { Template } from 'e2b'
 import { template } from './template'
 
-await Template.build(template, {
-  alias: 'start-cmd',
-  cpuCount: 2,
-  memoryMB: 1024,
-})
+async function main() {
+  await Template.build(template, {
+    alias: 'start-cmd',
+    cpuCount: 2,
+    memoryMB: 1024,
+  });
+}
+
+main().catch(console.error);


### PR DESCRIPTION
Scope template build for typescript and python. You can see the generated files in the fixtures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scope/encapsulate Python and TypeScript template build entrypoints and standardize complex-python alias to kebab-case, updating fixtures accordingly.
> 
> - **Templates**:
>   - **Python (sync)**: wrap `Template.build(...)` in `if __name__ == "__main__":` in `packages/cli/src/templates/python-build-sync.hbs`.
>   - **TypeScript**: wrap `Template.build(...)` in `async function main()` with `main().catch(console.error)` in `packages/cli/src/templates/typescript-build.hbs`.
> - **Fixtures/Expected Outputs**:
>   - Update all Python sync and TypeScript build fixtures to match new scoped entrypoints.
>   - Standardize `complex-python` naming: change `template_name` and all aliases from `"Complex Python App"` to `"complex-python-app"` (incl. `-dev`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f22af8ea2a22855ed4cbdeb65766423a576b0ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->