### PR TITLE
chore: allow canary releases

### DIFF
--- a/.github/workflows/release_candidates.yml
+++ b/.github/workflows/release_candidates.yml
@@ -47,9 +47,13 @@ jobs:
       IS_CLI: ${{ contains(github.event.pull_request.labels.*.name, 'cli-rc') || (github.event_name == 'workflow_dispatch' && github.event.inputs.cli == 'true') }}
       IS_PYTHON: ${{ contains(github.event.pull_request.labels.*.name, 'python-rc') || (github.event_name == 'workflow_dispatch' && github.event.inputs.python-sdk == 'true') }}
       PUBLISH_TAG: ${{ github.event.inputs.tag || 'rc' }}
-      PREID: ${{ github.event.inputs.preid || github.head_ref || github.ref_name }}
 
     steps:
+      - name: Sanitize preid
+        run: |
+          RAW_PREID="${{ github.event.inputs.preid || github.head_ref || github.ref_name }}"
+          echo "PREID=$(echo "$RAW_PREID" | sed 's/[^0-9A-Za-z-]/-/g')" >> "$GITHUB_ENV"
+
       - name: Block production tags
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI release/publishing behavior and adds manual triggers with custom tags/preids, increasing the chance of accidental or mis-tagged prerelease publishes if inputs/labels are wrong.
> 
> **Overview**
> Adds `workflow_dispatch` support to `release_candidates.yml` so maintainers can manually publish prereleases for `js-sdk`, `cli`, and `python-sdk` without relying solely on PR labels.
> 
> Introduces a sanitized `PREID` (defaults to branch/ref) and a configurable npm dist-tag (`tag`, default `rc`), updates publish steps to use these values, and blocks publishing with the `latest` tag from this workflow. Also refines step gating via `IS_JS`/`IS_CLI`/`IS_PYTHON` env flags and adjusts checkout ref to work for both PR and manual runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 339a95d7b13bb8a4b3db749362f66af1ce9f7d98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->