### PR TITLE
chore: use template versioning in tests

### DIFF
--- a/packages/js-sdk/tests/setup.ts
+++ b/packages/js-sdk/tests/setup.ts
@@ -30,7 +30,7 @@ async function buildTemplate(
   options?: { name?: string; skipCache?: boolean },
   onBuildLogs?: (logEntry: LogEntry) => void
 ): Promise<BuildInfo> {
-  const buildName = options?.name || `e2b-test-${randomUUID()}`
+  const buildName = options?.name || `e2b-test:v1-${randomUUID()}`
   const buildInfo: { templateId?: string; buildId?: string } = {}
 
   const captureLogs = (log: LogEntry) => {

--- a/packages/js-sdk/tests/template/backgroundBuild.test.ts
+++ b/packages/js-sdk/tests/template/backgroundBuild.test.ts
@@ -9,7 +9,7 @@ test('build template in background', async () => {
     .runCmd('sleep 5') // Add a delay to ensure build takes time
     .setStartCmd('echo "Hello"', waitForTimeout(10_000))
 
-  const name = `e2b-test-${randomUUID()}`
+  const name = `e2b-test:v1-${randomUUID()}`
 
   const buildInfo = await Template.buildInBackground(template, name, {
     cpuCount: 1,

--- a/packages/js-sdk/tests/template/tags.test.ts
+++ b/packages/js-sdk/tests/template/tags.test.ts
@@ -87,8 +87,8 @@ describe('Template tags unit tests', () => {
 buildTemplateTest.skipIf(isDebug)(
   'build template with tags, assign and delete',
   async ({ buildTemplate }) => {
-    const templateAlias = `e2b-js-tags-test-${randomUUID()}`
-    const initialTag = `${templateAlias}:v1.0`
+    const templateName = 'e2b-tags-test'
+    const initialTag = `${templateName}:v1-${randomUUID()}`
 
     // Build a template with initial tag
     const template = Template().fromBaseImage()
@@ -113,8 +113,8 @@ buildTemplateTest.skipIf(isDebug)(
 buildTemplateTest.skipIf(isDebug)(
   'assign single tag to existing template',
   async ({ buildTemplate }) => {
-    const templateAlias = `e2b-js-single-tag-${randomUUID()}`
-    const initialTag = `${templateAlias}:v1.0`
+    const templateName = 'e2b-tags-test'
+    const initialTag = `${templateName}:v1-${randomUUID()}`
 
     const template = Template().fromBaseImage()
     await buildTemplate(template, { name: initialTag })
@@ -131,8 +131,8 @@ buildTemplateTest.skipIf(isDebug)(
 buildTemplateTest.skipIf(isDebug)(
   'rejects invalid tag format - missing alias',
   async ({ buildTemplate }) => {
-    const templateAlias = `e2b-js-invalid-tag-${randomUUID()}`
-    const initialTag = `${templateAlias}:v1.0`
+    const templateName = 'e2b-tags-test'
+    const initialTag = `${templateName}:v1-${randomUUID()}`
 
     const template = Template().fromBaseImage()
     await buildTemplate(template, { name: initialTag })
@@ -148,15 +148,15 @@ buildTemplateTest.skipIf(isDebug)(
 buildTemplateTest.skipIf(isDebug)(
   'rejects invalid tag format - missing tag',
   async ({ buildTemplate }) => {
-    const templateAlias = `e2b-js-invalid-tag2-${randomUUID()}`
-    const initialTag = `${templateAlias}:v1.0`
+    const templateName = 'e2b-tags-test'
+    const initialTag = `${templateName}:v1-${randomUUID()}`
 
     const template = Template().fromBaseImage()
     await buildTemplate(template, { name: initialTag })
 
     // Tag without tag portion (ends with colon) should be rejected
     await expect(
-      Template.assignTags(initialTag, `${templateAlias}:`)
+      Template.assignTags(initialTag, `${templateName}:`)
     ).rejects.toThrow()
   },
   { timeout: 300_000 }

--- a/packages/python-sdk/tests/async/template_async/test_background_build.py
+++ b/packages/python-sdk/tests/async/template_async/test_background_build.py
@@ -17,7 +17,7 @@ async def test_build_in_background_should_start_build_and_return_info():
         .set_start_cmd('echo "Hello"', wait_for_timeout(10_000))
     )
 
-    name = f"e2b-test-{uuid.uuid4()}"
+    name = f"e2b-test:v1-{uuid.uuid4()}"
 
     build_info = await AsyncTemplate.build_in_background(
         template,

--- a/packages/python-sdk/tests/async/template_async/test_tags.py
+++ b/packages/python-sdk/tests/async/template_async/test_tags.py
@@ -122,8 +122,8 @@ class TestTagsIntegration:
     @pytest.mark.skip_debug()
     async def test_build_template_with_tags_assign_and_delete(self, async_build):
         """Test building a template with tags, assigning new tags, and deleting."""
-        template_alias = f"e2b-async-tags-test-{uuid.uuid4().hex}"
-        initial_tag = f"{template_alias}:v1.0"
+        template_name = "e2b-tags-test"
+        initial_tag = f"{template_name}:v1-{uuid.uuid4().hex}"
 
         # Build a template with initial tag
         template = Template().from_base_image()
@@ -145,8 +145,8 @@ class TestTagsIntegration:
     @pytest.mark.skip_debug()
     async def test_assign_single_tag_to_existing_template(self, async_build):
         """Test assigning a single tag (not array) to an existing template."""
-        template_alias = f"e2b-async-single-tag-{uuid.uuid4().hex}"
-        initial_tag = f"{template_alias}:v1.0"
+        template_name = "e2b-tags-test"
+        initial_tag = f"{template_name}:v1-{uuid.uuid4().hex}"
 
         template = Template().from_base_image()
         await async_build(template, name=initial_tag)
@@ -161,8 +161,8 @@ class TestTagsIntegration:
     @pytest.mark.skip_debug()
     async def test_rejects_invalid_tag_format_missing_alias(self, async_build):
         """Test that tag without alias (starts with colon) is rejected."""
-        template_alias = f"e2b-async-invalid-tag-{uuid.uuid4().hex}"
-        initial_tag = f"{template_alias}:v1.0"
+        template_name = "e2b-tags-test"
+        initial_tag = f"{template_name}:v1-{uuid.uuid4().hex}"
 
         template = Template().from_base_image()
         await async_build(template, name=initial_tag)
@@ -174,12 +174,12 @@ class TestTagsIntegration:
     @pytest.mark.skip_debug()
     async def test_rejects_invalid_tag_format_missing_tag(self, async_build):
         """Test that tag without tag portion (ends with colon) is rejected."""
-        template_alias = f"e2b-async-invalid-tag2-{uuid.uuid4().hex}"
-        initial_tag = f"{template_alias}:v1.0"
+        template_name = "e2b-tags-test"
+        initial_tag = f"{template_name}:v1-{uuid.uuid4().hex}"
 
         template = Template().from_base_image()
         await async_build(template, name=initial_tag)
 
         # Tag without tag portion (ends with colon) should be rejected
         with pytest.raises(Exception):
-            await AsyncTemplate.assign_tags(initial_tag, f"{template_alias}:")
+            await AsyncTemplate.assign_tags(initial_tag, f"{template_name}:")

--- a/packages/python-sdk/tests/conftest.py
+++ b/packages/python-sdk/tests/conftest.py
@@ -112,7 +112,7 @@ def build():
         skip_cache: bool = False,
         on_build_logs: Optional[Callable[[LogEntry], None]] = None,
     ):
-        build_name = name or f"e2b-test-{uuid4()}"
+        build_name = name or f"e2b-test:v1-{uuid4()}"
         build_info: Dict[str, Optional[str]] = {"template_id": None, "build_id": None}
 
         def capture_logs(log: LogEntry):
@@ -156,7 +156,7 @@ def async_build():
         skip_cache: bool = False,
         on_build_logs: Optional[Callable[[LogEntry], None]] = None,
     ):
-        build_name = name or f"e2b-test-{uuid4()}"
+        build_name = name or f"e2b-test:v1-{uuid4()}"
         build_info: Dict[str, Optional[str]] = {"template_id": None, "build_id": None}
 
         def capture_logs(log: LogEntry):

--- a/packages/python-sdk/tests/sync/template_sync/test_background_build.py
+++ b/packages/python-sdk/tests/sync/template_sync/test_background_build.py
@@ -17,7 +17,7 @@ def test_build_in_background_should_start_build_and_return_info():
         .set_start_cmd('echo "Hello"', wait_for_timeout(10_000))
     )
 
-    name = f"e2b-test-{uuid.uuid4()}"
+    name = f"e2b-test:v1-{uuid.uuid4()}"
 
     build_info = Template.build_in_background(
         template,

--- a/packages/python-sdk/tests/sync/template_sync/test_tags.py
+++ b/packages/python-sdk/tests/sync/template_sync/test_tags.py
@@ -113,8 +113,8 @@ class TestTagsIntegration:
     @pytest.mark.skip_debug()
     def test_build_template_with_tags_assign_and_delete(self, build):
         """Test building a template with tags, assigning new tags, and deleting."""
-        template_alias = f"e2b-sync-tags-test-{uuid.uuid4().hex}"
-        initial_tag = f"{template_alias}:v1.0"
+        template_name = "e2b-tags-test"
+        initial_tag = f"{template_name}:v1-{uuid.uuid4().hex}"
 
         # Build a template with initial tag
         template = Template().from_base_image()
@@ -134,8 +134,8 @@ class TestTagsIntegration:
     @pytest.mark.skip_debug()
     def test_assign_single_tag_to_existing_template(self, build):
         """Test assigning a single tag (not array) to an existing template."""
-        template_alias = f"e2b-sync-single-tag-{uuid.uuid4().hex}"
-        initial_tag = f"{template_alias}:v1.0"
+        template_name = "e2b-tags-test"
+        initial_tag = f"{template_name}:v1-{uuid.uuid4().hex}"
 
         template = Template().from_base_image()
         build(template, name=initial_tag)
@@ -150,8 +150,8 @@ class TestTagsIntegration:
     @pytest.mark.skip_debug()
     def test_rejects_invalid_tag_format_missing_alias(self, build):
         """Test that tag without alias (starts with colon) is rejected."""
-        template_alias = f"e2b-sync-invalid-tag-{uuid.uuid4().hex}"
-        initial_tag = f"{template_alias}:v1.0"
+        template_name = "e2b-tags-test"
+        initial_tag = f"{template_name}:v1-{uuid.uuid4().hex}"
 
         template = Template().from_base_image()
         build(template, name=initial_tag)
@@ -163,12 +163,12 @@ class TestTagsIntegration:
     @pytest.mark.skip_debug()
     def test_rejects_invalid_tag_format_missing_tag(self, build):
         """Test that tag without tag portion (ends with colon) is rejected."""
-        template_alias = f"e2b-sync-invalid-tag2-{uuid.uuid4().hex}"
-        initial_tag = f"{template_alias}:v1.0"
+        template_name = "e2b-tags-test"
+        initial_tag = f"{template_name}:v1-{uuid.uuid4().hex}"
 
         template = Template().from_base_image()
         build(template, name=initial_tag)
 
         # Tag without tag portion (ends with colon) should be rejected
         with pytest.raises(Exception):
-            Template.assign_tags(initial_tag, f"{template_alias}:")
+            Template.assign_tags(initial_tag, f"{template_name}:")


### PR DESCRIPTION
## Summary
- Use fixed template names with unique version tags (`name:v1-{uuid}`) instead of creating entirely new templates per test run
- All build fixtures and tag integration tests now create new versions of existing templates via the `name:tag` syntax
- Tag integration tests share a single `e2b-tags-test` template name across all test cases

## Test plan
- [ ] Run JS SDK tests: `cd packages/js-sdk && pnpm run test`
- [ ] Run Python SDK tests: `cd packages/python-sdk && pnpm run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that standardize template naming; risk is limited to potential integration test flakiness if the `name:tag` version syntax behaves differently in some environments.
> 
> **Overview**
> **Test template builds now use versioned names.** JS and Python test build helpers and background-build tests switch default build names from `e2b-test-{uuid}` to `e2b-test:v1-{uuid}` to exercise the `name:tag` versioning path.
> 
> **Tag integration tests now share a fixed template name.** The tags integration suites in both SDKs use a constant `e2b-tags-test` template name and generate unique `v1-{uuid}` tags per test, including updating invalid-tag cases to reference the shared name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71631ed474dc08a7a4ffa6c785cd60956edb45ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->