### PR TITLE
fix(tests): vitest state cross pollution

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -52,7 +52,7 @@
     "@typescript-eslint/eslint-plugin": "^7.11.0",
     "@typescript-eslint/parser": "^7.11.0",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/browser": "^3.1.1",
+    "@vitest/browser": "^3.2.4",
     "dotenv": "^16.4.5",
     "eslint": "^8.57.1",
     "json-schema-to-typescript": "^15.0.4",
@@ -66,7 +66,7 @@
     "typedoc": "0.26.8",
     "typedoc-plugin-markdown": "4.2.7",
     "typescript": "^5.4.5",
-    "vitest": "^3.1.1",
+    "vitest": "^3.2.4",
     "vitest-browser-react": "^0.1.1"
   },
   "files": [

--- a/packages/js-sdk/tests/sandbox/commands/envVars.test.ts
+++ b/packages/js-sdk/tests/sandbox/commands/envVars.test.ts
@@ -1,14 +1,23 @@
-import { assert } from 'vitest'
+import { assert, describe } from 'vitest'
 
-import { sandboxTest, isDebug, template } from '../../setup.js'
-import { Sandbox } from '../../../src'
+import { sandboxTest, isDebug } from '../../setup.js'
 
-sandboxTest.skipIf(isDebug)('sandbox global env vars', async () => {
-  const sandbox = await Sandbox.create(template, { envs: { FOO: 'bar' } })
-  const cmd = await sandbox.commands.run('echo $FOO')
+describe('sandbox global env vars', () => {
+  sandboxTest.scoped({
+    sandboxOpts: {
+      envs: { FOO: 'bar' },
+    },
+  })
 
-  assert.equal(cmd.exitCode, 0)
-  assert.equal(cmd.stdout.trim(), 'bar')
+  sandboxTest.skipIf(isDebug)(
+    'sandbox global env vars',
+    async ({ sandbox }) => {
+      const cmd = await sandbox.commands.run('echo $FOO')
+
+      assert.equal(cmd.exitCode, 0)
+      assert.equal(cmd.stdout.trim(), 'bar')
+    }
+  )
 })
 
 sandboxTest('bash command scoped env vars', async ({ sandbox }) => {

--- a/packages/js-sdk/tests/sandbox/files/signing.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/signing.test.ts
@@ -1,164 +1,152 @@
-import { assert, test } from 'vitest'
+import { assert, describe } from 'vitest'
 
-import { Sandbox } from '../../../src'
-import { template, isDebug } from '../../setup'
+import { sandboxTest, isDebug } from '../../setup'
 
-const timeout = 20 * 1000
-
-test.skipIf(isDebug)('test access file with expired signing', async () => {
-  const sbx = await Sandbox.create(template, {
-    timeoutMs: timeout,
-    secure: true,
-  })
-  await sbx.files.write('hello.txt', 'hello world')
-
-  const fileUrlWithSigning = await sbx.downloadUrl('hello.txt', {
-    useSignatureExpiration: -10_000,
-  })
-
-  const res = await fetch(fileUrlWithSigning)
-  const resBody = await res.text()
-  const resStatus = res.status
-
-  assert.equal(resStatus, 401)
-  assert.deepEqual(JSON.parse(resBody), {
-    code: 401,
-    message: 'signature is already expired',
-  })
-
-  await sbx.kill()
-})
-
-test.skipIf(isDebug)('test access file with valid signing', async () => {
-  const sbx = await Sandbox.create(template, {
-    timeoutMs: timeout,
-    secure: true,
-  })
-  await sbx.files.write('hello.txt', 'hello world')
-
-  const fileUrlWithSigning = await sbx.downloadUrl('hello.txt', {
-    useSignatureExpiration: 10_000,
-  })
-
-  const res = await fetch(fileUrlWithSigning)
-  const resBody = await res.text()
-  const resStatus = res.status
-
-  assert.equal(resStatus, 200)
-  assert.equal(resBody, 'hello world')
-
-  await sbx.kill()
-})
-
-test.skipIf(isDebug)(
-  'test access file with valid signing as root',
-  async () => {
-    const sbx = await Sandbox.create(template, {
-      timeoutMs: timeout,
+describe('file signing', () => {
+  sandboxTest.scoped({
+    sandboxOpts: {
       secure: true,
-    })
-    await sbx.files.write('hello.txt', 'hello world', { user: 'root' })
-
-    const fileUrlWithSigning = await sbx.downloadUrl('hello.txt', {
-      user: 'root',
-      useSignatureExpiration: 10_000,
-    })
-
-    const res = await fetch(fileUrlWithSigning)
-    const resBody = await res.text()
-    const resStatus = res.status
-
-    assert.equal(resStatus, 200)
-    assert.equal(resBody, 'hello world')
-
-    await sbx.kill()
-  }
-)
-
-test.skipIf(isDebug)('test upload file with valid signing', async () => {
-  const sbx = await Sandbox.create(template, {
-    timeoutMs: timeout,
-    secure: true,
-  })
-  const fileUrlWithSigning = await sbx.uploadUrl('hello.txt', {
-    useSignatureExpiration: 10_000,
+    },
   })
 
-  const form = new FormData()
-  form.append('file', 'file content')
+  sandboxTest.skipIf(isDebug)(
+    'test access file with expired signing',
+    async ({ sandbox }) => {
+      await sandbox.files.write('hello.txt', 'hello world')
 
-  const res = await fetch(fileUrlWithSigning, { method: 'POST', body: form })
-  const resBody = await res.text()
-  const resStatus = res.status
+      const fileUrlWithSigning = await sandbox.downloadUrl('hello.txt', {
+        useSignatureExpiration: -10_000,
+      })
 
-  assert.equal(resStatus, 200)
-  assert.deepEqual(JSON.parse(resBody), [
-    { name: 'hello.txt', path: '/home/user/hello.txt', type: 'file' },
-  ])
+      const res = await fetch(fileUrlWithSigning)
+      const resBody = await res.text()
+      const resStatus = res.status
 
-  await sbx.kill()
-})
+      assert.equal(resStatus, 401)
+      assert.deepEqual(JSON.parse(resBody), {
+        code: 401,
+        message: 'signature is already expired',
+      })
+    }
+  )
 
-test.skipIf(isDebug)(
-  'test upload file with valid signing as root user',
-  async () => {
-    const sbx = await Sandbox.create(template, {
-      timeoutMs: timeout,
-      secure: true,
-    })
+  sandboxTest.skipIf(isDebug)(
+    'test access file with valid signing',
+    async ({ sandbox }) => {
+      await sandbox.files.write('hello.txt', 'hello world')
 
-    const fileUrlWithSigning = await sbx.uploadUrl('hello.txt', {
-      user: 'root',
-      useSignatureExpiration: 10_000,
-    })
+      const fileUrlWithSigning = await sandbox.downloadUrl('hello.txt', {
+        useSignatureExpiration: 10_000,
+      })
 
-    const form = new FormData()
-    form.append('file', 'file content')
+      const res = await fetch(fileUrlWithSigning)
+      const resBody = await res.text()
+      const resStatus = res.status
 
-    const res = await fetch(fileUrlWithSigning, { method: 'POST', body: form })
-    const resBody = await res.text()
-    const resStatus = res.status
+      assert.equal(resStatus, 200)
+      assert.equal(resBody, 'hello world')
+    }
+  )
 
-    assert.equal(resStatus, 200)
-    assert.deepEqual(JSON.parse(resBody), [
-      { name: 'hello.txt', path: '/root/hello.txt', type: 'file' },
-    ])
+  sandboxTest.skipIf(isDebug)(
+    'test access file with valid signing as root',
+    async ({ sandbox }) => {
+      await sandbox.files.write('hello.txt', 'hello world', { user: 'root' })
 
-    await sbx.kill()
-  }
-)
+      const fileUrlWithSigning = await sandbox.downloadUrl('hello.txt', {
+        user: 'root',
+        useSignatureExpiration: 10_000,
+      })
 
-test.skipIf(isDebug)('test upload file with invalid signing', async () => {
-  const sbx = await Sandbox.create(template, {
-    timeoutMs: timeout,
-    secure: true,
-  })
-  const fileUrlWithSigning = await sbx.uploadUrl('hello.txt', {
-    useSignatureExpiration: -100_000,
-  })
+      const res = await fetch(fileUrlWithSigning)
+      const resBody = await res.text()
+      const resStatus = res.status
 
-  const form = new FormData()
-  form.append('file', 'file content')
+      assert.equal(resStatus, 200)
+      assert.equal(resBody, 'hello world')
+    }
+  )
 
-  const res = await fetch(fileUrlWithSigning, { method: 'POST', body: form })
-  const resBody = await res.text()
-  const resStatus = res.status
+  sandboxTest.skipIf(isDebug)(
+    'test upload file with valid signing',
+    async ({ sandbox }) => {
+      const fileUrlWithSigning = await sandbox.uploadUrl('hello.txt', {
+        useSignatureExpiration: 10_000,
+      })
 
-  assert.equal(resStatus, 401)
-  assert.deepEqual(JSON.parse(resBody), {
-    code: 401,
-    message: 'signature is already expired',
-  })
+      const form = new FormData()
+      form.append('file', 'file content')
 
-  await sbx.kill()
-})
+      const res = await fetch(fileUrlWithSigning, {
+        method: 'POST',
+        body: form,
+      })
+      const resBody = await res.text()
+      const resStatus = res.status
 
-test.skipIf(isDebug)('test command run with secured sbx', async () => {
-  const sbx = await Sandbox.create(template, {
-    timeoutMs: timeout,
-    secure: true,
-  })
-  const response = await sbx.commands.run('echo Hello World!')
+      assert.equal(resStatus, 200)
+      assert.deepEqual(JSON.parse(resBody), [
+        { name: 'hello.txt', path: '/home/user/hello.txt', type: 'file' },
+      ])
+    }
+  )
 
-  assert.equal(response.stdout, 'Hello World!\n')
+  sandboxTest.skipIf(isDebug)(
+    'test upload file with valid signing as root user',
+    async ({ sandbox }) => {
+      const fileUrlWithSigning = await sandbox.uploadUrl('hello.txt', {
+        user: 'root',
+        useSignatureExpiration: 10_000,
+      })
+
+      const form = new FormData()
+      form.append('file', 'file content')
+
+      const res = await fetch(fileUrlWithSigning, {
+        method: 'POST',
+        body: form,
+      })
+      const resBody = await res.text()
+      const resStatus = res.status
+
+      assert.equal(resStatus, 200)
+      assert.deepEqual(JSON.parse(resBody), [
+        { name: 'hello.txt', path: '/root/hello.txt', type: 'file' },
+      ])
+    }
+  )
+
+  sandboxTest.skipIf(isDebug)(
+    'test upload file with invalid signing',
+    async ({ sandbox }) => {
+      const fileUrlWithSigning = await sandbox.uploadUrl('hello.txt', {
+        useSignatureExpiration: -100_000,
+      })
+
+      const form = new FormData()
+      form.append('file', 'file content')
+
+      const res = await fetch(fileUrlWithSigning, {
+        method: 'POST',
+        body: form,
+      })
+      const resBody = await res.text()
+      const resStatus = res.status
+
+      assert.equal(resStatus, 401)
+      assert.deepEqual(JSON.parse(resBody), {
+        code: 401,
+        message: 'signature is already expired',
+      })
+    }
+  )
+
+  sandboxTest.skipIf(isDebug)(
+    'test command run with secured sbx',
+    async ({ sandbox }) => {
+      const response = await sandbox.commands.run('echo Hello World!')
+
+      assert.equal(response.stdout, 'Hello World!\n')
+    }
+  )
 })

--- a/packages/js-sdk/tests/sandbox/internetAccess.test.ts
+++ b/packages/js-sdk/tests/sandbox/internetAccess.test.ts
@@ -1,56 +1,64 @@
-import { assert, test } from 'vitest'
+import { assert, describe } from 'vitest'
 
-import { CommandExitError, Sandbox } from '../../src'
-import { template, isDebug } from '../setup.js'
+import { CommandExitError } from '../../src'
+import { sandboxTest, isDebug } from '../setup.js'
 
-test.skipIf(isDebug)('internet access enabled', async () => {
-  const sbx = await Sandbox.create(template, {
-    allowInternetAccess: true,
+describe('internet access enabled', () => {
+  sandboxTest.scoped({
+    sandboxOpts: {
+      allowInternetAccess: true,
+    },
   })
-  try {
-    // Test internet connectivity by making a curl request to a reliable external site
-    const result = await sbx.commands.run(
-      "curl -s -o /dev/null -w '%{http_code}' https://e2b.dev"
-    )
-    assert.equal(result.exitCode, 0)
-    assert.equal(result.stdout.trim(), '200')
-  } finally {
-    await sbx.kill()
-  }
-})
 
-test.skipIf(isDebug)('internet access disabled', async () => {
-  const sbx = await Sandbox.create(template, {
-    allowInternetAccess: false,
-  })
-  try {
-    // Test that internet connectivity is blocked by making a curl request
-    try {
-      await sbx.commands.run(
-        'curl --connect-timeout 3 --max-time 5 -Is https://e2b.dev'
+  sandboxTest.skipIf(isDebug)(
+    'internet access enabled',
+    async ({ sandbox }) => {
+      // Test internet connectivity by making a curl request to a reliable external site
+      const result = await sandbox.commands.run(
+        "curl -s -o /dev/null -w '%{http_code}' https://e2b.dev"
       )
-      // If we reach here, the command succeeded, which means internet access is not properly disabled
-      assert.fail('Expected command to fail when internet access is disabled')
-    } catch (error) {
-      // The command should fail or timeout when internet access is disabled
-      assert.isTrue(error instanceof CommandExitError)
-      assert.notEqual(error.exitCode, 0)
+      assert.equal(result.exitCode, 0)
+      assert.equal(result.stdout.trim(), '200')
     }
-  } finally {
-    await sbx.kill()
-  }
+  )
 })
 
-test.skipIf(isDebug)('internet access default', async () => {
-  const sbx = await Sandbox.create(template)
-  try {
-    // Test internet connectivity by making a curl request to a reliable external site
-    const result = await sbx.commands.run(
-      "curl -s -o /dev/null -w '%{http_code}' https://e2b.dev"
-    )
-    assert.equal(result.exitCode, 0)
-    assert.equal(result.stdout.trim(), '200')
-  } finally {
-    await sbx.kill()
-  }
+describe('internet access disabled', () => {
+  sandboxTest.scoped({
+    sandboxOpts: {
+      allowInternetAccess: false,
+    },
+  })
+
+  sandboxTest.skipIf(isDebug)(
+    'internet access disabled',
+    async ({ sandbox }) => {
+      // Test that internet connectivity is blocked by making a curl request
+      try {
+        await sandbox.commands.run(
+          'curl --connect-timeout 3 --max-time 5 -Is https://e2b.dev'
+        )
+        // If we reach here, the command succeeded, which means internet access is not properly disabled
+        assert.fail('Expected command to fail when internet access is disabled')
+      } catch (error) {
+        // The command should fail or timeout when internet access is disabled
+        assert.isTrue(error instanceof CommandExitError)
+        assert.notEqual(error.exitCode, 0)
+      }
+    }
+  )
+})
+
+describe('internet access default', () => {
+  sandboxTest.skipIf(isDebug)(
+    'internet access default',
+    async ({ sandbox }) => {
+      // Test internet connectivity by making a curl request to a reliable external site
+      const result = await sandbox.commands.run(
+        "curl -s -o /dev/null -w '%{http_code}' https://e2b.dev"
+      )
+      assert.equal(result.exitCode, 0)
+      assert.equal(result.stdout.trim(), '200')
+    }
+  )
 })

--- a/packages/js-sdk/tests/sandbox/snapshot.test.ts
+++ b/packages/js-sdk/tests/sandbox/snapshot.test.ts
@@ -1,7 +1,6 @@
-import { assert } from 'vitest'
+import { assert, describe } from 'vitest'
 
 import { sandboxTest, isDebug } from '../setup.js'
-import { Sandbox } from '../../src'
 
 sandboxTest.skipIf(isDebug)(
   'pause and resume a sandbox',
@@ -19,36 +18,39 @@ sandboxTest.skipIf(isDebug)(
   }
 )
 
-sandboxTest.skipIf(isDebug)(
-  'pause and resume a sandbox with env vars',
-  async ({ template, sandboxTestId }) => {
-    // Environment variables of a process exist at runtime, and are not stored in some file or so.
-    // They are stored in the process's own memory
-    const sandbox = await Sandbox.create(template, {
+describe('pause and resume with env vars', () => {
+  sandboxTest.scoped({
+    sandboxOpts: {
       envs: { TEST_VAR: 'sfisback' },
-      metadata: { sandboxTestId },
-    })
+    },
+  })
 
-    const cmd = await sandbox.commands.run('echo "$TEST_VAR"')
+  sandboxTest.skipIf(isDebug)(
+    'pause and resume a sandbox with env vars',
+    async ({ sandbox }) => {
+      // Environment variables of a process exist at runtime, and are not stored in some file or so.
+      // They are stored in the process's own memory
+      const cmd = await sandbox.commands.run('echo "$TEST_VAR"')
 
-    assert.equal(cmd.exitCode, 0)
-    assert.equal(cmd.stdout.trim(), 'sfisback')
+      assert.equal(cmd.exitCode, 0)
+      assert.equal(cmd.stdout.trim(), 'sfisback')
 
-    await sandbox.betaPause()
+      await sandbox.betaPause()
 
-    assert.isFalse(await sandbox.isRunning())
+      assert.isFalse(await sandbox.isRunning())
 
-    const resumedSandbox = await sandbox.connect()
-    assert.isTrue(await sandbox.isRunning())
-    assert.isTrue(await resumedSandbox.isRunning())
-    assert.equal(resumedSandbox.sandboxId, sandbox.sandboxId)
+      const resumedSandbox = await sandbox.connect()
+      assert.isTrue(await sandbox.isRunning())
+      assert.isTrue(await resumedSandbox.isRunning())
+      assert.equal(resumedSandbox.sandboxId, sandbox.sandboxId)
 
-    const cmd2 = await sandbox.commands.run('echo "$TEST_VAR"')
+      const cmd2 = await sandbox.commands.run('echo "$TEST_VAR"')
 
-    assert.equal(cmd2.exitCode, 0)
-    assert.equal(cmd2.stdout.trim(), 'sfisback')
-  }
-)
+      assert.equal(cmd2.exitCode, 0)
+      assert.equal(cmd2.stdout.trim(), 'sfisback')
+    }
+  )
+})
 
 sandboxTest.skipIf(isDebug)(
   'pause and resume a sandbox with file',

--- a/packages/js-sdk/tests/setup.ts
+++ b/packages/js-sdk/tests/setup.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { test as base } from 'vitest'
+import { test as base, onTestFailed } from 'vitest'
 import {
   BuildInfo,
   LogEntry,
@@ -79,6 +79,9 @@ export const sandboxTest = base.extend<SandboxFixture>({
       const sandbox = await Sandbox.create(template, {
         metadata: { sandboxTestId },
         ...sandboxOpts,
+      })
+      onTestFailed(() => {
+        console.error(`\n[TEST FAILED] Sandbox ID: ${sandbox.sandboxId}`)
       })
       try {
         await use(sandbox)

--- a/packages/python-sdk/tests/async/sandbox_async/test_connect.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_connect.py
@@ -30,27 +30,26 @@ async def test_connect_with_secure(async_sandbox_factory):
 
 
 @pytest.mark.skip_debug()
-async def test_connect_does_not_shorten_timeout_on_running_sandbox(template):
+async def test_connect_does_not_shorten_timeout_on_running_sandbox(
+    async_sandbox_factory,
+):
     # Create sandbox with a 300 second timeout
-    sbx = await AsyncSandbox.create(template, timeout=300)
-    try:
-        assert await sbx.is_running()
+    sbx = await async_sandbox_factory(timeout=300)
+    assert await sbx.is_running()
 
-        # Get initial info to check end_at
-        info_before = await AsyncSandbox.get_info(sbx.sandbox_id)
+    # Get initial info to check end_at
+    info_before = await AsyncSandbox.get_info(sbx.sandbox_id)
 
-        # Connect with a shorter timeout (10 seconds)
-        await AsyncSandbox.connect(sbx.sandbox_id, timeout=10)
+    # Connect with a shorter timeout (10 seconds)
+    await AsyncSandbox.connect(sbx.sandbox_id, timeout=10)
 
-        # Get info after connection
-        info_after = await AsyncSandbox.get_info(sbx.sandbox_id)
+    # Get info after connection
+    info_after = await AsyncSandbox.get_info(sbx.sandbox_id)
 
-        # The end_at time should not have been shortened. It should be the same
-        assert info_after.end_at == info_before.end_at, (
-            f"Timeout was changed: before={info_before.end_at}, after={info_after.end_at}"
-        )
-    finally:
-        await sbx.kill()
+    # The end_at time should not have been shortened. It should be the same
+    assert info_after.end_at == info_before.end_at, (
+        f"Timeout was changed: before={info_before.end_at}, after={info_after.end_at}"
+    )
 
 
 @pytest.mark.skip_debug()

--- a/packages/python-sdk/tests/conftest.py
+++ b/packages/python-sdk/tests/conftest.py
@@ -20,6 +20,14 @@ from e2b import (
 )
 
 
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    rep = outcome.get_result()
+    if rep.when == "call":
+        item._test_failed = rep.failed
+
+
 @pytest.fixture(scope="session")
 def sandbox_test_id():
     return f"test_{uuid.uuid4()}"
@@ -41,7 +49,12 @@ def sandbox_factory(request, template, sandbox_test_id):
 
         sandbox = Sandbox.create(template_name, **kwargs)
 
-        request.addfinalizer(lambda: sandbox.kill())
+        def finalizer():
+            if getattr(request.node, "_test_failed", False):
+                print(f"\n[TEST FAILED] Sandbox ID: {sandbox.sandbox_id}")
+            sandbox.kill()
+
+        request.addfinalizer(finalizer)
 
         return sandbox
 
@@ -75,13 +88,16 @@ def async_sandbox_factory(request, template, sandbox_test_id, event_loop):
 
         sandbox = await AsyncSandbox.create(template_name, **kwargs)
 
-        def kill():
+        def finalizer():
+            if getattr(request.node, "_test_failed", False):
+                print(f"\n[TEST FAILED] Sandbox ID: {sandbox.sandbox_id}")
+
             async def _kill():
                 await sandbox.kill()
 
             event_loop.run_until_complete(_kill())
 
-        request.addfinalizer(kill)
+        request.addfinalizer(finalizer)
 
         return sandbox
 

--- a/packages/python-sdk/tests/sync/api_sync/test_sbx_list.py
+++ b/packages/python-sdk/tests/sync/api_sync/test_sbx_list.py
@@ -16,17 +16,14 @@ def test_list_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
 
 
 @pytest.mark.skip_debug()
-def test_list_sandboxes_with_filter(sandbox_test_id: str):
+def test_list_sandboxes_with_filter(sandbox_factory, sandbox_test_id: str):
     unique_id = str(int(time.time()))
-    extra_sbx = Sandbox.create(metadata={"unique_id": unique_id})
+    extra_sbx = sandbox_factory(metadata={"unique_id": unique_id})
 
-    try:
-        paginator = Sandbox.list(query=SandboxQuery(metadata={"unique_id": unique_id}))
-        sandboxes = paginator.next_items()
-        assert len(sandboxes) == 1
-        assert sandboxes[0].sandbox_id == extra_sbx.sandbox_id
-    finally:
-        extra_sbx.kill()
+    paginator = Sandbox.list(query=SandboxQuery(metadata={"unique_id": unique_id}))
+    sandboxes = paginator.next_items()
+    assert len(sandboxes) == 1
+    assert sandboxes[0].sandbox_id == extra_sbx.sandbox_id
 
 
 @pytest.mark.skip_debug()
@@ -66,118 +63,115 @@ def test_list_paused_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
 
 
 @pytest.mark.skip_debug()
-def test_paginate_running_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
+def test_paginate_running_sandboxes(
+    sandbox: Sandbox, sandbox_factory, sandbox_test_id: str
+):
     # Create two sandboxes
-    extra_sbx = Sandbox.create(metadata={"sandbox_test_id": sandbox_test_id})
+    extra_sbx = sandbox_factory(metadata={"sandbox_test_id": sandbox_test_id})
 
-    try:
-        # Test pagination with limit
-        paginator = Sandbox.list(
-            query=SandboxQuery(
-                metadata={"sandbox_test_id": sandbox_test_id},
-                state=[SandboxState.RUNNING],
-            ),
-            limit=1,
-        )
+    # Test pagination with limit
+    paginator = Sandbox.list(
+        query=SandboxQuery(
+            metadata={"sandbox_test_id": sandbox_test_id},
+            state=[SandboxState.RUNNING],
+        ),
+        limit=1,
+    )
 
-        sandboxes = paginator.next_items()
+    sandboxes = paginator.next_items()
 
-        # Check first page
-        assert len(sandboxes) == 1
-        assert sandboxes[0].state == SandboxState.RUNNING
-        assert paginator.has_next is True
-        assert paginator.next_token is not None
-        assert sandboxes[0].sandbox_id == extra_sbx.sandbox_id
+    # Check first page
+    assert len(sandboxes) == 1
+    assert sandboxes[0].state == SandboxState.RUNNING
+    assert paginator.has_next is True
+    assert paginator.next_token is not None
+    assert sandboxes[0].sandbox_id == extra_sbx.sandbox_id
 
-        # Get second page
-        sandboxes = paginator.next_items()
+    # Get second page
+    sandboxes = paginator.next_items()
 
-        # Check second page
-        assert len(sandboxes) == 1
-        assert sandboxes[0].state == SandboxState.RUNNING
-        assert paginator.has_next is False
-        assert paginator.next_token is None
-        assert sandboxes[0].sandbox_id == sandbox.sandbox_id
-    finally:
-        extra_sbx.kill()
+    # Check second page
+    assert len(sandboxes) == 1
+    assert sandboxes[0].state == SandboxState.RUNNING
+    assert paginator.has_next is False
+    assert paginator.next_token is None
+    assert sandboxes[0].sandbox_id == sandbox.sandbox_id
 
 
 @pytest.mark.skip_debug()
-def test_paginate_paused_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
+def test_paginate_paused_sandboxes(
+    sandbox: Sandbox, sandbox_factory, sandbox_test_id: str
+):
     sandbox.beta_pause()
 
     # create another paused sandbox
-    extra_sbx = Sandbox.create(metadata={"sandbox_test_id": sandbox_test_id})
+    extra_sbx = sandbox_factory(metadata={"sandbox_test_id": sandbox_test_id})
     extra_sbx.beta_pause()
 
-    try:
-        # Test pagination with limit
-        paginator = Sandbox.list(
-            query=SandboxQuery(
-                state=[SandboxState.PAUSED],
-                metadata={"sandbox_test_id": sandbox_test_id},
-            ),
-            limit=1,
-        )
+    # Test pagination with limit
+    paginator = Sandbox.list(
+        query=SandboxQuery(
+            state=[SandboxState.PAUSED],
+            metadata={"sandbox_test_id": sandbox_test_id},
+        ),
+        limit=1,
+    )
 
-        sandboxes = paginator.next_items()
+    sandboxes = paginator.next_items()
 
-        # Check first page
-        assert len(sandboxes) == 1
-        assert sandboxes[0].state == SandboxState.PAUSED
-        assert paginator.has_next is True
-        assert paginator.next_token is not None
-        assert sandboxes[0].sandbox_id == extra_sbx.sandbox_id
+    # Check first page
+    assert len(sandboxes) == 1
+    assert sandboxes[0].state == SandboxState.PAUSED
+    assert paginator.has_next is True
+    assert paginator.next_token is not None
+    assert sandboxes[0].sandbox_id == extra_sbx.sandbox_id
 
-        # Get second page
-        sandboxes = paginator.next_items()
+    # Get second page
+    sandboxes = paginator.next_items()
 
-        # Check second page
-        assert len(sandboxes) == 1
-        assert sandboxes[0].state == SandboxState.PAUSED
-        assert paginator.has_next is False
-        assert paginator.next_token is None
-        assert sandboxes[0].sandbox_id == sandbox.sandbox_id
-    finally:
-        extra_sbx.kill()
+    # Check second page
+    assert len(sandboxes) == 1
+    assert sandboxes[0].state == SandboxState.PAUSED
+    assert paginator.has_next is False
+    assert paginator.next_token is None
+    assert sandboxes[0].sandbox_id == sandbox.sandbox_id
 
 
 @pytest.mark.skip_debug()
-def test_paginate_running_and_paused_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
+def test_paginate_running_and_paused_sandboxes(
+    sandbox: Sandbox, sandbox_factory, sandbox_test_id: str
+):
     # Create extra paused sandbox
-    extra_sbx = Sandbox.create(metadata={"sandbox_test_id": sandbox_test_id})
+    extra_sbx = sandbox_factory(metadata={"sandbox_test_id": sandbox_test_id})
     extra_sbx.beta_pause()
 
-    try:
-        # Test pagination with limit
-        paginator = Sandbox.list(
-            query=SandboxQuery(
-                metadata={"sandbox_test_id": sandbox_test_id},
-                state=[SandboxState.RUNNING, SandboxState.PAUSED],
-            ),
-            limit=1,
-        )
+    # Test pagination with limit
+    paginator = Sandbox.list(
+        query=SandboxQuery(
+            metadata={"sandbox_test_id": sandbox_test_id},
+            state=[SandboxState.RUNNING, SandboxState.PAUSED],
+        ),
+        limit=1,
+    )
 
-        sandboxes = paginator.next_items()
+    sandboxes = paginator.next_items()
 
-        # Check first page
-        assert len(sandboxes) == 1
-        assert sandboxes[0].state == SandboxState.PAUSED
-        assert paginator.has_next is True
-        assert paginator.next_token is not None
-        assert sandboxes[0].sandbox_id == extra_sbx.sandbox_id
+    # Check first page
+    assert len(sandboxes) == 1
+    assert sandboxes[0].state == SandboxState.PAUSED
+    assert paginator.has_next is True
+    assert paginator.next_token is not None
+    assert sandboxes[0].sandbox_id == extra_sbx.sandbox_id
 
-        # Get second page
-        sandboxes = paginator.next_items()
+    # Get second page
+    sandboxes = paginator.next_items()
 
-        # Check second page
-        assert len(sandboxes) == 1
-        assert sandboxes[0].state == SandboxState.RUNNING
-        assert paginator.has_next is False
-        assert paginator.next_token is None
-        assert sandboxes[0].sandbox_id == sandbox.sandbox_id
-    finally:
-        extra_sbx.kill()
+    # Check second page
+    assert len(sandboxes) == 1
+    assert sandboxes[0].state == SandboxState.RUNNING
+    assert paginator.has_next is False
+    assert paginator.next_token is None
+    assert sandboxes[0].sandbox_id == sandbox.sandbox_id
 
 
 @pytest.mark.skip_debug()

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_connect.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_connect.py
@@ -30,27 +30,24 @@ def test_connect_with_secure(sandbox_factory):
 
 
 @pytest.mark.skip_debug()
-def test_connect_does_not_shorten_timeout_on_running_sandbox(template):
+def test_connect_does_not_shorten_timeout_on_running_sandbox(sandbox_factory):
     # Create sandbox with a 300 second timeout
-    sbx = Sandbox.create(template, timeout=300)
-    try:
-        assert sbx.is_running()
+    sbx = sandbox_factory(timeout=300)
+    assert sbx.is_running()
 
-        # Get initial info to check end_at
-        info_before = Sandbox.get_info(sbx.sandbox_id)
+    # Get initial info to check end_at
+    info_before = Sandbox.get_info(sbx.sandbox_id)
 
-        # Connect with a shorter timeout (10 seconds)
-        Sandbox.connect(sbx.sandbox_id, timeout=10)
+    # Connect with a shorter timeout (10 seconds)
+    Sandbox.connect(sbx.sandbox_id, timeout=10)
 
-        # Get info after connection
-        info_after = Sandbox.get_info(sbx.sandbox_id)
+    # Get info after connection
+    info_after = Sandbox.get_info(sbx.sandbox_id)
 
-        # The end_at time should not have been shortened. It should be the same
-        assert info_after.end_at == info_before.end_at, (
-            f"Timeout was shortened: before={info_before.end_at}, after={info_after.end_at}"
-        )
-    finally:
-        sbx.kill()
+    # The end_at time should not have been shortened. It should be the same
+    assert info_after.end_at == info_before.end_at, (
+        f"Timeout was shortened: before={info_before.end_at}, after={info_after.end_at}"
+    )
 
 
 @pytest.mark.skip_debug()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,7 +325,7 @@ importers:
         version: 6.0.5
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@20.19.19)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0)(yaml@2.5.1))
+        version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
       json2md:
         specifier: ^2.0.1
         version: 2.0.1
@@ -340,7 +340,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.19)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0)(yaml@2.5.1)
+        version: 3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0)(yaml@2.5.1)
 
   packages/js-sdk:
     dependencies:
@@ -397,8 +397,8 @@ importers:
         specifier: ^4.3.4
         version: 4.3.4(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))
       '@vitest/browser':
-        specifier: ^3.1.1
-        version: 3.1.1(bufferutil@4.0.8)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))(vitest@3.1.1)
+        specifier: ^3.2.4
+        version: 3.2.4(bufferutil@4.0.8)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))(vitest@3.2.4)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -439,11 +439,11 @@ importers:
         specifier: ^5.4.5
         version: 5.5.3
       vitest:
-        specifier: ^3.1.1
-        version: 3.1.1(@types/node@20.19.19)(@vitest/browser@3.1.1)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(terser@5.46.0)(yaml@2.5.1)
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(terser@5.46.0)(yaml@2.5.1)
       vitest-browser-react:
         specifier: ^0.1.1
-        version: 0.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(@vitest/browser@3.1.1)(react-dom@18.2.0(react@18.3.1))(react@18.3.1)(vitest@3.1.1)
+        version: 0.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(@vitest/browser@3.2.4)(react-dom@18.2.0(react@18.3.1))(react@18.3.1)(vitest@3.2.4)
 
   packages/python-sdk: {}
 
@@ -517,10 +517,6 @@ packages:
     resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
     engines: {node: '>= 16'}
 
-  '@babel/code-frame@7.26.2':
-    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
@@ -565,10 +561,6 @@ packages:
 
   '@babel/helper-validator-identifier@7.25.7':
     resolution: {integrity: sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.25.9':
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.27.1':
@@ -3051,12 +3043,12 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
-  '@vitest/browser@3.1.1':
-    resolution: {integrity: sha512-A+A69mMtrj1RPh96LfXGc309KSXhy2MslvyL+cp9+Y5EVdoJD4KfXDx/3SSlRGN70+hIoJ3RRbTidTvj18PZ/A==}
+  '@vitest/browser@3.2.4':
+    resolution: {integrity: sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==}
     peerDependencies:
       playwright: '*'
       safaridriver: '*'
-      vitest: 3.1.1
+      vitest: 3.2.4
       webdriverio: ^7.0.0 || ^8.0.0 || ^9.0.0
     peerDependenciesMeta:
       playwright:
@@ -3075,22 +3067,8 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@3.1.1':
-    resolution: {integrity: sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==}
-
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
-
-  '@vitest/mocker@3.1.1':
-    resolution: {integrity: sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -3103,32 +3081,17 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.1.1':
-    resolution: {integrity: sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==}
-
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
-
-  '@vitest/runner@3.1.1':
-    resolution: {integrity: sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
-  '@vitest/snapshot@3.1.1':
-    resolution: {integrity: sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==}
-
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
-  '@vitest/spy@3.1.1':
-    resolution: {integrity: sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==}
-
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
-
-  '@vitest/utils@3.1.1':
-    resolution: {integrity: sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
@@ -4024,9 +3987,6 @@ packages:
 
   es-iterator-helpers@1.0.15:
     resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
-
-  es-module-lexer@1.6.0:
-    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -5165,9 +5125,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loupe@3.1.3:
-    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
-
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -5196,9 +5153,6 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
-
-  magic-string@0.30.11:
-    resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -6670,7 +6624,7 @@ packages:
   tar@7.5.4:
     resolution: {integrity: sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terser-webpack-plugin@5.3.16:
     resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
@@ -6724,20 +6678,12 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.0.2:
-    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.3:
@@ -7099,11 +7045,6 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-node@3.1.1:
-    resolution: {integrity: sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -7163,34 +7104,6 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
-        optional: true
-
-  vitest@3.1.1:
-    resolution: {integrity: sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.1.1
-      '@vitest/ui': 3.1.1
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/debug':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
         optional: true
 
   vitest@3.2.4:
@@ -7345,8 +7258,8 @@ packages:
   write-file-atomic@3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
 
-  ws@8.18.1:
-    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7542,12 +7455,6 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.1
 
-  '@babel/code-frame@7.26.2':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -7616,8 +7523,6 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.25.7': {}
 
-  '@babel/helper-validator-identifier@7.25.9': {}
-
   '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-option@7.27.1': {}
@@ -7660,7 +7565,7 @@ snapshots:
       '@babel/parser': 7.27.2
       '@babel/template': 7.27.2
       '@babel/types': 7.27.1
-      debug: 4.4.0
+      debug: 4.4.3(supports-color@10.2.2)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -9466,10 +9371,10 @@ snapshots:
       '@rollup/pluginutils': 5.0.4(rollup@3.29.5)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.4.0(picomatch@4.0.2)
+      fdir: 6.4.0(picomatch@4.0.3)
       is-reference: 1.2.1
-      magic-string: 0.30.11
-      picomatch: 4.0.2
+      magic-string: 0.30.17
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 3.29.5
 
@@ -9926,7 +9831,7 @@ snapshots:
 
   '@testing-library/dom@10.4.0':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/runtime': 7.27.1
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -10311,7 +10216,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0
+      debug: 4.4.3(supports-color@10.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -10446,17 +10351,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.1.1(bufferutil@4.0.8)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))(vitest@3.1.1)':
+  '@vitest/browser@3.2.4(bufferutil@4.0.8)(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.1.1(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))
-      '@vitest/utils': 3.1.1
+      '@vitest/mocker': 3.2.4(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))
+      '@vitest/utils': 3.2.4
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/node@20.19.19)(@vitest/browser@3.1.1)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(terser@5.46.0)(yaml@2.5.1)
-      ws: 8.18.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      vitest: 3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0)(yaml@2.5.1)
+      ws: 8.19.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+    optionalDependencies:
+      playwright: 1.55.1
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@3.2.4(bufferutil@4.0.8)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))(vitest@3.2.4)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/mocker': 3.2.4(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))
+      '@vitest/utils': 3.2.4
+      magic-string: 0.30.17
+      sirv: 3.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(terser@5.46.0)(yaml@2.5.1)
+      ws: 8.19.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     optionalDependencies:
       playwright: 1.55.1
     transitivePeerDependencies:
@@ -10465,7 +10390,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@20.19.19)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0)(yaml@2.5.1))':
+  '@vitest/coverage-v8@3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -10480,16 +10405,11 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.19)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0)(yaml@2.5.1)
+      vitest: 3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0)(yaml@2.5.1)
+    optionalDependencies:
+      '@vitest/browser': 3.2.4(bufferutil@4.0.8)(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
-
-  '@vitest/expect@3.1.1':
-    dependencies:
-      '@vitest/spy': 3.1.1
-      '@vitest/utils': 3.1.1
-      chai: 5.2.0
-      tinyrainbow: 2.0.0
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -10498,15 +10418,6 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.2.0
       tinyrainbow: 2.0.0
-
-  '@vitest/mocker@3.1.1(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))':
-    dependencies:
-      '@vitest/spy': 3.1.1
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      msw: 2.12.3(@types/node@20.19.19)(typescript@5.5.3)
-      vite: 6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1)
 
   '@vitest/mocker@3.2.4(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))':
     dependencies:
@@ -10517,18 +10428,18 @@ snapshots:
       msw: 2.12.3(@types/node@20.19.19)(typescript@5.2.2)
       vite: 6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1)
 
-  '@vitest/pretty-format@3.1.1':
+  '@vitest/mocker@3.2.4(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))':
     dependencies:
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      msw: 2.12.3(@types/node@20.19.19)(typescript@5.5.3)
+      vite: 6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
-
-  '@vitest/runner@3.1.1':
-    dependencies:
-      '@vitest/utils': 3.1.1
-      pathe: 2.0.3
 
   '@vitest/runner@3.2.4':
     dependencies:
@@ -10536,31 +10447,15 @@ snapshots:
       pathe: 2.0.3
       strip-literal: 3.0.0
 
-  '@vitest/snapshot@3.1.1':
-    dependencies:
-      '@vitest/pretty-format': 3.1.1
-      magic-string: 0.30.17
-      pathe: 2.0.3
-
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.17
       pathe: 2.0.3
 
-  '@vitest/spy@3.1.1':
-    dependencies:
-      tinyspy: 3.0.2
-
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.3
-
-  '@vitest/utils@3.1.1':
-    dependencies:
-      '@vitest/pretty-format': 3.1.1
-      loupe: 3.1.3
-      tinyrainbow: 2.0.0
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11014,7 +10909,7 @@ snapshots:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
-      loupe: 3.1.3
+      loupe: 3.2.1
       pathval: 2.0.0
 
   chalk@2.4.2:
@@ -11574,8 +11469,6 @@ snapshots:
       iterator.prototype: 1.1.2
       safe-array-concat: 1.1.3
 
-  es-module-lexer@1.6.0: {}
-
   es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
@@ -11988,9 +11881,9 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
-  fdir@6.4.0(picomatch@4.0.2):
+  fdir@6.4.0(picomatch@4.0.3):
     optionalDependencies:
-      picomatch: 4.0.2
+      picomatch: 4.0.3
 
   fdir@6.4.4(picomatch@4.0.2):
     optionalDependencies:
@@ -12365,7 +12258,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12902,8 +12795,6 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loupe@3.1.3: {}
-
   loupe@3.2.1: {}
 
   lowercase-keys@3.0.0: {}
@@ -12923,10 +12814,6 @@ snapshots:
   lunr@2.3.9: {}
 
   lz-string@1.5.0: {}
-
-  magic-string@0.30.11:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.17:
     dependencies:
@@ -14807,13 +14694,9 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@1.0.2: {}
-
   tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
-
-  tinyspy@3.0.2: {}
 
   tinyspy@4.0.3: {}
 
@@ -15238,27 +15121,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.1.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.0
-      es-module-lexer: 1.6.0
-      pathe: 2.0.3
-      vite: 6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-node@3.2.4(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1):
     dependencies:
       cac: 6.7.14
@@ -15295,56 +15157,17 @@ snapshots:
       terser: 5.46.0
       yaml: 2.5.1
 
-  vitest-browser-react@0.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(@vitest/browser@3.1.1)(react-dom@18.2.0(react@18.3.1))(react@18.3.1)(vitest@3.1.1):
+  vitest-browser-react@0.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(@vitest/browser@3.2.4)(react-dom@18.2.0(react@18.3.1))(react@18.3.1)(vitest@3.2.4):
     dependencies:
-      '@vitest/browser': 3.1.1(bufferutil@4.0.8)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))(vitest@3.1.1)
+      '@vitest/browser': 3.2.4(bufferutil@4.0.8)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))(vitest@3.2.4)
       react: 18.3.1
       react-dom: 18.2.0(react@18.3.1)
-      vitest: 3.1.1(@types/node@20.19.19)(@vitest/browser@3.1.1)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(terser@5.46.0)(yaml@2.5.1)
+      vitest: 3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(terser@5.46.0)(yaml@2.5.1)
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
-  vitest@3.1.1(@types/node@20.19.19)(@vitest/browser@3.1.1)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(terser@5.46.0)(yaml@2.5.1):
-    dependencies:
-      '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))
-      '@vitest/pretty-format': 3.1.1
-      '@vitest/runner': 3.1.1
-      '@vitest/snapshot': 3.1.1
-      '@vitest/spy': 3.1.1
-      '@vitest/utils': 3.1.1
-      chai: 5.2.0
-      debug: 4.4.0
-      expect-type: 1.2.1
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.0.2
-      tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1)
-      vite-node: 3.1.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 20.19.19
-      '@vitest/browser': 3.1.1(bufferutil@4.0.8)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))(vitest@3.1.1)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.2.4(@types/node@20.19.19)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0)(yaml@2.5.1):
+  vitest@3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0)(yaml@2.5.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -15359,7 +15182,7 @@ snapshots:
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3
-      picomatch: 4.0.2
+      picomatch: 4.0.3
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
@@ -15371,6 +15194,49 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.19
+      '@vitest/browser': 3.2.4(bufferutil@4.0.8)(msw@2.12.3(@types/node@20.19.19)(typescript@5.2.2))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))(vitest@3.2.4)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(terser@5.46.0)(yaml@2.5.1):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      debug: 4.4.3(supports-color@10.2.2)
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1)
+      vite-node: 3.2.4(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.19
+      '@vitest/browser': 3.2.4(bufferutil@4.0.8)(msw@2.12.3(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.1(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)(yaml@2.5.1))(vitest@3.2.4)
     transitivePeerDependencies:
       - jiti
       - less
@@ -15560,7 +15426,7 @@ snapshots:
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
 
-  ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@6.0.3):
+  ws@8.19.0(bufferutil@4.0.8)(utf-8-validate@6.0.3):
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 6.0.3


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only refactors and dependency bumps; main risk is increased CI flakiness if fixture scoping/cleanup behavior changes subtly.
> 
> **Overview**
> **Improves SDK test diagnostics and fixture reuse.** JS SDK sandbox tests were refactored to use `sandboxTest.scoped()` with shared sandbox options (e.g., `secure`, `envs`, `allowInternetAccess`) instead of manually creating/killing `Sandbox` instances.
> 
> When a JS sandbox test fails, `packages/js-sdk/tests/setup.ts` now logs the sandbox ID via `onTestFailed`, and Python test fixtures (`packages/python-sdk/tests/conftest.py`) similarly print the sandbox ID on failure using a `pytest_runtest_makereport` hook and finalizers; several Python tests were updated to use `sandbox_factory`/`async_sandbox_factory` for cleanup consistency. Dev dependencies were also bumped (`vitest`/`@vitest/browser` to `3.2.4`) with lockfile updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 715b224ab705331a2e302d40a5b0122a736ab891. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->