### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/e2b-dev/E2B/security/code-scanning/3](https://github.com/e2b-dev/E2B/security/code-scanning/3)

In general, the fix is to declare an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the minimal scope required. For this workflow, the steps only need to read the repository contents to check out code and run tooling; they do not perform any write operations against the GitHub API, so `contents: read` at the workflow or job level is sufficient.

The best minimal fix is to add a top-level `permissions` block immediately after the `name: Lint` line in `.github/workflows/lint.yml`. This will apply to all jobs in the workflow (currently just `lint`) without altering any existing steps. The block should be:

```yaml
permissions:
  contents: read
```

No additional imports, steps, or changes to the existing job logic are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that narrows GitHub token permissions; no application logic or deployment behavior is affected.
> 
> **Overview**
> Adds an explicit top-level `permissions` block to the `Lint` GitHub Actions workflow, restricting the default `GITHUB_TOKEN` to **read-only** repository access (`contents: read`).
> 
> No lint job steps or behavior are changed; the update is purely to tighten workflow token scope to satisfy code-scanning guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd6bd36e778825fcf2f1c9d758c65b36ba0a045a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->