### PR TITLE
Some general pytest cleanup

### DIFF
--- a/.github/workflows/python_sdk_tests.yml
+++ b/.github/workflows/python_sdk_tests.yml
@@ -50,6 +50,6 @@ jobs:
         run: poetry build
 
       - name: Run tests
-        run: poetry run pytest --verbose -x
+        run: make test
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,4 +2,4 @@ deno 1.46.3
 nodejs 20.19.5
 pnpm 9.15.5
 python 3.9
-poetry 1.8.3
+poetry 2.1.1

--- a/packages/python-sdk/Makefile
+++ b/packages/python-sdk/Makefile
@@ -40,3 +40,11 @@ generate-mcp:
 			--use-field-description \
 			--disable-timestamp \
 			--extra-fields forbid
+
+.PHONY: setup
+setup:
+	poetry install
+
+.PHONY: test
+test: setup
+	poetry run pytest --verbose --numprocesses=4

--- a/packages/python-sdk/poetry.lock
+++ b/packages/python-sdk/poetry.lock
@@ -1192,6 +1192,21 @@ pytest = ">=5.0.0"
 python-dotenv = ">=0.9.1"
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+description = "pytest plugin to abort hanging tests"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
+    {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
@@ -1784,4 +1799,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "3cf44f2f5886def427740a1d22ee04e9714c963ebabf5c383b42fbad833ef7cd"
+content-hash = "3ea6aa999964f818bac76ba9932381e0ba66b5d7baa0b83969a6859ce195b67b"

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -31,6 +31,7 @@ pytest-asyncio = "^0.23.7"
 pydoc-markdown = "^4.8.2"
 datamodel-code-generator = "^0.34.0"
 ruff = "^0.11.12"
+pytest-timeout = "^2.4.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/packages/python-sdk/pytest.ini
+++ b/packages/python-sdk/pytest.ini
@@ -4,4 +4,5 @@ markers =
     skip_debug: skip test if E2B_DEBUG is set.
 
 asyncio_mode=auto
-addopts = "--import-mode=importlib" "--numprocesses=4"
+addopts = "--import-mode=importlib"
+timeout = 300

--- a/packages/python-sdk/tests/test_connection_config.py
+++ b/packages/python-sdk/tests/test_connection_config.py
@@ -1,7 +1,9 @@
 from e2b import ConnectionConfig
 
 
-def test_api_url_defaults_correctly():
+def test_api_url_defaults_correctly(monkeypatch):
+    monkeypatch.setenv("E2B_DOMAIN", "")
+
     config = ConnectionConfig()
     assert config.api_url == "https://api.e2b.app"
 


### PR DESCRIPTION
- Individual tests must complete in less than 5 minutes
- Add a `make test` option that runs tests
- Upgrade poetry to 2.1.1 (the lock file was generated by this version, so this just matches what we already expect)