### PR TITLE
fix: close httpx client on sandbox kill to prevent connection pool leaks

### DIFF
--- a/.changeset/fix-httpx-client-leak.md
+++ b/.changeset/fix-httpx-client-leak.md
@@ -1,0 +1,7 @@
+---
+"e2b": patch
+---
+
+fix: close httpx client on sandbox kill to prevent connection pool leaks
+
+Close the httpx AsyncClient/Client in the kill() method to prevent TCP connection and file descriptor leaks when sandboxes are destroyed.

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -359,10 +359,12 @@ class AsyncSandbox(SandboxApi):
 
         :return: `True` if the sandbox was killed, `False` if the sandbox was not found
         """
-        return await SandboxApi._cls_kill(
+        result = await SandboxApi._cls_kill(
             sandbox_id=self.sandbox_id,
             **self.connection_config.get_api_params(**opts),
         )
+        await self._envd_api.aclose()
+        return result
 
     @overload
     async def set_timeout(

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -358,10 +358,12 @@ class Sandbox(SandboxApi):
 
         :return: `True` if the sandbox was killed, `False` if the sandbox was not found
         """
-        return SandboxApi._cls_kill(
+        result = SandboxApi._cls_kill(
             sandbox_id=self.sandbox_id,
             **self.connection_config.get_api_params(**opts),
         )
+        self._envd_api.close()
+        return result
 
     @overload
     def set_timeout(


### PR DESCRIPTION
## Summary

Fixes #1155

When `Sandbox.kill()` is called, the httpx `AsyncClient`/`Client` used for envd API communication is never closed. This leaks TCP connections and file descriptors, which can accumulate when creating and destroying many sandboxes in a loop.

- Call `await self._envd_api.aclose()` in async `kill()` after the API call
- Call `self._envd_api.close()` in sync `kill()` after the API call
- The `__aexit__`/`__exit__` methods already call `kill()`, so this ensures cleanup happens in both explicit kill and context manager paths

## Test plan

- [ ] Verify `kill()` still returns the correct boolean result
- [ ] Verify no double-close when using context manager (`__aexit__` → `kill()` → `aclose()`)
- [ ] Verify httpx client is properly closed after `kill()` (no resource warnings)
- [ ] Run existing test suite to check for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)