### PR TITLE
Fix tmux rendering issues by adding UTF-8 locale env vars to PTY

### DIFF
--- a/.changeset/fix-tmux-rendering.md
+++ b/.changeset/fix-tmux-rendering.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Fix tmux rendering issues by adding UTF-8 locale environment variables (LANG, LC_ALL) to PTY creation. This fixes garbled Unicode and box-drawing characters when running applications like Claude Code inside tmux in E2B sandboxes.

--- a/packages/js-sdk/src/sandbox/commands/pty.ts
+++ b/packages/js-sdk/src/sandbox/commands/pty.ts
@@ -98,7 +98,9 @@ export class Pty {
     const requestTimeoutMs =
       opts?.requestTimeoutMs ?? this.connectionConfig.requestTimeoutMs
     const envs = opts?.envs ?? {}
-    envs.TERM = 'xterm-256color'
+    envs.TERM = envs.TERM ?? 'xterm-256color'
+    envs.LANG = envs.LANG ?? 'C.UTF-8'
+    envs.LC_ALL = envs.LC_ALL ?? 'C.UTF-8'
     const controller = new AbortController()
 
     const reqTimeout = setTimeout(() => {

--- a/packages/python-sdk/e2b/sandbox_async/commands/pty.py
+++ b/packages/python-sdk/e2b/sandbox_async/commands/pty.py
@@ -126,7 +126,9 @@ class Pty:
         :return: Handle to interact with the PTY
         """
         envs = envs or {}
-        envs["TERM"] = "xterm-256color"
+        envs.setdefault("TERM", "xterm-256color")
+        envs.setdefault("LANG", "C.UTF-8")
+        envs.setdefault("LC_ALL", "C.UTF-8")
         events = self._rpc.astart(
             process_pb2.StartRequest(
                 process=process_pb2.ProcessConfig(

--- a/packages/python-sdk/e2b/sandbox_sync/commands/pty.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/pty.py
@@ -120,7 +120,9 @@ class Pty:
         :return: Handle to interact with the PTY
         """
         envs = envs or {}
-        envs["TERM"] = "xterm-256color"
+        envs.setdefault("TERM", "xterm-256color")
+        envs.setdefault("LANG", "C.UTF-8")
+        envs.setdefault("LC_ALL", "C.UTF-8")
         events = self._rpc.start(
             process_pb2.StartRequest(
                 process=process_pb2.ProcessConfig(


### PR DESCRIPTION
## Summary

- Fixes garbled Unicode and box-drawing character rendering when running tmux inside E2B sandboxes
- Adds `LANG=C.UTF-8` and `LC_ALL=C.UTF-8` environment variable defaults to PTY creation in both JS/TS and Python SDKs

## Problem

When running applications like Claude Code inside tmux in an E2B sandbox, Unicode characters and box-drawing glyphs render incorrectly:

**Before (broken):**
- Box-drawing characters appear as broken dashes
- Text alignment is garbled
- The Claude mascot renders as `------` instead of proper pixel art

**After (fixed):**
- Proper Unicode rendering
- Correct box-drawing characters
- Properly aligned text

## Root Cause

The PTY session was created with `TERM=xterm-256color` but without UTF-8 locale settings. Running `locale` in the sandbox showed:

```
LANG=
LC_CTYPE="POSIX"
LC_ALL=
```

tmux requires UTF-8 locale settings to properly render Unicode characters. Without them, it falls back to ASCII-only rendering.

## Solution

Set `LANG` and `LC_ALL` to `C.UTF-8` by default when creating PTY sessions. This locale is:
- Available on most modern Linux distributions
- Provides UTF-8 character encoding
- Portable and doesn't require specific locale packages

The fix uses `setdefault` (Python) / nullish coalescing (JS) to allow users to override these values if needed.

## Files Changed

| File | Change |
|------|--------|
| `packages/js-sdk/src/sandbox/commands/pty.ts` | Add LANG and LC_ALL defaults |
| `packages/python-sdk/e2b/sandbox_async/commands/pty.py` | Add LANG and LC_ALL defaults |
| `packages/python-sdk/e2b/sandbox_sync/commands/pty.py` | Add LANG and LC_ALL defaults |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix tmux Unicode rendering by enforcing UTF-8 locale in PTYs**
> 
> - In PTY creation (JS `pty.ts`, Python async/sync `pty.py`), default `LANG` and `LC_ALL` to `C.UTF-8`; set `TERM` only if not already provided
> - Adds changeset entry documenting the patch
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a914027d39568da2c9b022cb25e6f9b4e9aab91c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->