### PR TITLE
Fix e2b sbx logs -f <id> not following

### DIFF
--- a/.changeset/forty-turtles-visit.md
+++ b/.changeset/forty-turtles-visit.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+fix sbx logs follow option

--- a/packages/cli/src/commands/sandbox/logs.ts
+++ b/packages/cli/src/commands/sandbox/logs.ts
@@ -225,14 +225,14 @@ function printLog(
     delete log['level']
     console.log(
       `${asTimestamp(time)} ${level} ` +
-      util.inspect(log, {
-        colors: true,
-        depth: null,
-        maxArrayLength: Infinity,
-        sorted: true,
-        compact: true,
-        breakLength: Infinity,
-      })
+        util.inspect(log, {
+          colors: true,
+          depth: null,
+          maxArrayLength: Infinity,
+          sorted: true,
+          compact: true,
+          breakLength: Infinity,
+        })
     )
   }
 }

--- a/packages/cli/src/commands/sandbox/logs.ts
+++ b/packages/cli/src/commands/sandbox/logs.ts
@@ -103,8 +103,6 @@ export const logsCommand = new commander.Command('logs')
           console.log(`\nLogs for sandbox ${asBold(sandboxID)}:`)
         }
 
-        const isRunningPromise = isRunning(sandboxID)
-
         do {
           const logs = await listSandboxLogs({ sandboxID, start })
 
@@ -123,9 +121,9 @@ export const logsCommand = new commander.Command('logs')
             )
           }
 
-          const isRunning = await isRunningPromise
+          const isSandboxRunning = await isRunning(sandboxID)
 
-          if (!isRunning && logs.length === 0 && isFirstRun) {
+          if (!isSandboxRunning && logs.length === 0 && isFirstRun) {
             if (format === Format.PRETTY) {
               console.log(
                 `\nStopped printing logs — sandbox ${withUnderline(
@@ -136,7 +134,7 @@ export const logsCommand = new commander.Command('logs')
             break
           }
 
-          if (!isRunning) {
+          if (!isSandboxRunning) {
             if (format === Format.PRETTY) {
               console.log(
                 `\nStopped printing logs — sandbox is ${withUnderline(
@@ -227,14 +225,14 @@ function printLog(
     delete log['level']
     console.log(
       `${asTimestamp(time)} ${level} ` +
-        util.inspect(log, {
-          colors: true,
-          depth: null,
-          maxArrayLength: Infinity,
-          sorted: true,
-          compact: true,
-          breakLength: Infinity,
-        })
+      util.inspect(log, {
+        colors: true,
+        depth: null,
+        maxArrayLength: Infinity,
+        sorted: true,
+        compact: true,
+        breakLength: Infinity,
+      })
     )
   }
 }

--- a/packages/cli/src/commands/sandbox/utils.ts
+++ b/packages/cli/src/commands/sandbox/utils.ts
@@ -1,6 +1,7 @@
 import { wait } from '../../utils/wait'
 import { asBold } from '../../utils/format'
 import { Sandbox } from 'e2b'
+import { ensureAPIKey } from 'src/api'
 
 export function formatEnum(e: { [key: string]: string }) {
   return Object.values(e)
@@ -51,7 +52,10 @@ export function getShortID(sandboxID: string) {
 
 export async function isRunning(sandboxID: string) {
   try {
-    const info = await Sandbox.getInfo(getShortID(sandboxID))
+    const apiKey = ensureAPIKey()
+    const info = await Sandbox.getInfo(getShortID(sandboxID), {
+      apiKey,
+    })
     return info.state === 'running'
   } catch {
     return false


### PR DESCRIPTION
This PR fixes 2 bugs that made the follow option in `e2b sbx logs` not work:

1. `e2b sbx logs -f <id>` failed to follow because the `isRunning` function was always returning false due to the API call being unauthenticated if you dont have the `E2B_API_KEY` environment variable set.

This follows the existing pattern from other API calls:
https://github.com/e2b-dev/E2B/blob/c4ce97e9b9a1809e3419d64499c1e56f9138e3d0/packages/cli/src/commands/sandbox/list.ts#L138-L152

Eventually it would make sense to handle the error here, for now just a hotfix to fix the --follow usage

2. Once it actually followed, it never stopped following because `isRunning` was not inside the loop and always true. Now when you kill the sandbox follow actually stops following

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `e2b sbx logs -f` by authenticating `isRunning` and re-checking sandbox state each loop so following works and stops when closed.
> 
> - **CLI — `packages/cli/src/commands/sandbox`**:
>   - **Logs follow behavior (`logs.ts`)**:
>     - Re-check `isRunning(sandboxID)` inside the loop (`isSandboxRunning`) instead of using a cached promise, ensuring follow stops when sandbox is closed or not found.
>   - **Sandbox state check auth (`utils.ts`)**:
>     - Use `ensureAPIKey()` and pass `apiKey` to `Sandbox.getInfo(getShortID(sandboxID), { apiKey })` so `isRunning` is authenticated.
> - **Release**:
>   - Changeset adds patch for `@e2b/cli` with note: fix sbx logs follow option.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fbd87166b70aca7229ccc1ff8fa2c27f12b1641. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->