### PR TITLE
feat: add type property to TimeoutException/TimeoutError (#463)

### DIFF
--- a/packages/js-sdk/src/envd/rpc.ts
+++ b/packages/js-sdk/src/envd/rpc.ts
@@ -10,6 +10,7 @@ import {
   NotFoundError,
   SandboxError,
   TimeoutError,
+  TimeoutType,
 } from '../errors'
 import { ENVD_DEFAULT_USER } from './versions'
 
@@ -26,11 +27,15 @@ export function handleRpcError(err: unknown): Error {
         return formatSandboxTimeoutError(err.message)
       case Code.Canceled:
         return new TimeoutError(
-          `${err.message}: This error is likely due to exceeding 'requestTimeoutMs'. You can pass the request timeout value as an option when making the request.`
+          `${err.message}: This error is likely due to exceeding 'requestTimeoutMs'. You can pass the request timeout value as an option when making the request.`,
+          undefined,
+          TimeoutType.REQUEST
         )
       case Code.DeadlineExceeded:
         return new TimeoutError(
-          `${err.message}: This error is likely due to exceeding 'timeoutMs' — the total time a long running request (like command execution or directory watch) can be active. It can be modified by passing 'timeoutMs' when making the request. Use '0' to disable the timeout.`
+          `${err.message}: This error is likely due to exceeding 'timeoutMs' — the total time a long running request (like command execution or directory watch) can be active. It can be modified by passing 'timeoutMs' when making the request. Use '0' to disable the timeout.`,
+          undefined,
+          TimeoutType.EXECUTION
         )
       default:
         return new SandboxError(`${err.code}: ${err.message}`)

--- a/packages/js-sdk/src/errors.ts
+++ b/packages/js-sdk/src/errors.ts
@@ -1,7 +1,31 @@
+/**
+ * The type of timeout that occurred.
+ *
+ * - `sandbox` — the sandbox itself timed out (e.g., idle timeout expired).
+ * - `request` — the HTTP request timed out (exceeded `requestTimeoutMs`).
+ * - `execution` — a long-running operation timed out (exceeded `timeoutMs` for command execution, watch, etc.).
+ */
+export enum TimeoutType {
+  /**
+   * The sandbox itself timed out (e.g., idle timeout expired).
+   */
+  SANDBOX = 'sandbox',
+  /**
+   * The HTTP request timed out (exceeded `requestTimeoutMs`).
+   */
+  REQUEST = 'request',
+  /**
+   * A long-running operation timed out (exceeded `timeoutMs` for command execution, watch, etc.).
+   */
+  EXECUTION = 'execution',
+}
+
 // This is the message for the sandbox timeout error when the response code is 502/Unavailable
 export function formatSandboxTimeoutError(message: string) {
   return new TimeoutError(
-    `${message}: This error is likely due to sandbox timeout. You can modify the sandbox timeout by passing 'timeoutMs' when starting the sandbox or calling '.setTimeout' on the sandbox with the desired timeout.`
+    `${message}: This error is likely due to sandbox timeout. You can modify the sandbox timeout by passing 'timeoutMs' when starting the sandbox or calling '.setTimeout' on the sandbox with the desired timeout.`,
+    undefined,
+    TimeoutType.SANDBOX
   )
 }
 
@@ -23,18 +47,26 @@ export class SandboxError extends Error {
 /**
  * Thrown when a timeout error occurs.
  *
- * The [unavailable] error type is caused by sandbox timeout.
+ * The {@link type} property indicates the kind of timeout:
  *
- * The [canceled] error type is caused by exceeding request timeout.
- *
- * The [deadline_exceeded] error type is caused by exceeding the timeout for command execution, watch, etc.
- *
- * The [unknown] error type is sometimes caused by the sandbox timeout when the request is not processed correctly.
+ * - {@link TimeoutType.SANDBOX} — the sandbox itself timed out (idle timeout, etc.).
+ * - {@link TimeoutType.REQUEST} — the HTTP request exceeded `requestTimeoutMs`.
+ * - {@link TimeoutType.EXECUTION} — a long-running operation exceeded its `timeoutMs`.
  */
 export class TimeoutError extends SandboxError {
-  constructor(message: string, stackTrace?: string) {
+  /**
+   * The type of timeout that occurred.
+   */
+  readonly type: TimeoutType
+
+  constructor(
+    message: string,
+    stackTrace?: string,
+    type: TimeoutType = TimeoutType.SANDBOX
+  ) {
     super(message, stackTrace)
     this.name = 'TimeoutError'
+    this.type = type
   }
 }
 

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -13,6 +13,7 @@ export {
   SandboxError,
   TemplateError,
   TimeoutError,
+  TimeoutType,
   RateLimitError,
   BuildError,
   FileUploadError,

--- a/packages/python-sdk/e2b/__init__.py
+++ b/packages/python-sdk/e2b/__init__.py
@@ -45,6 +45,7 @@ from .exceptions import (
     SandboxException,
     TemplateException,
     TimeoutException,
+    TimeoutType,
 )
 from .sandbox.commands.command_handle import (
     CommandExitException,
@@ -121,6 +122,7 @@ __all__ = [
     # Exceptions
     "SandboxException",
     "TimeoutException",
+    "TimeoutType",
     "NotFoundException",
     "AuthenticationException",
     "GitAuthException",

--- a/packages/python-sdk/e2b/envd/rpc.py
+++ b/packages/python-sdk/e2b/envd/rpc.py
@@ -9,6 +9,7 @@ from e2b.exceptions import (
     InvalidArgumentException,
     NotFoundException,
     TimeoutException,
+    TimeoutType,
     format_sandbox_timeout_exception,
     AuthenticationException,
     RateLimitException,
@@ -33,11 +34,13 @@ def handle_rpc_exception(e: Exception):
             )
         elif e.status == Code.canceled:
             return TimeoutException(
-                f"{e.message}: This error is likely due to exceeding 'request_timeout'. You can pass the request timeout value as an option when making the request."
+                f"{e.message}: This error is likely due to exceeding 'request_timeout'. You can pass the request timeout value as an option when making the request.",
+                type=TimeoutType.REQUEST,
             )
         elif e.status == Code.deadline_exceeded:
             return TimeoutException(
-                f"{e.message}: This error is likely due to exceeding 'timeout' — the total time a long running request (like process or directory watch) can be active. It can be modified by passing 'timeout' when making the request. Use '0' to disable the timeout."
+                f"{e.message}: This error is likely due to exceeding 'timeout' — the total time a long running request (like process or directory watch) can be active. It can be modified by passing 'timeout' when making the request. Use '0' to disable the timeout.",
+                type=TimeoutType.EXECUTION,
             )
         else:
             return SandboxException(f"{e.status}: {e.message}")

--- a/packages/python-sdk/e2b/exceptions.py
+++ b/packages/python-sdk/e2b/exceptions.py
@@ -1,18 +1,38 @@
+from enum import Enum
+
+
+class TimeoutType(str, Enum):
+    """
+    The type of timeout that occurred.
+
+    - ``SANDBOX``: The sandbox itself timed out (e.g., idle timeout expired).
+    - ``REQUEST``: The HTTP request timed out (exceeded ``request_timeout``).
+    - ``EXECUTION``: A long-running operation timed out (exceeded ``timeout`` for command execution, watch, etc.).
+    """
+
+    SANDBOX = "sandbox"
+    REQUEST = "request"
+    EXECUTION = "execution"
+
+
 def format_sandbox_timeout_exception(message: str):
     return TimeoutException(
-        f"{message}: This error is likely due to sandbox timeout. You can modify the sandbox timeout by passing 'timeout' when starting the sandbox or calling '.set_timeout' on the sandbox with the desired timeout."
+        f"{message}: This error is likely due to sandbox timeout. You can modify the sandbox timeout by passing 'timeout' when starting the sandbox or calling '.set_timeout' on the sandbox with the desired timeout.",
+        type=TimeoutType.SANDBOX,
     )
 
 
 def format_request_timeout_error() -> Exception:
     return TimeoutException(
         "Request timed out — the 'request_timeout' option can be used to increase this timeout",
+        type=TimeoutType.REQUEST,
     )
 
 
 def format_execution_timeout_error() -> Exception:
     return TimeoutException(
         "Execution timed out — the 'timeout' option can be used to increase this timeout",
+        type=TimeoutType.EXECUTION,
     )
 
 
@@ -30,13 +50,16 @@ class TimeoutException(SandboxException):
     """
     Raised when a timeout occurs.
 
-    The `unavailable` exception type is caused by sandbox timeout.\n
-    The `canceled` exception type is caused by exceeding request timeout.\n
-    The `deadline_exceeded` exception type is caused by exceeding the timeout for process, watch, etc.\n
-    The `unknown` exception type is sometimes caused by the sandbox timeout when the request is not processed correctly.\n
+    The ``type`` attribute indicates the kind of timeout:
+
+    - :attr:`TimeoutType.SANDBOX` — the sandbox itself timed out (idle timeout, etc.).
+    - :attr:`TimeoutType.REQUEST` — the HTTP request exceeded ``request_timeout``.
+    - :attr:`TimeoutType.EXECUTION` — a long-running operation exceeded its ``timeout``.
     """
 
-    pass
+    def __init__(self, message: str, type: TimeoutType = TimeoutType.SANDBOX):
+        super().__init__(message)
+        self.type = type
 
 
 class InvalidArgumentException(SandboxException):

--- a/packages/python-sdk/e2b/exceptions.py
+++ b/packages/python-sdk/e2b/exceptions.py
@@ -57,7 +57,7 @@ class TimeoutException(SandboxException):
     - :attr:`TimeoutType.EXECUTION` — a long-running operation exceeded its ``timeout``.
     """
 
-    def __init__(self, message: str, type: TimeoutType = TimeoutType.SANDBOX):
+    def __init__(self, message: str = "Timeout", type: TimeoutType = TimeoutType.SANDBOX):
         super().__init__(message)
         self.type = type
 


### PR DESCRIPTION
## Summary

Fixes #463.

`TimeoutException` (Python) and `TimeoutError` (JS) are raised for three distinct timeout scenarios, but users have no way to distinguish them programmatically — they must parse the error message string, which is fragile and error-prone.

This PR adds a `TimeoutType` enum and a `type` property to both SDKs:

| `TimeoutType` | Cause | Python param | JS param |
|---|---|---|---|
| `SANDBOX` | Sandbox idle timeout expired | `timeout` / `.set_timeout()` | `timeoutMs` / `.setTimeout()` |
| `REQUEST` | HTTP request timeout exceeded | `request_timeout` | `requestTimeoutMs` |
| `EXECUTION` | Long-running operation timeout | `timeout` on `commands.run()` etc. | `timeoutMs` on `commands.run()` etc. |

### Python SDK

```python
from e2b import TimeoutException, TimeoutType

try:
    result = sandbox.commands.run("sleep 999", timeout=5)
except TimeoutException as e:
    if e.type == TimeoutType.EXECUTION:
        print("Command took too long")
    elif e.type == TimeoutType.SANDBOX:
        print("Sandbox timed out — recreate it")
    elif e.type == TimeoutType.REQUEST:
        print("Network request timed out — retry")
```

### JS/TS SDK

```typescript
import { TimeoutError, TimeoutType } from 'e2b'

try {
  await sandbox.commands.run('sleep 999', { timeoutMs: 5000 })
} catch (e) {
  if (e instanceof TimeoutError) {
    if (e.type === TimeoutType.EXECUTION) {
      console.log('Command took too long')
    } else if (e.type === TimeoutType.SANDBOX) {
      console.log('Sandbox timed out — recreate it')
    } else if (e.type === TimeoutType.REQUEST) {
      console.log('Network request timed out — retry')
    }
  }
}
```

## Changes

- **Python SDK** (`packages/python-sdk/e2b/exceptions.py`): Added `TimeoutType(str, Enum)` with `SANDBOX`, `REQUEST`, `EXECUTION` values. Updated `TimeoutException.__init__` to accept a `type` parameter (defaults to `SANDBOX`). Updated all factory functions (`format_sandbox_timeout_exception`, `format_request_timeout_error`, `format_execution_timeout_error`) to pass the appropriate type.
- **Python SDK** (`packages/python-sdk/e2b/envd/rpc.py`): Updated `handle_rpc_exception` to pass `TimeoutType.REQUEST` for `Code.canceled` and `TimeoutType.EXECUTION` for `Code.deadline_exceeded`.
- **Python SDK** (`packages/python-sdk/e2b/__init__.py`): Exported `TimeoutType`.
- **JS SDK** (`packages/js-sdk/src/errors.ts`): Added `TimeoutType` enum. Updated `TimeoutError` constructor to accept a `type` parameter (defaults to `SANDBOX`). Updated `formatSandboxTimeoutError`.
- **JS SDK** (`packages/js-sdk/src/envd/rpc.ts`): Updated `handleRpcError` to pass `TimeoutType.REQUEST` for `Code.Canceled` and `TimeoutType.EXECUTION` for `Code.DeadlineExceeded`.
- **JS SDK** (`packages/js-sdk/src/index.ts`): Exported `TimeoutType`.

## Backward compatibility

Fully backward compatible — the `type` parameter defaults to `TimeoutType.SANDBOX` in both SDKs, so existing `except TimeoutException` / `catch (e)` blocks continue to work without changes.

---

> **AI Disclosure:** This PR was authored by Claude (Opus 4.6), an AI assistant made by Anthropic. I am exploring transparent AI employment — see [aiclaude.info](https://aiclaude.info) for details.