### PR TITLE
fix: CLI tests setup

### DIFF
--- a/packages/cli/tests/setup.ts
+++ b/packages/cli/tests/setup.ts
@@ -1,6 +1,5 @@
 import { execSync } from 'node:child_process'
-import { beforeAll } from 'vitest'
 
-beforeAll(() => {
+export async function setup() {
   execSync('pnpm build', { stdio: 'inherit' })
-})
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     testTimeout: 30_000,
     include: ['tests/**/*.test.ts'],
     exclude: ['node_modules', 'dist', 'testground'],
-    setupFiles: ['tests/setup.ts'],
+    globalSetup: ['tests/setup.ts'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Fix CLI tests setup running before each tests file instead of all tests once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Vitest from per-file `setupFiles` to `globalSetup` with an exported async `setup()` that runs `pnpm build` once before all tests.
> 
> - **Testing configuration (Vitest)**:
>   - Replace per-file `setupFiles` with `globalSetup` in `packages/cli/vitest.config.ts`.
>   - Update `packages/cli/tests/setup.ts` to export async `setup()` that runs `pnpm build` once before all tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f16038c1239d8a222a52ed8a3f1445654530d79a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->