### PR TITLE
fix: convert float timeout to int before string conversion

### DIFF
--- a/.changeset/fix-timeout-float-conversion.md
+++ b/.changeset/fix-timeout-float-conversion.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+fix float timeout to int conversion for Go backend compatibility

--- a/packages/python-sdk/e2b_connect/client.py
+++ b/packages/python-sdk/e2b_connect/client.py
@@ -305,9 +305,9 @@ class Client:
         res = self.pool.request(**req_data)
         return self._process_unary_response(res)
 
-    def _create_stream_timeout(self, timeout: Optional[int]):
+    def _create_stream_timeout(self, timeout: Optional[float]):
         if timeout:
-            return {"connect-timeout-ms": str(timeout * 1000)}
+            return {"connect-timeout-ms": str(int(timeout * 1000))}
         return {}
 
     def _prepare_server_stream_request(


### PR DESCRIPTION
## Summary

The public API accepts `Optional[float]` for timeout parameters (e.g., `60.0`), but `_create_stream_timeout` was typed as `Optional[int]` and passed the value directly to `str()`, producing `'60000.0'` instead of `'60000'`.

The Go backend's `strconv.ParseInt` fails on float strings, causing 'invalid syntax' errors for valid timeout values.

## Changes

- Updates type hint to `Optional[float]` for consistency with public API
- Wraps `timeout * 1000` in `int()` before `str()` conversion

## Test

```python
# Before: str(60.0 * 1000) -> '60000.0' (fails ParseInt)
# After:  str(int(60.0 * 1000)) -> '60000' (works)
```

Fixes #1063