### PR TITLE
SandboxId-clientId pattern references

### DIFF
--- a/packages/cli/src/commands/sandbox/utils.ts
+++ b/packages/cli/src/commands/sandbox/utils.ts
@@ -46,14 +46,10 @@ export function waitForSandboxEnd(sandboxID: string) {
   return () => isRunning
 }
 
-export function getShortID(sandboxID: string) {
-  return sandboxID.split('-')[0]
-}
-
 export async function isRunning(sandboxID: string) {
   try {
     const apiKey = ensureAPIKey()
-    const info = await Sandbox.getInfo(getShortID(sandboxID), {
+    const info = await Sandbox.getInfo(sandboxID, {
       apiKey,
     })
     return info.state === 'running'

--- a/packages/js-sdk/tests/api/list.test.ts
+++ b/packages/js-sdk/tests/api/list.test.ts
@@ -75,9 +75,8 @@ sandboxTest.skipIf(isDebug)(
       assert.isAtLeast(sandboxes.length, 1)
 
       // Verify our paused sandbox is in the list
-      const pausedSandboxId = extraSbx.sandboxId.split('-')[0]
       const found = sandboxes.some(
-        (s) => s.sandboxId.startsWith(pausedSandboxId) && s.state === 'paused'
+        (s) => s.sandboxId === extraSbx.sandboxId && s.state === 'paused'
       )
       assert.isTrue(found)
     } finally {
@@ -125,13 +124,11 @@ sandboxTest.skipIf(isDebug)(
 sandboxTest.skipIf(isDebug)(
   'paginate paused sandboxes',
   async ({ sandbox, sandboxTestId }) => {
-    const sandboxId = sandbox.sandboxId.split('-')[0]
     await sandbox.betaPause()
 
     // Create extra paused sandbox
     const extraSbx = await Sandbox.create({ metadata: { sandboxTestId } })
     await extraSbx.betaPause()
-    const extraSbxId = extraSbx.sandboxId.split('-')[0]
 
     try {
       // Test pagination with limit
@@ -146,7 +143,7 @@ sandboxTest.skipIf(isDebug)(
       assert.equal(sandboxes[0].state, 'paused')
       assert.isTrue(paginator.hasNext)
       assert.notEqual(paginator.nextToken, undefined)
-      assert.equal(sandboxes[0].sandboxId.startsWith(extraSbxId), true)
+      assert.equal(sandboxes[0].sandboxId, extraSbx.sandboxId)
 
       // Get second page
       const sandboxes2 = await paginator.nextItems()
@@ -156,7 +153,7 @@ sandboxTest.skipIf(isDebug)(
       assert.equal(sandboxes2[0].state, 'paused')
       assert.isFalse(paginator.hasNext)
       assert.equal(paginator.nextToken, undefined)
-      assert.equal(sandboxes2[0].sandboxId.startsWith(sandboxId), true)
+      assert.equal(sandboxes2[0].sandboxId, sandbox.sandboxId)
     } finally {
       await extraSbx.kill()
     }
@@ -168,7 +165,6 @@ sandboxTest.skipIf(isDebug)(
   async ({ sandbox, sandboxTestId }) => {
     // Create extra sandbox
     const extraSbx = await Sandbox.create({ metadata: { sandboxTestId } })
-    const extraSbxId = extraSbx.sandboxId.split('-')[0]
 
     // Pause the extra sandbox
     await extraSbx.betaPause()
@@ -189,7 +185,7 @@ sandboxTest.skipIf(isDebug)(
       assert.equal(sandboxes[0].state, 'paused')
       assert.isTrue(paginator.hasNext)
       assert.notEqual(paginator.nextToken, undefined)
-      assert.equal(sandboxes[0].sandboxId.startsWith(extraSbxId), true)
+      assert.equal(sandboxes[0].sandboxId, extraSbx.sandboxId)
 
       // Get second page
       const sandboxes2 = await paginator.nextItems()
@@ -296,9 +292,8 @@ sandboxTest.skipIf(isDebug)(
       assert.isAtLeast(sandboxes.length, 1)
 
       // Verify our paused sandbox is in the list
-      const pausedSandboxId = extraSbx.sandboxId.split('-')[0]
       const found = sandboxes.some(
-        (s) => s.sandboxId.startsWith(pausedSandboxId) && s.state === 'paused'
+        (s) => s.sandboxId === extraSbx.sandboxId && s.state === 'paused'
       )
       assert.isTrue(found)
     } finally {
@@ -351,7 +346,6 @@ sandboxTest.skipIf(isDebug)(
     // Create extra paused sandbox
     const extraSbx = await Sandbox.create({ metadata: { sandboxTestId } })
     await Sandbox.betaPause(extraSbx.sandboxId)
-    const extraSbxId = extraSbx.sandboxId.split('-')[0]
 
     try {
       // Test pagination with limit
@@ -366,7 +360,7 @@ sandboxTest.skipIf(isDebug)(
       assert.equal(sandboxes[0].state, 'paused')
       assert.isTrue(paginator.hasNext)
       assert.notEqual(paginator.nextToken, undefined)
-      assert.equal(sandboxes[0].sandboxId.startsWith(extraSbxId), true)
+      assert.equal(sandboxes[0].sandboxId, extraSbx.sandboxId)
 
       // Get second page
       const sandboxes2 = await paginator.nextItems()
@@ -388,7 +382,6 @@ sandboxTest.skipIf(isDebug)(
   async ({ sandbox, sandboxTestId }) => {
     // Create extra sandbox
     const extraSbx = await Sandbox.create({ metadata: { sandboxTestId } })
-    const extraSbxId = extraSbx.sandboxId.split('-')[0]
 
     // Pause the extra sandbox
     await Sandbox.betaPause(sandbox.sandboxId)
@@ -410,7 +403,7 @@ sandboxTest.skipIf(isDebug)(
 
       assert.isTrue(paginator.hasNext)
       assert.notEqual(paginator.nextToken, undefined)
-      assert.equal(sandboxes[0].sandboxId, extraSbxId)
+      assert.equal(sandboxes[0].sandboxId, extraSbx.sandboxId)
 
       // Get second page
       const sandboxes2 = await paginator.nextItems()

--- a/packages/python-sdk/tests/async/api_async/test_sbx_list.py
+++ b/packages/python-sdk/tests/async/api_async/test_sbx_list.py
@@ -58,9 +58,8 @@ async def test_list_paused_sandboxes(async_sandbox: AsyncSandbox, sandbox_test_i
     assert len(sandboxes) >= 1
 
     # Verify our paused sandbox is in the list
-    paused_sandbox_id = async_sandbox.sandbox_id.split("-")[0]
     assert any(
-        s.sandbox_id.startswith(paused_sandbox_id) and s.state == SandboxState.PAUSED
+        s.sandbox_id == async_sandbox.sandbox_id and s.state == SandboxState.PAUSED
         for s in sandboxes
     )
 
@@ -102,14 +101,12 @@ async def test_paginate_running_sandboxes(sandbox_test_id: str, async_sandbox_fa
 async def test_paginate_paused_sandboxes(
     async_sandbox: AsyncSandbox, sandbox_test_id: str, async_sandbox_factory
 ):
-    sandbox_id = async_sandbox.sandbox_id.split("-")[0]
     await async_sandbox.beta_pause()
 
     # create another paused sandbox
     extra_sbx = await async_sandbox_factory(
         metadata={"sandbox_test_id": sandbox_test_id}
     )
-    extra_sbx_id = extra_sbx.sandbox_id.split("-")[0]
     await extra_sbx.beta_pause()
 
     # Test pagination with limit
@@ -127,7 +124,7 @@ async def test_paginate_paused_sandboxes(
     assert sandboxes[0].state == SandboxState.PAUSED
     assert paginator.has_next is True
     assert paginator.next_token is not None
-    assert sandboxes[0].sandbox_id.startswith(extra_sbx_id) is True
+    assert sandboxes[0].sandbox_id == extra_sbx.sandbox_id
 
     # Get second page
     sandboxes2 = await paginator.next_items()
@@ -137,7 +134,7 @@ async def test_paginate_paused_sandboxes(
     assert sandboxes2[0].state == SandboxState.PAUSED
     assert paginator.has_next is False
     assert paginator.next_token is None
-    assert sandboxes2[0].sandbox_id.startswith(sandbox_id) is True
+    assert sandboxes2[0].sandbox_id == async_sandbox.sandbox_id
 
 
 @pytest.mark.skip_debug()
@@ -148,7 +145,6 @@ async def test_paginate_running_and_paused_sandboxes(
     extra_sbx = await async_sandbox_factory(
         metadata={"sandbox_test_id": sandbox_test_id}
     )
-    extra_sbx_id = extra_sbx.sandbox_id.split("-")[0]
     await extra_sbx.beta_pause()
 
     # Test pagination with limit
@@ -166,7 +162,7 @@ async def test_paginate_running_and_paused_sandboxes(
     assert sandboxes[0].state == SandboxState.PAUSED
     assert paginator.has_next is True
     assert paginator.next_token is not None
-    assert sandboxes[0].sandbox_id.startswith(extra_sbx_id) is True
+    assert sandboxes[0].sandbox_id == extra_sbx.sandbox_id
 
     # Get second page
     sandboxes2 = await paginator.next_items()

--- a/packages/python-sdk/tests/sync/api_sync/test_sbx_list.py
+++ b/packages/python-sdk/tests/sync/api_sync/test_sbx_list.py
@@ -59,9 +59,8 @@ def test_list_paused_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
     assert len(sandboxes) >= 1
 
     # Verify our paused sandbox is in the list
-    paused_sandbox_id = sandbox.sandbox_id.split("-")[0]
     assert any(
-        s.sandbox_id.startswith(paused_sandbox_id) and s.state == SandboxState.PAUSED
+        s.sandbox_id == sandbox.sandbox_id and s.state == SandboxState.PAUSED
         for s in sandboxes
     )
 
@@ -105,12 +104,10 @@ def test_paginate_running_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
 
 @pytest.mark.skip_debug()
 def test_paginate_paused_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
-    sandbox_id = sandbox.sandbox_id.split("-")[0]
     sandbox.beta_pause()
 
     # create another paused sandbox
     extra_sbx = Sandbox.create(metadata={"sandbox_test_id": sandbox_test_id})
-    extra_sbx_id = extra_sbx.sandbox_id.split("-")[0]
     extra_sbx.beta_pause()
 
     try:
@@ -130,7 +127,7 @@ def test_paginate_paused_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
         assert sandboxes[0].state == SandboxState.PAUSED
         assert paginator.has_next is True
         assert paginator.next_token is not None
-        assert sandboxes[0].sandbox_id.startswith(extra_sbx_id) is True
+        assert sandboxes[0].sandbox_id == extra_sbx.sandbox_id
 
         # Get second page
         sandboxes = paginator.next_items()
@@ -140,7 +137,7 @@ def test_paginate_paused_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
         assert sandboxes[0].state == SandboxState.PAUSED
         assert paginator.has_next is False
         assert paginator.next_token is None
-        assert sandboxes[0].sandbox_id.startswith(sandbox_id) is True
+        assert sandboxes[0].sandbox_id == sandbox.sandbox_id
     finally:
         extra_sbx.kill()
 
@@ -149,7 +146,6 @@ def test_paginate_paused_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
 def test_paginate_running_and_paused_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
     # Create extra paused sandbox
     extra_sbx = Sandbox.create(metadata={"sandbox_test_id": sandbox_test_id})
-    extra_sbx_id = extra_sbx.sandbox_id.split("-")[0]
     extra_sbx.beta_pause()
 
     try:
@@ -169,7 +165,7 @@ def test_paginate_running_and_paused_sandboxes(sandbox: Sandbox, sandbox_test_id
         assert sandboxes[0].state == SandboxState.PAUSED
         assert paginator.has_next is True
         assert paginator.next_token is not None
-        assert sandboxes[0].sandbox_id.startswith(extra_sbx_id) is True
+        assert sandboxes[0].sandbox_id == extra_sbx.sandbox_id
 
         # Get second page
         sandboxes = paginator.next_items()


### PR DESCRIPTION
Remove references to the `sandboxId-clientId` pattern as it is no longer in use.

We're also converting the long sandbox id's in the API already: https://github.com/e2b-dev/infra/blob/main/packages/api/internal/handlers/sandbox_get.go#L27

---
<a href="https://cursor.com/background-agent?bcId=bc-e3bed60d-6524-431f-bce8-4934ddcc81d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3bed60d-6524-431f-bce8-4934ddcc81d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates reliance on the deprecated `sandboxId-clientId` (short ID) pattern and standardizes on full `sandboxId`.
> 
> - Removes `getShortID` and uses full `sandboxId` in `isRunning` (CLI `utils.ts`), calling `Sandbox.getInfo` with the complete ID
> - Updates JS SDK tests to compare `sandboxId` via exact equality (no `split`/`startsWith`) across list and pagination cases for running/paused sandboxes
> - Updates Python SDK (async/sync) tests similarly to assert exact `sandbox_id` equality in list and pagination scenarios
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ec60a51e5b22ed9b3e90aa46110c016ce0fd73a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->