### PR TITLE
feat: add host mask and public access auth

### DIFF
--- a/.changeset/cuddly-horses-push.md
+++ b/.changeset/cuddly-horses-push.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': minor
+'e2b': minor
+---
+
+add possibility to mask the Host in public requests with custom value

--- a/.changeset/loud-bottles-provide.md
+++ b/.changeset/loud-bottles-provide.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': minor
+'e2b': minor
+---
+
+add ability to secure public traffic using token

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -90,6 +90,11 @@ export class Sandbox extends SandboxApi {
    */
   readonly sandboxDomain: string
 
+  /**
+   * Traffic access token for accessing sandbox services with restricted public traffic.
+   */
+  readonly trafficAccessToken?: string
+
   protected readonly envdPort = 49983
   protected readonly mcpPort = 50005
 
@@ -113,6 +118,7 @@ export class Sandbox extends SandboxApi {
       sandboxDomain?: string
       envdVersion: string
       envdAccessToken?: string
+      trafficAccessToken?: string
     }
   ) {
     super()
@@ -123,6 +129,7 @@ export class Sandbox extends SandboxApi {
     this.sandboxDomain = opts.sandboxDomain ?? this.connectionConfig.domain
 
     this.envdAccessToken = opts.envdAccessToken
+    this.trafficAccessToken = opts.trafficAccessToken
     this.envdApiUrl = this.connectionConfig.getSandboxUrl(this.sandboxId, {
       sandboxDomain: this.sandboxDomain,
       envdPort: this.envdPort,
@@ -420,6 +427,7 @@ export class Sandbox extends SandboxApi {
       sandboxId,
       sandboxDomain: sandbox.sandboxDomain,
       envdAccessToken: sandbox.envdAccessToken,
+      trafficAccessToken: sandbox.trafficAccessToken,
       envdVersion: sandbox.envdVersion,
       ...config,
     }) as InstanceType<S>

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -49,6 +49,19 @@ export type SandboxNetworkOpts = {
    * - To deny traffic to a specific addresses: `["1.1.1.1", "8.8.8.0/24"]`
    */
   denyOut?: string[]
+
+  /**
+   * Specify if the sandbox URLs should be accessible only with authentication.
+   * @default true
+   */
+  allowPublicTraffic?: boolean
+
+  /** Specify host mask which will be used for all sandbox requests in the header.
+   * You can use the ${PORT} variable that will be replaced with the actual port number of the service.
+   *
+   * @default ${PORT}-sandboxid.e2b.app
+   */
+  maskRequestHost?: string
 }
 
 /**
@@ -552,6 +565,7 @@ export class SandboxApi {
       sandboxDomain: res.data!.domain || undefined,
       envdVersion: res.data!.envdVersion,
       envdAccessToken: res.data!.envdAccessToken,
+      trafficAccessToken: res.data!.trafficAccessToken || undefined,
     }
   }
 
@@ -590,6 +604,7 @@ export class SandboxApi {
       sandboxDomain: res.data!.domain || undefined,
       envdVersion: res.data!.envdVersion,
       envdAccessToken: res.data!.envdAccessToken,
+      trafficAccessToken: res.data!.trafficAccessToken || undefined,
     }
   }
 }

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -1,20 +1,21 @@
-import os
-from types import TracebackType
 import json
 import logging
-from typing import Optional, Union
-from httpx import Limits, BaseTransport, AsyncBaseTransport
+import os
 from dataclasses import dataclass
+from types import TracebackType
+from typing import Optional, Union
+
+from httpx import AsyncBaseTransport, BaseTransport, Limits
 
 from e2b.api.client.client import AuthenticatedClient
-from e2b.connection_config import ConnectionConfig
+from e2b.api.client.types import Response
 from e2b.api.metadata import default_headers
+from e2b.connection_config import ConnectionConfig
 from e2b.exceptions import (
     AuthenticationException,
-    SandboxException,
     RateLimitException,
+    SandboxException,
 )
-from e2b.api.client.types import Response
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,7 @@ class SandboxCreateResponse:
     sandbox_domain: Optional[str]
     envd_version: str
     envd_access_token: str
+    traffic_access_token: Optional[str]
 
 
 def handle_api_exception(

--- a/packages/python-sdk/e2b/sandbox/main.py
+++ b/packages/python-sdk/e2b/sandbox/main.py
@@ -1,12 +1,12 @@
 import urllib.parse
-from packaging.version import Version
-
 from typing import Optional, TypedDict
 
-from e2b.sandbox.signature import get_signature
+from packaging.version import Version
+
 from e2b.connection_config import ConnectionConfig, default_username
 from e2b.envd.api import ENVD_API_FILES_ROUTE
 from e2b.envd.versions import ENVD_DEFAULT_USER
+from e2b.sandbox.signature import get_signature
 
 
 class SandboxOpts(TypedDict):
@@ -15,6 +15,7 @@ class SandboxOpts(TypedDict):
     envd_version: Version
     envd_access_token: Optional[str]
     sandbox_url: Optional[str]
+    traffic_access_token: Optional[str]
     connection_config: ConnectionConfig
 
 
@@ -33,12 +34,14 @@ class SandboxBase:
         envd_access_token: Optional[str],
         sandbox_domain: Optional[str],
         connection_config: ConnectionConfig,
+        traffic_access_token: Optional[str] = None,
     ):
         self.__connection_config = connection_config
         self.__sandbox_id = sandbox_id
         self.__sandbox_domain = sandbox_domain or self.connection_config.domain
         self.__envd_version = envd_version
         self.__envd_access_token = envd_access_token
+        self.__traffic_access_token = traffic_access_token
         self.__envd_api_url = self.connection_config.get_sandbox_url(
             self.sandbox_id, self.sandbox_domain
         )
@@ -64,6 +67,10 @@ class SandboxBase:
     @property
     def _envd_version(self) -> Version:
         return self.__envd_version
+
+    @property
+    def traffic_access_token(self) -> Optional[str]:
+        return self.__traffic_access_token
 
     @property
     def sandbox_domain(self) -> Optional[str]:

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -60,6 +60,21 @@ class SandboxNetworkOpts(TypedDict):
     - To deny traffic to specific addresses: `["1.1.1.1", "8.8.8.0/24"]`
     """
 
+    allow_public_traffic: NotRequired[bool]
+    """
+    Controls whether sandbox URLs should be publicly accessible or require authentication.
+    Defaults to True.
+    """
+
+    mask_request_host: NotRequired[str]
+    """
+    Allows specifying a custom host mask for all sandbox requests.
+    Supports ${PORT} variable. Defaults to "${PORT}-sandboxid.e2b.app".
+
+    Examples:
+    - Custom subdomain: `"${PORT}-myapp.example.com"`
+    """
+
 
 @dataclass
 class SandboxInfo:

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -664,6 +664,7 @@ class AsyncSandbox(SandboxApi):
             sandbox_domain=sandbox.domain,
             envd_version=Version(sandbox.envd_version),
             envd_access_token=envd_access_token,
+            traffic_access_token=sandbox.traffic_access_token,
             connection_config=connection_config,
         )
 
@@ -689,6 +690,7 @@ class AsyncSandbox(SandboxApi):
             sandbox_domain = None
             envd_version = ENVD_DEBUG_FALLBACK
             envd_access_token = None
+            traffic_access_token = None
         else:
             response = await SandboxApi._create_sandbox(
                 template=template or cls.default_template,
@@ -707,6 +709,7 @@ class AsyncSandbox(SandboxApi):
             sandbox_domain = response.sandbox_domain
             envd_version = Version(response.envd_version)
             envd_access_token = response.envd_access_token
+            traffic_access_token = response.traffic_access_token
 
             if envd_access_token is not None and not isinstance(
                 envd_access_token, Unset
@@ -726,5 +729,6 @@ class AsyncSandbox(SandboxApi):
             sandbox_domain=sandbox_domain,
             envd_version=envd_version,
             envd_access_token=envd_access_token,
+            traffic_access_token=traffic_access_token,
             connection_config=connection_config,
         )

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -200,6 +200,7 @@ class SandboxApi(SandboxBase):
             sandbox_domain=res.parsed.domain,
             envd_version=res.parsed.envd_version,
             envd_access_token=res.parsed.envd_access_token,
+            traffic_access_token=res.parsed.traffic_access_token,
         )
 
     @classmethod

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -657,6 +657,7 @@ class Sandbox(SandboxApi):
             connection_config=connection_config,
             envd_version=Version(sandbox.envd_version),
             envd_access_token=envd_access_token,
+            traffic_access_token=sandbox.traffic_access_token,
         )
 
     @classmethod
@@ -681,6 +682,7 @@ class Sandbox(SandboxApi):
             sandbox_domain = None
             envd_version = ENVD_DEBUG_FALLBACK
             envd_access_token = None
+            traffic_access_token = None
         else:
             response = SandboxApi._create_sandbox(
                 template=template or cls.default_template,
@@ -699,6 +701,7 @@ class Sandbox(SandboxApi):
             sandbox_domain = response.sandbox_domain
             envd_version = Version(response.envd_version)
             envd_access_token = response.envd_access_token
+            traffic_access_token = response.traffic_access_token
 
             if envd_access_token is not None and not isinstance(
                 envd_access_token, Unset
@@ -718,5 +721,6 @@ class Sandbox(SandboxApi):
             sandbox_domain=sandbox_domain,
             envd_version=envd_version,
             envd_access_token=envd_access_token,
+            traffic_access_token=traffic_access_token,
             connection_config=connection_config,
         )

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -199,6 +199,7 @@ class SandboxApi(SandboxBase):
             sandbox_domain=res.parsed.domain,
             envd_version=res.parsed.envd_version,
             envd_access_token=res.parsed.envd_access_token,
+            traffic_access_token=res.parsed.traffic_access_token,
         )
 
     @classmethod

--- a/packages/python-sdk/tests/async/sandbox_async/test_network.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_network.py
@@ -91,3 +91,122 @@ async def test_allow_takes_precedence_over_deny(async_sandbox_factory):
     )
     assert result2.exit_code == 0
     assert result2.stdout.strip() == "302"
+
+
+@pytest.mark.skip_debug()
+async def test_allow_public_traffic_false(async_sandbox_factory):
+    """Test that sandbox with allow_public_traffic=False requires traffic access token."""
+    async_sandbox = async_sandbox_factory(
+        network=SandboxNetworkOpts(allow_public_traffic=False)
+    )
+
+    import asyncio
+
+    import httpx
+
+    # Verify the sandbox was created successfully and has a traffic access token
+    assert async_sandbox.traffic_access_token is not None
+
+    # Start a simple HTTP server in the sandbox
+    port = 8080
+    async_sandbox.commands.run(
+        f"python3 -m http.server {port}",
+        background=True,
+    )
+
+    # Wait for server to start
+    await asyncio.sleep(3)
+
+    # Get the public URL for the sandbox
+    sandbox_url = f"https://{async_sandbox.get_host(port)}"
+
+    async with httpx.AsyncClient() as client:
+        # Test 1: Request without traffic access token should fail with 403
+        response = await client.get(sandbox_url, follow_redirects=True)
+        assert response.status_code == 403
+
+        # Test 2: Request with valid traffic access token should succeed
+        headers = {"e2b-traffic-access-token": async_sandbox.traffic_access_token}
+        response = await client.get(sandbox_url, headers=headers, follow_redirects=True)
+        assert response.status_code == 200
+
+
+@pytest.mark.skip_debug()
+async def test_allow_public_traffic_true(async_sandbox_factory):
+    """Test that sandbox with allow_public_traffic=True works without token."""
+    async_sandbox = async_sandbox_factory(
+        network=SandboxNetworkOpts(allow_public_traffic=True)
+    )
+
+    import asyncio
+
+    import httpx
+
+    # Start a simple HTTP server in the sandbox
+    port = 8080
+    async_sandbox.commands.run(
+        f"python3 -m http.server {port}",
+        background=True,
+    )
+
+    # Wait for server to start
+    await asyncio.sleep(3)
+
+    # Get the public URL for the sandbox
+    sandbox_url = f"https://{async_sandbox.get_host(port)}"
+
+    async with httpx.AsyncClient() as client:
+        # Request without traffic access token should succeed (public access enabled)
+        response = await client.get(sandbox_url, follow_redirects=True)
+        assert response.status_code == 200
+
+
+@pytest.mark.skip_debug()
+async def test_mask_request_host(async_sandbox_factory):
+    """Test that mask_request_host modifies the Host header correctly."""
+    async_sandbox = async_sandbox_factory(
+        network=SandboxNetworkOpts(mask_request_host="custom-host.example.com:${PORT}")
+    )
+
+    import asyncio
+
+    import httpx
+
+    # Install netcat for testing
+    await async_sandbox.commands.run("apt-get update", user="root")
+    await async_sandbox.commands.run(
+        "apt-get install -y netcat-traditional", user="root"
+    )
+
+    port = 8080
+    output_file = "/tmp/nc_output.txt"
+
+    # Start netcat listener in background to capture request headers
+    async_sandbox.commands.run(
+        f"nc -l -p {port} > {output_file}",
+        background=True,
+        user="root",
+    )
+
+    # Wait for netcat to start
+    await asyncio.sleep(3)
+
+    # Get the public URL for the sandbox
+    sandbox_url = f"https://{async_sandbox.get_host(port)}"
+
+    # Make a request from OUTSIDE the sandbox through the proxy
+    # The Host header should be modified according to mask_request_host
+    async with httpx.AsyncClient() as client:
+        try:
+            await client.get(sandbox_url, timeout=5.0)
+        except Exception:
+            # Request may fail since netcat doesn't respond properly, but headers are captured
+            pass
+
+    # Read the captured output from inside the sandbox
+    result = await async_sandbox.commands.run(f"cat {output_file}", user="root")
+
+    # Verify the Host header was modified according to mask_request_host
+    assert "Host:" in result.stdout
+    assert "custom-host.example.com" in result.stdout
+    assert str(port) in result.stdout

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_network.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_network.py
@@ -87,3 +87,116 @@ def test_allow_takes_precedence_over_deny(sandbox_factory):
     )
     assert result2.exit_code == 0
     assert result2.stdout.strip() == "302"
+
+
+@pytest.mark.skip_debug()
+def test_allow_public_traffic_false(sandbox_factory):
+    """Test that sandbox with allow_public_traffic=False requires traffic access token."""
+    sandbox = sandbox_factory(network=SandboxNetworkOpts(allow_public_traffic=False))
+
+    import time
+
+    import httpx
+
+    # Verify the sandbox was created successfully and has a traffic access token
+    assert sandbox.traffic_access_token is not None
+
+    # Start a simple HTTP server in the sandbox
+    port = 8080
+    sandbox.commands.run(
+        f"python3 -m http.server {port}",
+        background=True,
+    )
+
+    # Wait for server to start
+    time.sleep(3)
+
+    # Get the public URL for the sandbox
+    sandbox_url = f"https://{sandbox.get_host(port)}"
+
+    with httpx.Client() as client:
+        # Test 1: Request without traffic access token should fail with 403
+        response = client.get(sandbox_url, follow_redirects=True)
+        assert response.status_code == 403
+
+        # Test 2: Request with valid traffic access token should succeed
+        headers = {"e2b-traffic-access-token": sandbox.traffic_access_token}
+        response = client.get(sandbox_url, headers=headers, follow_redirects=True)
+        assert response.status_code == 200
+
+
+@pytest.mark.skip_debug()
+def test_allow_public_traffic_true(sandbox_factory):
+    """Test that sandbox with allow_public_traffic=True works without token."""
+    sandbox = sandbox_factory(network=SandboxNetworkOpts(allow_public_traffic=True))
+
+    import time
+
+    import httpx
+
+    # Start a simple HTTP server in the sandbox
+    port = 8080
+    sandbox.commands.run(
+        f"python3 -m http.server {port}",
+        background=True,
+    )
+
+    # Wait for server to start
+    time.sleep(3)
+
+    # Get the public URL for the sandbox
+    sandbox_url = f"https://{sandbox.get_host(port)}"
+
+    with httpx.Client() as client:
+        # Request without traffic access token should succeed (public access enabled)
+        response = client.get(sandbox_url, follow_redirects=True)
+        assert response.status_code == 200
+
+
+@pytest.mark.skip_debug()
+def test_mask_request_host(sandbox_factory):
+    """Test that mask_request_host modifies the Host header correctly."""
+    sandbox = sandbox_factory(
+        network=SandboxNetworkOpts(mask_request_host="custom-host.example.com:${PORT}")
+    )
+
+    import time
+
+    import httpx
+
+    # Install netcat for testing
+    sandbox.commands.run("apt-get update", user="root")
+    sandbox.commands.run("apt-get install -y netcat-traditional", user="root")
+
+    port = 8080
+    output_file = "/tmp/nc_output.txt"
+
+    # Start netcat listener in background to capture request headers
+    sandbox.commands.run(
+        f"nc -l -p {port} > {output_file}",
+        background=True,
+        user="root",
+    )
+
+    # Wait for netcat to start
+    time.sleep(3)
+
+    # Get the public URL for the sandbox
+    sandbox_url = f"https://{sandbox.get_host(port)}"
+
+    # Make a request from OUTSIDE the sandbox through the proxy
+    # The Host header should be modified according to mask_request_host
+    with httpx.Client() as client:
+        try:
+            client.get(sandbox_url, timeout=5.0)
+        except Exception:
+            # Request may fail since netcat doesn't respond properly, but headers are captured
+            pass
+
+    # Read the captured output from inside the sandbox
+    result = sandbox.commands.run(f"cat {output_file}", user="root")
+
+    # Verify the Host header was modified according to mask_request_host
+    assert "Host:" in result.stdout
+    assert "custom-host.example.com" in result.stdout
+    assert str(port) in result.stdout


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds network options to require a traffic access token and to mask the Host header, exposing `trafficAccessToken` and wiring through create/connect flows in JS and Python SDKs with tests.
> 
> - **JS SDK**:
>   - Add `trafficAccessToken` to `Sandbox` and propagate via `createSandbox/connectSandbox`.
>   - Extend `SandboxNetworkOpts` with `allowPublicTraffic` and `maskRequestHost`.
>   - Tests: enforce 403 without token when `allowPublicTraffic=false`, allow access when `true`, and verify `maskRequestHost` updates `Host` header.
> - **Python SDK**:
>   - Add `traffic_access_token` to `SandboxCreateResponse` and surface on `SandboxBase`.
>   - Wire token through async/sync `create` and `connect` paths.
>   - Extend `SandboxNetworkOpts` with `allow_public_traffic` and `mask_request_host`.
>   - Tests (async/sync): same access-token gating and host masking validations.
> - **Changesets**:
>   - Minor releases for `@e2b/python-sdk` and `e2b` documenting host masking and public traffic token.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b23fc76d62537a375af0bb8c6436b5be3266e9de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->