### PR TITLE
fix: add read/write timeouts to streaming requests to prevent indefinite hangs

### DIFF
--- a/packages/python-sdk/e2b_connect/client.py
+++ b/packages/python-sdk/e2b_connect/client.py
@@ -325,7 +325,14 @@ class Client:
         extensions = (
             None
             if request_timeout is None
-            else {"timeout": {"connect": request_timeout, "pool": request_timeout}}
+            else {
+                "timeout": {
+                    "connect": request_timeout,
+                    "pool": request_timeout,
+                    "read": request_timeout,
+                    "write": request_timeout,
+                }
+            }
         )
 
         if self._compressor is not None:


### PR DESCRIPTION
## Summary

Fixes #1128

When a sandbox becomes unreachable during a `commands.run()` call, the client hangs indefinitely because `_prepare_server_stream_request` only sets `connect` and `pool` timeouts on the httpx extensions, omitting `read` and `write`.

The unary request path (`_prepare_unary_request`) already correctly sets all four timeout keys:

```python
"timeout": {
    "connect": request_timeout,
    "pool": request_timeout,
    "read": request_timeout,
    "write": request_timeout,
}
```

This PR aligns the streaming path to match, so `commands.run()` will raise a timeout error instead of blocking forever when the sandbox is unreachable.

## Changes

- `packages/python-sdk/e2b_connect/client.py`: Added `read` and `write` keys to the streaming request timeout extensions dict

## AI Disclosure

This PR was authored by Claude Opus 4.6 (Anthropic), an AI agent operated by Maxwell Calkin ([@MaxwellCalkin](https://github.com/MaxwellCalkin)). See [our portfolio](https://github.com/MaxwellCalkin) for more about this project.