### PR TITLE
Export ReadyCMD class

### DIFF
--- a/.changeset/early-trainers-repeat.md
+++ b/.changeset/early-trainers-repeat.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': patch
+'e2b': patch
+---
+
+export ReadyCmd class

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -67,6 +67,7 @@ export default Sandbox
 export * from './template'
 
 export {
+  ReadyCmd,
   waitForPort,
   waitForURL,
   waitForProcess,

--- a/packages/python-sdk/e2b/__init__.py
+++ b/packages/python-sdk/e2b/__init__.py
@@ -85,6 +85,7 @@ from .template.logger import (
 )
 from .template.main import TemplateBase, TemplateClass
 from .template.readycmd import (
+    ReadyCmd,
     wait_for_file,
     wait_for_url,
     wait_for_port,
@@ -149,6 +150,7 @@ __all__ = [
     "TemplateBase",
     "TemplateClass",
     "CopyItem",
+    "ReadyCmd",
     "wait_for_file",
     "wait_for_url",
     "wait_for_port",


### PR DESCRIPTION
for building type-safe wrappers around .setStartCmd/.setReadyCmd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose `ReadyCmd` via JS (`packages/js-sdk/src/index.ts`) and Python (`e2b/__init__.py`) SDK entrypoints, with patch version bumps.
> 
> - **SDK Exports**:
>   - **JS**: Re-exports `ReadyCmd` from `./template/readycmd` in `packages/js-sdk/src/index.ts`.
>   - **Python**: Exposes `ReadyCmd` in `e2b/__init__.py` imports and `__all__`.
> - **Versioning**:
>   - `.changeset/early-trainers-repeat.md`: Patch bumps for `@e2b/python-sdk` and `e2b`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff91a3e3578be8db6ea7644ee6717f1bd18b0165. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->