### PR TITLE
fix(python-sdk): missing functions in AsyncSandbox.git

### DIFF
--- a/packages/python-sdk/tests/shared/git/test_parity.py
+++ b/packages/python-sdk/tests/shared/git/test_parity.py
@@ -1,0 +1,34 @@
+import asyncio
+import inspect
+
+from e2b.sandbox_async.git import Git as AsyncGit
+from e2b.sandbox_sync.git import Git as SyncGit
+
+
+def _public_methods(cls):
+    return {
+        name: getattr(cls, name)
+        for name in sorted(dir(cls))
+        if not name.startswith("_") and callable(getattr(cls, name))
+    }
+
+
+def test_identical_method_signatures():
+    sync = _public_methods(SyncGit)
+    async_ = _public_methods(AsyncGit)
+
+    assert set(sync) == set(async_), (
+        f"missing from async: {set(sync) - set(async_)}, "
+        f"missing from sync: {set(async_) - set(sync)}"
+    )
+
+    for name in sync:
+        assert inspect.signature(sync[name]) == inspect.signature(async_[name]), (
+            f"{name}: sync{inspect.signature(sync[name])} "
+            f"!= async{inspect.signature(async_[name])}"
+        )
+
+
+def test_async_methods_are_coroutines():
+    for name, method in _public_methods(AsyncGit).items():
+        assert asyncio.iscoroutinefunction(method), f"AsyncGit.{name} is not async"


### PR DESCRIPTION
Directly related to https://github.com/e2b-dev/E2B/issues/1108. Please check the issue description for more details.

tldr: `.restore()` and .`reset()` functions are missing in the `AsyncSandbox` instance

also added test to check parity of methods/signatures between sync and async git instances

other potential concerns: 
- tests are only ran for the sync variant across the python-sdk - if there are any mismatches in the async logic (not only git i believe), the tests won't catch it