### PR TITLE
Add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,4 +2,4 @@ Use pnpm for node and poetry for python to install and update dependencies.
 Run `pnpm run format`, `pnpm run lint` and `pnpm run typecheck` before commiting changes.
 To re-generate the API client run `make codegen` in the repository root.
 Run tests on affected codepaths using `pnpm run test`.
-Dfault credentials are stored in .env.local in the repository root or inside ~/.e2b/config.json.
+Default credentials are stored in .env.local in the repository root or inside ~/.e2b/config.json.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or behavioral impact.
> 
> **Overview**
> Adds `CLAUDE.md` with contributor workflow notes: preferred dependency managers (pnpm/poetry), required formatting/lint/typecheck steps, how to run tests, how to regenerate the API client (`make codegen`), and where default credentials are stored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1c2f5a07871b7577f806f45ce3a52829b40fdd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->