### PR TITLE
fix: add queue for terminal input

### DIFF
--- a/.changeset/grumpy-moons-melt.md
+++ b/.changeset/grumpy-moons-melt.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+add queue for terminal input to help with network delays

--- a/packages/cli/src/terminal.ts
+++ b/packages/cli/src/terminal.ts
@@ -55,9 +55,9 @@ export async function spawnConnectedTerminal(sandbox: e2b.Sandbox) {
   } finally {
     // Cleanup
     process.stdout.write('\n')
-    await inputQueue.stop()
     resizeListener.destroy()
     stdinListener.destroy()
+    await inputQueue.stop()
     process.stdin.setRawMode(false)
   }
 }

--- a/packages/cli/src/terminal.ts
+++ b/packages/cli/src/terminal.ts
@@ -1,5 +1,7 @@
 import * as e2b from 'e2b'
 
+const FLUSH_INPUT_INTERVAL_MS = 10
+
 function getStdoutSize() {
   return {
     cols: process.stdout.columns,
@@ -22,12 +24,19 @@ export async function spawnConnectedTerminal(sandbox: e2b.Sandbox) {
     timeoutMs: 0,
   })
 
+  const inputQueue = new BatchedQueue<Buffer>(async (batch) => {
+    const combined = Buffer.concat(batch)
+    await sandbox.pty.sendInput(terminalSession.pid, combined)
+  }, FLUSH_INPUT_INTERVAL_MS)
+
   const resizeListener = process.stdout.on('resize', () =>
     sandbox.pty.resize(terminalSession.pid, getStdoutSize())
   )
-  const stdinListener = process.stdin.on('data', async (data) => {
-    await sandbox.pty.sendInput(terminalSession.pid, data)
+  const stdinListener = process.stdin.on('data', (data) => {
+    inputQueue.push(data)
   })
+
+  inputQueue.start()
 
   // Wait for terminal session to finish
   try {
@@ -46,8 +55,48 @@ export async function spawnConnectedTerminal(sandbox: e2b.Sandbox) {
   } finally {
     // Cleanup
     process.stdout.write('\n')
+    inputQueue.stop()
     resizeListener.destroy()
     stdinListener.destroy()
     process.stdin.setRawMode(false)
+  }
+}
+
+class BatchedQueue<T> {
+  private queue: T[] = []
+  private isFlushing = false
+  private intervalId?: NodeJS.Timeout
+
+  constructor(
+    private flushHandler: (batch: T[]) => Promise<void>,
+    private flushIntervalMs: number
+  ) {}
+
+  push(item: T) {
+    this.queue.push(item)
+  }
+
+  start() {
+    this.intervalId = setInterval(async () => {
+      if (this.isFlushing || this.queue.length === 0) return
+
+      this.isFlushing = true
+      const batch = this.queue.splice(0, this.queue.length)
+
+      try {
+        await this.flushHandler(batch)
+      } catch (err) {
+        console.error('Error sending input:', err)
+      }
+
+      this.isFlushing = false
+    }, this.flushIntervalMs)
+  }
+
+  stop() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId)
+      this.intervalId = undefined
+    }
   }
 }


### PR DESCRIPTION
This PR adds a queue for the terminal input. This should help when network delay is large to prevent mangling characters order.

I couldn't use the streamed input, because we need to support browser in our SDK.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Queues and batches stdin to the sandbox PTY (flushed every 10ms) to preserve input order under network latency, with proper start/stop cleanup.
> 
> - **CLI Terminal (`packages/cli/src/terminal.ts`)**:
>   - Introduce `BatchedQueue` to batch stdin `Buffer`s and send combined input to `sandbox.pty.sendInput`.
>   - Add `FLUSH_INPUT_INTERVAL_MS = 10` and use queued flushing (`start`/`stop`) around session lifecycle.
>   - Replace direct stdin handler with queued `inputQueue.push(data)`; ensure cleanup awaits `inputQueue.stop()`.
>   - Add error handling in queue flush to log send failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3d0401c5bcc5d3e2d9e665f8c6e1c97e4e7530e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->