### PR TITLE
Simplify getAllFilesInPath with single glob call

### DIFF
--- a/.changeset/itchy-planes-carry.md
+++ b/.changeset/itchy-planes-carry.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': patch
+'e2b': patch
+---
+
+simplify getAllFilesInPath function

--- a/.changeset/itchy-planes-carry.md
+++ b/.changeset/itchy-planes-carry.md
@@ -1,6 +1,0 @@
----
-'@e2b/python-sdk': patch
-'e2b': patch
----
-
-simplify getAllFilesInPath function

--- a/packages/js-sdk/src/template/utils.ts
+++ b/packages/js-sdk/src/template/utils.ts
@@ -95,13 +95,15 @@ export async function getAllFilesInPath(
   const globFiles = await glob(patterns, {
     ignore: ignorePatterns,
     withFileTypes: true,
-    nodir: !includeDirectories,
     cwd: contextPath,
   })
 
   // Deduplicate by full path
   const files = new Map<string, Path>()
   for (const file of globFiles) {
+    if (!includeDirectories && file.isDirectory()) {
+      continue
+    }
     files.set(file.fullpath(), file)
   }
 

--- a/packages/js-sdk/src/template/utils.ts
+++ b/packages/js-sdk/src/template/utils.ts
@@ -86,25 +86,37 @@ export async function getAllFilesInPath(
   includeDirectories: boolean = true
 ) {
   const { glob } = await dynamicImport<typeof import('glob')>('glob')
+  const files = new Map<string, Path>()
 
-  // Match both the pattern and its recursive contents in one call
-  // This handles directories (src -> src + src/**/*) and file patterns (*.txt -> just files)
-  const normalizedSrc = normalizePath(src)
-  const patterns = [normalizedSrc, `${normalizedSrc}/**/*`]
-
-  const globFiles = await glob(patterns, {
+  const globFiles = await glob(src, {
     ignore: ignorePatterns,
     withFileTypes: true,
+    // this is required so that the ignore pattern is relative to the file path
     cwd: contextPath,
   })
 
-  // Deduplicate by full path
-  const files = new Map<string, Path>()
   for (const file of globFiles) {
-    if (!includeDirectories && file.isDirectory()) {
-      continue
+    if (file.isDirectory()) {
+      // For directories, add the directory itself and all files inside it
+      if (includeDirectories) {
+        files.set(file.fullpath(), file)
+      }
+      const dirPattern = normalizePath(
+        // When the matched directory is '.', `file.relative()` can be an empty string.
+        // In that case, we want to match all files under the current directory instead of
+        // creating an absolute glob like '/**/*' which would traverse the entire filesystem.
+        path.join(file.relative() || '.', '**/*')
+      )
+      const dirFiles = await glob(dirPattern, {
+        ignore: ignorePatterns,
+        withFileTypes: true,
+        cwd: contextPath,
+      })
+      dirFiles.forEach((f) => files.set(f.fullpath(), f))
+    } else {
+      // For files, just add the file
+      files.set(file.fullpath(), file)
     }
-    files.set(file.fullpath(), file)
   }
 
   return Array.from(files.values()).sort()

--- a/packages/js-sdk/src/template/utils.ts
+++ b/packages/js-sdk/src/template/utils.ts
@@ -86,37 +86,23 @@ export async function getAllFilesInPath(
   includeDirectories: boolean = true
 ) {
   const { glob } = await dynamicImport<typeof import('glob')>('glob')
-  const files = new Map<string, Path>()
 
-  const globFiles = await glob(src, {
+  // Match both the pattern and its recursive contents in one call
+  // This handles directories (src -> src + src/**/*) and file patterns (*.txt -> just files)
+  const normalizedSrc = normalizePath(src)
+  const patterns = [normalizedSrc, `${normalizedSrc}/**/*`]
+
+  const globFiles = await glob(patterns, {
     ignore: ignorePatterns,
     withFileTypes: true,
-    // this is required so that the ignore pattern is relative to the file path
+    nodir: !includeDirectories,
     cwd: contextPath,
   })
 
+  // Deduplicate by full path
+  const files = new Map<string, Path>()
   for (const file of globFiles) {
-    if (file.isDirectory()) {
-      // For directories, add the directory itself and all files inside it
-      if (includeDirectories) {
-        files.set(file.fullpath(), file)
-      }
-      const dirPattern = normalizePath(
-        // When the matched directory is '.', `file.relative()` can be an empty string.
-        // In that case, we want to match all files under the current directory instead of
-        // creating an absolute glob like '/**/*' which would traverse the entire filesystem.
-        path.join(file.relative() || '.', '**/*')
-      )
-      const dirFiles = await glob(dirPattern, {
-        ignore: ignorePatterns,
-        withFileTypes: true,
-        cwd: contextPath,
-      })
-      dirFiles.forEach((f) => files.set(f.fullpath(), f))
-    } else {
-      // For files, just add the file
-      files.set(file.fullpath(), file)
-    }
+    files.set(file.fullpath(), file)
   }
 
   return Array.from(files.values()).sort()

--- a/packages/python-sdk/e2b/template/utils.py
+++ b/packages/python-sdk/e2b/template/utils.py
@@ -81,27 +81,36 @@ def get_all_files_in_path(
     :param include_directories: Whether to include directories
     :return: Array of files
     """
+    files = set()
+
+    # Use glob to find all files/directories matching the pattern under context_path
     abs_context_path = os.path.abspath(context_path)
-    normalized_src = normalize_path(src)
-
-    # Match both the pattern and its recursive contents in one call
-    # This handles directories (src -> src + src/**/*) and file patterns (*.txt -> just files)
-    patterns = [normalized_src, f"{normalized_src}/**/*"]
-
     files_glob = glob.glob(
-        patterns,
+        src,
         flags=glob.GLOBSTAR,
         root_dir=abs_context_path,
         exclude=ignore_patterns,
     )
 
-    # Deduplicate and convert to absolute paths
-    files = set()
     for file in files_glob:
+        # Join it with abs_context_path to get the absolute path
         file_path = os.path.join(abs_context_path, file)
-        if not include_directories and os.path.isdir(file_path):
-            continue
-        files.add(file_path)
+
+        if os.path.isdir(file_path):
+            # If it's a directory, add the directory and all entries recursively
+            if include_directories:
+                files.add(file_path)
+            dir_files = glob.glob(
+                normalize_path(file) + "/**/*",
+                flags=glob.GLOBSTAR,
+                root_dir=abs_context_path,
+                exclude=ignore_patterns,
+            )
+            for dir_file in dir_files:
+                dir_file_path = os.path.join(abs_context_path, dir_file)
+                files.add(dir_file_path)
+        else:
+            files.add(file_path)
 
     return sorted(list(files))
 

--- a/packages/python-sdk/e2b/template/utils.py
+++ b/packages/python-sdk/e2b/template/utils.py
@@ -81,36 +81,27 @@ def get_all_files_in_path(
     :param include_directories: Whether to include directories
     :return: Array of files
     """
-    files = set()
-
-    # Use glob to find all files/directories matching the pattern under context_path
     abs_context_path = os.path.abspath(context_path)
+    normalized_src = normalize_path(src)
+
+    # Match both the pattern and its recursive contents in one call
+    # This handles directories (src -> src + src/**/*) and file patterns (*.txt -> just files)
+    patterns = [normalized_src, f"{normalized_src}/**/*"]
+
     files_glob = glob.glob(
-        src,
+        patterns,
         flags=glob.GLOBSTAR,
         root_dir=abs_context_path,
         exclude=ignore_patterns,
     )
 
+    # Deduplicate and convert to absolute paths
+    files = set()
     for file in files_glob:
-        # Join it with abs_context_path to get the absolute path
         file_path = os.path.join(abs_context_path, file)
-
-        if os.path.isdir(file_path):
-            # If it's a directory, add the directory and all entries recursively
-            if include_directories:
-                files.add(file_path)
-            dir_files = glob.glob(
-                normalize_path(file) + "/**/*",
-                flags=glob.GLOBSTAR,
-                root_dir=abs_context_path,
-                exclude=ignore_patterns,
-            )
-            for dir_file in dir_files:
-                dir_file_path = os.path.join(abs_context_path, dir_file)
-                files.add(dir_file_path)
-        else:
-            files.add(file_path)
+        if not include_directories and os.path.isdir(file_path):
+            continue
+        files.add(file_path)
 
     return sorted(list(files))
 


### PR DESCRIPTION
## Summary
Simplified `getAllFilesInPath` in both JS and Python SDKs by using a single glob call with multiple patterns instead of nested sequential calls. This eliminates the need to loop through matched directories and make additional glob calls for each one.

## Changes
- Changed from `glob(src)` + loop + `glob(dir/**/*)` to `glob([src, src/**/*])`
- Reduces complexity and improves performance by avoiding multiple filesystem traversals
- All 25 tests pass (12 JS + 13 Python)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor to file globbing logic; risk is limited to edge-case differences in which paths are returned for certain patterns/directories.
> 
> **Overview**
> Simplifies Python SDK template file discovery by replacing per-directory recursive globbing with a single `glob.glob([src, src/**/*])` call, normalizing paths for cross-platform matching, and deduplicating results.
> 
> Adds a changeset to publish patch releases for `@e2b/python-sdk` and `e2b` reflecting this internal behavior/performance change; directory inclusion is now handled via a simple filter when `include_directories` is false.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bdbb4175e7758caa50768d451e207e52125a2c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->