### PR TITLE
Revert "Add a postinstall that downloads chromium"

### DIFF
--- a/.github/workflows/js_sdk_tests.yml
+++ b/.github/workflows/js_sdk_tests.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           pnpm install --frozen-lockfile
+          npx playwright install --with-deps
 
       - name: Test build
         run: pnpm build

--- a/.github/workflows/release_candidates.yml
+++ b/.github/workflows/release_candidates.yml
@@ -86,6 +86,7 @@ jobs:
         working-directory: packages/js-sdk
         if: ${{ contains( github.event.pull_request.labels.*.name, 'js-rc') }}
         run: |
+          npx playwright install --with-deps
           pnpm run test
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -41,7 +41,6 @@
     "test:deno": "deno test tests/runtimes/deno/ --allow-net --allow-read --allow-env --unstable-sloppy-imports --trace-leaks",
     "test:integration": "E2B_INTEGRATION_TEST=1 vitest run tests/integration/**",
     "lint": "eslint src/ tests/",
-    "postinstall": "pnpm exec playwright install chromium",
     "format": "prettier --write src/ tests/ example.mts"
   },
   "devDependencies": {


### PR DESCRIPTION
This change needs to be reverted, it's a postinstall script that will pull chromium after SDK installation.

Reverts e2b-dev/E2B#962

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves Playwright installation from package postinstall to CI workflows for JS SDK tests and release candidates.
> 
> - **CI Workflows**:
>   - `/.github/workflows/js_sdk_tests.yml`: Add `npx playwright install --with-deps` before running tests.
>   - `/.github/workflows/release_candidates.yml`: Add `npx playwright install --with-deps` in JS SDK test step.
> - **JS SDK Package**:
>   - Remove `postinstall` script that installed Playwright Chromium in `packages/js-sdk/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57dad49a8ddac9c46f5e7834eff9b19a57cbf552. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->