### PR TITLE
fix(cli): resolve team ID from env var, avoid config mismatch

### DIFF
--- a/.changeset/fix-team-id-env-override.md
+++ b/.changeset/fix-team-id-env-override.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Fix CLI team ID resolution when E2B_API_KEY is set via environment variable. Add E2B_TEAM_ID env var support. Previously, the CLI always used the team ID from ~/.e2b/config.json, causing "Team ID param mismatch" errors when the API key belonged to a different team.

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -6,6 +6,7 @@ import { asBold, asPrimary } from './utils/format'
 
 export let apiKey = process.env.E2B_API_KEY
 export let accessToken = process.env.E2B_ACCESS_TOKEN
+export const teamId = process.env.E2B_TEAM_ID
 
 const authErrorBox = (keyName: string) => {
   let link
@@ -80,6 +81,28 @@ export function ensureAccessToken() {
   } else {
     return accessToken
   }
+}
+
+/**
+ * Resolve team ID with proper precedence:
+ * 1. CLI --team flag
+ * 2. E2B_TEAM_ID env var
+ * 3. Local e2b.toml team_id (if provided)
+ * 4. ~/.e2b/config.json teamId (only if E2B_API_KEY env var is NOT set,
+ *    to avoid mismatch between env var API key and config file team ID)
+ */
+export function resolveTeamId(
+  cliTeamId?: string,
+  localConfigTeamId?: string
+): string | undefined {
+  if (cliTeamId) return cliTeamId
+  if (teamId) return teamId
+  if (localConfigTeamId) return localConfigTeamId
+  if (!process.env.E2B_API_KEY) {
+    const config = getUserConfig()
+    return config?.teamId
+  }
+  return undefined
 }
 
 const userConfig = getUserConfig()

--- a/packages/cli/src/commands/template/build.ts
+++ b/packages/cli/src/commands/template/build.ts
@@ -5,7 +5,12 @@ import * as commander from 'commander'
 import * as e2b from 'e2b'
 import * as fs from 'fs'
 import * as path from 'path'
