### PR TITLE
fix: resolve CLI sandbox logs timeout and waitForSandboxEnd bug

### DIFF
--- a/packages/cli/src/commands/sandbox/logs.ts
+++ b/packages/cli/src/commands/sandbox/logs.ts
@@ -121,6 +121,8 @@ export const logsCommand = new commander.Command('logs')
             )
           }
 
+          if (!opts?.follow) break
+
           const isSandboxRunning = await isRunning(sandboxID)
 
           if (!isSandboxRunning && logs.length === 0 && isFirstRun) {

--- a/packages/cli/src/commands/sandbox/utils.ts
+++ b/packages/cli/src/commands/sandbox/utils.ts
@@ -43,7 +43,7 @@ export function waitForSandboxEnd(sandboxID: string) {
 
   monitor()
 
-  return () => isRunning
+  return () => running
 }
 
 export async function isRunning(sandboxID: string) {


### PR DESCRIPTION
## Summary
- Skip the unnecessary `isRunning()` API call and `wait(400)` when `--follow` is not set in `sandbox logs`, preventing flaky timeouts in the backend integration test
- Fix `waitForSandboxEnd` to return the `running` variable instead of the `isRunning` function reference, so the follow-mode loop actually terminates when the sandbox stops

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow fixes in the CLI logs loop and sandbox status monitor; low blast radius with minimal behavioral change beyond making termination conditions correct.
> 
> **Overview**
> `sandbox logs` now breaks out immediately after printing the first batch when `--follow` isn’t set, avoiding extra status polling/sleeps that could cause flaky timeouts.
> 
> Fixes `waitForSandboxEnd` to return the mutable `running` boolean (instead of the `isRunning` function reference), so follow-mode loops can actually stop when the sandbox exits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87cd7af5b1bdf9a7a4fe16e7a2100256b3d55d7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->