### PR TITLE
fix: increase timeout for backgroundBuild test

### DIFF
--- a/packages/js-sdk/tests/template/backgroundBuild.test.ts
+++ b/packages/js-sdk/tests/template/backgroundBuild.test.ts
@@ -22,4 +22,4 @@ test('build template in background', async () => {
   // Verify the build is actually running
   const status = await Template.getBuildStatus(buildInfo)
   expect(status.status).toEqual('building')
-}, 10_000)
+})


### PR DESCRIPTION
The buildInBackground test was timing out with a 10 second limit. The `buildInBackground` method makes multiple sequential API calls (create template, get file upload links, trigger build) before returning, which exceeds the tight 10 second budget. Removed the explicit timeout override so the test inherits the workspace default of 180 seconds, which is appropriate for integration tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes a Vitest integration test timeout behavior to avoid flaky failures; no production logic is modified.
> 
> **Overview**
> Removes the explicit `10_000`ms timeout override from `backgroundBuild.test.ts` so the `build template in background` test can use the suite/workspace default timeout (reducing flakiness from slow sequential API calls in `Template.buildInBackground`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e945a4d24476bce1d5fc0280cd6e97d1ac4c0cc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->