### PR TITLE
Fix tar upload content-length mismatch (#1086)

### DIFF
--- a/packages/js-sdk/src/template/utils.ts
+++ b/packages/js-sdk/src/template/utils.ts
@@ -278,11 +278,10 @@ export async function tarFileStream(
 
   const filePaths = allFiles.map((file) => file.relativePosix())
 
-  // portable: true ensures deterministic gzip output across runs
+  // gzip.portable ensures deterministic gzip header without affecting file modes
   return create(
     {
-      gzip: true,
-      portable: true,
+      gzip: { portable: true },
       cwd: fileContextPath,
       follow: resolveSymlinks,
       noDirRecurse: true,


### PR DESCRIPTION
Fixes https://github.com/e2b-dev/E2B/issues/1086

Use portable mode for deterministic gzip output