### PR TITLE
fix: include dotfiles in Template.copy() (#1161)

### DIFF
--- a/packages/js-sdk/src/template/utils.ts
+++ b/packages/js-sdk/src/template/utils.ts
@@ -147,6 +147,7 @@ export async function getAllFilesInPath(
     withFileTypes: true,
     // this is required so that the ignore pattern is relative to the file path
     cwd: contextPath,
+    dot: true,
   })
 
   for (const file of globFiles) {
@@ -165,6 +166,7 @@ export async function getAllFilesInPath(
         ignore: ignorePatterns,
         withFileTypes: true,
         cwd: contextPath,
+        dot: true,
       })
       dirFiles.forEach((f) => files.set(f.fullpath(), f))
     } else {

--- a/packages/js-sdk/tests/template/utils/getAllFilesInPath.test.ts
+++ b/packages/js-sdk/tests/template/utils/getAllFilesInPath.test.ts
@@ -261,4 +261,22 @@ describe('getAllFilesInPath', () => {
     expect(files.some((f) => f.fullpath().endsWith('helper.ts'))).toBe(true)
     expect(files.some((f) => f.fullpath().endsWith('test.spec.ts'))).toBe(false)
   })
+
+  test('should include dotfiles and dot-directories', async () => {
+    // Create structure with dotfiles
+    await mkdir(join(testDir, '.claude'), { recursive: true })
+    await writeFile(join(testDir, '.claude', 'settings.json'), 'settings')
+    await writeFile(join(testDir, '.env'), 'env config')
+    await writeFile(join(testDir, 'regular.txt'), 'regular text')
+
+    const files = await getAllFilesInPath('*', testDir, [])
+
+    // Depending on shell expansion `*` might not explicitly include dotfiles in bash, 
+    // but fast-glob/glob with `dot: true` will match them for `*` or `**/*`
+    expect(files.length).toBeGreaterThan(0)
+    expect(files.some((f) => f.fullpath().endsWith('.env'))).toBe(true)
+    expect(files.some((f) => f.fullpath().endsWith('.claude'))).toBe(true)
+    expect(files.some((f) => f.fullpath().endsWith('settings.json'))).toBe(true)
+    expect(files.some((f) => f.fullpath().endsWith('regular.txt'))).toBe(true)
+  })
 })


### PR DESCRIPTION
Fixes issue #1161 where `Template.copy()` silently ignored dotfiles and dot-directories like `.env` or `.claude/`.

This PR passes `dot: true` to the glob patterns in `getAllFilesInPath` in `packages/js-sdk/src/template/utils.ts` and adds a regression test.