### PR TITLE
fix: scope sandbox_test_id fixture per-test to prevent cross-worker interference

### DIFF
--- a/packages/python-sdk/tests/conftest.py
+++ b/packages/python-sdk/tests/conftest.py
@@ -28,7 +28,7 @@ def pytest_runtest_makereport(item, call):
         item._test_failed = rep.failed
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def sandbox_test_id():
     return f"test_{uuid.uuid4()}"
 


### PR DESCRIPTION
## Summary
- The `sandbox_test_id` pytest fixture was `scope="session"`, meaning all 4 parallel workers shared the same ID
- Pagination tests that assert exact sandbox counts (`has_next is False`) failed when other workers' sandboxes matched the same metadata filter
- Changed to test scope (default), matching JS SDK behavior, so each test gets its own unique ID

## Change
Single-line change in `packages/python-sdk/tests/conftest.py`:
```python
# Before
@pytest.fixture(scope="session")

# After
@pytest.fixture()
```

## Test plan
- [x] All 16 list/pagination tests pass locally (sync + async)
- [ ] CI passes on Python SDK test suites (ubuntu + windows, staging + production)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that narrows fixture scope; main risk is unintended increase in sandbox creation/cleanup volume or exposing hidden test dependencies on a shared ID.
> 
> **Overview**
> Updates the pytest `sandbox_test_id` fixture in `packages/python-sdk/tests/conftest.py` from session-scoped to function-scoped so each test gets a unique metadata identifier.
> 
> This isolates sandbox listing/pagination tests that filter by `sandbox_test_id` from interference by other parallel pytest workers creating sandboxes with the same metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc8c83dec59f86fd96163ba3fa364e184ec8feba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->