### PR TITLE
Support labeling a PR after opening it

### DIFF
--- a/.github/workflows/release_candidates.yml
+++ b/.github/workflows/release_candidates.yml
@@ -2,6 +2,11 @@ name: Release Candidates
 
 on:
   pull_request:
+    types:
+      - labeled
+      - opened
+      - reopened
+      - synchronize
 
 permissions:
   contents: write


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expand Release Candidates workflow to run on PR label, open, reopen, and sync events.
> 
> - **CI/CD**:
>   - Update `on.pull_request.types` in `.github/workflows/release_candidates.yml` to include `labeled`, `opened`, `reopened`, and `synchronize` so the Release Candidate workflow runs on these events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0842f5d6e0902ed04f9d42fa9b258dd098d56da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->