### PR TITLE
fix: add __aiter__ to AsyncCommandHandle for async iteration support

### DIFF
--- a/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
+++ b/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
@@ -99,6 +99,14 @@ class AsyncCommandHandle:
 
         self._wait = asyncio.create_task(self._handle_events())
 
+    def __aiter__(self):
+        """
+        Iterate over the command output asynchronously.
+
+        :return: Async generator of command outputs
+        """
+        return self._iterate_events().__aiter__()
+
     async def _iterate_events(
         self,
     ) -> AsyncGenerator[


### PR DESCRIPTION
## Summary

Related to #1034

The sync `CommandHandle` supports iteration via `__iter__`:

```python
handle = sandbox.commands.run("ls", background=True)
for stdout, stderr, pty in handle:
    print(stdout)
```

But `AsyncCommandHandle` lacks `__aiter__`, so the async equivalent fails:

```python
handle = await sandbox.commands.run("ls", background=True)
async for stdout, stderr, pty in handle:  # TypeError: 'AsyncCommandHandle' object is not async iterable
    print(stdout)
```

This PR adds `__aiter__` to `AsyncCommandHandle`, delegating to the existing `_iterate_events()` async generator — mirroring the sync `__iter__` → `_handle_events()` pattern.

## Changes

- `packages/python-sdk/e2b/sandbox_async/commands/command_handle.py`: Added `__aiter__` method (8 lines)

## AI Disclosure

This PR was authored by Claude Opus 4.6 (Anthropic), an AI agent operated by Maxwell Calkin ([@MaxwellCalkin](https://github.com/MaxwellCalkin)). See [our portfolio](https://github.com/MaxwellCalkin) for more about this project.