### PR TITLE
feat: snapshots

### DIFF
--- a/.changeset/snapshot-api-support.md
+++ b/.changeset/snapshot-api-support.md
@@ -1,0 +1,6 @@
+---
+'e2b': minor
+'@e2b/python-sdk': minor
+---
+
+Add snapshot API for creating persistent sandbox snapshots

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -29,7 +29,7 @@
     "example": "tsx example.mts",
     "test": "vitest run",
     "generate": "npm-run-all generate:* && pnpm run format",
-    "generate:api": "python ./../../spec/remove_extra_tags.py sandboxes templates tags auth && openapi-typescript ../../spec/openapi_generated.yml -x api_key --array-length --alphabetize --default-non-nullable false --output src/api/schema.gen.ts",
+    "generate:api": "python ./../../spec/remove_extra_tags.py sandboxes snapshots templates tags auth && openapi-typescript ../../spec/openapi_generated.yml -x api_key --array-length --alphabetize --default-non-nullable false --output src/api/schema.gen.ts",
     "generate:envd": "cd ../../spec/envd && buf generate --template buf-js.gen.yaml\n",
     "generate:envd-api": "openapi-typescript ../../spec/envd/envd.yaml -x api_key --array-length --alphabetize --output src/envd/schema.gen.ts",
     "generate:mcp": "json2ts -i ./../../spec/mcp-server.json -o src/sandbox/mcp.d.ts --unreachableDefinitions --style.singleQuote --no-style.semi",

--- a/packages/js-sdk/src/api/schema.gen.ts
+++ b/packages/js-sdk/src/api/schema.gen.ts
@@ -73,6 +73,48 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/sandboxes/metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description List metrics for given sandboxes */
+        get: {
+            parameters: {
+                query: {
+                    /** @description Comma-separated list of sandbox IDs to get metrics for */
+                    sandbox_ids: string[];
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned all running sandboxes with metrics */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SandboxesWithMetrics"];
+                    };
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/sandboxes/{sandboxID}": {
         parameters: {
             query?: never;
@@ -203,10 +245,10 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    /** @description Maximum number of logs that should be returned */
-                    limit?: number;
                     /** @description Starting timestamp of the logs that should be returned in milliseconds */
                     start?: number;
+                    /** @description Maximum number of logs that should be returned */
+                    limit?: number;
                 };
                 header?: never;
                 path: {
@@ -249,9 +291,9 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    end?: number;
                     /** @description Unix timestamp for the start of the interval, in seconds, for which the metrics */
                     start?: number;
+                    end?: number;
                 };
                 header?: never;
                 path: {
@@ -418,6 +460,48 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/sandboxes/{sandboxID}/snapshots": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new sandboxes and persist beyond the original sandbox's lifetime. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    sandboxID: components["parameters"]["sandboxID"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Snapshot created successfully */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SnapshotInfo"];
+                    };
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/sandboxes/{sandboxID}/timeout": {
         parameters: {
             query?: never;
@@ -467,169 +551,39 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/sandboxes/metrics": {
+    "/snapshots": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** @description List metrics for given sandboxes */
-        get: {
-            parameters: {
-                query: {
-                    /** @description Comma-separated list of sandbox IDs to get metrics for */
-                    sandbox_ids: string[];
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully returned all running sandboxes with metrics */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SandboxesWithMetrics"];
-                    };
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/teams": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description List all teams */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully returned all teams */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Team"][];
-                    };
-                };
-                401: components["responses"]["401"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/teams/{teamID}/metrics": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Get metrics for the team */
+        /** @description List all snapshots for the team */
         get: {
             parameters: {
                 query?: {
-                    end?: number;
-                    /** @description Unix timestamp for the start of the interval, in seconds, for which the metrics */
-                    start?: number;
+                    sandboxID?: string;
+                    /** @description Maximum number of items to return per page */
+                    limit?: components["parameters"]["paginationLimit"];
+                    /** @description Cursor to start the list from */
+                    nextToken?: components["parameters"]["paginationNextToken"];
                 };
                 header?: never;
-                path: {
-                    teamID: components["parameters"]["teamID"];
-                };
+                path?: never;
                 cookie?: never;
             };
             requestBody?: never;
             responses: {
-                /** @description Successfully returned the team metrics */
+                /** @description Successfully returned snapshots */
                 200: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["TeamMetric"][];
+                        "application/json": components["schemas"]["SnapshotInfo"][];
                     };
                 };
-                400: components["responses"]["400"];
                 401: components["responses"]["401"];
-                403: components["responses"]["403"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/teams/{teamID}/metrics/max": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Get the maximum metrics for the team in the given interval */
-        get: {
-            parameters: {
-                query: {
-                    end?: number;
-                    /** @description Metric to retrieve the maximum value for */
-                    metric: "concurrent_sandboxes" | "sandbox_start_rate";
-                    /** @description Unix timestamp for the start of the interval, in seconds, for which the metrics */
-                    start?: number;
-                };
-                header?: never;
-                path: {
-                    teamID: components["parameters"]["teamID"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully returned the team metrics */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["MaxTeamMetric"];
-                    };
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                403: components["responses"]["403"];
                 500: components["responses"]["500"];
             };
         };
@@ -711,6 +665,118 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/templates/aliases/{alias}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Check if template with given alias exists */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    alias: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully queried template by alias */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TemplateAliasResponse"];
+                    };
+                };
+                400: components["responses"]["400"];
+                403: components["responses"]["403"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/templates/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Assign tag(s) to a template build */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["AssignTemplateTagsRequest"];
+                };
+            };
+            responses: {
+                /** @description Tag assigned successfully */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AssignedTemplateTags"];
+                    };
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        /** @description Delete multiple tags from templates */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["DeleteTemplateTagsRequest"];
+                };
+            };
+            responses: {
+                /** @description Tags deleted successfully */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/templates/{templateID}": {
         parameters: {
             query?: never;
@@ -722,10 +788,10 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    /** @description Maximum number of items to return per page */
-                    limit?: components["parameters"]["paginationLimit"];
                     /** @description Cursor to start the list from */
                     nextToken?: components["parameters"]["paginationNextToken"];
+                    /** @description Maximum number of items to return per page */
+                    limit?: components["parameters"]["paginationLimit"];
                 };
                 header?: never;
                 path: {
@@ -857,8 +923,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    buildID: components["parameters"]["buildID"];
                     templateID: components["parameters"]["templateID"];
+                    buildID: components["parameters"]["buildID"];
                 };
                 cookie?: never;
             };
@@ -894,17 +960,17 @@ export interface paths {
                 query?: {
                     /** @description Starting timestamp of the logs that should be returned in milliseconds */
                     cursor?: number;
-                    direction?: components["schemas"]["LogsDirection"];
-                    level?: components["schemas"]["LogLevel"];
                     /** @description Maximum number of logs that should be returned */
                     limit?: number;
+                    direction?: components["schemas"]["LogsDirection"];
+                    level?: components["schemas"]["LogLevel"];
                     /** @description Source of the logs that should be returned from */
                     source?: components["schemas"]["LogsSource"];
                 };
                 header?: never;
                 path: {
-                    buildID: components["parameters"]["buildID"];
                     templateID: components["parameters"]["templateID"];
+                    buildID: components["parameters"]["buildID"];
                 };
                 cookie?: never;
             };
@@ -943,16 +1009,16 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    level?: components["schemas"]["LogLevel"];
-                    /** @description Maximum number of logs that should be returned */
-                    limit?: number;
                     /** @description Index of the starting build log that should be returned with the template */
                     logsOffset?: number;
+                    /** @description Maximum number of logs that should be returned */
+                    limit?: number;
+                    level?: components["schemas"]["LogLevel"];
                 };
                 header?: never;
                 path: {
-                    buildID: components["parameters"]["buildID"];
                     templateID: components["parameters"]["templateID"];
+                    buildID: components["parameters"]["buildID"];
                 };
                 cookie?: never;
             };
@@ -993,8 +1059,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    hash: string;
                     templateID: components["parameters"]["templateID"];
+                    hash: string;
                 };
                 cookie?: never;
             };
@@ -1023,118 +1089,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/templates/aliases/{alias}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Check if template with given alias exists */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    alias: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully queried template by alias */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TemplateAliasResponse"];
-                    };
-                };
-                400: components["responses"]["400"];
-                403: components["responses"]["403"];
-                404: components["responses"]["404"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/templates/tags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** @description Assign tag(s) to a template build */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["AssignTemplateTagsRequest"];
-                };
-            };
-            responses: {
-                /** @description Tag assigned successfully */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AssignedTemplateTags"];
-                    };
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                404: components["responses"]["404"];
-                500: components["responses"]["500"];
-            };
-        };
-        /** @description Delete multiple tags from templates */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["DeleteTemplateTagsRequest"];
-                };
-            };
-            responses: {
-                /** @description Tags deleted successfully */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                404: components["responses"]["404"];
-                500: components["responses"]["500"];
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v2/sandboxes": {
         parameters: {
             query?: never;
@@ -1146,14 +1100,14 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    /** @description Maximum number of items to return per page */
-                    limit?: components["parameters"]["paginationLimit"];
                     /** @description Metadata query used to filter the sandboxes (e.g. "user=abc&app=prod"). Each key and values must be URL encoded. */
                     metadata?: string;
-                    /** @description Cursor to start the list from */
-                    nextToken?: components["parameters"]["paginationNextToken"];
                     /** @description Filter sandboxes by one or more states */
                     state?: components["schemas"]["SandboxState"][];
+                    /** @description Cursor to start the list from */
+                    nextToken?: components["parameters"]["paginationNextToken"];
+                    /** @description Maximum number of items to return per page */
+                    limit?: components["parameters"]["paginationLimit"];
                 };
                 header?: never;
                 path?: never;
@@ -1289,8 +1243,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    buildID: components["parameters"]["buildID"];
                     templateID: components["parameters"]["templateID"];
+                    buildID: components["parameters"]["buildID"];
                 };
                 cookie?: never;
             };
