### PR TITLE
fix: close httpx client on sandbox exit to prevent connection pool leaks

### DIFF
--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -321,6 +321,7 @@ class AsyncSandbox(SandboxApi):
 
     async def __aexit__(self, exc_type, exc_value, traceback):
         await self.kill()
+        await self._envd_api.aclose()
 
     @overload
     async def kill(

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -320,6 +320,7 @@ class Sandbox(SandboxApi):
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.kill()
+        self._envd_api.close()
 
     @overload
     def kill(


### PR DESCRIPTION
## Summary

- Close `httpx.AsyncClient` (`self._envd_api`) in `AsyncSandbox.__aexit__` via `await self._envd_api.aclose()`
- Close `httpx.Client` (`self._envd_api`) in `Sandbox.__exit__` via `self._envd_api.close()`
- Prevents TCP connection and file descriptor leaks in long-running applications that create many sandboxes

Fixes #1155

## Problem

When a sandbox exits (via context manager, `kill()`, or `__aexit__`/`__exit__`), the `httpx.AsyncClient`/`httpx.Client` stored as `self._envd_api` is never closed. Each unclosed client retains its connection pool, leaking TCP sockets and file descriptors. In applications that create hundreds of sandboxes (common for AI agent orchestrators), this leads to:

- `OSError: [Errno 24] Too many open files`
- `ResourceWarning: unclosed` on garbage collection
- Unbounded connection pool growth

## Fix

Added one line to each SDK variant:

**`sandbox_async/main.py`:**
```python
async def __aexit__(self, exc_type, exc_value, traceback):
    await self.kill()
    await self._envd_api.aclose()  # <-- added
```

**`sandbox_sync/main.py`:**
```python
def __exit__(self, exc_type, exc_value, traceback):
    self.kill()
    self._envd_api.close()  # <-- added
```

## Notes

- The JS SDK does not have this issue since it uses browser `fetch()` via `openapi-fetch` and `@connectrpc/connect-web`, which don't maintain persistent connection pools.
- No breaking changes. The cleanup happens after `kill()` completes, so existing behavior is preserved.

AI Disclosure: This PR was authored by Claude Opus 4.6 (Anthropic), an AI agent operated by [@MaxwellCalkin](https://github.com/MaxwellCalkin).