-import { client, connectionConfig, ensureAccessToken } from 'src/api'
+import {
+  client,
+  connectionConfig,
+  ensureAccessToken,
+  resolveTeamId,
+} from 'src/api'
 import { configName, getConfigPath, loadConfig, saveConfig } from 'src/config'
 import {
   defaultDockerfileName,
@@ -288,13 +293,9 @@ Migration guide: ${asPrimary('https://e2b.dev/docs/template/migration-v2')}`
           readyCmd = opts.readyCmd || config.ready_cmd
           cpuCount = opts.cpuCount || config.cpu_count
           memoryMB = opts.memoryMb || config.memory_mb
-          teamID = opts.team || config.team_id
         }
 
-        const userConfig = getUserConfig()
-        if (userConfig) {
-          teamID = teamID || userConfig.teamId
-        }
+        teamID = resolveTeamId(opts.team, config?.team_id)
 
         if (config && templateID && config.template_id !== templateID) {
           // error: you can't specify different ID than the one in config
@@ -444,6 +445,7 @@ Migration guide: ${asPrimary('https://e2b.dev/docs/template/migration-v2')}`
             cwd: root,
           })
         } catch (err: any) {
+          const userConfig = getUserConfig()
           await buildWithProxy(
             userConfig,
             connectionConfig,

--- a/packages/cli/src/commands/template/delete.ts
+++ b/packages/cli/src/commands/template/delete.ts
@@ -26,9 +26,8 @@ import { getRoot } from 'src/utils/filesystem'
 import { listSandboxTemplates } from './list'
 import { getPromptTemplates } from 'src/utils/templatePrompt'
 import { confirm } from 'src/utils/confirm'
-import { client } from 'src/api'
+import { client, resolveTeamId } from 'src/api'
 import { handleE2BRequestError } from '../../utils/errors'
-import { getUserConfig } from 'src/user'
 
 async function deleteTemplate(templateID: string) {
   const res = await client.api.DELETE('/templates/{templateID}', {
@@ -84,10 +83,7 @@ export const deleteCommand = new commander.Command('delete')
             template_id: template,
           })
         } else if (opts.select) {
-          const userConfig = getUserConfig()
-          if (userConfig) {
-            teamId = teamId || userConfig.teamId
-          }
+          teamId = resolveTeamId(teamId)
 
           const allTemplates = await listSandboxTemplates({
             teamID: teamId,

--- a/packages/cli/src/commands/template/list.ts
+++ b/packages/cli/src/commands/template/list.ts
@@ -4,10 +4,9 @@ import * as e2b from 'e2b'
 
 import { listAliases } from '../../utils/format'
 import { sortTemplatesAliases } from 'src/utils/templateSort'
-import { client, ensureAccessToken } from 'src/api'
+import { client, ensureAccessToken, resolveTeamId } from 'src/api'
 import { teamOption } from '../../options'
 import { handleE2BRequestError } from '../../utils/errors'
-import { getUserConfig } from '../../user'
 
 export const listCommand = new commander.Command('list')
   .description('list sandbox templates')
@@ -17,12 +16,11 @@ export const listCommand = new commander.Command('list')
   .action(async (opts: { team: string; format: string }) => {
     try {
       const format = opts.format || 'pretty'
-      const userConfig = getUserConfig()
       ensureAccessToken()
       process.stdout.write('\n')
 
       const templates = await listSandboxTemplates({
-        teamID: opts.team || userConfig?.teamId,
+        teamID: resolveTeamId(opts.team),
       })
 
       for (const template of templates) {

--- a/packages/cli/src/commands/template/publish.ts
+++ b/packages/cli/src/commands/template/publish.ts
@@ -20,9 +20,8 @@ import { getRoot } from 'src/utils/filesystem'
 import { listSandboxTemplates } from './list'
 import { getPromptTemplates } from 'src/utils/templatePrompt'
 import { confirm } from 'src/utils/confirm'
-import { client } from 'src/api'
+import { client, resolveTeamId } from 'src/api'
 import { handleE2BRequestError } from '../../utils/errors'
-import { getUserConfig } from 'src/user'
 
 async function publishTemplate(templateID: string, publish: boolean) {
   const res = await client.api.PATCH('/v2/templates/{templateID}', {
@@ -69,10 +68,7 @@ async function templateAction(
         template_id: template,
       })
     } else if (opts.select) {
-      const userConfig = getUserConfig()
-      if (userConfig) {
-        teamId = teamId || userConfig.teamId
-      }
+      teamId = resolveTeamId(teamId)
 
       const allTemplates = await listSandboxTemplates({
         teamID: teamId,


### PR DESCRIPTION
  Summary

  - When E2B_API_KEY is set via environment variable, the CLI no longer falls back to the teamId from
  ~/.e2b/config.json, avoiding "Team ID param mismatch with the API key" errors
  - Adds E2B_TEAM_ID environment variable support
  - Introduces resolveTeamId() helper with clear precedence: --team CLI flag > E2B_TEAM_ID env var > config
   file (only when E2B_API_KEY env var is not set)

  Problem

  When using E2B_API_KEY env var (e.g. for local development or CI with a different team), the CLI still
  reads teamId from ~/.e2b/config.json and sends it as a query parameter. If the config file belongs to a
  different team than the API key, the API rejects the request with 400: Team ID param mismatch with the
  API key.

  Changes

  - api.ts: Export E2B_TEAM_ID env var, add resolveTeamId() helper
  - list.ts, build.ts, delete.ts, publish.ts: Use resolveTeamId() instead of inline userConfig?.teamId
  fallback

  Test plan

  - Set E2B_API_KEY to a key from team A, have ~/.e2b/config.json with team B's ID → e2b template list
  should work (no mismatch error)
  - Set both E2B_API_KEY and E2B_TEAM_ID → CLI uses the env var team ID
  - Without any env vars, normal e2b auth login flow still works as before
  - --team flag still takes highest priority

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to CLI argument/env/config precedence for team selection; main risk is behavior changes for users relying on implicit `~/.e2b/config.json` teamId when also setting `E2B_API_KEY`.
> 
> **Overview**
> Fixes sandbox template commands failing with "Team ID param mismatch" when `E2B_API_KEY` is set via environment by changing team resolution precedence and avoiding `~/.e2b/config.json` team fallback in that case.
> 
> Introduces `E2B_TEAM_ID` and a centralized `resolveTeamId()` helper (CLI flag > env var > local `e2b.toml` > user config *only when no env API key*), and updates template `build`, `list`, `delete`, and `publish` flows to use it consistently. Adds a changeset bump for `@e2b/cli`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 905172fc8e59f8325a8d36af913326f7eb47a15f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->