### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated_files.yml
+++ b/.github/workflows/generated_files.yml
@@ -3,6 +3,9 @@ name: Generated files
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check-generated:
     name: Generated files


### PR DESCRIPTION
Potential fix for [https://github.com/e2b-dev/E2B/security/code-scanning/4](https://github.com/e2b-dev/E2B/security/code-scanning/4)

In general, the fix is to explicitly declare a `permissions:` block that grants only the minimal required scopes. Since this workflow only needs to read repository contents (to check out code and inspect git status/diff) and does not perform any writes via the GitHub API, `contents: read` is sufficient.

The best minimally invasive fix is to add a `permissions:` block at the workflow root (top level, alongside `on:` and `jobs:`) so that it applies to all jobs in this workflow. Concretely, in `.github/workflows/generated_files.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–5) and the `jobs:` block (line 6). No changes to steps, images, or other configuration are required, and no additional imports or tools are needed. This documents the workflow’s needs and prevents it from gaining unintended write powers if repository defaults change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that restricts token permissions; no application logic or data paths are affected.
> 
> **Overview**
> Tightens the GitHub Actions `Generated files` workflow by explicitly setting top-level `permissions` to `contents: read`.
> 
> This addresses code-scanning guidance by ensuring the workflow token is read-only while still allowing `actions/checkout` and the generated-file checks to run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 225a3ee2370629605e4372768b3d018031e68e9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->