### PR TITLE
Add a postinstall that downloads chromium

### DIFF
--- a/.github/workflows/js_sdk_tests.yml
+++ b/.github/workflows/js_sdk_tests.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Install dependencies
         run: |
           pnpm install --frozen-lockfile
-          npx playwright install --with-deps
 
       - name: Test build
         run: pnpm build

--- a/.github/workflows/release_candidates.yml
+++ b/.github/workflows/release_candidates.yml
@@ -79,7 +79,6 @@ jobs:
         working-directory: packages/js-sdk
         if: ${{ contains( github.event.pull_request.labels.*.name, 'js-rc') }}
         run: |
-          npx playwright install --with-deps
           pnpm run test
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -41,6 +41,7 @@
     "test:deno": "deno test tests/runtimes/deno/ --allow-net --allow-read --allow-env --unstable-sloppy-imports --trace-leaks",
     "test:integration": "E2B_INTEGRATION_TEST=1 vitest run tests/integration/**",
     "lint": "eslint src/ tests/",
+    "postinstall": "pnpm exec playwright install chromium",
     "format": "prettier --write src/ tests/ example.mts"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Move Playwright installation to JS SDK postinstall (Chromium) and remove explicit installs from CI workflows.
> 
> - **Workflows**:
>   - Remove `npx playwright install --with-deps` from `/.github/workflows/js_sdk_tests.yml` and `/.github/workflows/release_candidates.yml`.
> - **JS SDK (`packages/js-sdk/package.json`)**:
>   - Add `postinstall` script: `pnpm exec playwright install chromium`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bc96ae4b8da0e03d98e99e6ecdc4e952d530866. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->