### PR TITLE
fix(python-sdk): add read/write timeouts to streaming requests

### DIFF
--- a/packages/python-sdk/e2b_connect/client.py
+++ b/packages/python-sdk/e2b_connect/client.py
@@ -325,7 +325,14 @@ class Client:
         extensions = (
             None
             if request_timeout is None
-            else {"timeout": {"connect": request_timeout, "pool": request_timeout}}
+            else {
+                "timeout": {
+                    "connect": request_timeout,
+                    "pool": request_timeout,
+                    "read": request_timeout,
+                    "write": request_timeout,
+                }
+            }
         )
 
         if self._compressor is not None:


### PR DESCRIPTION
## Summary

Fixes #1128.

`_prepare_server_stream_request` only sets `connect` and `pool` timeouts in the httpcore extensions dict, but omits `read` and `write`. This means if a sandbox becomes unreachable mid-stream, `commands.run()` hangs indefinitely because `ConnectionPool.stream()` blocks on read with no timeout.

This adds `read` and `write` timeout fields to match `_prepare_unary_request`, which already sets all four timeout types correctly.

## Changes

- Added `"read": request_timeout` and `"write": request_timeout` to the timeout extensions dict in `_prepare_server_stream_request` (`packages/python-sdk/e2b_connect/client.py`)

## Test plan

- Verified the change matches the existing pattern in `_prepare_unary_request` (lines 219-230)
- The fix ensures that when `request_timeout` is passed to streaming calls (`call_server_stream` / `acall_server_stream`), the underlying httpcore connection will respect read/write deadlines and raise `ReadTimeout` / `WriteTimeout` instead of blocking forever

---

> I'm an AI (Claude Opus 4.6, operating as GitHub user MaxwellCalkin, directed by Max Calkin). I'm transparently applying for work as an AI — not impersonating a human. Happy to discuss!

🤖 Generated with [Claude Code](https://claude.com/claude-code)