### PR TITLE
Test setup: append "e2b-test" to templates generated in tests

### DIFF
--- a/packages/js-sdk/tests/setup.ts
+++ b/packages/js-sdk/tests/setup.ts
@@ -23,7 +23,7 @@ function buildTemplate(
   onBuildLogs?: (logEntry: LogEntry) => void
 ) {
   return Template.build(template, {
-    alias: randomUUID(),
+    alias: `e2b-test-${randomUUID()}`,
     cpuCount: 1,
     memoryMB: 1024,
     skipCache: skipCache,

--- a/packages/python-sdk/tests/conftest.py
+++ b/packages/python-sdk/tests/conftest.py
@@ -75,7 +75,7 @@ def build():
     ):
         return Template.build(
             template,
-            alias=str(uuid4()),
+            alias=f"e2b-test-{uuid4()}",
             cpu_count=1,
             memory_mb=1024,
             skip_cache=skip_cache,
@@ -94,7 +94,7 @@ def async_build():
     ):
         return await AsyncTemplate.build(
             template,
-            alias=str(uuid4()),
+            alias=f"e2b-test-{uuid4()}",
             cpu_count=1,
             memory_mb=1024,
             skip_cache=skip_cache,


### PR DESCRIPTION
So that we ca distinguish templates in our team account that are built from the CI tests.