### PR TITLE
Meta feature: add devcontainer support for standardization (Fedora Linux fails when running tests)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    wget \
+    vim \
+    ssh \
+    sudo \
+    gnupg \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
+    && echo "node ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/node \
+    && chmod 0440 /etc/sudoers.d/node
+
+RUN npm install -g pnpm
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PNPM_HOME=/home/node/.local/share/pnpm
+ENV PATH=$PATH:$NPM_CONFIG_PREFIX/bin:$PNPM_HOME
+ENV NPM_CONFIG_STORE_DIR=/home/node/.local/share/pnpm/store
+
+# This prevents a pnpm-store folder from being created in the project folder.
+RUN mkdir -p /home/node/.local/share/pnpm/store \
+    && chown -R node:node /home/node
+
+USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+    "name": "E2B JS SDK Dev",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "runArgs": [
+        "--ipc=host"
+    ],
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash",
+                "editor.formatOnSave": true
+            },
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "ms-playwright.playwright"
+            ]
+        }
+    },
+    "remoteUser": "node",
+    "postCreateCommand": "pnpm install"
+}


### PR DESCRIPTION
# Issue
Running tests in `js-sdk` in a Fedora Linux distribution fails, because Playwright does not have official support for Linux distributions outside of Debian / Ubuntu based distros.

# Details
Ran into the issue while running the tests for a change I was trying to do regarding bug #1055. I was trying to fix it to get a feel for the repository and code structure.

# Fix
Add a `.devcontainer` folder with a configuration file for VSCode and a generic Dockerfile. This allows for development in an isolated container based on Ubuntu, no matter the Linux distribution.

This should allow Linux users to more freely contribute to the project.