### PR TITLE
Fixes dot copy

### DIFF
--- a/.changeset/humble-badgers-cross.md
+++ b/.changeset/humble-badgers-cross.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+fix copy bug when attempting to copy '.' as a source directory

--- a/packages/js-sdk/src/template/utils.ts
+++ b/packages/js-sdk/src/template/utils.ts
@@ -63,7 +63,13 @@ export async function getAllFilesInPath(
       if (includeDirectories) {
         files.set(file.fullpath(), file)
       }
-      const dirFiles = await glob(normalizePath(file.relative()) + '/**/*', {
+      const dirPattern = normalizePath(
+        // When the matched directory is '.', `file.relative()` can be an empty string.
+        // In that case, we want to match all files under the current directory instead of
+        // creating an absolute glob like '/**/*' which would traverse the entire filesystem.
+        path.join(file.relative() || '.', '**/*')
+      )
+      const dirFiles = await glob(dirPattern, {
         ignore: ignorePatterns,
         withFileTypes: true,
         cwd: contextPath,

--- a/packages/js-sdk/tests/template/utils/getAllFilesInPath.test.ts
+++ b/packages/js-sdk/tests/template/utils/getAllFilesInPath.test.ts
@@ -208,6 +208,24 @@ describe('getAllFilesInPath', () => {
     expect(files).toHaveLength(0)
   })
 
+  test('should handle listing all files in current directory with dot pattern', async () => {
+    // Create a small directory tree inside the test directory
+    await writeFile(join(testDir, 'root.txt'), 'root')
+    await mkdir(join(testDir, 'subdir'), { recursive: true })
+    await writeFile(join(testDir, 'subdir', 'nested.txt'), 'nested')
+
+    const files = await getAllFilesInPath('.', testDir, [])
+
+    // We should get at least the testDir itself (.) plus its children
+    expect(files.length).toBeGreaterThanOrEqual(3)
+
+    // All returned paths must stay within the testDir - we must not traverse the whole filesystem
+    const allWithinTestDir = files.every((f) =>
+      f.fullpath().startsWith(testDir)
+    )
+    expect(allWithinTestDir).toBe(true)
+  })
+
   test('should handle complex ignore patterns with directories', async () => {
     // Create a complex structure
     await mkdir(join(testDir, 'src'), { recursive: true })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes glob expansion when source is '.' to avoid absolute '/**/*' traversal and adds targeted tests.
> 
> - **Bug fix (js-sdk)**:
>   - Update `getAllFilesInPath` in `packages/js-sdk/src/template/utils.ts` to construct a safe directory pattern when the matched directory is `'.'` (uses `path.join(file.relative() || '.', '**/*')`) preventing accidental `/**/*` traversal.
> - **Tests**:
>   - Add coverage for dot pattern in `packages/js-sdk/tests/template/utils/getAllFilesInPath.test.ts`, ensuring results stay within the context directory.
> - **Release**:
>   - Add changeset `'.changeset/humble-badgers-cross.md'` (patch for `e2b`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aac954e0625a97a50ebab03416de8e61b5fde7a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->