### PR TITLE
fix(types): make stdin optional in CommandOptions

### DIFF
--- a/packages/js-sdk/src/sandbox/commands/index.ts
+++ b/packages/js-sdk/src/sandbox/commands/index.ts
@@ -72,7 +72,7 @@ export interface CommandStartOpts extends CommandRequestOpts {
    * If true, command stdin is kept open and you can send data to it using {@link Commands.sendStdin} or {@link CommandHandle.sendStdin}.
    * @default false
    */
-  stdin: boolean
+  stdin?: boolean
   /**
    * Timeout for the command in **milliseconds**.
    *


### PR DESCRIPTION
This PR fixes a mismatch between the TypeScript types and the documented/default runtime behavior in the JS SDK.

- The docs indicate `stdin` defaults to `false` (`@default false`).
- The current type declares `stdin: boolean;` (required), which causes TypeScript errors for callers who rely on the default.
- Change: mark `stdin` as optional (`stdin?: boolean;`) so types match docs/runtime.