@@ -1364,27 +1318,6 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
-        AdminSandboxKillResult: {
-            /** @description Number of sandboxes that failed to kill */
-            failedCount: number;
-            /** @description Number of sandboxes successfully killed */
-            killedCount: number;
-        };
-        AssignedTemplateTags: {
-            /**
-             * Format: uuid
-             * @description Identifier of the build associated with these tags
-             */
-            buildID: string;
-            /** @description Assigned tags of the template */
-            tags: string[];
-        };
-        AssignTemplateTagsRequest: {
-            /** @description Tags to assign to the template */
-            tags: string[];
-            /** @description Target template in "name:tag" format */
-            target: string;
-        };
         AWSRegistry: {
             /** @description AWS Access Key ID for ECR authentication */
             awsAccessKeyId: string;
@@ -1397,6 +1330,27 @@ export interface components {
              * @enum {string}
              */
             type: "aws";
+        };
+        AdminSandboxKillResult: {
+            /** @description Number of sandboxes that failed to kill */
+            failedCount: number;
+            /** @description Number of sandboxes successfully killed */
+            killedCount: number;
+        };
+        AssignTemplateTagsRequest: {
+            /** @description Tags to assign to the template */
+            tags: string[];
+            /** @description Target template in "name:tag" format */
+            target: string;
+        };
+        AssignedTemplateTags: {
+            /**
+             * Format: uuid
+             * @description Identifier of the build associated with these tags
+             */
+            buildID: string;
+            /** @description Assigned tags of the template */
+            tags: string[];
         };
         BuildLogEntry: {
             level: components["schemas"]["LogLevel"];
@@ -1415,12 +1369,17 @@ export interface components {
              * @description Log entries related to the status reason
              * @default []
              */
-            logEntries?: components["schemas"]["BuildLogEntry"][];
+            logEntries: components["schemas"]["BuildLogEntry"][];
             /** @description Message with the status reason, currently reporting only for error status */
             message: string;
             /** @description Step that failed */
             step?: string;
         };
+        /**
+         * Format: int32
+         * @description CPU cores for the sandbox
+         */
+        CPUCount: number;
         ConnectSandbox: {
             /**
              * Format: int32
@@ -1428,11 +1387,6 @@ export interface components {
              */
             timeout: number;
         };
-        /**
-         * Format: int32
-         * @description CPU cores for the sandbox
-         */
-        CPUCount: number;
         CreatedAccessToken: {
             /**
              * Format: date-time
@@ -1502,11 +1456,11 @@ export interface components {
          * @description Disk size for the sandbox in MiB
          */
         DiskSizeMB: number;
-        /** @description Version of the envd running in the sandbox */
-        EnvdVersion: string;
         EnvVars: {
             [key: string]: string;
         };
+        /** @description Version of the envd running in the sandbox */
+        EnvdVersion: string;
         Error: {
             /**
              * Format: int32
@@ -1637,7 +1591,7 @@ export interface components {
              * @description Automatically pauses the sandbox after the timeout
              * @default false
              */
-            autoPause?: boolean;
+            autoPause: boolean;
             envVars?: components["schemas"]["EnvVars"];
             mcp?: components["schemas"]["Mcp"];
             metadata?: components["schemas"]["SandboxMetadata"];
@@ -1651,7 +1605,7 @@ export interface components {
              * @description Time to live for the sandbox in seconds.
              * @default 15
              */
-            timeout?: number;
+            timeout: number;
         };
         NewTeamAPIKey: {
             /** @description Name of the API key */
@@ -1790,7 +1744,7 @@ export interface components {
              * @description Time to live for the sandbox in seconds.
              * @default 15
              */
-            timeout?: number;
+            timeout: number;
         };
         Sandbox: {
             /** @description Alias of the template */
@@ -1844,11 +1798,6 @@ export interface components {
             state: components["schemas"]["SandboxState"];
             /** @description Identifier of the template from which is the sandbox created */
             templateID: string;
-        };
-        SandboxesWithMetrics: {
-            sandboxes: {
-                [key: string]: components["schemas"]["SandboxMetric"];
-            };
         };
         /** @description Log entry with timestamp and line */
         SandboxLog: {
@@ -1933,7 +1882,7 @@ export interface components {
              * @description Specify if the sandbox URLs should be accessible only with authentication.
              * @default true
              */
-            allowPublicTraffic?: boolean;
+            allowPublicTraffic: boolean;
             /** @description List of denied CIDR blocks or IP addresses for egress traffic */
             denyOut?: string[];
             /** @description Specify host mask which will be used for all sandbox requests */
@@ -1944,6 +1893,15 @@ export interface components {
          * @enum {string}
          */
         SandboxState: "running" | "paused";
+        SandboxesWithMetrics: {
+            sandboxes: {
+                [key: string]: components["schemas"]["SandboxMetric"];
+            };
+        };
+        SnapshotInfo: {
+            /** @description Unique identifier for the snapshot, can be used as template name */
+            snapshotID: string;
+        };
         Team: {
             /** @description API key for the team */
             apiKey: string;
@@ -2166,7 +2124,7 @@ export interface components {
              * @description Whether the whole build should be forced to run regardless of the cache
              * @default false
              */
-            force?: boolean;
+            force: boolean;
             /** @description Image to use as a base for the template build */
             fromImage?: string;
             fromImageRegistry?: components["schemas"]["FromImageRegistry"];
@@ -2180,7 +2138,7 @@ export interface components {
              * @description List of steps to execute in the template build
              * @default []
              */
-            steps?: components["schemas"]["TemplateStep"][];
+            steps: components["schemas"]["TemplateStep"][];
         };
         /**
          * @description Status of the template build
@@ -2250,14 +2208,14 @@ export interface components {
              * @description Arguments for the step
              * @default []
              */
-            args?: string[];
+            args: string[];
             /** @description Hash of the files used in the step */
             filesHash?: string;
             /**
              * @description Whether the step should be forced to run regardless of the cache
              * @default false
              */
-            force?: boolean;
+            force: boolean;
             /** @description Type of the step */
             type: string;
         };
@@ -2375,6 +2333,7 @@ export interface components {
         /** @description Cursor to start the list from */
         paginationNextToken: string;
         sandboxID: string;
+        snapshotID: string;
         tag: string;
         teamID: string;
         templateID: string;

--- a/packages/js-sdk/src/api/schema.gen.ts
+++ b/packages/js-sdk/src/api/schema.gen.ts
@@ -1761,7 +1761,7 @@ export interface components {
             state: components["schemas"]["SandboxState"];
             /** @description Identifier of the template from which is the sandbox created */
             templateID: string;
-            volumeMounts: components["schemas"]["SandboxVolumeMount"][];
+            volumeMounts?: components["schemas"]["SandboxVolumeMount"][];
         };
         /**
          * @description State of the sandbox
@@ -2047,7 +2047,7 @@ export interface components {
             state: components["schemas"]["SandboxState"];
             /** @description Identifier of the template from which is the sandbox created */
             templateID: string;
-            volumeMounts: components["schemas"]["SandboxVolumeMount"][];
+            volumeMounts?: components["schemas"]["SandboxVolumeMount"][];
         };
         SandboxesWithMetrics: {
             sandboxes: {

--- a/packages/js-sdk/src/api/schema.gen.ts
+++ b/packages/js-sdk/src/api/schema.gen.ts
@@ -73,48 +73,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/sandboxes/metrics": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description List metrics for given sandboxes */
-        get: {
-            parameters: {
-                query: {
-                    /** @description Comma-separated list of sandbox IDs to get metrics for */
-                    sandbox_ids: string[];
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully returned all running sandboxes with metrics */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SandboxesWithMetrics"];
-                    };
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/sandboxes/{sandboxID}": {
         parameters: {
             query?: never;
@@ -241,14 +199,17 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description Get sandbox logs */
+        /**
+         * @deprecated
+         * @description Get sandbox logs. Use /v2/sandboxes/{sandboxID}/logs instead.
+         */
         get: {
             parameters: {
                 query?: {
-                    /** @description Starting timestamp of the logs that should be returned in milliseconds */
-                    start?: number;
                     /** @description Maximum number of logs that should be returned */
                     limit?: number;
+                    /** @description Starting timestamp of the logs that should be returned in milliseconds */
+                    start?: number;
                 };
                 header?: never;
                 path: {
@@ -291,9 +252,9 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
+                    end?: number;
                     /** @description Unix timestamp for the start of the interval, in seconds, for which the metrics */
                     start?: number;
-                    end?: number;
                 };
                 header?: never;
                 path: {
@@ -479,7 +440,14 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description Optional name for the snapshot template. If a snapshot template with this name already exists, a new build will be assigned to the existing template instead of creating a new one. */
+                        name?: string;
+                    };
+                };
+            };
             responses: {
                 /** @description Snapshot created successfully */
                 201: {
@@ -551,6 +519,48 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/sandboxes/metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description List metrics for given sandboxes */
+        get: {
+            parameters: {
+                query: {
+                    /** @description Comma-separated list of sandbox IDs to get metrics for */
+                    sandbox_ids: string[];
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned all running sandboxes with metrics */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SandboxesWithMetrics"];
+                    };
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/snapshots": {
         parameters: {
             query?: never;
@@ -562,11 +572,11 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    sandboxID?: string;
                     /** @description Maximum number of items to return per page */
                     limit?: components["parameters"]["paginationLimit"];
                     /** @description Cursor to start the list from */
                     nextToken?: components["parameters"]["paginationNextToken"];
+                    sandboxID?: string;
                 };
                 header?: never;
                 path?: never;
@@ -584,6 +594,138 @@ export interface paths {
                     };
                 };
                 401: components["responses"]["401"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teams": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description List all teams */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned all teams */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Team"][];
+                    };
+                };
+                401: components["responses"]["401"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teams/{teamID}/metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Get metrics for the team */
+        get: {
+            parameters: {
+                query?: {
+                    end?: number;
+                    /** @description Unix timestamp for the start of the interval, in seconds, for which the metrics */
+                    start?: number;
+                };
+                header?: never;
+                path: {
+                    teamID: components["parameters"]["teamID"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned the team metrics */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TeamMetric"][];
+                    };
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teams/{teamID}/metrics/max": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Get the maximum metrics for the team in the given interval */
+        get: {
+            parameters: {
+                query: {
+                    end?: number;
+                    /** @description Metric to retrieve the maximum value for */
+                    metric: "concurrent_sandboxes" | "sandbox_start_rate";
+                    /** @description Unix timestamp for the start of the interval, in seconds, for which the metrics */
+                    start?: number;
+                };
+                header?: never;
+                path: {
+                    teamID: components["parameters"]["teamID"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned the team metrics */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MaxTeamMetric"];
+                    };
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
                 500: components["responses"]["500"];
             };
         };
@@ -665,118 +807,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/templates/aliases/{alias}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Check if template with given alias exists */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    alias: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully queried template by alias */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TemplateAliasResponse"];
-                    };
-                };
-                400: components["responses"]["400"];
-                403: components["responses"]["403"];
-                404: components["responses"]["404"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/templates/tags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** @description Assign tag(s) to a template build */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["AssignTemplateTagsRequest"];
-                };
-            };
-            responses: {
-                /** @description Tag assigned successfully */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AssignedTemplateTags"];
-                    };
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                404: components["responses"]["404"];
-                500: components["responses"]["500"];
-            };
-        };
-        /** @description Delete multiple tags from templates */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["DeleteTemplateTagsRequest"];
-                };
-            };
-            responses: {
-                /** @description Tags deleted successfully */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                404: components["responses"]["404"];
-                500: components["responses"]["500"];
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/templates/{templateID}": {
         parameters: {
             query?: never;
@@ -788,10 +818,10 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    /** @description Cursor to start the list from */
-                    nextToken?: components["parameters"]["paginationNextToken"];
                     /** @description Maximum number of items to return per page */
                     limit?: components["parameters"]["paginationLimit"];
+                    /** @description Cursor to start the list from */
+                    nextToken?: components["parameters"]["paginationNextToken"];
                 };
                 header?: never;
                 path: {
@@ -923,8 +953,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    templateID: components["parameters"]["templateID"];
                     buildID: components["parameters"]["buildID"];
+                    templateID: components["parameters"]["templateID"];
                 };
                 cookie?: never;
             };
@@ -960,17 +990,17 @@ export interface paths {
                 query?: {
                     /** @description Starting timestamp of the logs that should be returned in milliseconds */
                     cursor?: number;
-                    /** @description Maximum number of logs that should be returned */
-                    limit?: number;
                     direction?: components["schemas"]["LogsDirection"];
                     level?: components["schemas"]["LogLevel"];
+                    /** @description Maximum number of logs that should be returned */
+                    limit?: number;
                     /** @description Source of the logs that should be returned from */
                     source?: components["schemas"]["LogsSource"];
                 };
                 header?: never;
                 path: {
-                    templateID: components["parameters"]["templateID"];
                     buildID: components["parameters"]["buildID"];
+                    templateID: components["parameters"]["templateID"];
                 };
                 cookie?: never;
             };
@@ -1009,16 +1039,16 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    /** @description Index of the starting build log that should be returned with the template */
-                    logsOffset?: number;
+                    level?: components["schemas"]["LogLevel"];
                     /** @description Maximum number of logs that should be returned */
                     limit?: number;
-                    level?: components["schemas"]["LogLevel"];
+                    /** @description Index of the starting build log that should be returned with the template */
+                    logsOffset?: number;
                 };
                 header?: never;
                 path: {
-                    templateID: components["parameters"]["templateID"];
                     buildID: components["parameters"]["buildID"];
+                    templateID: components["parameters"]["templateID"];
                 };
                 cookie?: never;
             };
@@ -1059,8 +1089,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    templateID: components["parameters"]["templateID"];
                     hash: string;
+                    templateID: components["parameters"]["templateID"];
                 };
                 cookie?: never;
             };
@@ -1089,6 +1119,160 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/templates/{templateID}/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description List all tags for a template */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    templateID: components["parameters"]["templateID"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned the template tags */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TemplateTag"][];
+                    };
+                };
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/templates/aliases/{alias}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Check if template with given alias exists */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    alias: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully queried template by alias */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TemplateAliasResponse"];
+                    };
+                };
+                400: components["responses"]["400"];
+                403: components["responses"]["403"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/templates/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Assign tag(s) to a template build */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["AssignTemplateTagsRequest"];
+                };
+            };
+            responses: {
+                /** @description Tag assigned successfully */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AssignedTemplateTags"];
+                    };
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        /** @description Delete multiple tags from templates */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["DeleteTemplateTagsRequest"];
+                };
+            };
+            responses: {
+                /** @description Tags deleted successfully */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/sandboxes": {
         parameters: {
             query?: never;
@@ -1100,14 +1284,14 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    /** @description Metadata query used to filter the sandboxes (e.g. "user=abc&app=prod"). Each key and values must be URL encoded. */
-                    metadata?: string;
-                    /** @description Filter sandboxes by one or more states */
-                    state?: components["schemas"]["SandboxState"][];
-                    /** @description Cursor to start the list from */
-                    nextToken?: components["parameters"]["paginationNextToken"];
                     /** @description Maximum number of items to return per page */
                     limit?: components["parameters"]["paginationLimit"];
+                    /** @description Metadata query used to filter the sandboxes (e.g. "user=abc&app=prod"). Each key and values must be URL encoded. */
+                    metadata?: string;
+                    /** @description Cursor to start the list from */
+                    nextToken?: components["parameters"]["paginationNextToken"];
+                    /** @description Filter sandboxes by one or more states */
+                    state?: components["schemas"]["SandboxState"][];
                 };
                 header?: never;
                 path?: never;
@@ -1126,6 +1310,54 @@ export interface paths {
                 };
                 400: components["responses"]["400"];
                 401: components["responses"]["401"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/sandboxes/{sandboxID}/logs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Get sandbox logs */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Starting timestamp of the logs that should be returned in milliseconds */
+                    cursor?: number;
+                    /** @description Direction of the logs that should be returned */
+                    direction?: components["schemas"]["LogsDirection"];
+                    /** @description Maximum number of logs that should be returned */
+                    limit?: number;
+                };
+                header?: never;
+                path: {
+                    sandboxID: components["parameters"]["sandboxID"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned the sandbox logs */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SandboxLogsV2Response"];
+                    };
+                };
+                401: components["responses"]["401"];
+                404: components["responses"]["404"];
                 500: components["responses"]["500"];
             };
         };
@@ -1243,8 +1475,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    templateID: components["parameters"]["templateID"];
                     buildID: components["parameters"]["buildID"];
+                    templateID: components["parameters"]["templateID"];
                 };
                 cookie?: never;
             };
@@ -1318,6 +1550,27 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        AdminSandboxKillResult: {
+            /** @description Number of sandboxes that failed to kill */
+            failedCount: number;
+            /** @description Number of sandboxes successfully killed */
+            killedCount: number;
+        };
+        AssignedTemplateTags: {
+            /**
+             * Format: uuid
+             * @description Identifier of the build associated with these tags
+             */
+            buildID: string;
+            /** @description Assigned tags of the template */
+            tags: string[];
+        };
+        AssignTemplateTagsRequest: {
+            /** @description Tags to assign to the template */
+            tags: string[];
+            /** @description Target template in "name:tag" format */
+            target: string;
+        };
         AWSRegistry: {
             /** @description AWS Access Key ID for ECR authentication */
             awsAccessKeyId: string;
@@ -1330,27 +1583,6 @@ export interface components {
              * @enum {string}
              */
             type: "aws";
-        };
-        AdminSandboxKillResult: {
-            /** @description Number of sandboxes that failed to kill */
-            failedCount: number;
-            /** @description Number of sandboxes successfully killed */
-            killedCount: number;
-        };
-        AssignTemplateTagsRequest: {
-            /** @description Tags to assign to the template */
-            tags: string[];
-            /** @description Target template in "name:tag" format */
-            target: string;
-        };
-        AssignedTemplateTags: {
-            /**
-             * Format: uuid
-             * @description Identifier of the build associated with these tags
-             */
-            buildID: string;
-            /** @description Assigned tags of the template */
-            tags: string[];
         };
         BuildLogEntry: {
             level: components["schemas"]["LogLevel"];
@@ -1369,17 +1601,12 @@ export interface components {
              * @description Log entries related to the status reason
              * @default []
              */
-            logEntries: components["schemas"]["BuildLogEntry"][];
+            logEntries?: components["schemas"]["BuildLogEntry"][];
             /** @description Message with the status reason, currently reporting only for error status */
             message: string;
             /** @description Step that failed */
             step?: string;
         };
-        /**
-         * Format: int32
-         * @description CPU cores for the sandbox
-         */
-        CPUCount: number;
         ConnectSandbox: {
             /**
              * Format: int32
@@ -1387,6 +1614,11 @@ export interface components {
              */
             timeout: number;
         };
+        /**
+         * Format: int32
+         * @description CPU cores for the sandbox
+         */
+        CPUCount: number;
         CreatedAccessToken: {
             /**
              * Format: date-time
@@ -1456,11 +1688,11 @@ export interface components {
          * @description Disk size for the sandbox in MiB
          */
         DiskSizeMB: number;
+        /** @description Version of the envd running in the sandbox */
+        EnvdVersion: string;
         EnvVars: {
             [key: string]: string;
         };
-        /** @description Version of the envd running in the sandbox */
-        EnvdVersion: string;
         Error: {
             /**
              * Format: int32
@@ -1529,6 +1761,7 @@ export interface components {
             state: components["schemas"]["SandboxState"];
             /** @description Identifier of the template from which is the sandbox created */
             templateID: string;
+            volumeMounts: components["schemas"]["SandboxVolumeMount"][];
         };
         /**
          * @description State of the sandbox
@@ -1591,7 +1824,8 @@ export interface components {
              * @description Automatically pauses the sandbox after the timeout
              * @default false
              */
-            autoPause: boolean;
+            autoPause?: boolean;
+            autoResume?: components["schemas"]["SandboxAutoResumeConfig"];
             envVars?: components["schemas"]["EnvVars"];
             mcp?: components["schemas"]["Mcp"];
             metadata?: components["schemas"]["SandboxMetadata"];
@@ -1605,10 +1839,15 @@ export interface components {
              * @description Time to live for the sandbox in seconds.
              * @default 15
              */
-            timeout: number;
+            timeout?: number;
+            volumeMounts?: components["schemas"]["SandboxVolumeMount"][];
         };
         NewTeamAPIKey: {
             /** @description Name of the API key */
+            name: string;
+        };
+        NewVolume: {
+            /** @description Name of the volume */
             name: string;
         };
         Node: {
@@ -1744,7 +1983,7 @@ export interface components {
              * @description Time to live for the sandbox in seconds.
              * @default 15
              */
-            timeout: number;
+            timeout?: number;
         };
         Sandbox: {
             /** @description Alias of the template */
@@ -1766,6 +2005,16 @@ export interface components {
             /** @description Token required for accessing sandbox via proxy. */
             trafficAccessToken?: string | null;
         };
+        /** @description Auto-resume configuration for paused sandboxes. Default is off. */
+        SandboxAutoResumeConfig: {
+            policy: components["schemas"]["SandboxAutoResumePolicy"];
+        };
+        /**
+         * @description Auto-resume policy for paused sandboxes. Default is off.
+         * @default off
+         * @enum {string}
+         */
+        SandboxAutoResumePolicy: "any" | "off";
         SandboxDetail: {
             /** @description Alias of the template */
             alias?: string;
@@ -1798,6 +2047,12 @@ export interface components {
             state: components["schemas"]["SandboxState"];
             /** @description Identifier of the template from which is the sandbox created */
             templateID: string;
+            volumeMounts: components["schemas"]["SandboxVolumeMount"][];
+        };
+        SandboxesWithMetrics: {
+            sandboxes: {
+                [key: string]: components["schemas"]["SandboxMetric"];
+            };
         };
         /** @description Log entry with timestamp and line */
         SandboxLog: {
@@ -1827,6 +2082,13 @@ export interface components {
             logEntries: components["schemas"]["SandboxLogEntry"][];
             /** @description Logs of the sandbox */
             logs: components["schemas"]["SandboxLog"][];
+        };
+        SandboxLogsV2Response: {
+            /**
+             * @description Sandbox logs structured
+             * @default []
+             */
+            logs: components["schemas"]["SandboxLogEntry"][];
         };
         SandboxMetadata: {
             [key: string]: string;
@@ -1882,7 +2144,7 @@ export interface components {
              * @description Specify if the sandbox URLs should be accessible only with authentication.
              * @default true
              */
-            allowPublicTraffic: boolean;
+            allowPublicTraffic?: boolean;
             /** @description List of denied CIDR blocks or IP addresses for egress traffic */
             denyOut?: string[];
             /** @description Specify host mask which will be used for all sandbox requests */
@@ -1893,13 +2155,16 @@ export interface components {
          * @enum {string}
          */
         SandboxState: "running" | "paused";
-        SandboxesWithMetrics: {
-            sandboxes: {
-                [key: string]: components["schemas"]["SandboxMetric"];
-            };
+        SandboxVolumeMount: {
+            /** @description Name of the volume */
+            name: string;
+            /** @description Path of the volume */
+            path: string;
         };
         SnapshotInfo: {
-            /** @description Unique identifier for the snapshot, can be used as template name */
+            /** @description Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-snapshot:v2) */
+            names: string[];
+            /** @description Identifier of the snapshot template */
             snapshotID: string;
         };
         Team: {
@@ -2124,7 +2389,7 @@ export interface components {
              * @description Whether the whole build should be forced to run regardless of the cache
              * @default false
              */
-            force: boolean;
+            force?: boolean;
             /** @description Image to use as a base for the template build */
             fromImage?: string;
             fromImageRegistry?: components["schemas"]["FromImageRegistry"];
@@ -2138,7 +2403,7 @@ export interface components {
              * @description List of steps to execute in the template build
              * @default []
              */
-            steps: components["schemas"]["TemplateStep"][];
+            steps?: components["schemas"]["TemplateStep"][];
         };
         /**
          * @description Status of the template build
@@ -2208,16 +2473,30 @@ export interface components {
              * @description Arguments for the step
              * @default []
              */
-            args: string[];
+            args?: string[];
             /** @description Hash of the files used in the step */
             filesHash?: string;
             /**
              * @description Whether the step should be forced to run regardless of the cache
              * @default false
              */
-            force: boolean;
+            force?: boolean;
             /** @description Type of the step */
             type: string;
+        };
+        TemplateTag: {
+            /**
+             * Format: uuid
+             * @description Identifier of the build associated with this tag
+             */
+            buildID: string;
+            /**
+             * Format: date-time
+             * @description Time when the tag was assigned
+             */
+            createdAt: string;
+            /** @description The tag name */
+            tag: string;
         };
         TemplateUpdateRequest: {
             /** @description Whether the template is public or only accessible by the team */
@@ -2265,6 +2544,12 @@ export interface components {
         UpdateTeamAPIKey: {
             /** @description New name for the API key */
             name: string;
+        };
+        Volume: {
+            /** @description Name of the volume */
+            name: string;
+            /** @description ID of the volume */
+            volumeID: string;
         };
     };
     responses: {
@@ -2337,6 +2622,7 @@ export interface components {
         tag: string;
         teamID: string;
         templateID: string;
+        volumeID: string;
     };
     requestBodies: never;
     headers: never;

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -50,7 +50,6 @@ export type {
   SandboxPaginator,
   SandboxNetworkOpts,
   SnapshotInfo,
-  SnapshotOpts,
   SnapshotListOpts,
   SnapshotPaginator,
 } from './sandbox/sandboxApi'

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -49,6 +49,10 @@ export type {
   SandboxListOpts,
   SandboxPaginator,
   SandboxNetworkOpts,
+  SnapshotInfo,
+  SnapshotOpts,
+  SnapshotListOpts,
+  SnapshotPaginator,
 } from './sandbox/sandboxApi'
 
 export type { McpServer } from './sandbox/mcp'

--- a/packages/js-sdk/src/sandbox/commands/index.ts
+++ b/packages/js-sdk/src/sandbox/commands/index.ts
@@ -28,9 +28,8 @@ export { Pty } from './pty'
 /**
  * Options for sending a command request.
  */
-export interface CommandRequestOpts extends Partial<
-  Pick<ConnectionOpts, 'requestTimeoutMs'>
-> {}
+export interface CommandRequestOpts
+  extends Partial<Pick<ConnectionOpts, 'requestTimeoutMs'>> {}
 
 /**
  * Options for starting a new command.

--- a/packages/js-sdk/src/sandbox/commands/index.ts
+++ b/packages/js-sdk/src/sandbox/commands/index.ts
@@ -28,8 +28,9 @@ export { Pty } from './pty'
 /**
  * Options for sending a command request.
  */
-export interface CommandRequestOpts
-  extends Partial<Pick<ConnectionOpts, 'requestTimeoutMs'>> {}
+export interface CommandRequestOpts extends Partial<
+  Pick<ConnectionOpts, 'requestTimeoutMs'>
+> {}
 
 /**
  * Options for starting a new command.

--- a/packages/js-sdk/src/sandbox/commands/pty.ts
+++ b/packages/js-sdk/src/sandbox/commands/pty.ts
@@ -21,8 +21,10 @@ import { CommandHandle } from './commandHandle'
 import { authenticationHeader, handleRpcError } from '../../envd/rpc'
 import { handleProcessStartEvent } from '../../envd/api'
 
-export interface PtyCreateOpts
-  extends Pick<ConnectionOpts, 'requestTimeoutMs'> {
+export interface PtyCreateOpts extends Pick<
+  ConnectionOpts,
+  'requestTimeoutMs'
+> {
   /**
    * Number of columns for the PTY.
    */

--- a/packages/js-sdk/src/sandbox/commands/pty.ts
+++ b/packages/js-sdk/src/sandbox/commands/pty.ts
@@ -21,10 +21,8 @@ import { CommandHandle } from './commandHandle'
 import { authenticationHeader, handleRpcError } from '../../envd/rpc'
 import { handleProcessStartEvent } from '../../envd/api'
 
-export interface PtyCreateOpts extends Pick<
-  ConnectionOpts,
-  'requestTimeoutMs'
-> {
+export interface PtyCreateOpts
+  extends Pick<ConnectionOpts, 'requestTimeoutMs'> {
   /**
    * Number of columns for the PTY.
    */

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -129,9 +129,8 @@ function mapModifiedTime(modifiedTime: Timestamp | undefined) {
 /**
  * Options for the sandbox filesystem operations.
  */
-export interface FilesystemRequestOpts extends Partial<
-  Pick<ConnectionOpts, 'requestTimeoutMs'>
-> {
+export interface FilesystemRequestOpts
+  extends Partial<Pick<ConnectionOpts, 'requestTimeoutMs'>> {
   /**
    * User to use for the operation in the sandbox.
    * This affects the resolution of relative paths and ownership of the created filesystem objects.

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -129,8 +129,9 @@ function mapModifiedTime(modifiedTime: Timestamp | undefined) {
 /**
  * Options for the sandbox filesystem operations.
  */
-export interface FilesystemRequestOpts
-  extends Partial<Pick<ConnectionOpts, 'requestTimeoutMs'>> {
+export interface FilesystemRequestOpts extends Partial<
+  Pick<ConnectionOpts, 'requestTimeoutMs'>
+> {
   /**
    * User to use for the operation in the sandbox.
    * This affects the resolution of relative paths and ownership of the created filesystem objects.

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -20,6 +20,10 @@ import {
   SandboxListOpts,
   SandboxPaginator,
   SandboxBetaCreateOpts,
+  SnapshotOpts,
+  SnapshotListOpts,
+  SnapshotInfo,
+  SnapshotPaginator,
 } from './sandboxApi'
 import { getSignature } from './signature'
 import { compareVersions } from 'compare-versions'
@@ -577,6 +581,52 @@ export class Sandbox extends SandboxApi {
    */
   async betaPause(opts?: ConnectionOpts): Promise<boolean> {
     return await SandboxApi.betaPause(this.sandboxId, opts)
+  }
+
+  /**
+   * Create a snapshot of the sandbox's current state.
+   *
+   * The snapshot can be used to create new sandboxes with the same filesystem and state.
+   * Snapshots are persistent and survive sandbox deletion.
+   *
+   * Use the returned `snapshotId` with `Sandbox.create(snapshotId)` to create a new sandbox from the snapshot.
+   *
+   * @param opts snapshot options.
+   *
+   * @returns snapshot information including the snapshot ID.
+   *
+   * @example
+   * ```ts
+   * const sandbox = await Sandbox.create()
+   * await sandbox.files.write('/app/state.json', '{"step": 1}')
+   *
+   * // Create a snapshot
+   * const snapshot = await sandbox.snapshot()
+   *
+   * // Create a new sandbox from the snapshot
+   * const newSandbox = await Sandbox.create(snapshot.snapshotId)
+   * ```
+   */
+  async snapshot(opts?: SnapshotOpts): Promise<SnapshotInfo> {
+    return await SandboxApi.createSnapshot(this.sandboxId, {
+      ...this.connectionConfig,
+      ...opts,
+    })
+  }
+
+  /**
+   * List all snapshots created from this sandbox.
+   *
+   * @param opts list options.
+   *
+   * @returns paginator for listing snapshots from this sandbox.
+   */
+  listSnapshots(opts?: Omit<SnapshotListOpts, 'sandboxId'>): SnapshotPaginator {
+    return SandboxApi.listSnapshots({
+      ...this.connectionConfig,
+      ...opts,
+      sandboxId: this.sandboxId,
+    })
   }
 
   /**

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -601,13 +601,13 @@ export class Sandbox extends SandboxApi {
    * await sandbox.files.write('/app/state.json', '{"step": 1}')
    *
    * // Create a snapshot
-   * const snapshot = await sandbox.snapshot()
+   * const snapshot = await sandbox.createSnapshot()
    *
    * // Create a new sandbox from the snapshot
    * const newSandbox = await Sandbox.create(snapshot.snapshotId)
    * ```
    */
-  async snapshot(opts?: SnapshotOpts): Promise<SnapshotInfo> {
+  async createSnapshot(opts?: SnapshotOpts): Promise<SnapshotInfo> {
     return await SandboxApi.createSnapshot(this.sandboxId, {
       ...this.connectionConfig,
       ...opts,

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -20,7 +20,7 @@ import {
   SandboxListOpts,
   SandboxPaginator,
   SandboxBetaCreateOpts,
-  SnapshotOpts,
+  SandboxApiOpts,
   SnapshotListOpts,
   SnapshotInfo,
   SnapshotPaginator,
@@ -586,12 +586,13 @@ export class Sandbox extends SandboxApi {
   /**
    * Create a snapshot of the sandbox's current state.
    *
+   * The sandbox will be paused while the snapshot is being created.
    * The snapshot can be used to create new sandboxes with the same filesystem and state.
    * Snapshots are persistent and survive sandbox deletion.
    *
    * Use the returned `snapshotId` with `Sandbox.create(snapshotId)` to create a new sandbox from the snapshot.
    *
-   * @param opts snapshot options.
+   * @param opts connection options.
    *
    * @returns snapshot information including the snapshot ID.
    *
@@ -607,7 +608,7 @@ export class Sandbox extends SandboxApi {
    * const newSandbox = await Sandbox.create(snapshot.snapshotId)
    * ```
    */
-  async createSnapshot(opts?: SnapshotOpts): Promise<SnapshotInfo> {
+  async createSnapshot(opts?: SandboxApiOpts): Promise<SnapshotInfo> {
     return await SandboxApi.createSnapshot(this.sandboxId, {
       ...this.connectionConfig,
       ...opts,

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -793,7 +793,7 @@ export class SandboxPaginator {
   }
 
   /**
-   * Returns True if there are more items to fetch.
+   * Returns true if there are more items to fetch.
    */
   get hasNext(): boolean {
     return this._hasNext
@@ -920,7 +920,7 @@ export class SnapshotPaginator {
   }
 
   /**
-   * Returns True if there are more items to fetch.
+   * Returns true if there are more items to fetch.
    */
   get hasNext(): boolean {
     return this._hasNext

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -67,12 +67,13 @@ export type SandboxNetworkOpts = {
 /**
  * Options for request to the Sandbox API.
  */
-export interface SandboxApiOpts extends Partial<
-  Pick<
-    ConnectionOpts,
-    'apiKey' | 'headers' | 'debug' | 'domain' | 'requestTimeoutMs'
-  >
-> {}
+export interface SandboxApiOpts
+  extends Partial<
+    Pick<
+      ConnectionOpts,
+      'apiKey' | 'headers' | 'debug' | 'domain' | 'requestTimeoutMs'
+    >
+  > {}
 
 /**
  * Options for creating a new Sandbox.
@@ -590,6 +591,7 @@ export class SandboxApi {
           sandboxID: sandboxId,
         },
       },
+      body: {},
       signal: config.getSignal(opts?.requestTimeoutMs),
     })
 

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -232,8 +232,8 @@ export interface SnapshotListOpts extends SandboxApiOpts {
  */
 export interface SnapshotInfo {
   /**
-   * Unique identifier for the snapshot.
-   * Can be used as templateId in Sandbox.create() to create a new sandbox from this snapshot.
+   * Snapshot identifier — template ID with tag, or namespaced name with tag (e.g. my-snapshot:latest).
+   * Can be used with Sandbox.create() to create a new sandbox from this snapshot.
    */
   snapshotId: string
 }
@@ -576,7 +576,7 @@ export class SandboxApi {
    * @param sandboxId sandbox ID to create snapshot from.
    * @param opts snapshot options.
    *
-   * @returns snapshot information including the snapshot ID that can be used with Sandbox.create().
+   * @returns snapshot information including the snapshot name that can be used with Sandbox.create().
    */
   static async createSnapshot(
     sandboxId: string,

--- a/packages/js-sdk/tests/api/list.test.ts
+++ b/packages/js-sdk/tests/api/list.test.ts
@@ -1,4 +1,5 @@
 import { assert } from 'vitest'
+import { randomUUID } from 'crypto'
 
 import { Sandbox, SandboxInfo } from '../../src'
 import { sandboxTest, isDebug } from '../setup.js'
@@ -19,7 +20,7 @@ sandboxTest.skipIf(isDebug)(
 )
 
 sandboxTest.skipIf(isDebug)('list sandboxes with filter', async () => {
-  const uniqueId = Date.now().toString()
+  const uniqueId = randomUUID()
   const extraSbx = await Sandbox.create({ metadata: { uniqueId } })
 
   try {
@@ -236,7 +237,7 @@ sandboxTest.skipIf(isDebug)(
 )
 
 sandboxTest.skipIf(isDebug)('list sandboxes with filter', async () => {
-  const uniqueId = Date.now().toString()
+  const uniqueId = randomUUID()
   const extraSbx = await Sandbox.create({ metadata: { uniqueId } })
 
   try {

--- a/packages/js-sdk/tests/sandbox/snapshot-api.test.ts
+++ b/packages/js-sdk/tests/sandbox/snapshot-api.test.ts
@@ -1,0 +1,189 @@
+import { assert } from 'vitest'
+
+import { sandboxTest, isDebug } from '../setup.js'
+import { Sandbox } from '../../src'
+
+sandboxTest.skipIf(isDebug)(
+  'create a snapshot from sandbox',
+  async ({ sandbox }) => {
+    // Write a file to the sandbox
+    await sandbox.files.write('/home/user/test.txt', 'snapshot test content')
+
+    // Create a snapshot
+    const snapshot = await sandbox.snapshot()
+
+    assert.isString(snapshot.snapshotId)
+    assert.isTrue(snapshot.snapshotId.length > 0)
+
+    // Cleanup
+    await Sandbox.deleteSnapshot(snapshot.snapshotId)
+  }
+)
+
+sandboxTest.skipIf(isDebug)(
+  'create sandbox from snapshot',
+  async ({ sandbox, sandboxTestId }) => {
+    const testContent = 'content from original sandbox'
+
+    // Write a file to the sandbox
+    await sandbox.files.write('/home/user/test.txt', testContent)
+
+    // Create a snapshot
+    const snapshot = await sandbox.snapshot()
+
+    try {
+      // Create a new sandbox from the snapshot
+      const newSandbox = await Sandbox.create(snapshot.snapshotId, {
+        metadata: { sandboxTestId: `${sandboxTestId}-from-snapshot` },
+      })
+
+      try {
+        // Verify the file exists in the new sandbox
+        const content = await newSandbox.files.read('/home/user/test.txt')
+        assert.equal(content, testContent)
+      } finally {
+        await newSandbox.kill()
+      }
+    } finally {
+      await Sandbox.deleteSnapshot(snapshot.snapshotId)
+    }
+  }
+)
+
+sandboxTest.skipIf(isDebug)(
+  'create multiple sandboxes from same snapshot',
+  async ({ sandbox, sandboxTestId }) => {
+    const testContent = 'shared snapshot content'
+
+    await sandbox.files.write('/home/user/shared.txt', testContent)
+
+    const snapshot = await sandbox.snapshot()
+
+    try {
+      // Create two sandboxes from the same snapshot
+      const sandbox1 = await Sandbox.create(snapshot.snapshotId, {
+        metadata: { sandboxTestId: `${sandboxTestId}-branch-1` },
+      })
+      const sandbox2 = await Sandbox.create(snapshot.snapshotId, {
+        metadata: { sandboxTestId: `${sandboxTestId}-branch-2` },
+      })
+
+      try {
+        // Both should have the same initial content
+        const content1 = await sandbox1.files.read('/home/user/shared.txt')
+        const content2 = await sandbox2.files.read('/home/user/shared.txt')
+
+        assert.equal(content1, testContent)
+        assert.equal(content2, testContent)
+
+        // Modify one sandbox - should not affect the other
+        await sandbox1.files.write(
+          '/home/user/shared.txt',
+          'modified in sandbox1'
+        )
+
+        const modifiedContent = await sandbox1.files.read(
+          '/home/user/shared.txt'
+        )
+        const unchangedContent = await sandbox2.files.read(
+          '/home/user/shared.txt'
+        )
+
+        assert.equal(modifiedContent, 'modified in sandbox1')
+        assert.equal(unchangedContent, testContent)
+      } finally {
+        await sandbox1.kill()
+        await sandbox2.kill()
+      }
+    } finally {
+      await Sandbox.deleteSnapshot(snapshot.snapshotId)
+    }
+  }
+)
+
+sandboxTest.skipIf(isDebug)('list snapshots', async ({ sandbox }) => {
+  // Create a snapshot
+  const snapshot = await sandbox.snapshot()
+
+  try {
+    // List all snapshots
+    const paginator = Sandbox.listSnapshots()
+    assert.isTrue(paginator.hasNext)
+
+    const snapshots = await paginator.nextItems()
+    assert.isArray(snapshots)
+
+    // Find our snapshot in the list
+    const found = snapshots.find((s) => s.snapshotId === snapshot.snapshotId)
+    assert.isDefined(found)
+  } finally {
+    await Sandbox.deleteSnapshot(snapshot.snapshotId)
+  }
+})
+
+sandboxTest.skipIf(isDebug)(
+  'list snapshots for specific sandbox',
+  async ({ sandbox }) => {
+    // Create a snapshot
+    const snapshot = await sandbox.snapshot()
+
+    try {
+      // List snapshots for this sandbox using instance method
+      const paginator = sandbox.listSnapshots()
+      const snapshots = await paginator.nextItems()
+
+      // Should find our snapshot
+      const found = snapshots.find((s) => s.snapshotId === snapshot.snapshotId)
+      assert.isDefined(found)
+    } finally {
+      await Sandbox.deleteSnapshot(snapshot.snapshotId)
+    }
+  }
+)
+
+sandboxTest.skipIf(isDebug)('delete snapshot', async ({ sandbox }) => {
+  const snapshot = await sandbox.snapshot()
+
+  // Delete should succeed
+  const deleted = await Sandbox.deleteSnapshot(snapshot.snapshotId)
+  assert.isTrue(deleted)
+
+  // Second delete should return false (not found)
+  const deletedAgain = await Sandbox.deleteSnapshot(snapshot.snapshotId)
+  assert.isFalse(deletedAgain)
+})
+
+sandboxTest.skipIf(isDebug)(
+  'snapshot preserves file system state',
+  async ({ sandbox, sandboxTestId }) => {
+    // Create directory structure
+    await sandbox.files.makeDir('/home/user/app')
+    await sandbox.files.write('/home/user/app/config.json', '{"env": "test"}')
+    await sandbox.files.write('/home/user/app/data.txt', 'important data')
+
+    const snapshot = await sandbox.snapshot()
+
+    try {
+      const newSandbox = await Sandbox.create(snapshot.snapshotId, {
+        metadata: { sandboxTestId: `${sandboxTestId}-fs-test` },
+      })
+
+      try {
+        // Verify directory exists
+        const dirExists = await newSandbox.files.exists('/home/user/app')
+        assert.isTrue(dirExists)
+
+        // Verify files exist with correct content
+        const config = await newSandbox.files.read('/home/user/app/config.json')
+        const data = await newSandbox.files.read('/home/user/app/data.txt')
+
+        assert.equal(config, '{"env": "test"}')
+        assert.equal(data, 'important data')
+      } finally {
+        await newSandbox.kill()
+      }
+    } finally {
+      await Sandbox.deleteSnapshot(snapshot.snapshotId)
+    }
+  }
+)

--- a/packages/js-sdk/tests/sandbox/snapshot-api.test.ts
+++ b/packages/js-sdk/tests/sandbox/snapshot-api.test.ts
@@ -156,10 +156,15 @@ sandboxTest.skipIf(isDebug)('delete snapshot', async ({ sandbox }) => {
 sandboxTest.skipIf(isDebug)(
   'snapshot preserves file system state',
   async ({ sandbox, sandboxTestId }) => {
-    // Create directory structure
-    await sandbox.files.makeDir('/home/user/app')
-    await sandbox.files.write('/home/user/app/config.json', '{"env": "test"}')
-    await sandbox.files.write('/home/user/app/data.txt', 'important data')
+    const appDir = '/home/user/app'
+    const configPath = `${appDir}/config.json`
+    const configContent = '{"env": "test"}'
+    const dataPath = `${appDir}/data.txt`
+    const dataContent = 'important data'
+
+    await sandbox.files.makeDir(appDir)
+    await sandbox.files.write(configPath, configContent)
+    await sandbox.files.write(dataPath, dataContent)
 
     const snapshot = await sandbox.createSnapshot()
 
@@ -170,15 +175,15 @@ sandboxTest.skipIf(isDebug)(
 
       try {
         // Verify directory exists
-        const dirExists = await newSandbox.files.exists('/home/user/app')
+        const dirExists = await newSandbox.files.exists(appDir)
         assert.isTrue(dirExists)
 
         // Verify files exist with correct content
-        const config = await newSandbox.files.read('/home/user/app/config.json')
-        const data = await newSandbox.files.read('/home/user/app/data.txt')
+        const config = await newSandbox.files.read(configPath)
+        const data = await newSandbox.files.read(dataPath)
 
-        assert.equal(config, '{"env": "test"}')
-        assert.equal(data, 'important data')
+        assert.equal(config, configContent)
+        assert.equal(data, dataContent)
       } finally {
         await newSandbox.kill()
       }

--- a/packages/js-sdk/tests/sandbox/snapshot-api.test.ts
+++ b/packages/js-sdk/tests/sandbox/snapshot-api.test.ts
@@ -10,7 +10,7 @@ sandboxTest.skipIf(isDebug)(
     await sandbox.files.write('/home/user/test.txt', 'snapshot test content')
 
     // Create a snapshot
-    const snapshot = await sandbox.snapshot()
+    const snapshot = await sandbox.createSnapshot()
 
     assert.isString(snapshot.snapshotId)
     assert.isTrue(snapshot.snapshotId.length > 0)
@@ -29,7 +29,7 @@ sandboxTest.skipIf(isDebug)(
     await sandbox.files.write('/home/user/test.txt', testContent)
 
     // Create a snapshot
-    const snapshot = await sandbox.snapshot()
+    const snapshot = await sandbox.createSnapshot()
 
     try {
       // Create a new sandbox from the snapshot
@@ -57,7 +57,7 @@ sandboxTest.skipIf(isDebug)(
 
     await sandbox.files.write('/home/user/shared.txt', testContent)
 
-    const snapshot = await sandbox.snapshot()
+    const snapshot = await sandbox.createSnapshot()
 
     try {
       // Create two sandboxes from the same snapshot
@@ -103,7 +103,7 @@ sandboxTest.skipIf(isDebug)(
 
 sandboxTest.skipIf(isDebug)('list snapshots', async ({ sandbox }) => {
   // Create a snapshot
-  const snapshot = await sandbox.snapshot()
+  const snapshot = await sandbox.createSnapshot()
 
   try {
     // List all snapshots
@@ -125,7 +125,7 @@ sandboxTest.skipIf(isDebug)(
   'list snapshots for specific sandbox',
   async ({ sandbox }) => {
     // Create a snapshot
-    const snapshot = await sandbox.snapshot()
+    const snapshot = await sandbox.createSnapshot()
 
     try {
       // List snapshots for this sandbox using instance method
@@ -142,7 +142,7 @@ sandboxTest.skipIf(isDebug)(
 )
 
 sandboxTest.skipIf(isDebug)('delete snapshot', async ({ sandbox }) => {
-  const snapshot = await sandbox.snapshot()
+  const snapshot = await sandbox.createSnapshot()
 
   // Delete should succeed
   const deleted = await Sandbox.deleteSnapshot(snapshot.snapshotId)
@@ -161,7 +161,7 @@ sandboxTest.skipIf(isDebug)(
     await sandbox.files.write('/home/user/app/config.json', '{"env": "test"}')
     await sandbox.files.write('/home/user/app/data.txt', 'important data')
 
-    const snapshot = await sandbox.snapshot()
+    const snapshot = await sandbox.createSnapshot()
 
     try {
       const newSandbox = await Sandbox.create(snapshot.snapshotId, {

--- a/packages/python-sdk/Makefile
+++ b/packages/python-sdk/Makefile
@@ -1,7 +1,7 @@
 ROOT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
 
 generate-api:
-	python $(ROOT_DIR)/spec/remove_extra_tags.py sandboxes templates tags
+	python $(ROOT_DIR)/spec/remove_extra_tags.py sandboxes snapshots templates tags
 	openapi-python-client generate --output-path $(ROOT_DIR)/packages/python-sdk/e2b/api/api --overwrite --path $(ROOT_DIR)/spec/openapi_generated.yml
 	rm -rf e2b/api/client
 	mv e2b/api/api/e2b_api_client e2b/api/client

--- a/packages/python-sdk/e2b/__init__.py
+++ b/packages/python-sdk/e2b/__init__.py
@@ -71,16 +71,17 @@ from .sandbox.sandbox_api import (
     SandboxNetworkOpts,
     SandboxQuery,
     SandboxState,
+    SnapshotInfo,
 )
 from .sandbox_async.commands.command_handle import AsyncCommandHandle
 from .sandbox_async.filesystem.watch_handle import AsyncWatchHandle
 from .sandbox_async.main import AsyncSandbox
-from .sandbox_async.paginator import AsyncSandboxPaginator
+from .sandbox_async.paginator import AsyncSandboxPaginator, AsyncSnapshotPaginator
 from .sandbox_async.utils import OutputHandler
 from .sandbox_sync.commands.command_handle import CommandHandle
 from .sandbox_sync.filesystem.watch_handle import WatchHandle
 from .sandbox_sync.main import Sandbox
-from .sandbox_sync.paginator import SandboxPaginator
+from .sandbox_sync.paginator import SandboxPaginator, SnapshotPaginator
 from .template.logger import (
     LogEntry,
     LogEntryEnd,
@@ -153,6 +154,10 @@ __all__ = [
     # Network
     "SandboxNetworkOpts",
     "ALL_TRAFFIC",
+    # Snapshot
+    "SnapshotInfo",
+    "SnapshotPaginator",
+    "AsyncSnapshotPaginator",
     # Sync sandbox
     "Sandbox",
     "SandboxPaginator",

--- a/packages/python-sdk/e2b/api/client/api/sandboxes/get_sandboxes_sandbox_id_logs.py
+++ b/packages/python-sdk/e2b/api/client/api/sandboxes/get_sandboxes_sandbox_id_logs.py
@@ -76,7 +76,7 @@ def sync_detailed(
     start: Union[Unset, int] = UNSET,
     limit: Union[Unset, int] = 1000,
 ) -> Response[Union[Error, SandboxLogs]]:
-    """Get sandbox logs
+    """Get sandbox logs. Use /v2/sandboxes/{sandboxID}/logs instead.
 
     Args:
         sandbox_id (str):
@@ -111,7 +111,7 @@ def sync(
     start: Union[Unset, int] = UNSET,
     limit: Union[Unset, int] = 1000,
 ) -> Optional[Union[Error, SandboxLogs]]:
-    """Get sandbox logs
+    """Get sandbox logs. Use /v2/sandboxes/{sandboxID}/logs instead.
 
     Args:
         sandbox_id (str):
@@ -141,7 +141,7 @@ async def asyncio_detailed(
     start: Union[Unset, int] = UNSET,
     limit: Union[Unset, int] = 1000,
 ) -> Response[Union[Error, SandboxLogs]]:
-    """Get sandbox logs
+    """Get sandbox logs. Use /v2/sandboxes/{sandboxID}/logs instead.
 
     Args:
         sandbox_id (str):
@@ -174,7 +174,7 @@ async def asyncio(
     start: Union[Unset, int] = UNSET,
     limit: Union[Unset, int] = 1000,
 ) -> Optional[Union[Error, SandboxLogs]]:
-    """Get sandbox logs
+    """Get sandbox logs. Use /v2/sandboxes/{sandboxID}/logs instead.
 
     Args:
         sandbox_id (str):

--- a/packages/python-sdk/e2b/api/client/api/sandboxes/get_v_2_sandboxes_sandbox_id_logs.py
+++ b/packages/python-sdk/e2b/api/client/api/sandboxes/get_v_2_sandboxes_sandbox_id_logs.py
@@ -6,44 +6,48 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
-from ...models.post_sandboxes_sandbox_id_snapshots_body import (
-    PostSandboxesSandboxIDSnapshotsBody,
-)
-from ...models.snapshot_info import SnapshotInfo
-from ...types import Response
+from ...models.logs_direction import LogsDirection
+from ...models.sandbox_logs_v2_response import SandboxLogsV2Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     sandbox_id: str,
     *,
-    body: PostSandboxesSandboxIDSnapshotsBody,
+    cursor: Union[Unset, int] = UNSET,
+    limit: Union[Unset, int] = 1000,
+    direction: Union[Unset, LogsDirection] = UNSET,
 ) -> dict[str, Any]:
-    headers: dict[str, Any] = {}
+    params: dict[str, Any] = {}
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    json_direction: Union[Unset, str] = UNSET
+    if not isinstance(direction, Unset):
+        json_direction = direction.value
+
+    params["direction"] = json_direction
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
-        "method": "post",
-        "url": f"/sandboxes/{sandbox_id}/snapshots",
+        "method": "get",
+        "url": f"/v2/sandboxes/{sandbox_id}/logs",
+        "params": params,
     }
 
-    _kwargs["json"] = body.to_dict()
-
-    headers["Content-Type"] = "application/json"
-
-    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SnapshotInfo]]:
-    if response.status_code == 201:
-        response_201 = SnapshotInfo.from_dict(response.json())
+) -> Optional[Union[Error, SandboxLogsV2Response]]:
+    if response.status_code == 200:
+        response_200 = SandboxLogsV2Response.from_dict(response.json())
 
-        return response_201
-    if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
-
-        return response_400
+        return response_200
     if response.status_code == 401:
         response_401 = Error.from_dict(response.json())
 
@@ -64,7 +68,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Error, SnapshotInfo]]:
+) -> Response[Union[Error, SandboxLogsV2Response]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -77,26 +81,31 @@ def sync_detailed(
     sandbox_id: str,
     *,
     client: AuthenticatedClient,
-    body: PostSandboxesSandboxIDSnapshotsBody,
-) -> Response[Union[Error, SnapshotInfo]]:
-    """Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new
-    sandboxes and persist beyond the original sandbox's lifetime.
+    cursor: Union[Unset, int] = UNSET,
+    limit: Union[Unset, int] = 1000,
+    direction: Union[Unset, LogsDirection] = UNSET,
+) -> Response[Union[Error, SandboxLogsV2Response]]:
+    """Get sandbox logs
 
     Args:
         sandbox_id (str):
-        body (PostSandboxesSandboxIDSnapshotsBody):
+        cursor (Union[Unset, int]):
+        limit (Union[Unset, int]):  Default: 1000.
+        direction (Union[Unset, LogsDirection]): Direction of the logs that should be returned
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, SnapshotInfo]]
+        Response[Union[Error, SandboxLogsV2Response]]
     """
 
     kwargs = _get_kwargs(
         sandbox_id=sandbox_id,
-        body=body,
+        cursor=cursor,
+        limit=limit,
+        direction=direction,
     )
 
     response = client.get_httpx_client().request(
@@ -110,27 +119,32 @@ def sync(
     sandbox_id: str,
     *,
     client: AuthenticatedClient,
-    body: PostSandboxesSandboxIDSnapshotsBody,
-) -> Optional[Union[Error, SnapshotInfo]]:
-    """Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new
-    sandboxes and persist beyond the original sandbox's lifetime.
+    cursor: Union[Unset, int] = UNSET,
+    limit: Union[Unset, int] = 1000,
+    direction: Union[Unset, LogsDirection] = UNSET,
+) -> Optional[Union[Error, SandboxLogsV2Response]]:
+    """Get sandbox logs
 
     Args:
         sandbox_id (str):
-        body (PostSandboxesSandboxIDSnapshotsBody):
+        cursor (Union[Unset, int]):
+        limit (Union[Unset, int]):  Default: 1000.
+        direction (Union[Unset, LogsDirection]): Direction of the logs that should be returned
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, SnapshotInfo]
+        Union[Error, SandboxLogsV2Response]
     """
 
     return sync_detailed(
         sandbox_id=sandbox_id,
         client=client,
-        body=body,
+        cursor=cursor,
+        limit=limit,
+        direction=direction,
     ).parsed
 
 
@@ -138,26 +152,31 @@ async def asyncio_detailed(
     sandbox_id: str,
     *,
     client: AuthenticatedClient,
-    body: PostSandboxesSandboxIDSnapshotsBody,
-) -> Response[Union[Error, SnapshotInfo]]:
-    """Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new
-    sandboxes and persist beyond the original sandbox's lifetime.
+    cursor: Union[Unset, int] = UNSET,
+    limit: Union[Unset, int] = 1000,
+    direction: Union[Unset, LogsDirection] = UNSET,
+) -> Response[Union[Error, SandboxLogsV2Response]]:
+    """Get sandbox logs
 
     Args:
         sandbox_id (str):
-        body (PostSandboxesSandboxIDSnapshotsBody):
+        cursor (Union[Unset, int]):
+        limit (Union[Unset, int]):  Default: 1000.
+        direction (Union[Unset, LogsDirection]): Direction of the logs that should be returned
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, SnapshotInfo]]
+        Response[Union[Error, SandboxLogsV2Response]]
     """
 
     kwargs = _get_kwargs(
         sandbox_id=sandbox_id,
-        body=body,
+        cursor=cursor,
+        limit=limit,
+        direction=direction,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -169,27 +188,32 @@ async def asyncio(
     sandbox_id: str,
     *,
     client: AuthenticatedClient,
-    body: PostSandboxesSandboxIDSnapshotsBody,
-) -> Optional[Union[Error, SnapshotInfo]]:
-    """Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new
-    sandboxes and persist beyond the original sandbox's lifetime.
+    cursor: Union[Unset, int] = UNSET,
+    limit: Union[Unset, int] = 1000,
+    direction: Union[Unset, LogsDirection] = UNSET,
+) -> Optional[Union[Error, SandboxLogsV2Response]]:
+    """Get sandbox logs
 
     Args:
         sandbox_id (str):
-        body (PostSandboxesSandboxIDSnapshotsBody):
+        cursor (Union[Unset, int]):
+        limit (Union[Unset, int]):  Default: 1000.
+        direction (Union[Unset, LogsDirection]): Direction of the logs that should be returned
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, SnapshotInfo]
+        Union[Error, SandboxLogsV2Response]
     """
 
     return (
         await asyncio_detailed(
             sandbox_id=sandbox_id,
             client=client,
-            body=body,
+            cursor=cursor,
+            limit=limit,
+            direction=direction,
         )
     ).parsed

--- a/packages/python-sdk/e2b/api/client/api/sandboxes/post_sandboxes_sandbox_id_snapshots.py
+++ b/packages/python-sdk/e2b/api/client/api/sandboxes/post_sandboxes_sandbox_id_snapshots.py
@@ -1,0 +1,171 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.snapshot_info import SnapshotInfo
+from ...types import Response
+
+
+def _get_kwargs(
+    sandbox_id: str,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": f"/sandboxes/{sandbox_id}/snapshots",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Error, SnapshotInfo]]:
+    if response.status_code == 201:
+        response_201 = SnapshotInfo.from_dict(response.json())
+
+        return response_201
+    if response.status_code == 400:
+        response_400 = Error.from_dict(response.json())
+
+        return response_400
+    if response.status_code == 401:
+        response_401 = Error.from_dict(response.json())
+
+        return response_401
+    if response.status_code == 404:
+        response_404 = Error.from_dict(response.json())
+
+        return response_404
+    if response.status_code == 500:
+        response_500 = Error.from_dict(response.json())
+
+        return response_500
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, SnapshotInfo]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    sandbox_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Union[Error, SnapshotInfo]]:
+    """Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new
+    sandboxes and persist beyond the original sandbox's lifetime.
+
+    Args:
+        sandbox_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Error, SnapshotInfo]]
+    """
+
+    kwargs = _get_kwargs(
+        sandbox_id=sandbox_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    sandbox_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Optional[Union[Error, SnapshotInfo]]:
+    """Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new
+    sandboxes and persist beyond the original sandbox's lifetime.
+
+    Args:
+        sandbox_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Error, SnapshotInfo]
+    """
+
+    return sync_detailed(
+        sandbox_id=sandbox_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    sandbox_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Union[Error, SnapshotInfo]]:
+    """Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new
+    sandboxes and persist beyond the original sandbox's lifetime.
+
+    Args:
+        sandbox_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Error, SnapshotInfo]]
+    """
+
+    kwargs = _get_kwargs(
+        sandbox_id=sandbox_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    sandbox_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Optional[Union[Error, SnapshotInfo]]:
+    """Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new
+    sandboxes and persist beyond the original sandbox's lifetime.
+
+    Args:
+        sandbox_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Error, SnapshotInfo]
+    """
+
+    return (
+        await asyncio_detailed(
+            sandbox_id=sandbox_id,
+            client=client,
+        )
+    ).parsed

--- a/packages/python-sdk/e2b/api/client/api/snapshots/__init__.py
+++ b/packages/python-sdk/e2b/api/client/api/snapshots/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/packages/python-sdk/e2b/api/client/api/snapshots/get_snapshots.py
+++ b/packages/python-sdk/e2b/api/client/api/snapshots/get_snapshots.py
@@ -1,0 +1,202 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.snapshot_info import SnapshotInfo
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    sandbox_id: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    next_token: Union[Unset, str] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["sandboxID"] = sandbox_id
+
+    params["limit"] = limit
+
+    params["nextToken"] = next_token
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/snapshots",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Error, list["SnapshotInfo"]]]:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = SnapshotInfo.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = Error.from_dict(response.json())
+
+        return response_401
+    if response.status_code == 500:
+        response_500 = Error.from_dict(response.json())
+
+        return response_500
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, list["SnapshotInfo"]]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    sandbox_id: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    next_token: Union[Unset, str] = UNSET,
+) -> Response[Union[Error, list["SnapshotInfo"]]]:
+    """List all snapshots for the team
+
+    Args:
+        sandbox_id (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        next_token (Union[Unset, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Error, list['SnapshotInfo']]]
+    """
+
+    kwargs = _get_kwargs(
+        sandbox_id=sandbox_id,
+        limit=limit,
+        next_token=next_token,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    sandbox_id: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    next_token: Union[Unset, str] = UNSET,
+) -> Optional[Union[Error, list["SnapshotInfo"]]]:
+    """List all snapshots for the team
+
+    Args:
+        sandbox_id (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        next_token (Union[Unset, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Error, list['SnapshotInfo']]
+    """
+
+    return sync_detailed(
+        client=client,
+        sandbox_id=sandbox_id,
+        limit=limit,
+        next_token=next_token,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    sandbox_id: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    next_token: Union[Unset, str] = UNSET,
+) -> Response[Union[Error, list["SnapshotInfo"]]]:
+    """List all snapshots for the team
+
+    Args:
+        sandbox_id (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        next_token (Union[Unset, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Error, list['SnapshotInfo']]]
+    """
+
+    kwargs = _get_kwargs(
+        sandbox_id=sandbox_id,
+        limit=limit,
+        next_token=next_token,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    sandbox_id: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    next_token: Union[Unset, str] = UNSET,
+) -> Optional[Union[Error, list["SnapshotInfo"]]]:
+    """List all snapshots for the team
+
+    Args:
+        sandbox_id (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        next_token (Union[Unset, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Error, list['SnapshotInfo']]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            sandbox_id=sandbox_id,
+            limit=limit,
+            next_token=next_token,
+        )
+    ).parsed

--- a/packages/python-sdk/e2b/api/client/api/snapshots/get_snapshots.py
+++ b/packages/python-sdk/e2b/api/client/api/snapshots/get_snapshots.py
@@ -13,7 +13,7 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     *,
     sandbox_id: Union[Unset, str] = UNSET,
-    limit: Union[Unset, int] = UNSET,
+    limit: Union[Unset, int] = 100,
     next_token: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
@@ -76,14 +76,14 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     sandbox_id: Union[Unset, str] = UNSET,
-    limit: Union[Unset, int] = UNSET,
+    limit: Union[Unset, int] = 100,
     next_token: Union[Unset, str] = UNSET,
 ) -> Response[Union[Error, list["SnapshotInfo"]]]:
     """List all snapshots for the team
 
     Args:
-        sandbox_id (Union[Unset, str]):
-        limit (Union[Unset, int]):
+        sandbox_id (Union[Unset, str]): Filter snapshots by source sandbox ID
+        limit (Union[Unset, int]):  Default: 100.
         next_token (Union[Unset, str]):
 
     Raises:
@@ -111,14 +111,14 @@ def sync(
     *,
     client: AuthenticatedClient,
     sandbox_id: Union[Unset, str] = UNSET,
-    limit: Union[Unset, int] = UNSET,
+    limit: Union[Unset, int] = 100,
     next_token: Union[Unset, str] = UNSET,
 ) -> Optional[Union[Error, list["SnapshotInfo"]]]:
     """List all snapshots for the team
 
     Args:
-        sandbox_id (Union[Unset, str]):
-        limit (Union[Unset, int]):
+        sandbox_id (Union[Unset, str]): Filter snapshots by source sandbox ID
+        limit (Union[Unset, int]):  Default: 100.
         next_token (Union[Unset, str]):
 
     Raises:
@@ -141,14 +141,14 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     sandbox_id: Union[Unset, str] = UNSET,
-    limit: Union[Unset, int] = UNSET,
+    limit: Union[Unset, int] = 100,
     next_token: Union[Unset, str] = UNSET,
 ) -> Response[Union[Error, list["SnapshotInfo"]]]:
     """List all snapshots for the team
 
     Args:
-        sandbox_id (Union[Unset, str]):
-        limit (Union[Unset, int]):
+        sandbox_id (Union[Unset, str]): Filter snapshots by source sandbox ID
+        limit (Union[Unset, int]):  Default: 100.
         next_token (Union[Unset, str]):
 
     Raises:
@@ -174,14 +174,14 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     sandbox_id: Union[Unset, str] = UNSET,
-    limit: Union[Unset, int] = UNSET,
+    limit: Union[Unset, int] = 100,
     next_token: Union[Unset, str] = UNSET,
 ) -> Optional[Union[Error, list["SnapshotInfo"]]]:
     """List all snapshots for the team
 
     Args:
-        sandbox_id (Union[Unset, str]):
-        limit (Union[Unset, int]):
+        sandbox_id (Union[Unset, str]): Filter snapshots by source sandbox ID
+        limit (Union[Unset, int]):  Default: 100.
         next_token (Union[Unset, str]):
 
     Raises:

--- a/packages/python-sdk/e2b/api/client/api/tags/get_templates_template_id_tags.py
+++ b/packages/python-sdk/e2b/api/client/api/tags/get_templates_template_id_tags.py
@@ -6,48 +6,41 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
-from ...models.post_sandboxes_sandbox_id_snapshots_body import (
-    PostSandboxesSandboxIDSnapshotsBody,
-)
-from ...models.snapshot_info import SnapshotInfo
+from ...models.template_tag import TemplateTag
 from ...types import Response
 
 
 def _get_kwargs(
-    sandbox_id: str,
-    *,
-    body: PostSandboxesSandboxIDSnapshotsBody,
+    template_id: str,
 ) -> dict[str, Any]:
-    headers: dict[str, Any] = {}
-
     _kwargs: dict[str, Any] = {
-        "method": "post",
-        "url": f"/sandboxes/{sandbox_id}/snapshots",
+        "method": "get",
+        "url": f"/templates/{template_id}/tags",
     }
 
-    _kwargs["json"] = body.to_dict()
-
-    headers["Content-Type"] = "application/json"
-
-    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SnapshotInfo]]:
-    if response.status_code == 201:
-        response_201 = SnapshotInfo.from_dict(response.json())
+) -> Optional[Union[Error, list["TemplateTag"]]]:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = TemplateTag.from_dict(response_200_item_data)
 
-        return response_201
-    if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+            response_200.append(response_200_item)
 
-        return response_400
+        return response_200
     if response.status_code == 401:
         response_401 = Error.from_dict(response.json())
 
         return response_401
+    if response.status_code == 403:
+        response_403 = Error.from_dict(response.json())
+
+        return response_403
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
@@ -64,7 +57,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Error, SnapshotInfo]]:
+) -> Response[Union[Error, list["TemplateTag"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -74,29 +67,25 @@ def _build_response(
 
 
 def sync_detailed(
-    sandbox_id: str,
+    template_id: str,
     *,
     client: AuthenticatedClient,
-    body: PostSandboxesSandboxIDSnapshotsBody,
-) -> Response[Union[Error, SnapshotInfo]]:
-    """Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new
-    sandboxes and persist beyond the original sandbox's lifetime.
+) -> Response[Union[Error, list["TemplateTag"]]]:
+    """List all tags for a template
 
     Args:
-        sandbox_id (str):
-        body (PostSandboxesSandboxIDSnapshotsBody):
+        template_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, SnapshotInfo]]
+        Response[Union[Error, list['TemplateTag']]]
     """
 
     kwargs = _get_kwargs(
-        sandbox_id=sandbox_id,
-        body=body,
+        template_id=template_id,
     )
 
     response = client.get_httpx_client().request(
@@ -107,57 +96,49 @@ def sync_detailed(
 
 
 def sync(
-    sandbox_id: str,
+    template_id: str,
     *,
     client: AuthenticatedClient,
-    body: PostSandboxesSandboxIDSnapshotsBody,
-) -> Optional[Union[Error, SnapshotInfo]]:
-    """Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new
-    sandboxes and persist beyond the original sandbox's lifetime.
+) -> Optional[Union[Error, list["TemplateTag"]]]:
+    """List all tags for a template
 
     Args:
-        sandbox_id (str):
-        body (PostSandboxesSandboxIDSnapshotsBody):
+        template_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, SnapshotInfo]
+        Union[Error, list['TemplateTag']]
     """
 
     return sync_detailed(
-        sandbox_id=sandbox_id,
+        template_id=template_id,
         client=client,
-        body=body,
     ).parsed
 
 
 async def asyncio_detailed(
-    sandbox_id: str,
+    template_id: str,
     *,
     client: AuthenticatedClient,
-    body: PostSandboxesSandboxIDSnapshotsBody,
-) -> Response[Union[Error, SnapshotInfo]]:
-    """Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new
-    sandboxes and persist beyond the original sandbox's lifetime.
+) -> Response[Union[Error, list["TemplateTag"]]]:
+    """List all tags for a template
 
     Args:
-        sandbox_id (str):
-        body (PostSandboxesSandboxIDSnapshotsBody):
+        template_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, SnapshotInfo]]
+        Response[Union[Error, list['TemplateTag']]]
     """
 
     kwargs = _get_kwargs(
-        sandbox_id=sandbox_id,
-        body=body,
+        template_id=template_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -166,30 +147,26 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    sandbox_id: str,
+    template_id: str,
     *,
     client: AuthenticatedClient,
-    body: PostSandboxesSandboxIDSnapshotsBody,
-) -> Optional[Union[Error, SnapshotInfo]]:
-    """Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new
-    sandboxes and persist beyond the original sandbox's lifetime.
+) -> Optional[Union[Error, list["TemplateTag"]]]:
+    """List all tags for a template
 
     Args:
-        sandbox_id (str):
-        body (PostSandboxesSandboxIDSnapshotsBody):
+        template_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, SnapshotInfo]
+        Union[Error, list['TemplateTag']]
     """
 
     return (
         await asyncio_detailed(
-            sandbox_id=sandbox_id,
+            template_id=template_id,
             client=client,
-            body=body,
         )
     ).parsed

--- a/packages/python-sdk/e2b/api/client/models/__init__.py
+++ b/packages/python-sdk/e2b/api/client/models/__init__.py
@@ -48,6 +48,7 @@ from .sandbox_metric import SandboxMetric
 from .sandbox_network_config import SandboxNetworkConfig
 from .sandbox_state import SandboxState
 from .sandboxes_with_metrics import SandboxesWithMetrics
+from .snapshot_info import SnapshotInfo
 from .team import Team
 from .team_api_key import TeamAPIKey
 from .team_metric import TeamMetric
@@ -118,6 +119,7 @@ __all__ = (
     "SandboxMetric",
     "SandboxNetworkConfig",
     "SandboxState",
+    "SnapshotInfo",
     "Team",
     "TeamAPIKey",
     "TeamMetric",

--- a/packages/python-sdk/e2b/api/client/models/__init__.py
+++ b/packages/python-sdk/e2b/api/client/models/__init__.py
@@ -28,6 +28,7 @@ from .mcp_type_0 import McpType0
 from .new_access_token import NewAccessToken
 from .new_sandbox import NewSandbox
 from .new_team_api_key import NewTeamAPIKey
+from .new_volume import NewVolume
 from .node import Node
 from .node_detail import NodeDetail
 from .node_metrics import NodeMetrics
@@ -36,17 +37,24 @@ from .node_status_change import NodeStatusChange
 from .post_sandboxes_sandbox_id_refreshes_body import (
     PostSandboxesSandboxIDRefreshesBody,
 )
+from .post_sandboxes_sandbox_id_snapshots_body import (
+    PostSandboxesSandboxIDSnapshotsBody,
+)
 from .post_sandboxes_sandbox_id_timeout_body import PostSandboxesSandboxIDTimeoutBody
 from .resumed_sandbox import ResumedSandbox
 from .sandbox import Sandbox
+from .sandbox_auto_resume_config import SandboxAutoResumeConfig
+from .sandbox_auto_resume_policy import SandboxAutoResumePolicy
 from .sandbox_detail import SandboxDetail
 from .sandbox_log import SandboxLog
 from .sandbox_log_entry import SandboxLogEntry
 from .sandbox_log_entry_fields import SandboxLogEntryFields
 from .sandbox_logs import SandboxLogs
+from .sandbox_logs_v2_response import SandboxLogsV2Response
 from .sandbox_metric import SandboxMetric
 from .sandbox_network_config import SandboxNetworkConfig
 from .sandbox_state import SandboxState
+from .sandbox_volume_mount import SandboxVolumeMount
 from .sandboxes_with_metrics import SandboxesWithMetrics
 from .snapshot_info import SnapshotInfo
 from .team import Team
@@ -67,10 +75,12 @@ from .template_build_status import TemplateBuildStatus
 from .template_legacy import TemplateLegacy
 from .template_request_response_v3 import TemplateRequestResponseV3
 from .template_step import TemplateStep
+from .template_tag import TemplateTag
 from .template_update_request import TemplateUpdateRequest
 from .template_update_response import TemplateUpdateResponse
 from .template_with_builds import TemplateWithBuilds
 from .update_team_api_key import UpdateTeamAPIKey
+from .volume import Volume
 
 __all__ = (
     "AdminSandboxKillResult",
@@ -101,24 +111,30 @@ __all__ = (
     "NewAccessToken",
     "NewSandbox",
     "NewTeamAPIKey",
+    "NewVolume",
     "Node",
     "NodeDetail",
     "NodeMetrics",
     "NodeStatus",
     "NodeStatusChange",
     "PostSandboxesSandboxIDRefreshesBody",
+    "PostSandboxesSandboxIDSnapshotsBody",
     "PostSandboxesSandboxIDTimeoutBody",
     "ResumedSandbox",
     "Sandbox",
+    "SandboxAutoResumeConfig",
+    "SandboxAutoResumePolicy",
     "SandboxDetail",
     "SandboxesWithMetrics",
     "SandboxLog",
     "SandboxLogEntry",
     "SandboxLogEntryFields",
     "SandboxLogs",
+    "SandboxLogsV2Response",
     "SandboxMetric",
     "SandboxNetworkConfig",
     "SandboxState",
+    "SandboxVolumeMount",
     "SnapshotInfo",
     "Team",
     "TeamAPIKey",
@@ -138,8 +154,10 @@ __all__ = (
     "TemplateLegacy",
     "TemplateRequestResponseV3",
     "TemplateStep",
+    "TemplateTag",
     "TemplateUpdateRequest",
     "TemplateUpdateResponse",
     "TemplateWithBuilds",
     "UpdateTeamAPIKey",
+    "Volume",
 )

--- a/packages/python-sdk/e2b/api/client/models/listed_sandbox.py
+++ b/packages/python-sdk/e2b/api/client/models/listed_sandbox.py
@@ -1,6 +1,6 @@
 import datetime
 from collections.abc import Mapping
-from typing import Any, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -8,6 +8,10 @@ from dateutil.parser import isoparse
 
 from ..models.sandbox_state import SandboxState
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.sandbox_volume_mount import SandboxVolumeMount
+
 
 T = TypeVar("T", bound="ListedSandbox")
 
@@ -26,6 +30,7 @@ class ListedSandbox:
         started_at (datetime.datetime): Time when the sandbox was started
         state (SandboxState): State of the sandbox
         template_id (str): Identifier of the template from which is the sandbox created
+        volume_mounts (list['SandboxVolumeMount']):
         alias (Union[Unset, str]): Alias of the template
         metadata (Union[Unset, Any]):
     """
@@ -40,6 +45,7 @@ class ListedSandbox:
     started_at: datetime.datetime
     state: SandboxState
     template_id: str
+    volume_mounts: list["SandboxVolumeMount"]
     alias: Union[Unset, str] = UNSET
     metadata: Union[Unset, Any] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -65,6 +71,11 @@ class ListedSandbox:
 
         template_id = self.template_id
 
+        volume_mounts = []
+        for volume_mounts_item_data in self.volume_mounts:
+            volume_mounts_item = volume_mounts_item_data.to_dict()
+            volume_mounts.append(volume_mounts_item)
+
         alias = self.alias
 
         metadata = self.metadata
@@ -83,6 +94,7 @@ class ListedSandbox:
                 "startedAt": started_at,
                 "state": state,
                 "templateID": template_id,
+                "volumeMounts": volume_mounts,
             }
         )
         if alias is not UNSET:
@@ -94,6 +106,8 @@ class ListedSandbox:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.sandbox_volume_mount import SandboxVolumeMount
+
         d = dict(src_dict)
         client_id = d.pop("clientID")
 
@@ -115,6 +129,13 @@ class ListedSandbox:
 
         template_id = d.pop("templateID")
 
+        volume_mounts = []
+        _volume_mounts = d.pop("volumeMounts")
+        for volume_mounts_item_data in _volume_mounts:
+            volume_mounts_item = SandboxVolumeMount.from_dict(volume_mounts_item_data)
+
+            volume_mounts.append(volume_mounts_item)
+
         alias = d.pop("alias", UNSET)
 
         metadata = d.pop("metadata", UNSET)
@@ -130,6 +151,7 @@ class ListedSandbox:
             started_at=started_at,
             state=state,
             template_id=template_id,
+            volume_mounts=volume_mounts,
             alias=alias,
             metadata=metadata,
         )

--- a/packages/python-sdk/e2b/api/client/models/listed_sandbox.py
+++ b/packages/python-sdk/e2b/api/client/models/listed_sandbox.py
@@ -30,9 +30,9 @@ class ListedSandbox:
         started_at (datetime.datetime): Time when the sandbox was started
         state (SandboxState): State of the sandbox
         template_id (str): Identifier of the template from which is the sandbox created
-        volume_mounts (list['SandboxVolumeMount']):
         alias (Union[Unset, str]): Alias of the template
         metadata (Union[Unset, Any]):
+        volume_mounts (Union[Unset, list['SandboxVolumeMount']]):
     """
 
     client_id: str
@@ -45,9 +45,9 @@ class ListedSandbox:
     started_at: datetime.datetime
     state: SandboxState
     template_id: str
-    volume_mounts: list["SandboxVolumeMount"]
     alias: Union[Unset, str] = UNSET
     metadata: Union[Unset, Any] = UNSET
+    volume_mounts: Union[Unset, list["SandboxVolumeMount"]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -71,14 +71,16 @@ class ListedSandbox:
 
         template_id = self.template_id
 
-        volume_mounts = []
-        for volume_mounts_item_data in self.volume_mounts:
-            volume_mounts_item = volume_mounts_item_data.to_dict()
-            volume_mounts.append(volume_mounts_item)
-
         alias = self.alias
 
         metadata = self.metadata
+
+        volume_mounts: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.volume_mounts, Unset):
+            volume_mounts = []
+            for volume_mounts_item_data in self.volume_mounts:
+                volume_mounts_item = volume_mounts_item_data.to_dict()
+                volume_mounts.append(volume_mounts_item)
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -94,13 +96,14 @@ class ListedSandbox:
                 "startedAt": started_at,
                 "state": state,
                 "templateID": template_id,
-                "volumeMounts": volume_mounts,
             }
         )
         if alias is not UNSET:
             field_dict["alias"] = alias
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
+        if volume_mounts is not UNSET:
+            field_dict["volumeMounts"] = volume_mounts
 
         return field_dict
 
@@ -129,16 +132,16 @@ class ListedSandbox:
 
         template_id = d.pop("templateID")
 
-        volume_mounts = []
-        _volume_mounts = d.pop("volumeMounts")
-        for volume_mounts_item_data in _volume_mounts:
-            volume_mounts_item = SandboxVolumeMount.from_dict(volume_mounts_item_data)
-
-            volume_mounts.append(volume_mounts_item)
-
         alias = d.pop("alias", UNSET)
 
         metadata = d.pop("metadata", UNSET)
+
+        volume_mounts = []
+        _volume_mounts = d.pop("volumeMounts", UNSET)
+        for volume_mounts_item_data in _volume_mounts or []:
+            volume_mounts_item = SandboxVolumeMount.from_dict(volume_mounts_item_data)
+
+            volume_mounts.append(volume_mounts_item)
 
         listed_sandbox = cls(
             client_id=client_id,
@@ -151,9 +154,9 @@ class ListedSandbox:
             started_at=started_at,
             state=state,
             template_id=template_id,
-            volume_mounts=volume_mounts,
             alias=alias,
             metadata=metadata,
+            volume_mounts=volume_mounts,
         )
 
         listed_sandbox.additional_properties = d

--- a/packages/python-sdk/e2b/api/client/models/new_sandbox.py
+++ b/packages/python-sdk/e2b/api/client/models/new_sandbox.py
@@ -8,7 +8,9 @@ from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
     from ..models.mcp_type_0 import McpType0
+    from ..models.sandbox_auto_resume_config import SandboxAutoResumeConfig
     from ..models.sandbox_network_config import SandboxNetworkConfig
+    from ..models.sandbox_volume_mount import SandboxVolumeMount
 
 
 T = TypeVar("T", bound="NewSandbox")
@@ -22,23 +24,28 @@ class NewSandbox:
         allow_internet_access (Union[Unset, bool]): Allow sandbox to access the internet. When set to false, it behaves
             the same as specifying denyOut to 0.0.0.0/0 in the network config.
         auto_pause (Union[Unset, bool]): Automatically pauses the sandbox after the timeout Default: False.
+        auto_resume (Union[Unset, SandboxAutoResumeConfig]): Auto-resume configuration for paused sandboxes. Default is
+            off.
         env_vars (Union[Unset, Any]):
         mcp (Union['McpType0', None, Unset]): MCP configuration for the sandbox
         metadata (Union[Unset, Any]):
         network (Union[Unset, SandboxNetworkConfig]):
         secure (Union[Unset, bool]): Secure all system communication with sandbox
         timeout (Union[Unset, int]): Time to live for the sandbox in seconds. Default: 15.
+        volume_mounts (Union[Unset, list['SandboxVolumeMount']]):
     """
 
     template_id: str
     allow_internet_access: Union[Unset, bool] = UNSET
     auto_pause: Union[Unset, bool] = False
+    auto_resume: Union[Unset, "SandboxAutoResumeConfig"] = UNSET
     env_vars: Union[Unset, Any] = UNSET
     mcp: Union["McpType0", None, Unset] = UNSET
     metadata: Union[Unset, Any] = UNSET
     network: Union[Unset, "SandboxNetworkConfig"] = UNSET
     secure: Union[Unset, bool] = UNSET
     timeout: Union[Unset, int] = 15
+    volume_mounts: Union[Unset, list["SandboxVolumeMount"]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -49,6 +56,10 @@ class NewSandbox:
         allow_internet_access = self.allow_internet_access
 
         auto_pause = self.auto_pause
+
+        auto_resume: Union[Unset, dict[str, Any]] = UNSET
+        if not isinstance(self.auto_resume, Unset):
+            auto_resume = self.auto_resume.to_dict()
 
         env_vars = self.env_vars
 
@@ -70,6 +81,13 @@ class NewSandbox:
 
         timeout = self.timeout
 
+        volume_mounts: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.volume_mounts, Unset):
+            volume_mounts = []
+            for volume_mounts_item_data in self.volume_mounts:
+                volume_mounts_item = volume_mounts_item_data.to_dict()
+                volume_mounts.append(volume_mounts_item)
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -81,6 +99,8 @@ class NewSandbox:
             field_dict["allow_internet_access"] = allow_internet_access
         if auto_pause is not UNSET:
             field_dict["autoPause"] = auto_pause
+        if auto_resume is not UNSET:
+            field_dict["autoResume"] = auto_resume
         if env_vars is not UNSET:
             field_dict["envVars"] = env_vars
         if mcp is not UNSET:
@@ -93,13 +113,17 @@ class NewSandbox:
             field_dict["secure"] = secure
         if timeout is not UNSET:
             field_dict["timeout"] = timeout
+        if volume_mounts is not UNSET:
+            field_dict["volumeMounts"] = volume_mounts
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.mcp_type_0 import McpType0
+        from ..models.sandbox_auto_resume_config import SandboxAutoResumeConfig
         from ..models.sandbox_network_config import SandboxNetworkConfig
+        from ..models.sandbox_volume_mount import SandboxVolumeMount
 
         d = dict(src_dict)
         template_id = d.pop("templateID")
@@ -107,6 +131,13 @@ class NewSandbox:
         allow_internet_access = d.pop("allow_internet_access", UNSET)
 
         auto_pause = d.pop("autoPause", UNSET)
+
+        _auto_resume = d.pop("autoResume", UNSET)
+        auto_resume: Union[Unset, SandboxAutoResumeConfig]
+        if isinstance(_auto_resume, Unset):
+            auto_resume = UNSET
+        else:
+            auto_resume = SandboxAutoResumeConfig.from_dict(_auto_resume)
 
         env_vars = d.pop("envVars", UNSET)
 
@@ -140,16 +171,25 @@ class NewSandbox:
 
         timeout = d.pop("timeout", UNSET)
 
+        volume_mounts = []
+        _volume_mounts = d.pop("volumeMounts", UNSET)
+        for volume_mounts_item_data in _volume_mounts or []:
+            volume_mounts_item = SandboxVolumeMount.from_dict(volume_mounts_item_data)
+
+            volume_mounts.append(volume_mounts_item)
+
         new_sandbox = cls(
             template_id=template_id,
             allow_internet_access=allow_internet_access,
             auto_pause=auto_pause,
+            auto_resume=auto_resume,
             env_vars=env_vars,
             mcp=mcp,
             metadata=metadata,
             network=network,
             secure=secure,
             timeout=timeout,
+            volume_mounts=volume_mounts,
         )
 
         new_sandbox.additional_properties = d

--- a/packages/python-sdk/e2b/api/client/models/new_volume.py
+++ b/packages/python-sdk/e2b/api/client/models/new_volume.py
@@ -1,36 +1,30 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-T = TypeVar("T", bound="SnapshotInfo")
+T = TypeVar("T", bound="NewVolume")
 
 
 @_attrs_define
-class SnapshotInfo:
+class NewVolume:
     """
     Attributes:
-        names (list[str]): Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-
-            snapshot:v2)
-        snapshot_id (str): Identifier of the snapshot template
+        name (str): Name of the volume
     """
 
-    names: list[str]
-    snapshot_id: str
+    name: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        names = self.names
-
-        snapshot_id = self.snapshot_id
+        name = self.name
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "names": names,
-                "snapshotID": snapshot_id,
+                "name": name,
             }
         )
 
@@ -39,17 +33,14 @@ class SnapshotInfo:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        names = cast(list[str], d.pop("names"))
+        name = d.pop("name")
 
-        snapshot_id = d.pop("snapshotID")
-
-        snapshot_info = cls(
-            names=names,
-            snapshot_id=snapshot_id,
+        new_volume = cls(
+            name=name,
         )
 
-        snapshot_info.additional_properties = d
-        return snapshot_info
+        new_volume.additional_properties = d
+        return new_volume
 
     @property
     def additional_keys(self) -> list[str]:

--- a/packages/python-sdk/e2b/api/client/models/post_sandboxes_sandbox_id_snapshots_body.py
+++ b/packages/python-sdk/e2b/api/client/models/post_sandboxes_sandbox_id_snapshots_body.py
@@ -1,55 +1,47 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-T = TypeVar("T", bound="SnapshotInfo")
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="PostSandboxesSandboxIDSnapshotsBody")
 
 
 @_attrs_define
-class SnapshotInfo:
+class PostSandboxesSandboxIDSnapshotsBody:
     """
     Attributes:
-        names (list[str]): Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-
-            snapshot:v2)
-        snapshot_id (str): Identifier of the snapshot template
+        name (Union[Unset, str]): Optional name for the snapshot template. If a snapshot template with this name already
+            exists, a new build will be assigned to the existing template instead of creating a new one.
     """
 
-    names: list[str]
-    snapshot_id: str
+    name: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        names = self.names
-
-        snapshot_id = self.snapshot_id
+        name = self.name
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "names": names,
-                "snapshotID": snapshot_id,
-            }
-        )
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        names = cast(list[str], d.pop("names"))
+        name = d.pop("name", UNSET)
 
-        snapshot_id = d.pop("snapshotID")
-
-        snapshot_info = cls(
-            names=names,
-            snapshot_id=snapshot_id,
+        post_sandboxes_sandbox_id_snapshots_body = cls(
+            name=name,
         )
 
-        snapshot_info.additional_properties = d
-        return snapshot_info
+        post_sandboxes_sandbox_id_snapshots_body.additional_properties = d
+        return post_sandboxes_sandbox_id_snapshots_body
 
     @property
     def additional_keys(self) -> list[str]:

--- a/packages/python-sdk/e2b/api/client/models/sandbox_auto_resume_config.py
+++ b/packages/python-sdk/e2b/api/client/models/sandbox_auto_resume_config.py
@@ -1,36 +1,33 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-T = TypeVar("T", bound="SnapshotInfo")
+from ..models.sandbox_auto_resume_policy import SandboxAutoResumePolicy
+
+T = TypeVar("T", bound="SandboxAutoResumeConfig")
 
 
 @_attrs_define
-class SnapshotInfo:
-    """
+class SandboxAutoResumeConfig:
+    """Auto-resume configuration for paused sandboxes. Default is off.
+
     Attributes:
-        names (list[str]): Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-
-            snapshot:v2)
-        snapshot_id (str): Identifier of the snapshot template
+        policy (SandboxAutoResumePolicy): Auto-resume policy for paused sandboxes. Default is off.
     """
 
-    names: list[str]
-    snapshot_id: str
+    policy: SandboxAutoResumePolicy
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        names = self.names
-
-        snapshot_id = self.snapshot_id
+        policy = self.policy.value
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "names": names,
-                "snapshotID": snapshot_id,
+                "policy": policy,
             }
         )
 
@@ -39,17 +36,14 @@ class SnapshotInfo:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        names = cast(list[str], d.pop("names"))
+        policy = SandboxAutoResumePolicy(d.pop("policy"))
 
-        snapshot_id = d.pop("snapshotID")
-
-        snapshot_info = cls(
-            names=names,
-            snapshot_id=snapshot_id,
+        sandbox_auto_resume_config = cls(
+            policy=policy,
         )
 
-        snapshot_info.additional_properties = d
-        return snapshot_info
+        sandbox_auto_resume_config.additional_properties = d
+        return sandbox_auto_resume_config
 
     @property
     def additional_keys(self) -> list[str]:

--- a/packages/python-sdk/e2b/api/client/models/sandbox_auto_resume_policy.py
+++ b/packages/python-sdk/e2b/api/client/models/sandbox_auto_resume_policy.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class SandboxAutoResumePolicy(str, Enum):
+    ANY = "any"
+    OFF = "off"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/python-sdk/e2b/api/client/models/sandbox_detail.py
+++ b/packages/python-sdk/e2b/api/client/models/sandbox_detail.py
@@ -1,6 +1,6 @@
 import datetime
 from collections.abc import Mapping
-from typing import Any, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -8,6 +8,10 @@ from dateutil.parser import isoparse
 
 from ..models.sandbox_state import SandboxState
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.sandbox_volume_mount import SandboxVolumeMount
+
 
 T = TypeVar("T", bound="SandboxDetail")
 
@@ -26,6 +30,7 @@ class SandboxDetail:
         started_at (datetime.datetime): Time when the sandbox was started
         state (SandboxState): State of the sandbox
         template_id (str): Identifier of the template from which is the sandbox created
+        volume_mounts (list['SandboxVolumeMount']):
         alias (Union[Unset, str]): Alias of the template
         domain (Union[None, Unset, str]): Base domain where the sandbox traffic is accessible
         envd_access_token (Union[Unset, str]): Access token used for envd communication
@@ -42,6 +47,7 @@ class SandboxDetail:
     started_at: datetime.datetime
     state: SandboxState
     template_id: str
+    volume_mounts: list["SandboxVolumeMount"]
     alias: Union[Unset, str] = UNSET
     domain: Union[None, Unset, str] = UNSET
     envd_access_token: Union[Unset, str] = UNSET
@@ -69,6 +75,11 @@ class SandboxDetail:
 
         template_id = self.template_id
 
+        volume_mounts = []
+        for volume_mounts_item_data in self.volume_mounts:
+            volume_mounts_item = volume_mounts_item_data.to_dict()
+            volume_mounts.append(volume_mounts_item)
+
         alias = self.alias
 
         domain: Union[None, Unset, str]
@@ -95,6 +106,7 @@ class SandboxDetail:
                 "startedAt": started_at,
                 "state": state,
                 "templateID": template_id,
+                "volumeMounts": volume_mounts,
             }
         )
         if alias is not UNSET:
@@ -110,6 +122,8 @@ class SandboxDetail:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.sandbox_volume_mount import SandboxVolumeMount
+
         d = dict(src_dict)
         client_id = d.pop("clientID")
 
@@ -130,6 +144,13 @@ class SandboxDetail:
         state = SandboxState(d.pop("state"))
 
         template_id = d.pop("templateID")
+
+        volume_mounts = []
+        _volume_mounts = d.pop("volumeMounts")
+        for volume_mounts_item_data in _volume_mounts:
+            volume_mounts_item = SandboxVolumeMount.from_dict(volume_mounts_item_data)
+
+            volume_mounts.append(volume_mounts_item)
 
         alias = d.pop("alias", UNSET)
 
@@ -157,6 +178,7 @@ class SandboxDetail:
             started_at=started_at,
             state=state,
             template_id=template_id,
+            volume_mounts=volume_mounts,
             alias=alias,
             domain=domain,
             envd_access_token=envd_access_token,

--- a/packages/python-sdk/e2b/api/client/models/sandbox_detail.py
+++ b/packages/python-sdk/e2b/api/client/models/sandbox_detail.py
@@ -30,11 +30,11 @@ class SandboxDetail:
         started_at (datetime.datetime): Time when the sandbox was started
         state (SandboxState): State of the sandbox
         template_id (str): Identifier of the template from which is the sandbox created
-        volume_mounts (list['SandboxVolumeMount']):
         alias (Union[Unset, str]): Alias of the template
         domain (Union[None, Unset, str]): Base domain where the sandbox traffic is accessible
         envd_access_token (Union[Unset, str]): Access token used for envd communication
         metadata (Union[Unset, Any]):
+        volume_mounts (Union[Unset, list['SandboxVolumeMount']]):
     """
 
     client_id: str
@@ -47,11 +47,11 @@ class SandboxDetail:
     started_at: datetime.datetime
     state: SandboxState
     template_id: str
-    volume_mounts: list["SandboxVolumeMount"]
     alias: Union[Unset, str] = UNSET
     domain: Union[None, Unset, str] = UNSET
     envd_access_token: Union[Unset, str] = UNSET
     metadata: Union[Unset, Any] = UNSET
+    volume_mounts: Union[Unset, list["SandboxVolumeMount"]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -75,11 +75,6 @@ class SandboxDetail:
 
         template_id = self.template_id
 
-        volume_mounts = []
-        for volume_mounts_item_data in self.volume_mounts:
-            volume_mounts_item = volume_mounts_item_data.to_dict()
-            volume_mounts.append(volume_mounts_item)
-
         alias = self.alias
 
         domain: Union[None, Unset, str]
@@ -91,6 +86,13 @@ class SandboxDetail:
         envd_access_token = self.envd_access_token
 
         metadata = self.metadata
+
+        volume_mounts: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.volume_mounts, Unset):
+            volume_mounts = []
+            for volume_mounts_item_data in self.volume_mounts:
+                volume_mounts_item = volume_mounts_item_data.to_dict()
+                volume_mounts.append(volume_mounts_item)
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -106,7 +108,6 @@ class SandboxDetail:
                 "startedAt": started_at,
                 "state": state,
                 "templateID": template_id,
-                "volumeMounts": volume_mounts,
             }
         )
         if alias is not UNSET:
@@ -117,6 +118,8 @@ class SandboxDetail:
             field_dict["envdAccessToken"] = envd_access_token
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
+        if volume_mounts is not UNSET:
+            field_dict["volumeMounts"] = volume_mounts
 
         return field_dict
 
@@ -145,13 +148,6 @@ class SandboxDetail:
 
         template_id = d.pop("templateID")
 
-        volume_mounts = []
-        _volume_mounts = d.pop("volumeMounts")
-        for volume_mounts_item_data in _volume_mounts:
-            volume_mounts_item = SandboxVolumeMount.from_dict(volume_mounts_item_data)
-
-            volume_mounts.append(volume_mounts_item)
-
         alias = d.pop("alias", UNSET)
 
         def _parse_domain(data: object) -> Union[None, Unset, str]:
@@ -167,6 +163,13 @@ class SandboxDetail:
 
         metadata = d.pop("metadata", UNSET)
 
+        volume_mounts = []
+        _volume_mounts = d.pop("volumeMounts", UNSET)
+        for volume_mounts_item_data in _volume_mounts or []:
+            volume_mounts_item = SandboxVolumeMount.from_dict(volume_mounts_item_data)
+
+            volume_mounts.append(volume_mounts_item)
+
         sandbox_detail = cls(
             client_id=client_id,
             cpu_count=cpu_count,
@@ -178,11 +181,11 @@ class SandboxDetail:
             started_at=started_at,
             state=state,
             template_id=template_id,
-            volume_mounts=volume_mounts,
             alias=alias,
             domain=domain,
             envd_access_token=envd_access_token,
             metadata=metadata,
+            volume_mounts=volume_mounts,
         )
 
         sandbox_detail.additional_properties = d

--- a/packages/python-sdk/e2b/api/client/models/sandbox_logs_v2_response.py
+++ b/packages/python-sdk/e2b/api/client/models/sandbox_logs_v2_response.py
@@ -1,36 +1,37 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-T = TypeVar("T", bound="SnapshotInfo")
+if TYPE_CHECKING:
+    from ..models.sandbox_log_entry import SandboxLogEntry
+
+
+T = TypeVar("T", bound="SandboxLogsV2Response")
 
 
 @_attrs_define
-class SnapshotInfo:
+class SandboxLogsV2Response:
     """
     Attributes:
-        names (list[str]): Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-
-            snapshot:v2)
-        snapshot_id (str): Identifier of the snapshot template
+        logs (list['SandboxLogEntry']): Sandbox logs structured
     """
 
-    names: list[str]
-    snapshot_id: str
+    logs: list["SandboxLogEntry"]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        names = self.names
-
-        snapshot_id = self.snapshot_id
+        logs = []
+        for logs_item_data in self.logs:
+            logs_item = logs_item_data.to_dict()
+            logs.append(logs_item)
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "names": names,
-                "snapshotID": snapshot_id,
+                "logs": logs,
             }
         )
 
@@ -38,18 +39,22 @@ class SnapshotInfo:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.sandbox_log_entry import SandboxLogEntry
+
         d = dict(src_dict)
-        names = cast(list[str], d.pop("names"))
+        logs = []
+        _logs = d.pop("logs")
+        for logs_item_data in _logs:
+            logs_item = SandboxLogEntry.from_dict(logs_item_data)
 
-        snapshot_id = d.pop("snapshotID")
+            logs.append(logs_item)
 
-        snapshot_info = cls(
-            names=names,
-            snapshot_id=snapshot_id,
+        sandbox_logs_v2_response = cls(
+            logs=logs,
         )
 
-        snapshot_info.additional_properties = d
-        return snapshot_info
+        sandbox_logs_v2_response.additional_properties = d
+        return sandbox_logs_v2_response
 
     @property
     def additional_keys(self) -> list[str]:

--- a/packages/python-sdk/e2b/api/client/models/sandbox_volume_mount.py
+++ b/packages/python-sdk/e2b/api/client/models/sandbox_volume_mount.py
@@ -1,36 +1,35 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-T = TypeVar("T", bound="SnapshotInfo")
+T = TypeVar("T", bound="SandboxVolumeMount")
 
 
 @_attrs_define
-class SnapshotInfo:
+class SandboxVolumeMount:
     """
     Attributes:
-        names (list[str]): Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-
-            snapshot:v2)
-        snapshot_id (str): Identifier of the snapshot template
+        name (str): Name of the volume
+        path (str): Path of the volume
     """
 
-    names: list[str]
-    snapshot_id: str
+    name: str
+    path: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        names = self.names
+        name = self.name
 
-        snapshot_id = self.snapshot_id
+        path = self.path
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "names": names,
-                "snapshotID": snapshot_id,
+                "name": name,
+                "path": path,
             }
         )
 
@@ -39,17 +38,17 @@ class SnapshotInfo:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        names = cast(list[str], d.pop("names"))
+        name = d.pop("name")
 
-        snapshot_id = d.pop("snapshotID")
+        path = d.pop("path")
 
-        snapshot_info = cls(
-            names=names,
-            snapshot_id=snapshot_id,
+        sandbox_volume_mount = cls(
+            name=name,
+            path=path,
         )
 
-        snapshot_info.additional_properties = d
-        return snapshot_info
+        sandbox_volume_mount.additional_properties = d
+        return sandbox_volume_mount
 
     @property
     def additional_keys(self) -> list[str]:

--- a/packages/python-sdk/e2b/api/client/models/snapshot_info.py
+++ b/packages/python-sdk/e2b/api/client/models/snapshot_info.py
@@ -1,0 +1,59 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SnapshotInfo")
+
+
+@_attrs_define
+class SnapshotInfo:
+    """
+    Attributes:
+        snapshot_id (str): Unique identifier for the snapshot, can be used as template name
+    """
+
+    snapshot_id: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        snapshot_id = self.snapshot_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "snapshotID": snapshot_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        snapshot_id = d.pop("snapshotID")
+
+        snapshot_info = cls(
+            snapshot_id=snapshot_id,
+        )
+
+        snapshot_info.additional_properties = d
+        return snapshot_info
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/python-sdk/e2b/api/client/models/template_tag.py
+++ b/packages/python-sdk/e2b/api/client/models/template_tag.py
@@ -1,36 +1,43 @@
+import datetime
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
+from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from dateutil.parser import isoparse
 
-T = TypeVar("T", bound="SnapshotInfo")
+T = TypeVar("T", bound="TemplateTag")
 
 
 @_attrs_define
-class SnapshotInfo:
+class TemplateTag:
     """
     Attributes:
-        names (list[str]): Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-
-            snapshot:v2)
-        snapshot_id (str): Identifier of the snapshot template
+        build_id (UUID): Identifier of the build associated with this tag
+        created_at (datetime.datetime): Time when the tag was assigned
+        tag (str): The tag name
     """
 
-    names: list[str]
-    snapshot_id: str
+    build_id: UUID
+    created_at: datetime.datetime
+    tag: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        names = self.names
+        build_id = str(self.build_id)
 
-        snapshot_id = self.snapshot_id
+        created_at = self.created_at.isoformat()
+
+        tag = self.tag
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "names": names,
-                "snapshotID": snapshot_id,
+                "buildID": build_id,
+                "createdAt": created_at,
+                "tag": tag,
             }
         )
 
@@ -39,17 +46,20 @@ class SnapshotInfo:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        names = cast(list[str], d.pop("names"))
+        build_id = UUID(d.pop("buildID"))
 
-        snapshot_id = d.pop("snapshotID")
+        created_at = isoparse(d.pop("createdAt"))
 
-        snapshot_info = cls(
-            names=names,
-            snapshot_id=snapshot_id,
+        tag = d.pop("tag")
+
+        template_tag = cls(
+            build_id=build_id,
+            created_at=created_at,
+            tag=tag,
         )
 
-        snapshot_info.additional_properties = d
-        return snapshot_info
+        template_tag.additional_properties = d
+        return template_tag
 
     @property
     def additional_keys(self) -> list[str]:

--- a/packages/python-sdk/e2b/api/client/models/volume.py
+++ b/packages/python-sdk/e2b/api/client/models/volume.py
@@ -1,36 +1,35 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-T = TypeVar("T", bound="SnapshotInfo")
+T = TypeVar("T", bound="Volume")
 
 
 @_attrs_define
-class SnapshotInfo:
+class Volume:
     """
     Attributes:
-        names (list[str]): Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-
-            snapshot:v2)
-        snapshot_id (str): Identifier of the snapshot template
+        name (str): Name of the volume
+        volume_id (str): ID of the volume
     """
 
-    names: list[str]
-    snapshot_id: str
+    name: str
+    volume_id: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        names = self.names
+        name = self.name
 
-        snapshot_id = self.snapshot_id
+        volume_id = self.volume_id
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "names": names,
-                "snapshotID": snapshot_id,
+                "name": name,
+                "volumeID": volume_id,
             }
         )
 
@@ -39,17 +38,17 @@ class SnapshotInfo:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        names = cast(list[str], d.pop("names"))
+        name = d.pop("name")
 
-        snapshot_id = d.pop("snapshotID")
+        volume_id = d.pop("volumeID")
 
-        snapshot_info = cls(
-            names=names,
-            snapshot_id=snapshot_id,
+        volume = cls(
+            name=name,
+            volume_id=volume_id,
         )
 
-        snapshot_info.additional_properties = d
-        return snapshot_info
+        volume.additional_properties = d
+        return volume
 
     @property
     def additional_keys(self) -> list[str]:

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -187,7 +187,7 @@ class SnapshotInfo:
     """Information about a snapshot."""
 
     snapshot_id: str
-    """Unique identifier for the snapshot. Can be used as template ID in Sandbox.create() to create a new sandbox from this snapshot."""
+    """Snapshot identifier — template ID with tag, or namespaced name with tag (e.g. my-snapshot:latest). Can be used with Sandbox.create() to create a new sandbox from this snapshot."""
 
 
 class SnapshotPaginatorBase:

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -182,6 +182,45 @@ class SandboxMetrics:
     """Timestamp of the metric entry."""
 
 
+@dataclass
+class SnapshotInfo:
+    """Information about a snapshot."""
+
+    snapshot_id: str
+    """Unique identifier for the snapshot. Can be used as template ID in Sandbox.create() to create a new sandbox from this snapshot."""
+
+
+class SnapshotPaginatorBase:
+    def __init__(
+        self,
+        sandbox_id: Optional[str] = None,
+        limit: Optional[int] = None,
+        next_token: Optional[str] = None,
+        **opts: Unpack[ApiParams],
+    ):
+        self._config = ConnectionConfig(**opts)
+
+        self.sandbox_id = sandbox_id
+        self.limit = limit
+
+        self._has_next = True
+        self._next_token = next_token
+
+    @property
+    def has_next(self) -> bool:
+        """
+        Returns True if there are more items to fetch.
+        """
+        return self._has_next
+
+    @property
+    def next_token(self) -> Optional[str]:
+        """
+        Returns the next token to use for pagination.
+        """
+        return self._next_token
+
+
 class SandboxPaginatorBase:
     def __init__(
         self,

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -190,7 +190,34 @@ class SnapshotInfo:
     """Snapshot identifier — template ID with tag, or namespaced name with tag (e.g. my-snapshot:latest). Can be used with Sandbox.create() to create a new sandbox from this snapshot."""
 
 
-class SnapshotPaginatorBase:
+class PaginatorBase:
+    def __init__(
+        self,
+        limit: Optional[int] = None,
+        next_token: Optional[str] = None,
+        **opts: Unpack[ApiParams],
+    ):
+        self._config = ConnectionConfig(**opts)
+        self.limit = limit
+        self._has_next = True
+        self._next_token = next_token
+
+    @property
+    def has_next(self) -> bool:
+        """
+        Returns True if there are more items to fetch.
+        """
+        return self._has_next
+
+    @property
+    def next_token(self) -> Optional[str]:
+        """
+        Returns the next token to use for pagination.
+        """
+        return self._next_token
+
+
+class SnapshotPaginatorBase(PaginatorBase):
     def __init__(
         self,
         sandbox_id: Optional[str] = None,
@@ -198,30 +225,11 @@ class SnapshotPaginatorBase:
         next_token: Optional[str] = None,
         **opts: Unpack[ApiParams],
     ):
-        self._config = ConnectionConfig(**opts)
-
+        super().__init__(limit=limit, next_token=next_token, **opts)
         self.sandbox_id = sandbox_id
-        self.limit = limit
-
-        self._has_next = True
-        self._next_token = next_token
-
-    @property
-    def has_next(self) -> bool:
-        """
-        Returns True if there are more items to fetch.
-        """
-        return self._has_next
-
-    @property
-    def next_token(self) -> Optional[str]:
-        """
-        Returns the next token to use for pagination.
-        """
-        return self._next_token
 
 
-class SandboxPaginatorBase:
+class SandboxPaginatorBase(PaginatorBase):
     def __init__(
         self,
         query: Optional[SandboxQuery] = None,
@@ -229,24 +237,5 @@ class SandboxPaginatorBase:
         next_token: Optional[str] = None,
         **opts: Unpack[ApiParams],
     ):
-        self._config = ConnectionConfig(**opts)
-
+        super().__init__(limit=limit, next_token=next_token, **opts)
         self.query = query
-        self.limit = limit
-
-        self._has_next = True
-        self._next_token = next_token
-
-    @property
-    def has_next(self) -> bool:
-        """
-        Returns True if there are more items to fetch.
-        """
-        return self._has_next
-
-    @property
-    def next_token(self) -> Optional[str]:
-        """
-        Returns the next token to use for pagination.
-        """
-        return self._next_token

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -15,13 +15,19 @@ from e2b.envd.api import ENVD_API_HEALTH_ROUTE, ahandle_envd_api_exception
 from e2b.envd.versions import ENVD_DEBUG_FALLBACK
 from e2b.exceptions import SandboxException, format_request_timeout_error
 from e2b.sandbox.main import SandboxOpts
-from e2b.sandbox.sandbox_api import McpServer, SandboxMetrics, SandboxNetworkOpts
+from e2b.sandbox.sandbox_api import (
+    McpServer,
+    SandboxMetrics,
+    SandboxNetworkOpts,
+    SnapshotInfo,
+)
 from e2b.sandbox.utils import class_method_variant
 from e2b.sandbox_async.commands.command import Commands
 from e2b.sandbox_async.commands.pty import Pty
 from e2b.sandbox_async.filesystem.filesystem import Filesystem
 from e2b.sandbox_async.git import Git
 from e2b.sandbox_async.sandbox_api import SandboxApi, SandboxInfo
+from e2b.sandbox_async.paginator import AsyncSnapshotPaginator
 
 logger = logging.getLogger(__name__)
 
@@ -626,6 +632,97 @@ class AsyncSandbox(SandboxApi):
 
         await SandboxApi._cls_pause(
             sandbox_id=self.sandbox_id,
+            **opts,
+        )
+
+    @overload
+    async def create_snapshot(
+        self,
+        **opts: Unpack[ApiParams],
+    ) -> SnapshotInfo:
+        """
+        Create a snapshot of the sandbox's current state.
+
+        The snapshot can be used to create new sandboxes with the same filesystem and state.
+        Snapshots are persistent and survive sandbox deletion.
+
+        Use the returned `snapshot_id` with `AsyncSandbox.create(snapshot_id)` to create a new sandbox from the snapshot.
+
+        :return: Snapshot information including the snapshot ID
+        """
+        ...
+
+    @overload
+    @staticmethod
+    async def create_snapshot(
+        sandbox_id: str,
+        **opts: Unpack[ApiParams],
+    ) -> SnapshotInfo:
+        """
+        Create a snapshot from the sandbox specified by sandbox ID.
+
+        :param sandbox_id: Sandbox ID
+
+        :return: Snapshot information including the snapshot ID
+        """
+        ...
+
+    @class_method_variant("_cls_create_snapshot")
+    async def create_snapshot(
+        self,
+        **opts: Unpack[ApiParams],
+    ) -> SnapshotInfo:
+        """
+        Create a snapshot of the sandbox's current state.
+
+        The snapshot can be used to create new sandboxes with the same filesystem and state.
+        Snapshots are persistent and survive sandbox deletion.
+
+        Use the returned `snapshot_id` with `AsyncSandbox.create(snapshot_id)` to create a new sandbox from the snapshot.
+
+        :return: Snapshot information including the snapshot ID
+        """
+        return await SandboxApi._cls_create_snapshot(
+            sandbox_id=self.sandbox_id,
+            **self.connection_config.get_api_params(**opts),
+        )
+
+    @staticmethod
+    def list_snapshots(
+        sandbox_id: Optional[str] = None,
+        limit: Optional[int] = None,
+        next_token: Optional[str] = None,
+        **opts: Unpack[ApiParams],
+    ) -> AsyncSnapshotPaginator:
+        """
+        List all snapshots.
+
+        :param sandbox_id: Filter snapshots by source sandbox ID
+        :param limit: Maximum number of snapshots to return per page
+        :param next_token: Token for pagination
+
+        :return: Paginator for listing snapshots
+        """
+        return AsyncSnapshotPaginator(
+            sandbox_id=sandbox_id,
+            limit=limit,
+            next_token=next_token,
+            **opts,
+        )
+
+    @staticmethod
+    async def delete_snapshot(
+        snapshot_id: str,
+        **opts: Unpack[ApiParams],
+    ) -> bool:
+        """
+        Delete a snapshot.
+
+        :param snapshot_id: Snapshot ID
+        :return: `True` if the snapshot was deleted, `False` if it was not found
+        """
+        return await SandboxApi._cls_delete_snapshot(
+            snapshot_id=snapshot_id,
             **opts,
         )
 

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -643,6 +643,7 @@ class AsyncSandbox(SandboxApi):
         """
         Create a snapshot of the sandbox's current state.
 
+        The sandbox will be paused while the snapshot is being created.
         The snapshot can be used to create new sandboxes with the same filesystem and state.
         Snapshots are persistent and survive sandbox deletion.
 
@@ -661,6 +662,8 @@ class AsyncSandbox(SandboxApi):
         """
         Create a snapshot from the sandbox specified by sandbox ID.
 
+        The sandbox will be paused while the snapshot is being created.
+
         :param sandbox_id: Sandbox ID
 
         :return: Snapshot information including the snapshot ID
@@ -675,6 +678,7 @@ class AsyncSandbox(SandboxApi):
         """
         Create a snapshot of the sandbox's current state.
 
+        The sandbox will be paused while the snapshot is being created.
         The snapshot can be used to create new sandboxes with the same filesystem and state.
         Snapshots are persistent and survive sandbox deletion.
 
@@ -687,6 +691,24 @@ class AsyncSandbox(SandboxApi):
             **self.connection_config.get_api_params(**opts),
         )
 
+    @overload
+    def list_snapshots(
+        self,
+        limit: Optional[int] = None,
+        next_token: Optional[str] = None,
+        **opts: Unpack[ApiParams],
+    ) -> AsyncSnapshotPaginator:
+        """
+        List snapshots for this sandbox.
+
+        :param limit: Maximum number of snapshots to return per page
+        :param next_token: Token for pagination
+
+        :return: Paginator for listing snapshots
+        """
+        ...
+
+    @overload
     @staticmethod
     def list_snapshots(
         sandbox_id: Optional[str] = None,
@@ -703,6 +725,37 @@ class AsyncSandbox(SandboxApi):
 
         :return: Paginator for listing snapshots
         """
+        ...
+
+    @class_method_variant("_cls_list_snapshots")
+    def list_snapshots(
+        self,
+        limit: Optional[int] = None,
+        next_token: Optional[str] = None,
+        **opts: Unpack[ApiParams],
+    ) -> AsyncSnapshotPaginator:
+        """
+        List snapshots for this sandbox.
+
+        :param limit: Maximum number of snapshots to return per page
+        :param next_token: Token for pagination
+
+        :return: Paginator for listing snapshots
+        """
+        return AsyncSnapshotPaginator(
+            sandbox_id=self.sandbox_id,
+            limit=limit,
+            next_token=next_token,
+            **self.connection_config.get_api_params(**opts),
+        )
+
+    @staticmethod
+    def _cls_list_snapshots(
+        sandbox_id: Optional[str] = None,
+        limit: Optional[int] = None,
+        next_token: Optional[str] = None,
+        **opts: Unpack[ApiParams],
+    ) -> AsyncSnapshotPaginator:
         return AsyncSnapshotPaginator(
             sandbox_id=sandbox_id,
             limit=limit,

--- a/packages/python-sdk/e2b/sandbox_async/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_async/paginator.py
@@ -39,7 +39,7 @@ class AsyncSandboxPaginator(SandboxPaginatorBase):
         :returns: List of sandboxes
         """
         if not self.has_next:
-            raise Exception("No more items to fetch")
+            raise SandboxException("No more items to fetch")
 
         # Convert filters to the format expected by the API
         metadata: Optional[str] = None
@@ -68,7 +68,7 @@ class AsyncSandboxPaginator(SandboxPaginatorBase):
         if res.parsed is None:
             return []
 
-        # Check if res.parse is Error
+        # Check if res.parsed is Error
         if isinstance(res.parsed, Error):
             raise SandboxException(f"{res.parsed.message}: Request failed")
 
@@ -98,7 +98,7 @@ class AsyncSnapshotPaginator(SnapshotPaginatorBase):
         :returns: List of snapshots
         """
         if not self.has_next:
-            raise Exception("No more items to fetch")
+            raise SandboxException("No more items to fetch")
 
         api_client = get_api_client(self._config)
         res = await get_snapshots.asyncio_detailed(

--- a/packages/python-sdk/e2b/sandbox_async/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_async/paginator.py
@@ -39,7 +39,7 @@ class AsyncSandboxPaginator(SandboxPaginatorBase):
         :returns: List of sandboxes
         """
         if not self.has_next:
-            raise SandboxException("No more items to fetch")
+            raise Exception("No more items to fetch")
 
         # Convert filters to the format expected by the API
         metadata: Optional[str] = None
@@ -98,7 +98,7 @@ class AsyncSnapshotPaginator(SnapshotPaginatorBase):
         :returns: List of snapshots
         """
         if not self.has_next:
-            raise SandboxException("No more items to fetch")
+            raise Exception("No more items to fetch")
 
         api_client = get_api_client(self._config)
         res = await get_snapshots.asyncio_detailed(

--- a/packages/python-sdk/e2b/sandbox_async/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_async/paginator.py
@@ -2,9 +2,15 @@ import urllib.parse
 from typing import Optional, List
 
 from e2b.api.client.api.sandboxes import get_v2_sandboxes
+from e2b.api.client.api.snapshots import get_snapshots
 from e2b.api.client.types import UNSET
 from e2b.exceptions import SandboxException
-from e2b.sandbox.sandbox_api import SandboxPaginatorBase, SandboxInfo
+from e2b.sandbox.sandbox_api import (
+    SandboxPaginatorBase,
+    SandboxInfo,
+    SnapshotPaginatorBase,
+    SnapshotInfo,
+)
 from e2b.api import handle_api_exception
 from e2b.api.client.models.error import Error
 from e2b.api.client_async import get_api_client
@@ -67,3 +73,53 @@ class AsyncSandboxPaginator(SandboxPaginatorBase):
             raise SandboxException(f"{res.parsed.message}: Request failed")
 
         return [SandboxInfo._from_listed_sandbox(sandbox) for sandbox in res.parsed]
+
+
+class AsyncSnapshotPaginator(SnapshotPaginatorBase):
+    """
+    Paginator for listing snapshots.
+
+    Example:
+    ```python
+    paginator = AsyncSandbox.list_snapshots()
+
+    while paginator.has_next:
+        snapshots = await paginator.next_items()
+        print(snapshots)
+    ```
+    """
+
+    async def next_items(self) -> List[SnapshotInfo]:
+        """
+        Returns the next page of snapshots.
+
+        Call this method only if `has_next` is `True`, otherwise it will raise an exception.
+
+        :returns: List of snapshots
+        """
+        if not self.has_next:
+            raise Exception("No more items to fetch")
+
+        api_client = get_api_client(self._config)
+        res = await get_snapshots.asyncio_detailed(
+            client=api_client,
+            sandbox_id=self.sandbox_id if self.sandbox_id else UNSET,
+            limit=self.limit if self.limit else UNSET,
+            next_token=self._next_token if self._next_token else UNSET,
+        )
+
+        if res.status_code >= 300:
+            raise handle_api_exception(res)
+
+        self._next_token = res.headers.get("x-next-token")
+        self._has_next = bool(self._next_token)
+
+        if res.parsed is None:
+            return []
+
+        if isinstance(res.parsed, Error):
+            raise SandboxException(f"{res.parsed.message}: Request failed")
+
+        return [
+            SnapshotInfo(snapshot_id=snapshot.snapshot_id) for snapshot in res.parsed
+        ]

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -12,8 +12,10 @@ from e2b.api.client.api.sandboxes import (
     post_sandboxes,
     post_sandboxes_sandbox_id_connect,
     post_sandboxes_sandbox_id_pause,
+    post_sandboxes_sandbox_id_snapshots,
     post_sandboxes_sandbox_id_timeout,
 )
+from e2b.api.client.api.templates import delete_templates_template_id
 from e2b.api.client.models import (
     ConnectSandbox,
     Error,
@@ -33,6 +35,7 @@ from e2b.sandbox.sandbox_api import (
     SandboxMetrics,
     SandboxNetworkOpts,
     SandboxQuery,
+    SnapshotInfo,
 )
 from e2b.sandbox_async.paginator import AsyncSandboxPaginator
 
@@ -269,6 +272,56 @@ class SandboxApi(SandboxBase):
             )
             for metric in res.parsed
         ]
+
+    @classmethod
+    async def _cls_create_snapshot(
+        cls,
+        sandbox_id: str,
+        **opts: Unpack[ApiParams],
+    ) -> SnapshotInfo:
+        config = ConnectionConfig(**opts)
+
+        api_client = get_api_client(config)
+        res = await post_sandboxes_sandbox_id_snapshots.asyncio_detailed(
+            sandbox_id,
+            client=api_client,
+        )
+
+        if res.status_code == 404:
+            raise NotFoundException(f"Sandbox {sandbox_id} not found")
+
+        if res.status_code >= 300:
+            raise handle_api_exception(res)
+
+        if res.parsed is None:
+            raise SandboxException("Body of the request is None")
+
+        if isinstance(res.parsed, Error):
+            raise SandboxException(f"{res.parsed.message}: Request failed")
+
+        return SnapshotInfo(snapshot_id=res.parsed.snapshot_id)
+
+    @classmethod
+    async def _cls_delete_snapshot(
+        cls,
+        snapshot_id: str,
+        **opts: Unpack[ApiParams],
+    ) -> bool:
+        config = ConnectionConfig(**opts)
+
+        api_client = get_api_client(config)
+        res = await delete_templates_template_id.asyncio_detailed(
+            snapshot_id,
+            client=api_client,
+        )
+
+        if res.status_code == 404:
+            return False
+
+        if res.status_code >= 300:
+            raise handle_api_exception(res)
+
+        return True
 
     @classmethod
     async def _cls_pause(

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -20,6 +20,7 @@ from e2b.api.client.models import (
     ConnectSandbox,
     Error,
     NewSandbox,
+    PostSandboxesSandboxIDSnapshotsBody,
     PostSandboxesSandboxIDTimeoutBody,
     Sandbox,
     SandboxNetworkConfig,
@@ -285,6 +286,7 @@ class SandboxApi(SandboxBase):
         res = await post_sandboxes_sandbox_id_snapshots.asyncio_detailed(
             sandbox_id,
             client=api_client,
+            body=PostSandboxesSandboxIDSnapshotsBody(),
         )
 
         if res.status_code == 404:

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -15,13 +15,19 @@ from e2b.envd.api import ENVD_API_HEALTH_ROUTE, handle_envd_api_exception
 from e2b.envd.versions import ENVD_DEBUG_FALLBACK
 from e2b.exceptions import SandboxException, format_request_timeout_error
 from e2b.sandbox.main import SandboxOpts
-from e2b.sandbox.sandbox_api import McpServer, SandboxMetrics, SandboxNetworkOpts
+from e2b.sandbox.sandbox_api import (
+    McpServer,
+    SandboxMetrics,
+    SandboxNetworkOpts,
+    SnapshotInfo,
+)
 from e2b.sandbox.utils import class_method_variant
 from e2b.sandbox_sync.commands.command import Commands
 from e2b.sandbox_sync.commands.pty import Pty
 from e2b.sandbox_sync.filesystem.filesystem import Filesystem
 from e2b.sandbox_sync.git import Git
 from e2b.sandbox_sync.sandbox_api import SandboxApi, SandboxInfo
+from e2b.sandbox_sync.paginator import SnapshotPaginator
 
 logger = logging.getLogger(__name__)
 
@@ -623,6 +629,97 @@ class Sandbox(SandboxApi):
 
         SandboxApi._cls_pause(
             sandbox_id=self.sandbox_id,
+            **opts,
+        )
+
+    @overload
+    def create_snapshot(
+        self,
+        **opts: Unpack[ApiParams],
+    ) -> SnapshotInfo:
+        """
+        Create a snapshot of the sandbox's current state.
+
+        The snapshot can be used to create new sandboxes with the same filesystem and state.
+        Snapshots are persistent and survive sandbox deletion.
+
+        Use the returned `snapshot_id` with `Sandbox.create(snapshot_id)` to create a new sandbox from the snapshot.
+
+        :return: Snapshot information including the snapshot ID
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def create_snapshot(
+        sandbox_id: str,
+        **opts: Unpack[ApiParams],
+    ) -> SnapshotInfo:
+        """
+        Create a snapshot from the sandbox specified by sandbox ID.
+
+        :param sandbox_id: Sandbox ID
+
+        :return: Snapshot information including the snapshot ID
+        """
+        ...
+
+    @class_method_variant("_cls_create_snapshot")
+    def create_snapshot(
+        self,
+        **opts: Unpack[ApiParams],
+    ) -> SnapshotInfo:
+        """
+        Create a snapshot of the sandbox's current state.
+
+        The snapshot can be used to create new sandboxes with the same filesystem and state.
+        Snapshots are persistent and survive sandbox deletion.
+
+        Use the returned `snapshot_id` with `Sandbox.create(snapshot_id)` to create a new sandbox from the snapshot.
+
+        :return: Snapshot information including the snapshot ID
+        """
+        return SandboxApi._cls_create_snapshot(
+            sandbox_id=self.sandbox_id,
+            **self.connection_config.get_api_params(**opts),
+        )
+
+    @staticmethod
+    def list_snapshots(
+        sandbox_id: Optional[str] = None,
+        limit: Optional[int] = None,
+        next_token: Optional[str] = None,
+        **opts: Unpack[ApiParams],
+    ) -> SnapshotPaginator:
+        """
+        List all snapshots.
+
+        :param sandbox_id: Filter snapshots by source sandbox ID
+        :param limit: Maximum number of snapshots to return per page
+        :param next_token: Token for pagination
+
+        :return: Paginator for listing snapshots
+        """
+        return SnapshotPaginator(
+            sandbox_id=sandbox_id,
+            limit=limit,
+            next_token=next_token,
+            **opts,
+        )
+
+    @staticmethod
+    def delete_snapshot(
+        snapshot_id: str,
+        **opts: Unpack[ApiParams],
+    ) -> bool:
+        """
+        Delete a snapshot.
+
+        :param snapshot_id: Snapshot ID
+        :return: `True` if the snapshot was deleted, `False` if it was not found
+        """
+        return SandboxApi._cls_delete_snapshot(
+            snapshot_id=snapshot_id,
             **opts,
         )
 

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -640,6 +640,7 @@ class Sandbox(SandboxApi):
         """
         Create a snapshot of the sandbox's current state.
 
+        The sandbox will be paused while the snapshot is being created.
         The snapshot can be used to create new sandboxes with the same filesystem and state.
         Snapshots are persistent and survive sandbox deletion.
 
@@ -658,6 +659,8 @@ class Sandbox(SandboxApi):
         """
         Create a snapshot from the sandbox specified by sandbox ID.
 
+        The sandbox will be paused while the snapshot is being created.
+
         :param sandbox_id: Sandbox ID
 
         :return: Snapshot information including the snapshot ID
@@ -672,6 +675,7 @@ class Sandbox(SandboxApi):
         """
         Create a snapshot of the sandbox's current state.
 
+        The sandbox will be paused while the snapshot is being created.
         The snapshot can be used to create new sandboxes with the same filesystem and state.
         Snapshots are persistent and survive sandbox deletion.
 
@@ -684,6 +688,24 @@ class Sandbox(SandboxApi):
             **self.connection_config.get_api_params(**opts),
         )
 
+    @overload
+    def list_snapshots(
+        self,
+        limit: Optional[int] = None,
+        next_token: Optional[str] = None,
+        **opts: Unpack[ApiParams],
+    ) -> SnapshotPaginator:
+        """
+        List snapshots for this sandbox.
+
+        :param limit: Maximum number of snapshots to return per page
+        :param next_token: Token for pagination
+
+        :return: Paginator for listing snapshots
+        """
+        ...
+
+    @overload
     @staticmethod
     def list_snapshots(
         sandbox_id: Optional[str] = None,
@@ -700,6 +722,37 @@ class Sandbox(SandboxApi):
 
         :return: Paginator for listing snapshots
         """
+        ...
+
+    @class_method_variant("_cls_list_snapshots")
+    def list_snapshots(
+        self,
+        limit: Optional[int] = None,
+        next_token: Optional[str] = None,
+        **opts: Unpack[ApiParams],
+    ) -> SnapshotPaginator:
+        """
+        List snapshots for this sandbox.
+
+        :param limit: Maximum number of snapshots to return per page
+        :param next_token: Token for pagination
+
+        :return: Paginator for listing snapshots
+        """
+        return SnapshotPaginator(
+            sandbox_id=self.sandbox_id,
+            limit=limit,
+            next_token=next_token,
+            **self.connection_config.get_api_params(**opts),
+        )
+
+    @staticmethod
+    def _cls_list_snapshots(
+        sandbox_id: Optional[str] = None,
+        limit: Optional[int] = None,
+        next_token: Optional[str] = None,
+        **opts: Unpack[ApiParams],
+    ) -> SnapshotPaginator:
         return SnapshotPaginator(
             sandbox_id=sandbox_id,
             limit=limit,

--- a/packages/python-sdk/e2b/sandbox_sync/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_sync/paginator.py
@@ -3,10 +3,16 @@ from typing import Optional, List
 
 from e2b.api import handle_api_exception
 from e2b.api.client.api.sandboxes import get_v2_sandboxes
+from e2b.api.client.api.snapshots import get_snapshots
 from e2b.api.client.models.error import Error
 from e2b.api.client.types import UNSET
 from e2b.exceptions import SandboxException
-from e2b.sandbox.sandbox_api import SandboxPaginatorBase, SandboxInfo
+from e2b.sandbox.sandbox_api import (
+    SandboxPaginatorBase,
+    SandboxInfo,
+    SnapshotPaginatorBase,
+    SnapshotInfo,
+)
 from e2b.api.client_sync import get_api_client
 
 
@@ -67,3 +73,53 @@ class SandboxPaginator(SandboxPaginatorBase):
             raise SandboxException(f"{res.parsed.message}: Request failed")
 
         return [SandboxInfo._from_listed_sandbox(sandbox) for sandbox in res.parsed]
+
+
+class SnapshotPaginator(SnapshotPaginatorBase):
+    """
+    Paginator for listing snapshots.
+
+    Example:
+    ```python
+    paginator = Sandbox.list_snapshots()
+
+    while paginator.has_next:
+        snapshots = paginator.next_items()
+        print(snapshots)
+    ```
+    """
+
+    def next_items(self) -> List[SnapshotInfo]:
+        """
+        Returns the next page of snapshots.
+
+        Call this method only if `has_next` is `True`, otherwise it will raise an exception.
+
+        :returns: List of snapshots
+        """
+        if not self.has_next:
+            raise Exception("No more items to fetch")
+
+        api_client = get_api_client(self._config)
+        res = get_snapshots.sync_detailed(
+            client=api_client,
+            sandbox_id=self.sandbox_id if self.sandbox_id else UNSET,
+            limit=self.limit if self.limit else UNSET,
+            next_token=self._next_token if self._next_token else UNSET,
+        )
+
+        if res.status_code >= 300:
+            raise handle_api_exception(res)
+
+        self._next_token = res.headers.get("x-next-token")
+        self._has_next = bool(self._next_token)
+
+        if res.parsed is None:
+            return []
+
+        if isinstance(res.parsed, Error):
+            raise SandboxException(f"{res.parsed.message}: Request failed")
+
+        return [
+            SnapshotInfo(snapshot_id=snapshot.snapshot_id) for snapshot in res.parsed
+        ]

--- a/packages/python-sdk/e2b/sandbox_sync/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_sync/paginator.py
@@ -39,7 +39,7 @@ class SandboxPaginator(SandboxPaginatorBase):
         :returns: List of sandboxes
         """
         if not self.has_next:
-            raise SandboxException("No more items to fetch")
+            raise Exception("No more items to fetch")
 
         # Convert filters to the format expected by the API
         metadata: Optional[str] = None
@@ -98,7 +98,7 @@ class SnapshotPaginator(SnapshotPaginatorBase):
         :returns: List of snapshots
         """
         if not self.has_next:
-            raise SandboxException("No more items to fetch")
+            raise Exception("No more items to fetch")
 
         api_client = get_api_client(self._config)
         res = get_snapshots.sync_detailed(

--- a/packages/python-sdk/e2b/sandbox_sync/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_sync/paginator.py
@@ -39,7 +39,7 @@ class SandboxPaginator(SandboxPaginatorBase):
         :returns: List of sandboxes
         """
         if not self.has_next:
-            raise Exception("No more items to fetch")
+            raise SandboxException("No more items to fetch")
 
         # Convert filters to the format expected by the API
         metadata: Optional[str] = None
@@ -68,7 +68,7 @@ class SandboxPaginator(SandboxPaginatorBase):
         if res.parsed is None:
             return []
 
-        # Check if res.parse is Error
+        # Check if res.parsed is Error
         if isinstance(res.parsed, Error):
             raise SandboxException(f"{res.parsed.message}: Request failed")
 
@@ -98,7 +98,7 @@ class SnapshotPaginator(SnapshotPaginatorBase):
         :returns: List of snapshots
         """
         if not self.has_next:
-            raise Exception("No more items to fetch")
+            raise SandboxException("No more items to fetch")
 
         api_client = get_api_client(self._config)
         res = get_snapshots.sync_detailed(

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -12,8 +12,10 @@ from e2b.api.client.api.sandboxes import (
     post_sandboxes,
     post_sandboxes_sandbox_id_connect,
     post_sandboxes_sandbox_id_pause,
+    post_sandboxes_sandbox_id_snapshots,
     post_sandboxes_sandbox_id_timeout,
 )
+from e2b.api.client.api.templates import delete_templates_template_id
 from e2b.api.client.models import (
     ConnectSandbox,
     Error,
@@ -32,6 +34,7 @@ from e2b.sandbox.sandbox_api import (
     SandboxMetrics,
     SandboxNetworkOpts,
     SandboxQuery,
+    SnapshotInfo,
 )
 from e2b.sandbox_sync.paginator import SandboxPaginator, get_api_client
 
@@ -296,6 +299,56 @@ class SandboxApi(SandboxBase):
             raise SandboxException("Body of the request is None")
 
         return res.parsed
+
+    @classmethod
+    def _cls_create_snapshot(
+        cls,
+        sandbox_id: str,
+        **opts: Unpack[ApiParams],
+    ) -> SnapshotInfo:
+        config = ConnectionConfig(**opts)
+
+        api_client = get_api_client(config)
+        res = post_sandboxes_sandbox_id_snapshots.sync_detailed(
+            sandbox_id,
+            client=api_client,
+        )
+
+        if res.status_code == 404:
+            raise NotFoundException(f"Sandbox {sandbox_id} not found")
+
+        if res.status_code >= 300:
+            raise handle_api_exception(res)
+
+        if res.parsed is None:
+            raise SandboxException("Body of the request is None")
+
+        if isinstance(res.parsed, Error):
+            raise SandboxException(f"{res.parsed.message}: Request failed")
+
+        return SnapshotInfo(snapshot_id=res.parsed.snapshot_id)
+
+    @classmethod
+    def _cls_delete_snapshot(
+        cls,
+        snapshot_id: str,
+        **opts: Unpack[ApiParams],
+    ) -> bool:
+        config = ConnectionConfig(**opts)
+
+        api_client = get_api_client(config)
+        res = delete_templates_template_id.sync_detailed(
+            snapshot_id,
+            client=api_client,
+        )
+
+        if res.status_code == 404:
+            return False
+
+        if res.status_code >= 300:
+            raise handle_api_exception(res)
+
+        return True
 
     @classmethod
     def _cls_pause(

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -20,6 +20,7 @@ from e2b.api.client.models import (
     ConnectSandbox,
     Error,
     NewSandbox,
+    PostSandboxesSandboxIDSnapshotsBody,
     PostSandboxesSandboxIDTimeoutBody,
     Sandbox,
     SandboxNetworkConfig,
@@ -312,6 +313,7 @@ class SandboxApi(SandboxBase):
         res = post_sandboxes_sandbox_id_snapshots.sync_detailed(
             sandbox_id,
             client=api_client,
+            body=PostSandboxesSandboxIDSnapshotsBody(),
         )
 
         if res.status_code == 404:

--- a/packages/python-sdk/tests/async/api_async/test_sbx_list.py
+++ b/packages/python-sdk/tests/async/api_async/test_sbx_list.py
@@ -1,4 +1,4 @@
-import time
+import uuid
 
 import pytest
 
@@ -17,7 +17,7 @@ async def test_list_sandboxes(async_sandbox: AsyncSandbox, sandbox_test_id: str)
 
 @pytest.mark.skip_debug()
 async def test_list_sandboxes_with_filter(sandbox_test_id: str, async_sandbox_factory):
-    unique_id = str(int(time.time()))
+    unique_id = str(uuid.uuid4())
     extra_sbx = await async_sandbox_factory(metadata={"unique_id": unique_id})
 
     paginator = AsyncSandbox.list(query=SandboxQuery(metadata={"unique_id": unique_id}))

--- a/packages/python-sdk/tests/async/sandbox_async/test_snapshot_api.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_snapshot_api.py
@@ -109,9 +109,15 @@ async def test_delete_snapshot(async_sandbox: AsyncSandbox):
 
 @pytest.mark.skip_debug()
 async def test_snapshot_preserves_filesystem(async_sandbox: AsyncSandbox):
-    await async_sandbox.files.make_dir("/home/user/app")
-    await async_sandbox.files.write("/home/user/app/config.json", '{"env": "test"}')
-    await async_sandbox.files.write("/home/user/app/data.txt", "important data")
+    app_dir = "/home/user/app"
+    config_path = f"{app_dir}/config.json"
+    config_content = '{"env": "test"}'
+    data_path = f"{app_dir}/data.txt"
+    data_content = "important data"
+
+    await async_sandbox.files.make_dir(app_dir)
+    await async_sandbox.files.write(config_path, config_content)
+    await async_sandbox.files.write(data_path, data_content)
 
     snapshot = await async_sandbox.create_snapshot()
 
@@ -119,14 +125,14 @@ async def test_snapshot_preserves_filesystem(async_sandbox: AsyncSandbox):
         new_sandbox = await AsyncSandbox.create(snapshot.snapshot_id)
 
         try:
-            dir_exists = await new_sandbox.files.exists("/home/user/app")
+            dir_exists = await new_sandbox.files.exists(app_dir)
             assert dir_exists
 
-            config = await new_sandbox.files.read("/home/user/app/config.json")
-            data = await new_sandbox.files.read("/home/user/app/data.txt")
+            config = await new_sandbox.files.read(config_path)
+            data = await new_sandbox.files.read(data_path)
 
-            assert config == '{"env": "test"}'
-            assert data == "important data"
+            assert config == config_content
+            assert data == data_content
         finally:
             await new_sandbox.kill()
     finally:

--- a/packages/python-sdk/tests/async/sandbox_async/test_snapshot_api.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_snapshot_api.py
@@ -1,0 +1,143 @@
+import pytest
+from e2b import AsyncSandbox
+
+
+@pytest.mark.skip_debug()
+async def test_create_snapshot(async_sandbox: AsyncSandbox):
+    snapshot = await async_sandbox.create_snapshot()
+
+    assert snapshot.snapshot_id
+    assert len(snapshot.snapshot_id) > 0
+
+    await AsyncSandbox.delete_snapshot(snapshot.snapshot_id)
+
+
+@pytest.mark.skip_debug()
+async def test_create_sandbox_from_snapshot(async_sandbox: AsyncSandbox):
+    test_content = "content from original sandbox"
+    await async_sandbox.files.write("/home/user/test.txt", test_content)
+
+    snapshot = await async_sandbox.create_snapshot()
+
+    try:
+        new_sandbox = await AsyncSandbox.create(snapshot.snapshot_id)
+
+        try:
+            content = await new_sandbox.files.read("/home/user/test.txt")
+            assert content == test_content
+        finally:
+            await new_sandbox.kill()
+    finally:
+        await AsyncSandbox.delete_snapshot(snapshot.snapshot_id)
+
+
+@pytest.mark.skip_debug()
+async def test_create_multiple_sandboxes_from_snapshot(async_sandbox: AsyncSandbox):
+    test_content = "shared snapshot content"
+    await async_sandbox.files.write("/home/user/shared.txt", test_content)
+
+    snapshot = await async_sandbox.create_snapshot()
+
+    try:
+        sandbox1 = await AsyncSandbox.create(snapshot.snapshot_id)
+        sandbox2 = await AsyncSandbox.create(snapshot.snapshot_id)
+
+        try:
+            content1 = await sandbox1.files.read("/home/user/shared.txt")
+            content2 = await sandbox2.files.read("/home/user/shared.txt")
+
+            assert content1 == test_content
+            assert content2 == test_content
+
+            await sandbox1.files.write("/home/user/shared.txt", "modified in sandbox1")
+
+            modified_content = await sandbox1.files.read("/home/user/shared.txt")
+            unchanged_content = await sandbox2.files.read("/home/user/shared.txt")
+
+            assert modified_content == "modified in sandbox1"
+            assert unchanged_content == test_content
+        finally:
+            await sandbox1.kill()
+            await sandbox2.kill()
+    finally:
+        await AsyncSandbox.delete_snapshot(snapshot.snapshot_id)
+
+
+@pytest.mark.skip_debug()
+async def test_list_snapshots(async_sandbox: AsyncSandbox):
+    snapshot = await async_sandbox.create_snapshot()
+
+    try:
+        paginator = AsyncSandbox.list_snapshots()
+        assert paginator.has_next
+
+        snapshots = await paginator.next_items()
+        assert isinstance(snapshots, list)
+
+        found = any(s.snapshot_id == snapshot.snapshot_id for s in snapshots)
+        assert found
+    finally:
+        await AsyncSandbox.delete_snapshot(snapshot.snapshot_id)
+
+
+@pytest.mark.skip_debug()
+async def test_list_snapshots_for_sandbox(async_sandbox: AsyncSandbox):
+    snapshot = await async_sandbox.create_snapshot()
+
+    try:
+        paginator = AsyncSandbox.list_snapshots(
+            sandbox_id=async_sandbox.sandbox_id,
+        )
+        snapshots = await paginator.next_items()
+
+        found = any(s.snapshot_id == snapshot.snapshot_id for s in snapshots)
+        assert found
+    finally:
+        await AsyncSandbox.delete_snapshot(snapshot.snapshot_id)
+
+
+@pytest.mark.skip_debug()
+async def test_delete_snapshot(async_sandbox: AsyncSandbox):
+    snapshot = await async_sandbox.create_snapshot()
+
+    deleted = await AsyncSandbox.delete_snapshot(snapshot.snapshot_id)
+    assert deleted is True
+
+    deleted_again = await AsyncSandbox.delete_snapshot(snapshot.snapshot_id)
+    assert deleted_again is False
+
+
+@pytest.mark.skip_debug()
+async def test_snapshot_preserves_filesystem(async_sandbox: AsyncSandbox):
+    await async_sandbox.files.make_dir("/home/user/app")
+    await async_sandbox.files.write("/home/user/app/config.json", '{"env": "test"}')
+    await async_sandbox.files.write("/home/user/app/data.txt", "important data")
+
+    snapshot = await async_sandbox.create_snapshot()
+
+    try:
+        new_sandbox = await AsyncSandbox.create(snapshot.snapshot_id)
+
+        try:
+            dir_exists = await new_sandbox.files.exists("/home/user/app")
+            assert dir_exists
+
+            config = await new_sandbox.files.read("/home/user/app/config.json")
+            data = await new_sandbox.files.read("/home/user/app/data.txt")
+
+            assert config == '{"env": "test"}'
+            assert data == "important data"
+        finally:
+            await new_sandbox.kill()
+    finally:
+        await AsyncSandbox.delete_snapshot(snapshot.snapshot_id)
+
+
+@pytest.mark.skip_debug()
+async def test_create_snapshot_class_method(async_sandbox: AsyncSandbox):
+    snapshot = await AsyncSandbox.create_snapshot(async_sandbox.sandbox_id)
+
+    assert snapshot.snapshot_id
+    assert len(snapshot.snapshot_id) > 0
+
+    await AsyncSandbox.delete_snapshot(snapshot.snapshot_id)

--- a/packages/python-sdk/tests/sync/api_sync/test_sbx_list.py
+++ b/packages/python-sdk/tests/sync/api_sync/test_sbx_list.py
@@ -1,4 +1,4 @@
-import time
+import uuid
 
 import pytest
 
@@ -17,7 +17,7 @@ def test_list_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
 
 @pytest.mark.skip_debug()
 def test_list_sandboxes_with_filter(sandbox_factory, sandbox_test_id: str):
-    unique_id = str(int(time.time()))
+    unique_id = str(uuid.uuid4())
     extra_sbx = sandbox_factory(metadata={"unique_id": unique_id})
 
     paginator = Sandbox.list(query=SandboxQuery(metadata={"unique_id": unique_id}))

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_snapshot_api.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_snapshot_api.py
@@ -1,0 +1,141 @@
+import pytest
+from e2b import Sandbox
+
+
+@pytest.mark.skip_debug()
+def test_create_snapshot(sandbox: Sandbox):
+    snapshot = sandbox.create_snapshot()
+
+    assert snapshot.snapshot_id
+    assert len(snapshot.snapshot_id) > 0
+
+    Sandbox.delete_snapshot(snapshot.snapshot_id)
+
+
+@pytest.mark.skip_debug()
+def test_create_sandbox_from_snapshot(sandbox: Sandbox):
+    test_content = "content from original sandbox"
+    sandbox.files.write("/home/user/test.txt", test_content)
+
+    snapshot = sandbox.create_snapshot()
+
+    try:
+        new_sandbox = Sandbox.create(snapshot.snapshot_id)
+
+        try:
+            content = new_sandbox.files.read("/home/user/test.txt")
+            assert content == test_content
+        finally:
+            new_sandbox.kill()
+    finally:
+        Sandbox.delete_snapshot(snapshot.snapshot_id)
+
+
+@pytest.mark.skip_debug()
+def test_create_multiple_sandboxes_from_snapshot(sandbox: Sandbox):
+    test_content = "shared snapshot content"
+    sandbox.files.write("/home/user/shared.txt", test_content)
+
+    snapshot = sandbox.create_snapshot()
+
+    try:
+        sandbox1 = Sandbox.create(snapshot.snapshot_id)
+        sandbox2 = Sandbox.create(snapshot.snapshot_id)
+
+        try:
+            content1 = sandbox1.files.read("/home/user/shared.txt")
+            content2 = sandbox2.files.read("/home/user/shared.txt")
+
+            assert content1 == test_content
+            assert content2 == test_content
+
+            sandbox1.files.write("/home/user/shared.txt", "modified in sandbox1")
+
+            modified_content = sandbox1.files.read("/home/user/shared.txt")
+            unchanged_content = sandbox2.files.read("/home/user/shared.txt")
+
+            assert modified_content == "modified in sandbox1"
+            assert unchanged_content == test_content
+        finally:
+            sandbox1.kill()
+            sandbox2.kill()
+    finally:
+        Sandbox.delete_snapshot(snapshot.snapshot_id)
+
+
+@pytest.mark.skip_debug()
+def test_list_snapshots(sandbox: Sandbox):
+    snapshot = sandbox.create_snapshot()
+
+    try:
+        paginator = Sandbox.list_snapshots()
+        assert paginator.has_next
+
+        snapshots = paginator.next_items()
+        assert isinstance(snapshots, list)
+
+        found = any(s.snapshot_id == snapshot.snapshot_id for s in snapshots)
+        assert found
+    finally:
+        Sandbox.delete_snapshot(snapshot.snapshot_id)
+
+
+@pytest.mark.skip_debug()
+def test_list_snapshots_for_sandbox(sandbox: Sandbox):
+    snapshot = sandbox.create_snapshot()
+
+    try:
+        paginator = Sandbox.list_snapshots(sandbox_id=sandbox.sandbox_id)
+        snapshots = paginator.next_items()
+
+        found = any(s.snapshot_id == snapshot.snapshot_id for s in snapshots)
+        assert found
+    finally:
+        Sandbox.delete_snapshot(snapshot.snapshot_id)
+
+
+@pytest.mark.skip_debug()
+def test_delete_snapshot(sandbox: Sandbox):
+    snapshot = sandbox.create_snapshot()
+
+    deleted = Sandbox.delete_snapshot(snapshot.snapshot_id)
+    assert deleted is True
+
+    deleted_again = Sandbox.delete_snapshot(snapshot.snapshot_id)
+    assert deleted_again is False
+
+
+@pytest.mark.skip_debug()
+def test_snapshot_preserves_filesystem(sandbox: Sandbox):
+    sandbox.files.make_dir("/home/user/app")
+    sandbox.files.write("/home/user/app/config.json", '{"env": "test"}')
+    sandbox.files.write("/home/user/app/data.txt", "important data")
+
+    snapshot = sandbox.create_snapshot()
+
+    try:
+        new_sandbox = Sandbox.create(snapshot.snapshot_id)
+
+        try:
+            dir_exists = new_sandbox.files.exists("/home/user/app")
+            assert dir_exists
+
+            config = new_sandbox.files.read("/home/user/app/config.json")
+            data = new_sandbox.files.read("/home/user/app/data.txt")
+
+            assert config == '{"env": "test"}'
+            assert data == "important data"
+        finally:
+            new_sandbox.kill()
+    finally:
+        Sandbox.delete_snapshot(snapshot.snapshot_id)
+
+
+@pytest.mark.skip_debug()
+def test_create_snapshot_class_method(sandbox: Sandbox):
+    snapshot = Sandbox.create_snapshot(sandbox.sandbox_id)
+
+    assert snapshot.snapshot_id
+    assert len(snapshot.snapshot_id) > 0
+
+    Sandbox.delete_snapshot(snapshot.snapshot_id)

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_snapshot_api.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_snapshot_api.py
@@ -107,9 +107,15 @@ def test_delete_snapshot(sandbox: Sandbox):
 
 @pytest.mark.skip_debug()
 def test_snapshot_preserves_filesystem(sandbox: Sandbox):
-    sandbox.files.make_dir("/home/user/app")
-    sandbox.files.write("/home/user/app/config.json", '{"env": "test"}')
-    sandbox.files.write("/home/user/app/data.txt", "important data")
+    app_dir = "/home/user/app"
+    config_path = f"{app_dir}/config.json"
+    config_content = '{"env": "test"}'
+    data_path = f"{app_dir}/data.txt"
+    data_content = "important data"
+
+    sandbox.files.make_dir(app_dir)
+    sandbox.files.write(config_path, config_content)
+    sandbox.files.write(data_path, data_content)
 
     snapshot = sandbox.create_snapshot()
 
@@ -117,14 +123,14 @@ def test_snapshot_preserves_filesystem(sandbox: Sandbox):
         new_sandbox = Sandbox.create(snapshot.snapshot_id)
 
         try:
-            dir_exists = new_sandbox.files.exists("/home/user/app")
+            dir_exists = new_sandbox.files.exists(app_dir)
             assert dir_exists
 
-            config = new_sandbox.files.read("/home/user/app/config.json")
-            data = new_sandbox.files.read("/home/user/app/data.txt")
+            config = new_sandbox.files.read(config_path)
+            data = new_sandbox.files.read(data_path)
 
-            assert config == '{"env": "test"}'
-            assert data == "important data"
+            assert config == config_content
+            assert data == data_content
         finally:
             new_sandbox.kill()
     finally:

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -75,6 +75,13 @@ components:
       required: true
       schema:
         type: string
+    snapshotID:
+      name: snapshotID
+      in: path
+      required: true
+      schema:
+        type: string
+        description: Identifier of the snapshot (template ID)
     tag:
       name: tag
       in: path
@@ -222,6 +229,15 @@ components:
       enum:
         - running
         - paused
+
+    SnapshotInfo:
+      type: object
+      required:
+        - snapshotID
+      properties:
+        snapshotID:
+          type: string
+          description: Unique identifier for the snapshot, can be used as template name
 
     EnvVars:
       additionalProperties:
@@ -2155,6 +2171,63 @@ paths:
           $ref: "#/components/responses/401"
         "404":
           $ref: "#/components/responses/404"
+
+  /sandboxes/{sandboxID}/snapshots:
+    post:
+      description: Create a persistent snapshot from the sandbox's current state. Snapshots can be used to create new sandboxes and persist beyond the original sandbox's lifetime.
+      tags: [sandboxes]
+      security:
+        - ApiKeyAuth: []
+        - Supabase1TokenAuth: []
+          Supabase2TeamAuth: []
+      parameters:
+        - $ref: "#/components/parameters/sandboxID"
+      responses:
+        "201":
+          description: Snapshot created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SnapshotInfo"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /snapshots:
+    get:
+      description: List all snapshots for the team
+      tags: [snapshots]
+      security:
+        - ApiKeyAuth: []
+        - Supabase1TokenAuth: []
+          Supabase2TeamAuth: []
+      parameters:
+        - name: sandboxID
+          in: query
+          required: false
+          schema:
+            type: string
+            description: Filter snapshots by source sandbox ID
+        - $ref: "#/components/parameters/paginationLimit"
+        - $ref: "#/components/parameters/paginationNextToken"
+      responses:
+        "200":
+          description: Successfully returned snapshots
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SnapshotInfo"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /v3/templates:
     post:

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -107,6 +107,12 @@ components:
       required: false
       schema:
         type: string
+    volumeID:
+      name: volumeID
+      in: path
+      required: true
+      schema:
+        type: string
 
   responses:
     "400":
@@ -234,10 +240,16 @@ components:
       type: object
       required:
         - snapshotID
+        - names
       properties:
         snapshotID:
           type: string
-          description: Unique identifier for the snapshot, can be used as template name
+          description: Identifier of the snapshot template
+        names:
+          type: array
+          items:
+            type: string
+          description: Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-snapshot:v2)
 
     EnvVars:
       additionalProperties:
@@ -270,6 +282,23 @@ components:
         maskRequestHost:
           type: string
           description: Specify host mask which will be used for all sandbox requests
+
+    SandboxAutoResumePolicy:
+      type: string
+      description: Auto-resume policy for paused sandboxes. Default is off.
+      default: "off"
+      enum:
+        - any
+        - "off"
+
+    SandboxAutoResumeConfig:
+      type: object
+      description: Auto-resume configuration for paused sandboxes. Default is off.
+      required:
+        - policy
+      properties:
+        policy:
+          $ref: "#/components/schemas/SandboxAutoResumePolicy"
 
     SandboxLog:
       description: Log entry with timestamp and line
@@ -322,6 +351,17 @@ components:
           items:
             $ref: "#/components/schemas/SandboxLogEntry"
 
+    SandboxLogsV2Response:
+      required:
+        - logs
+      properties:
+        logs:
+          default: []
+          description: Sandbox logs structured
+          type: array
+          items:
+            $ref: "#/components/schemas/SandboxLogEntry"
+
     SandboxMetric:
       description: Metric entry with timestamp and line
       required:
@@ -367,6 +407,19 @@ components:
           type: integer
           format: int64
           description: Total disk space in bytes
+
+    SandboxVolumeMount:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the volume
+        path:
+          type: string
+          description: Path of the volume
+      required:
+        - name
+        - path
 
     Sandbox:
       required:
@@ -414,6 +467,7 @@ components:
         - endAt
         - state
         - envdVersion
+        - volumeMounts
       properties:
         templateID:
           type: string
@@ -455,6 +509,10 @@ components:
           $ref: "#/components/schemas/SandboxMetadata"
         state:
           $ref: "#/components/schemas/SandboxState"
+        volumeMounts:
+          type: array
+          items:
+            $ref: "#/components/schemas/SandboxVolumeMount"
 
     ListedSandbox:
       required:
@@ -468,6 +526,7 @@ components:
         - endAt
         - state
         - envdVersion
+        - volumeMounts
       properties:
         templateID:
           type: string
@@ -502,6 +561,10 @@ components:
           $ref: "#/components/schemas/SandboxState"
         envdVersion:
           $ref: "#/components/schemas/EnvdVersion"
+        volumeMounts:
+          type: array
+          items:
+            $ref: "#/components/schemas/SandboxVolumeMount"
 
     SandboxesWithMetrics:
       required:
@@ -528,6 +591,8 @@ components:
           type: boolean
           default: false
           description: Automatically pauses the sandbox after the timeout
+        autoResume:
+          $ref: "#/components/schemas/SandboxAutoResumeConfig"
         secure:
           type: boolean
           description: Secure all system communication with sandbox
@@ -544,6 +609,10 @@ components:
           $ref: "#/components/schemas/EnvVars"
         mcp:
           $ref: "#/components/schemas/Mcp"
+        volumeMounts:
+          type: array
+          items:
+            $ref: "#/components/schemas/SandboxVolumeMount"
 
     ResumedSandbox:
       properties:
@@ -1565,6 +1634,24 @@ components:
           format: uuid
           description: Identifier of the build associated with these tags
 
+    TemplateTag:
+      required:
+        - tag
+        - buildID
+        - createdAt
+      properties:
+        tag:
+          type: string
+          description: The tag name
+        buildID:
+          type: string
+          format: uuid
+          description: Identifier of the build associated with this tag
+        createdAt:
+          type: string
+          format: date-time
+          description: Time when the tag was assigned
+
     AssignTemplateTagsRequest:
       required:
         - target
@@ -1626,6 +1713,29 @@ components:
           type: string
           description: Suffix used in masked version of the token or key
 
+    Volume:
+      type: object
+      properties:
+        volumeID:
+          type: string
+          description: ID of the volume
+        name:
+          type: string
+          description: Name of the volume
+      required:
+        - volumeID
+        - name
+
+    NewVolume:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the volume
+          pattern: "^[a-zA-Z0-9_-]+$"
+      required:
+        - name
+
 tags:
   - name: templates
   - name: sandboxes
@@ -1633,6 +1743,7 @@ tags:
   - name: access-tokens
   - name: api-keys
   - name: tags
+  - name: volumes
 
 paths:
   /health:
@@ -1893,7 +2004,8 @@ paths:
 
   /sandboxes/{sandboxID}/logs:
     get:
-      description: Get sandbox logs
+      description: Get sandbox logs. Use /v2/sandboxes/{sandboxID}/logs instead.
+      deprecated: true
       tags: [sandboxes]
       security:
         - ApiKeyAuth: []
@@ -1927,6 +2039,51 @@ paths:
           $ref: "#/components/responses/404"
         "401":
           $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /v2/sandboxes/{sandboxID}/logs:
+    get:
+      description: Get sandbox logs
+      tags: [sandboxes]
+      security:
+        - ApiKeyAuth: []
+        - Supabase1TokenAuth: []
+          Supabase2TeamAuth: []
+      parameters:
+        - $ref: "#/components/parameters/sandboxID"
+        - in: query
+          name: cursor
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+          description: Starting timestamp of the logs that should be returned in milliseconds
+        - in: query
+          name: limit
+          schema:
+            default: 1000
+            type: integer
+            format: int32
+            minimum: 0
+            maximum: 1000
+          description: Maximum number of logs that should be returned
+        - in: query
+          name: direction
+          schema:
+            $ref: "#/components/schemas/LogsDirection"
+          description: Direction of the logs that should be returned
+      responses:
+        "200":
+          description: Successfully returned the sandbox logs
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SandboxLogsV2Response"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
         "500":
           $ref: "#/components/responses/500"
 
@@ -2182,6 +2339,16 @@ paths:
           Supabase2TeamAuth: []
       parameters:
         - $ref: "#/components/parameters/sandboxID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Optional name for the snapshot template. If a snapshot template with this name already exists, a new build will be assigned to the existing template instead of creating a new one.
       responses:
         "201":
           description: Snapshot created successfully
@@ -2708,6 +2875,34 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
+  /templates/{templateID}/tags:
+    get:
+      description: List all tags for a template
+      tags: [tags]
+      security:
+        - ApiKeyAuth: []
+        - Supabase1TokenAuth: []
+          Supabase2TeamAuth: []
+      parameters:
+        - $ref: "#/components/parameters/templateID"
+      responses:
+        "200":
+          description: Successfully returned the template tags
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TemplateTag"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
   /templates/aliases/{alias}:
     get:
       description: Check if template with given alias exists
@@ -2960,6 +3155,102 @@ paths:
       responses:
         "204":
           description: Team API key deleted successfully
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /volumes:
+    get:
+      description: List all team volumes
+      tags: [volumes]
+      security:
+        - AccessTokenAuth: []
+        - ApiKeyAuth: []
+        - Supabase1TokenAuth: []
+          Supabase2TeamAuth: []
+      responses:
+        "200":
+          description: Successfully listed all team volumes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Volume"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+    post:
+      description: Create a new team volume
+      tags: [volumes]
+      security:
+        - AccessTokenAuth: []
+        - ApiKeyAuth: []
+        - Supabase1TokenAuth: []
+          Supabase2TeamAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewVolume"
+      responses:
+        "201":
+          description: Successfully created a new team volume
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Volume"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /volumes/{volumeID}:
+    get:
+      description: Get team volume info
+      tags: [volumes]
+      security:
+        - AccessTokenAuth: []
+        - ApiKeyAuth: []
+        - Supabase1TokenAuth: []
+          Supabase2TeamAuth: []
+      parameters:
+        - $ref: "#/components/parameters/volumeID"
+      responses:
+        "200":
+          description: Successfully retrieved a team volume
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Volume"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
+    delete:
+      description: Delete a team volume
+      tags: [volumes]
+      security:
+        - AccessTokenAuth: []
+        - ApiKeyAuth: []
+        - Supabase1TokenAuth: []
+          Supabase2TeamAuth: []
+      parameters:
+        - $ref: "#/components/parameters/volumeID"
+      responses:
+        "204":
+          description: Successfully deleted a team volume
         "401":
           $ref: "#/components/responses/401"
         "404":

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -467,7 +467,6 @@ components:
         - endAt
         - state
         - envdVersion
-        - volumeMounts
       properties:
         templateID:
           type: string
@@ -526,7 +525,6 @@ components:
         - endAt
         - state
         - envdVersion
-        - volumeMounts
       properties:
         templateID:
           type: string


### PR DESCRIPTION
## Summary

Adds snapshot functionality to the SDK for creating persistent sandbox state that can be used to spawn new sandboxes.

## Usage

### JavaScript / TypeScript

```typescript
// Create a snapshot from a running sandbox
const snapshot = await sandbox.createSnapshot()

// Or by sandbox ID
const snapshot = await Sandbox.createSnapshot(sandboxId)

// Create new sandbox from snapshot
const newSandbox = await Sandbox.create(snapshot.snapshotId)

// List snapshots
for await (const s of Sandbox.listSnapshots()) {
  console.log(s.snapshotId)
}

// Delete snapshot
await Sandbox.deleteSnapshot(snapshot.snapshotId)
```

### Python (sync)

```python
# Create a snapshot from a running sandbox
snapshot = sandbox.create_snapshot()

# Or by sandbox ID
snapshot = Sandbox.create_snapshot(sandbox_id)

# Create new sandbox from snapshot
new_sandbox = Sandbox.create(snapshot.snapshot_id)

# List snapshots
paginator = Sandbox.list_snapshots()
while paginator.has_next:
    snapshots = paginator.next_items()

# Delete snapshot
Sandbox.delete_snapshot(snapshot.snapshot_id)
```

### Python (async)

```python
# Create a snapshot from a running sandbox
snapshot = await sandbox.create_snapshot()

# Or by sandbox ID
snapshot = await AsyncSandbox.create_snapshot(sandbox_id)

# Create new sandbox from snapshot
new_sandbox = await AsyncSandbox.create(snapshot.snapshot_id)

# List snapshots
paginator = AsyncSandbox.list_snapshots()
while paginator.has_next:
    snapshots = await paginator.next_items()

# Delete snapshot
await AsyncSandbox.delete_snapshot(snapshot.snapshot_id)
```

## API

### JS SDK
- `sandbox.createSnapshot()` - Create snapshot from current sandbox
- `Sandbox.createSnapshot(sandboxId)` - Create snapshot by sandbox ID
- `Sandbox.listSnapshots()` - List all snapshots (paginated, async iterable)
- `Sandbox.deleteSnapshot(snapshotId)` - Delete a snapshot

### Python SDK
- `sandbox.create_snapshot()` / `Sandbox.create_snapshot(sandbox_id)` - Create snapshot
- `Sandbox.list_snapshots(sandbox_id=None)` - List snapshots (paginated)
- `Sandbox.delete_snapshot(snapshot_id)` - Delete a snapshot
- Async variants on `AsyncSandbox` with the same signatures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new API surface and refactors pagination used by existing list calls, so regressions could affect listing behavior and snapshot lifecycle operations despite being additive overall.
> 
> **Overview**
> Adds **persistent sandbox snapshots** to both SDKs: create a snapshot from a sandbox, list snapshots (optionally filtered by source sandbox), and delete snapshots (implemented via template deletion).
> 
> Updates the OpenAPI spec and generated clients to include `/sandboxes/{sandboxID}/snapshots` and `/snapshots`, introduces `/v2/sandboxes/{sandboxID}/logs` while deprecating the old logs route, and extends sandbox schemas with `autoResume` and `volumeMounts` plus new `TemplateTag` and volume-related schemas/endpoints. JS pagination was refactored to a shared `BasePaginator`, and new integration tests cover snapshot flows in JS and Python (sync/async).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fd6132960b1b1d4b16ee8cd2845c10a76eb39c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->