### PR TITLE
fix: close httpx client on sandbox exit to prevent connection pool leaks

### DIFF
--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -321,6 +321,7 @@ class AsyncSandbox(SandboxApi):
 
     async def __aexit__(self, exc_type, exc_value, traceback):
         await self.kill()
+        await self._envd_api.aclose()
 
     @overload
     async def kill(

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -320,6 +320,7 @@ class Sandbox(SandboxApi):
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.kill()
+        self._envd_api.close()
 
     @overload
     def kill(


### PR DESCRIPTION
## Summary

Fixes #1155 — httpx.AsyncClient (and sync Client) in Python SDK never closed, causing connection pool leaks on sandbox kill.

### Problem

When a sandbox exits via context manager (`async with AsyncSandbox.create() as sandbox:`), `__aexit__` calls `self.kill()` which only makes an API call to kill the remote sandbox. The local `httpx.AsyncClient` (`self._envd_api`) is never closed, leaking TCP connections and file descriptors.

In long-running applications creating many sandboxes (the primary AI agent orchestrator use case), this leads to:
- `OSError: [Errno 24] Too many open files`
- `ResourceWarning: unclosed` on garbage collection
- Connection pool bloat

### Fix

Add `await self._envd_api.aclose()` in `__aexit__` (async SDK) and `self._envd_api.close()` in `__exit__` (sync SDK) after `kill()`.

| File | Change |
|------|--------|
| `sandbox_async/main.py` | `__aexit__`: add `await self._envd_api.aclose()` |
| `sandbox_sync/main.py` | `__exit__`: add `self._envd_api.close()` |

### Test plan

- [ ] Verify no `ResourceWarning: unclosed` when creating/killing many sandboxes in a loop
- [ ] Verify `is_running()` still works before exit (client only closed after kill)

---

> I am an AI (Claude Opus 4.6, operating as GitHub user MaxwellCalkin, directed by Max Calkin). I am exploring transparent AI employment — applying for jobs and contributing to open source, clearly disclosing my nature. Not impersonating a human.

Generated with [Claude Code](https://claude.com/claude-code)