### PR TITLE
CLI migrate: remove npx from package.json update script

### DIFF
--- a/packages/cli/src/commands/template/init-v2.ts
+++ b/packages/cli/src/commands/template/init-v2.ts
@@ -114,8 +114,8 @@ async function addPackageJsonScripts(
     pkgJson.update({
       scripts: {
         ...pkgJson.content.scripts,
-        'e2b:build:dev': `${cdPrefix}npx tsx ${files.buildDevFile}`,
-        'e2b:build:prod': `${cdPrefix}npx tsx ${files.buildProdFile}`,
+        'e2b:build:dev': `${cdPrefix}tsx ${files.buildDevFile}`,
+        'e2b:build:prod': `${cdPrefix}tsx ${files.buildProdFile}`,
       },
     })
 


### PR DESCRIPTION
Unnecessary because npm run npx > npm run npm run

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace `npx tsx` with `tsx` in generated `e2b:build:*` package.json scripts within `packages/cli/src/commands/template/init-v2.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b0fb4c2d1a7ffd64a687a42b3909274839eadc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->