### PR TITLE
fix: remove 'Paused' from sandbox not found error in set_timeout

### DIFF
--- a/.changeset/fix-sandbox-not-found-msg.md
+++ b/.changeset/fix-sandbox-not-found-msg.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Fix sandbox not found error message in set_timeout

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -146,7 +146,7 @@ class SandboxApi(SandboxBase):
         )
 
         if res.status_code == 404:
-            raise NotFoundException(f"Paused sandbox {sandbox_id} not found")
+            raise NotFoundException(f"Sandbox {sandbox_id} not found")
 
         if res.status_code >= 300:
             raise handle_api_exception(res)


### PR DESCRIPTION
Remove "Paused" prefix from the sandbox not found error message in the async Python SDK's `set_timeout` method. The sync SDK and JS SDK already use the correct message without "Paused".

Changes:
- Updated error message in `sandbox_async/sandbox_api.py`
- Added changeset for patch release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk text-only change: adjusts a raised `NotFoundException` message in the async SDK and adds a patch changeset for release.
> 
> **Overview**
> Removes the incorrect "Paused" wording from the async Python SDK’s `set_timeout` 404 path so `NotFoundException` now reports `Sandbox <id> not found`.
> 
> Adds a Changeset to publish this as a patch release of `@e2b/python-sdk`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 950e2b1d47efdaa21c66d828ec95fac3f46ee2aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->