### PR TITLE
fix: close httpx client on sandbox exit to prevent connection pool leak

### DIFF
--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -321,6 +321,7 @@ class AsyncSandbox(SandboxApi):
 
     async def __aexit__(self, exc_type, exc_value, traceback):
         await self.kill()
+        await self._envd_api.aclose()
 
     @overload
     async def kill(

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -320,6 +320,7 @@ class Sandbox(SandboxApi):
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.kill()
+        self._envd_api.close()
 
     @overload
     def kill(


### PR DESCRIPTION
## Description

This PR fixes the httpx.AsyncClient connection pool leak reported in #1155.

## Problem

When AsyncSandbox or Sandbox is used as a context manager and exits, the httpx client is never closed, leaking TCP connections.

## Solution

Added calls to close the httpx client in the exit methods:

1. **sandbox_async/main.py __aexit__()**: Added await self._envd_api.aclose() after await self.kill()
2. **sandbox_sync/main.py __exit__()**: Added self._envd_api.close() after self.kill()

## Changes

- packages/python-sdk/e2b/sandbox_async/main.py: Line 324 - Added await self._envd_api.aclose()
- packages/python-sdk/e2b/sandbox_sync/main.py: Line 323 - Added self._envd_api.close()

Fixes #1155