### PR TITLE
docs: remove inaccurate set timeout comment

### DIFF
--- a/.changeset/funny-foxes-visit.md
+++ b/.changeset/funny-foxes-visit.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': patch
+'e2b': patch
+---
+
+Remove inaccurate set timeout comment

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -520,7 +520,6 @@ export class Sandbox extends SandboxApi {
 
   /**
    * Set the timeout of the sandbox.
-   * After the timeout expires the sandbox will be automatically killed.
    *
    * This method can extend or reduce the sandbox timeout set when creating the sandbox or from the last call to `.setTimeout`.
    * Maximum time a sandbox can be kept alive is 24 hours (86_400_000 milliseconds) for Pro users and 1 hour (3_600_000 milliseconds) for Hobby users.

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -9,6 +9,7 @@ from packaging.version import Version
 from typing_extensions import Self, Unpack
 
 from e2b.api.client.types import Unset
+from e2b.api.client_async import get_transport
 from e2b.connection_config import ApiParams, ConnectionConfig
 from e2b.envd.api import ENVD_API_HEALTH_ROUTE, ahandle_envd_api_exception
 from e2b.envd.versions import ENVD_DEBUG_FALLBACK
@@ -20,7 +21,6 @@ from e2b.sandbox_async.commands.command import Commands
 from e2b.sandbox_async.commands.pty import Pty
 from e2b.sandbox_async.filesystem.filesystem import Filesystem
 from e2b.sandbox_async.sandbox_api import SandboxApi, SandboxInfo
-from e2b.api.client_async import get_transport
 
 logger = logging.getLogger(__name__)
 
@@ -351,7 +351,6 @@ class AsyncSandbox(SandboxApi):
     ) -> None:
         """
         Set the timeout of the sandbox.
-        After the timeout expires, the sandbox will be automatically killed.
         This method can extend or reduce the sandbox timeout set when creating the sandbox or from the last call to `.set_timeout`.
 
         The maximum time a sandbox can be kept alive is 24 hours (86_400 seconds) for Pro users and 1 hour (3_600 seconds) for Hobby users.
@@ -369,7 +368,6 @@ class AsyncSandbox(SandboxApi):
     ) -> None:
         """
         Set the timeout of the specified sandbox.
-        After the timeout expires, the sandbox will be automatically killed.
         This method can extend or reduce the sandbox timeout set when creating the sandbox or from the last call to `.set_timeout`.
 
         The maximum time a sandbox can be kept alive is 24 hours (86_400 seconds) for Pro users and 1 hour (3_600 seconds) for Hobby users.
@@ -387,7 +385,6 @@ class AsyncSandbox(SandboxApi):
     ) -> None:
         """
         Set the timeout of the specified sandbox.
-        After the timeout expires, the sandbox will be automatically killed.
         This method can extend or reduce the sandbox timeout set when creating the sandbox or from the last call to `.set_timeout`.
 
         The maximum time a sandbox can be kept alive is 24 hours (86_400 seconds) for Pro users and 1 hour (3_600 seconds) for Hobby users.

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -9,6 +9,7 @@ from packaging.version import Version
 from typing_extensions import Self, Unpack
 
 from e2b.api.client.types import Unset
+from e2b.api.client_sync import get_transport
 from e2b.connection_config import ApiParams, ConnectionConfig
 from e2b.envd.api import ENVD_API_HEALTH_ROUTE, handle_envd_api_exception
 from e2b.envd.versions import ENVD_DEBUG_FALLBACK
@@ -20,7 +21,6 @@ from e2b.sandbox_sync.commands.command import Commands
 from e2b.sandbox_sync.commands.pty import Pty
 from e2b.sandbox_sync.filesystem.filesystem import Filesystem
 from e2b.sandbox_sync.sandbox_api import SandboxApi, SandboxInfo
-from e2b.api.client_sync import get_transport
 
 logger = logging.getLogger(__name__)
 
@@ -350,7 +350,6 @@ class Sandbox(SandboxApi):
     ) -> None:
         """
         Set the timeout of the sandbox.
-        After the timeout expires, the sandbox will be automatically killed.
         This method can extend or reduce the sandbox timeout set when creating the sandbox or from the last call to `.set_timeout`.
 
         The maximum time a sandbox can be kept alive is 24 hours (86_400 seconds) for Pro users and 1 hour (3_600 seconds) for Hobby users.
@@ -368,7 +367,6 @@ class Sandbox(SandboxApi):
     ) -> None:
         """
         Set the timeout of the sandbox specified by sandbox ID.
-        After the timeout expires, the sandbox will be automatically killed.
         This method can extend or reduce the sandbox timeout set when creating the sandbox or from the last call to `.set_timeout`.
 
         The maximum time a sandbox can be kept alive is 24 hours (86_400 seconds) for Pro users and 1 hour (3_600 seconds) for Hobby users.
@@ -386,7 +384,6 @@ class Sandbox(SandboxApi):
     ) -> None:
         """
         Set the timeout of the sandbox.
-        After the timeout expires, the sandbox will be automatically killed.
         This method can extend or reduce the sandbox timeout set when creating the sandbox or from the last call to `.set_timeout`.
 
         The maximum time a sandbox can be kept alive is 24 hours (86_400 seconds) for Pro users and 1 hour (3_600 seconds) for Hobby users.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies sandbox timeout behavior in SDK docs without changing runtime logic.
> 
> - Removes the “After the timeout expires, the sandbox will be automatically killed.” line from `setTimeout` in `packages/js-sdk/src/sandbox/index.ts` and `set_timeout` docstrings in `e2b/sandbox_async/main.py` and `e2b/sandbox_sync/main.py`
> - Minor import reorders (`get_transport`) in Python files
> - Adds changeset for patch releases of `@e2b/python-sdk` and `e2b`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18e05fac1ee377d9958523ff06c5c6eb90e2b15f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->