### PR TITLE
Fix Python (sync) WatchHandle test

### DIFF
--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_watch.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_watch.py
@@ -21,8 +21,10 @@ def test_watch_directory_changes(sandbox: Sandbox):
         if event.type == FilesystemEventType.WRITE and event.name == filename:
             write_event = event
             break
-    
-    assert write_event is not None, f"Expected WRITE event for {filename}, but got events: {events}"
+
+    assert write_event is not None, (
+        f"Expected WRITE event for {filename}, but got events: {events}"
+    )
     assert write_event.name == filename
 
     handle.stop()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make the watch directory change test robust by scanning for the WRITE event and using modified content.
> 
> - **Tests (python-sdk)**:
>   - Update `tests/sync/sandbox_sync/files/test_watch.py::test_watch_directory_changes` to write modified content and robustly detect a `WRITE` event by scanning returned events instead of assuming event order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad2a1c00fc80d3ac45254a24dfa9768160347311. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->