### PR TITLE
fix: display reason for git failures

### DIFF
--- a/.changeset/khaki-birds-yell.md
+++ b/.changeset/khaki-birds-yell.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': minor
+'e2b': minor
+---
+
+improve distinction for different git permission failures

--- a/packages/js-sdk/src/errors.ts
+++ b/packages/js-sdk/src/errors.ts
@@ -89,6 +89,16 @@ export class GitAuthError extends AuthenticationError {
 }
 
 /**
+ * Thrown when git fails because the repository path is not writable.
+ */
+export class GitPermissionError extends SandboxError {
+  constructor(message: string, stackTrace?: string) {
+    super(message, stackTrace)
+    this.name = 'GitPermissionError'
+  }
+}
+
+/**
  * Thrown when git upstream tracking is missing.
  */
 export class GitUpstreamError extends SandboxError {

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -6,6 +6,7 @@ export type { ConnectionOpts, Username } from './connectionConfig'
 export {
   AuthenticationError,
   GitAuthError,
+  GitPermissionError,
   GitUpstreamError,
   InvalidArgumentError,
   NotEnoughSpaceError,

--- a/packages/js-sdk/src/sandbox/git/index.ts
+++ b/packages/js-sdk/src/sandbox/git/index.ts
@@ -1,5 +1,6 @@
 import {
   GitAuthError,
+  GitPermissionError,
   GitUpstreamError,
   InvalidArgumentError,
 } from '../../errors'
@@ -9,6 +10,7 @@ import { Commands } from '../commands'
 import {
   buildAuthErrorMessage,
   buildGitCommand,
+  buildPermissionErrorMessage,
   buildPushArgs,
   buildUpstreamErrorMessage,
   GitBranches,
@@ -17,6 +19,7 @@ import {
   getRepoPathForScope,
   getScopeFlag,
   isAuthFailure,
+  isPermissionFailure,
   isMissingUpstream,
   parseGitBranches,
   parseGitStatus,
@@ -359,6 +362,9 @@ export class Git {
         throw new GitAuthError(
           buildAuthErrorMessage('clone', Boolean(username) && !password)
         )
+      }
+      if (isPermissionFailure(err)) {
+        throw new GitPermissionError(buildPermissionErrorMessage('clone'))
       }
       throw err
     }
@@ -723,6 +729,9 @@ export class Git {
           buildAuthErrorMessage('push', Boolean(username) && !password)
         )
       }
+      if (isPermissionFailure(err)) {
+        throw new GitPermissionError(buildPermissionErrorMessage('push'))
+      }
       if (isMissingUpstream(err)) {
         throw new GitUpstreamError(buildUpstreamErrorMessage('push'))
       }
@@ -783,6 +792,9 @@ export class Git {
         throw new GitAuthError(
           buildAuthErrorMessage('pull', Boolean(username) && !password)
         )
+      }
+      if (isPermissionFailure(err)) {
+        throw new GitPermissionError(buildPermissionErrorMessage('pull'))
       }
       if (isMissingUpstream(err)) {
         throw new GitUpstreamError(buildUpstreamErrorMessage('pull'))

--- a/packages/js-sdk/src/sandbox/git/utils.ts
+++ b/packages/js-sdk/src/sandbox/git/utils.ts
@@ -516,8 +516,11 @@ export function isAuthFailure(err: unknown): boolean {
     'terminal prompts disabled',
     'could not read username',
     'invalid username or password',
+    'permission denied (publickey',
+    'permission denied (keyboard-interactive',
+    'permission to ',
+    'requested url returned error: 403',
     'access denied',
-    'permission denied',
     'not authorized',
   ]
 

--- a/packages/js-sdk/src/sandbox/git/utils.ts
+++ b/packages/js-sdk/src/sandbox/git/utils.ts
@@ -527,6 +527,52 @@ export function isAuthFailure(err: unknown): boolean {
   return authSnippets.some((snippet) => message.includes(snippet))
 }
 
+export function isPermissionFailure(err: unknown): boolean {
+  if (!(err instanceof CommandExitError)) {
+    return false
+  }
+
+  const message = `${err.stderr}\n${err.stdout}`.toLowerCase()
+  const permissionSignals = [
+    'permission denied',
+    'operation not permitted',
+    'read-only file system',
+  ]
+  const filesystemContexts = [
+    'could not create work tree dir',
+    'repository database',
+    '.git/index.lock',
+    '.git/config.lock',
+    '.git/fetch_head',
+    '.git/head.lock',
+  ]
+  const directSnippets = [
+    'insufficient permission for adding an object to repository database',
+  ]
+
+  return (
+    directSnippets.some((snippet) => message.includes(snippet)) ||
+    (permissionSignals.some((signal) => message.includes(signal)) &&
+      filesystemContexts.some((context) => message.includes(context)))
+  )
+}
+
+export function buildPermissionErrorMessage(
+  action: 'clone' | 'push' | 'pull'
+): string {
+  if (action === 'clone') {
+    return (
+      'Git clone failed because the target path is not writable by the current user. ' +
+      'Try using a writable path or running the command as the user that owns that path.'
+    )
+  }
+
+  return (
+    `Git ${action} failed because the repository path is not writable by the current user. ` +
+    'Try using a writable path or running the command as the user that owns the repository files.'
+  )
+}
+
 export function getScopeFlag(scope: GitConfigScope): `--${GitConfigScope}` {
   if (scope !== 'global' && scope !== 'local' && scope !== 'system') {
     throw new InvalidArgumentError(

--- a/packages/js-sdk/src/sandbox/git/utils.ts
+++ b/packages/js-sdk/src/sandbox/git/utils.ts
@@ -516,6 +516,7 @@ export function isAuthFailure(err: unknown): boolean {
     'terminal prompts disabled',
     'could not read username',
     'invalid username or password',
+    'permission denied (',
     'permission denied (publickey',
     'permission denied (keyboard-interactive',
     'permission to ',

--- a/packages/js-sdk/tests/sandbox/git/authDetection.test.ts
+++ b/packages/js-sdk/tests/sandbox/git/authDetection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
 
-import { GitAuthError, GitPermissionError } from '../../../src/errors'
+import { GitPermissionError } from '../../../src/errors'
 import { CommandExitError } from '../../../src/sandbox/commands/commandHandle'
 import { Git } from '../../../src/sandbox/git'
 import {
@@ -29,7 +29,7 @@ describe('Git auth detection', () => {
 
   test('classifies filesystem permission errors separately from auth failures', () => {
     const err = createFilesystemPermissionError(
-      "fatal: cannot open .git/FETCH_HEAD: Permission denied"
+      'fatal: cannot open .git/FETCH_HEAD: Permission denied'
     )
 
     expect(isPermissionFailure(err)).toBe(true)
@@ -88,7 +88,7 @@ describe('Git auth detection', () => {
 
   test('pull raises GitPermissionError for repository write failures', async () => {
     const err = createFilesystemPermissionError(
-      "error: cannot open .git/FETCH_HEAD: Permission denied"
+      'error: cannot open .git/FETCH_HEAD: Permission denied'
     )
     const git = new Git({
       run: vi.fn().mockRejectedValue(err),

--- a/packages/js-sdk/tests/sandbox/git/authDetection.test.ts
+++ b/packages/js-sdk/tests/sandbox/git/authDetection.test.ts
@@ -1,21 +1,38 @@
 import { describe, expect, test, vi } from 'vitest'
 
-import { GitAuthError } from '../../../src/errors'
+import { GitAuthError, GitPermissionError } from '../../../src/errors'
 import { CommandExitError } from '../../../src/sandbox/commands/commandHandle'
 import { Git } from '../../../src/sandbox/git'
-import { isAuthFailure } from '../../../src/sandbox/git/utils'
+import {
+  buildPermissionErrorMessage,
+  isAuthFailure,
+  isPermissionFailure,
+} from '../../../src/sandbox/git/utils'
+
+function createFilesystemPermissionError(stderr: string) {
+  return new CommandExitError({
+    exitCode: 128,
+    error: stderr,
+    stdout: '',
+    stderr,
+  })
+}
 
 describe('Git auth detection', () => {
   test('does not classify filesystem permission errors as auth failures', () => {
-    const err = new CommandExitError({
-      exitCode: 128,
-      error: "fatal: could not create work tree dir '/home/workspace': Permission denied",
-      stdout: '',
-      stderr:
-        "fatal: could not create work tree dir '/home/workspace': Permission denied",
-    })
+    const err = createFilesystemPermissionError(
+      "fatal: could not create work tree dir '/home/workspace': Permission denied"
+    )
 
     expect(isAuthFailure(err)).toBe(false)
+  })
+
+  test('classifies filesystem permission errors separately from auth failures', () => {
+    const err = createFilesystemPermissionError(
+      "fatal: cannot open .git/FETCH_HEAD: Permission denied"
+    )
+
+    expect(isPermissionFailure(err)).toBe(true)
   })
 
   test('classifies ssh publickey failures as auth failures', () => {
@@ -29,14 +46,10 @@ describe('Git auth detection', () => {
     expect(isAuthFailure(err)).toBe(true)
   })
 
-  test('clone preserves path permission failures instead of raising GitAuthError', async () => {
-    const err = new CommandExitError({
-      exitCode: 128,
-      error: "fatal: could not create work tree dir '/home/workspace': Permission denied",
-      stdout: '',
-      stderr:
-        "fatal: could not create work tree dir '/home/workspace': Permission denied",
-    })
+  test('clone raises GitPermissionError for path permission failures', async () => {
+    const err = createFilesystemPermissionError(
+      "fatal: could not create work tree dir '/home/workspace': Permission denied"
+    )
     const git = new Git({
       run: vi.fn().mockRejectedValue(err),
     } as any)
@@ -45,11 +58,49 @@ describe('Git auth detection', () => {
       git.clone('https://github.com/e2b-dev/e2b.git', {
         path: '/home/workspace',
       })
-    ).rejects.not.toBeInstanceOf(GitAuthError)
+    ).rejects.toBeInstanceOf(GitPermissionError)
     await expect(
       git.clone('https://github.com/e2b-dev/e2b.git', {
         path: '/home/workspace',
       })
-    ).rejects.toBe(err)
+    ).rejects.toMatchObject({
+      message: buildPermissionErrorMessage('clone'),
+    })
+  })
+
+  test('push raises GitPermissionError for repository write failures', async () => {
+    const err = createFilesystemPermissionError(
+      "error: unable to create '.git/index.lock': Permission denied"
+    )
+    const git = new Git({
+      run: vi.fn().mockRejectedValue(err),
+    } as any)
+
+    await expect(
+      git.push('/repo', { remote: 'origin', branch: 'main' })
+    ).rejects.toBeInstanceOf(GitPermissionError)
+    await expect(
+      git.push('/repo', { remote: 'origin', branch: 'main' })
+    ).rejects.toMatchObject({
+      message: buildPermissionErrorMessage('push'),
+    })
+  })
+
+  test('pull raises GitPermissionError for repository write failures', async () => {
+    const err = createFilesystemPermissionError(
+      "error: cannot open .git/FETCH_HEAD: Permission denied"
+    )
+    const git = new Git({
+      run: vi.fn().mockRejectedValue(err),
+    } as any)
+
+    await expect(
+      git.pull('/repo', { remote: 'origin', branch: 'main' })
+    ).rejects.toBeInstanceOf(GitPermissionError)
+    await expect(
+      git.pull('/repo', { remote: 'origin', branch: 'main' })
+    ).rejects.toMatchObject({
+      message: buildPermissionErrorMessage('pull'),
+    })
   })
 })

--- a/packages/js-sdk/tests/sandbox/git/authDetection.test.ts
+++ b/packages/js-sdk/tests/sandbox/git/authDetection.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { GitAuthError } from '../../../src/errors'
+import { CommandExitError } from '../../../src/sandbox/commands/commandHandle'
+import { Git } from '../../../src/sandbox/git'
+import { isAuthFailure } from '../../../src/sandbox/git/utils'
+
+describe('Git auth detection', () => {
+  test('does not classify filesystem permission errors as auth failures', () => {
+    const err = new CommandExitError({
+      exitCode: 128,
+      error: "fatal: could not create work tree dir '/home/workspace': Permission denied",
+      stdout: '',
+      stderr:
+        "fatal: could not create work tree dir '/home/workspace': Permission denied",
+    })
+
+    expect(isAuthFailure(err)).toBe(false)
+  })
+
+  test('classifies ssh publickey failures as auth failures', () => {
+    const err = new CommandExitError({
+      exitCode: 128,
+      error: 'git@github.com: Permission denied (publickey).',
+      stdout: '',
+      stderr: 'git@github.com: Permission denied (publickey).',
+    })
+
+    expect(isAuthFailure(err)).toBe(true)
+  })
+
+  test('clone preserves path permission failures instead of raising GitAuthError', async () => {
+    const err = new CommandExitError({
+      exitCode: 128,
+      error: "fatal: could not create work tree dir '/home/workspace': Permission denied",
+      stdout: '',
+      stderr:
+        "fatal: could not create work tree dir '/home/workspace': Permission denied",
+    })
+    const git = new Git({
+      run: vi.fn().mockRejectedValue(err),
+    } as any)
+
+    await expect(
+      git.clone('https://github.com/e2b-dev/e2b.git', {
+        path: '/home/workspace',
+      })
+    ).rejects.not.toBeInstanceOf(GitAuthError)
+    await expect(
+      git.clone('https://github.com/e2b-dev/e2b.git', {
+        path: '/home/workspace',
+      })
+    ).rejects.toBe(err)
+  })
+})

--- a/packages/js-sdk/tests/sandbox/git/authDetection.test.ts
+++ b/packages/js-sdk/tests/sandbox/git/authDetection.test.ts
@@ -46,6 +46,17 @@ describe('Git auth detection', () => {
     expect(isAuthFailure(err)).toBe(true)
   })
 
+  test('classifies ssh password failures as auth failures', () => {
+    const err = new CommandExitError({
+      exitCode: 128,
+      error: 'git@github.com: Permission denied (password).',
+      stdout: '',
+      stderr: 'git@github.com: Permission denied (password).',
+    })
+
+    expect(isAuthFailure(err)).toBe(true)
+  })
+
   test('clone raises GitPermissionError for path permission failures', async () => {
     const err = createFilesystemPermissionError(
       "fatal: could not create work tree dir '/home/workspace': Permission denied"

--- a/packages/python-sdk/e2b/__init__.py
+++ b/packages/python-sdk/e2b/__init__.py
@@ -36,6 +36,7 @@ from .connection_config import (
 from .exceptions import (
     AuthenticationException,
     GitAuthException,
+    GitPermissionException,
     GitUpstreamException,
     BuildException,
     FileUploadException,
@@ -124,6 +125,7 @@ __all__ = [
     "NotFoundException",
     "AuthenticationException",
     "GitAuthException",
+    "GitPermissionException",
     "GitUpstreamException",
     "InvalidArgumentException",
     "NotEnoughSpaceException",

--- a/packages/python-sdk/e2b/exceptions.py
+++ b/packages/python-sdk/e2b/exceptions.py
@@ -79,6 +79,14 @@ class GitAuthException(AuthenticationException):
     pass
 
 
+class GitPermissionException(SandboxException):
+    """
+    Raised when git cannot write to the target path or repository.
+    """
+
+    pass
+
+
 class GitUpstreamException(SandboxException):
     """
     Raised when git upstream tracking is missing.

--- a/packages/python-sdk/e2b/sandbox/_git/__init__.py
+++ b/packages/python-sdk/e2b/sandbox/_git/__init__.py
@@ -23,8 +23,10 @@ from e2b.sandbox._git.args import (
 )
 from e2b.sandbox._git.auth import (
     build_auth_error_message,
+    build_permission_error_message,
     build_upstream_error_message,
     is_auth_failure,
+    is_permission_failure,
     is_missing_upstream,
     strip_credentials,
     with_credentials,
@@ -41,6 +43,7 @@ from e2b.sandbox._git.types import ClonePlan, GitBranches, GitFileStatus, GitSta
 __all__ = [
     "build_add_args",
     "build_auth_error_message",
+    "build_permission_error_message",
     "build_branches_args",
     "build_checkout_branch_args",
     "build_clone_plan",
@@ -63,6 +66,7 @@ __all__ = [
     "build_upstream_error_message",
     "derive_repo_dir_from_url",
     "is_auth_failure",
+    "is_permission_failure",
     "is_missing_upstream",
     "parse_git_branches",
     "parse_git_status",

--- a/packages/python-sdk/e2b/sandbox/_git/auth.py
+++ b/packages/python-sdk/e2b/sandbox/_git/auth.py
@@ -77,6 +77,39 @@ def is_auth_failure(err: Exception) -> bool:
     return any(snippet in message for snippet in auth_snippets)
 
 
+def is_permission_failure(err: Exception) -> bool:
+    """
+    Check whether a git command failed because the target path is not writable.
+
+    :param err: Exception raised by a git command
+    :return: True when the error matches common filesystem permission failures
+    """
+    if not isinstance(err, CommandExitException):
+        return False
+
+    message = f"{err.stderr}\n{err.stdout}".lower()
+    permission_signals = [
+        "permission denied",
+        "operation not permitted",
+        "read-only file system",
+    ]
+    filesystem_contexts = [
+        "could not create work tree dir",
+        "repository database",
+        ".git/index.lock",
+        ".git/config.lock",
+        ".git/fetch_head",
+        ".git/head.lock",
+    ]
+    direct_snippets = [
+        "insufficient permission for adding an object to repository database",
+    ]
+    return any(snippet in message for snippet in direct_snippets) or (
+        any(signal in message for signal in permission_signals)
+        and any(context in message for context in filesystem_contexts)
+    )
+
+
 def is_missing_upstream(err: Exception) -> bool:
     """
     Check whether a git command failed due to missing upstream tracking.
@@ -112,6 +145,25 @@ def build_auth_error_message(action: str, missing_password: bool) -> str:
     if missing_password:
         return f"Git {action} requires a password/token for private repositories."
     return f"Git {action} requires credentials for private repositories."
+
+
+def build_permission_error_message(action: str) -> str:
+    """
+    Build a git filesystem permission error message for the given action.
+
+    :param action: Git action name
+    :return: Error message string
+    """
+    if action == "clone":
+        return (
+            "Git clone failed because the target path is not writable by the current user. "
+            "Try using a writable path or running the command as the user that owns that path."
+        )
+
+    return (
+        f"Git {action} failed because the repository path is not writable by the current user. "
+        "Try using a writable path or running the command as the user that owns the repository files."
+    )
 
 
 def build_upstream_error_message(action: str) -> str:

--- a/packages/python-sdk/e2b/sandbox/_git/auth.py
+++ b/packages/python-sdk/e2b/sandbox/_git/auth.py
@@ -67,8 +67,11 @@ def is_auth_failure(err: Exception) -> bool:
         "terminal prompts disabled",
         "could not read username",
         "invalid username or password",
+        "permission denied (publickey",
+        "permission denied (keyboard-interactive",
+        "permission to ",
+        "requested url returned error: 403",
         "access denied",
-        "permission denied",
         "not authorized",
     ]
     return any(snippet in message for snippet in auth_snippets)

--- a/packages/python-sdk/e2b/sandbox/_git/auth.py
+++ b/packages/python-sdk/e2b/sandbox/_git/auth.py
@@ -67,6 +67,7 @@ def is_auth_failure(err: Exception) -> bool:
         "terminal prompts disabled",
         "could not read username",
         "invalid username or password",
+        "permission denied (",
         "permission denied (publickey",
         "permission denied (keyboard-interactive",
         "permission to ",

--- a/packages/python-sdk/e2b/sandbox_async/git.py
+++ b/packages/python-sdk/e2b/sandbox_async/git.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional
 
 from e2b.exceptions import (
     GitAuthException,
+    GitPermissionException,
     GitUpstreamException,
     InvalidArgumentException,
 )
@@ -11,6 +12,7 @@ from e2b.sandbox._git import (
     GitStatus,
     build_add_args,
     build_auth_error_message,
+    build_permission_error_message,
     build_branches_args,
     build_checkout_branch_args,
     build_clone_plan,
@@ -32,6 +34,7 @@ from e2b.sandbox._git import (
     build_status_args,
     build_upstream_error_message,
     is_auth_failure,
+    is_permission_failure,
     is_missing_upstream,
     parse_git_branches,
     parse_git_status,
@@ -322,6 +325,10 @@ class Git:
             if is_auth_failure(err):
                 raise GitAuthException(
                     build_auth_error_message("clone", bool(username) and not password)
+                ) from err
+            if is_permission_failure(err):
+                raise GitPermissionException(
+                    build_permission_error_message("clone")
                 ) from err
             raise
 
@@ -807,6 +814,10 @@ class Git:
                 raise GitAuthException(
                     build_auth_error_message("push", bool(username) and not password)
                 ) from err
+            if is_permission_failure(err):
+                raise GitPermissionException(
+                    build_permission_error_message("push")
+                ) from err
             if is_missing_upstream(err):
                 raise GitUpstreamException(
                     build_upstream_error_message("push")
@@ -892,6 +903,10 @@ class Git:
             if is_auth_failure(err):
                 raise GitAuthException(
                     build_auth_error_message("pull", bool(username) and not password)
+                ) from err
+            if is_permission_failure(err):
+                raise GitPermissionException(
+                    build_permission_error_message("pull")
                 ) from err
             if is_missing_upstream(err):
                 raise GitUpstreamException(

--- a/packages/python-sdk/e2b/sandbox_sync/git.py
+++ b/packages/python-sdk/e2b/sandbox_sync/git.py
@@ -5,6 +5,7 @@ from e2b.sandbox._git import (
     GitStatus,
     build_add_args,
     build_auth_error_message,
+    build_permission_error_message,
     build_branches_args,
     build_checkout_branch_args,
     build_clone_plan,
@@ -26,6 +27,7 @@ from e2b.sandbox._git import (
     build_status_args,
     build_upstream_error_message,
     is_auth_failure,
+    is_permission_failure,
     is_missing_upstream,
     parse_git_branches,
     parse_git_status,
@@ -35,6 +37,7 @@ from e2b.sandbox._git import (
 )
 from e2b.exceptions import (
     GitAuthException,
+    GitPermissionException,
     GitUpstreamException,
     InvalidArgumentException,
 )
@@ -320,6 +323,10 @@ class Git:
             if is_auth_failure(err):
                 raise GitAuthException(
                     build_auth_error_message("clone", bool(username) and not password)
+                ) from err
+            if is_permission_failure(err):
+                raise GitPermissionException(
+                    build_permission_error_message("clone")
                 ) from err
             raise
 
@@ -789,6 +796,10 @@ class Git:
                 raise GitAuthException(
                     build_auth_error_message("push", bool(username) and not password)
                 ) from err
+            if is_permission_failure(err):
+                raise GitPermissionException(
+                    build_permission_error_message("push")
+                ) from err
             if is_missing_upstream(err):
                 raise GitUpstreamException(
                     build_upstream_error_message("push")
@@ -871,6 +882,10 @@ class Git:
             if is_auth_failure(err):
                 raise GitAuthException(
                     build_auth_error_message("pull", bool(username) and not password)
+                ) from err
+            if is_permission_failure(err):
+                raise GitPermissionException(
+                    build_permission_error_message("pull")
                 ) from err
             if is_missing_upstream(err):
                 raise GitUpstreamException(

--- a/packages/python-sdk/tests/shared/git/test_auth.py
+++ b/packages/python-sdk/tests/shared/git/test_auth.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import pytest
 
 from e2b.exceptions import GitAuthException, GitPermissionException
@@ -7,6 +9,7 @@ from e2b.sandbox._git.auth import (
     is_permission_failure,
 )
 from e2b.sandbox.commands.command_handle import CommandExitException
+from e2b.sandbox_sync.commands.command import Commands
 from e2b.sandbox_sync.git import Git
 
 
@@ -51,7 +54,7 @@ def test_clone_raises_permission_exception_for_path_permission_failures():
     err = _command_exit(
         "fatal: could not create work tree dir '/home/workspace': Permission denied"
     )
-    git = Git(FailingCommands(err))
+    git = Git(cast(Commands, FailingCommands(err)))
 
     with pytest.raises(GitPermissionException) as exc:
         git.clone("https://github.com/e2b-dev/e2b.git", "/home/workspace")
@@ -62,7 +65,7 @@ def test_clone_raises_permission_exception_for_path_permission_failures():
 
 def test_push_raises_permission_exception_for_repository_write_failures():
     err = _command_exit("error: unable to create '.git/index.lock': Permission denied")
-    git = Git(FailingCommands(err))
+    git = Git(cast(Commands, FailingCommands(err)))
 
     with pytest.raises(GitPermissionException) as exc:
         git.push("/repo", remote="origin", branch="main")
@@ -72,7 +75,7 @@ def test_push_raises_permission_exception_for_repository_write_failures():
 
 def test_pull_raises_permission_exception_for_repository_write_failures():
     err = _command_exit("error: cannot open .git/FETCH_HEAD: Permission denied")
-    git = Git(FailingCommands(err))
+    git = Git(cast(Commands, FailingCommands(err)))
 
     with pytest.raises(GitPermissionException) as exc:
         git.pull("/repo", remote="origin", branch="main")

--- a/packages/python-sdk/tests/shared/git/test_auth.py
+++ b/packages/python-sdk/tests/shared/git/test_auth.py
@@ -1,0 +1,47 @@
+import pytest
+
+from e2b.exceptions import GitAuthException
+from e2b.sandbox._git.auth import is_auth_failure
+from e2b.sandbox.commands.command_handle import CommandExitException
+from e2b.sandbox_sync.git import Git
+
+
+def _command_exit(stderr: str):
+    return CommandExitException(
+        stderr=stderr,
+        stdout="",
+        exit_code=128,
+        error=stderr,
+    )
+
+
+def test_is_auth_failure_ignores_filesystem_permission_errors():
+    err = _command_exit(
+        "fatal: could not create work tree dir '/home/workspace': Permission denied"
+    )
+
+    assert is_auth_failure(err) is False
+
+
+def test_is_auth_failure_detects_ssh_publickey_errors():
+    err = _command_exit("git@github.com: Permission denied (publickey).")
+
+    assert is_auth_failure(err) is True
+
+
+def test_clone_preserves_path_permission_failures():
+    err = _command_exit(
+        "fatal: could not create work tree dir '/home/workspace': Permission denied"
+    )
+
+    class FailingCommands:
+        def run(self, *args, **kwargs):
+            raise err
+
+    git = Git(FailingCommands())
+
+    with pytest.raises(CommandExitException) as exc:
+        git.clone("https://github.com/e2b-dev/e2b.git", "/home/workspace")
+
+    assert exc.value is err
+    assert not isinstance(exc.value, GitAuthException)

--- a/packages/python-sdk/tests/shared/git/test_auth.py
+++ b/packages/python-sdk/tests/shared/git/test_auth.py
@@ -39,6 +39,12 @@ def test_is_auth_failure_detects_ssh_publickey_errors():
     assert is_auth_failure(err) is True
 
 
+def test_is_auth_failure_detects_ssh_password_errors():
+    err = _command_exit("git@github.com: Permission denied (password).")
+
+    assert is_auth_failure(err) is True
+
+
 class FailingCommands:
     def __init__(self, err: CommandExitException):
         self.err = err

--- a/packages/python-sdk/tests/shared/git/test_auth.py
+++ b/packages/python-sdk/tests/shared/git/test_auth.py
@@ -1,7 +1,11 @@
 import pytest
 
-from e2b.exceptions import GitAuthException
-from e2b.sandbox._git.auth import is_auth_failure
+from e2b.exceptions import GitAuthException, GitPermissionException
+from e2b.sandbox._git.auth import (
+    build_permission_error_message,
+    is_auth_failure,
+    is_permission_failure,
+)
 from e2b.sandbox.commands.command_handle import CommandExitException
 from e2b.sandbox_sync.git import Git
 
@@ -23,25 +27,54 @@ def test_is_auth_failure_ignores_filesystem_permission_errors():
     assert is_auth_failure(err) is False
 
 
+def test_is_permission_failure_detects_git_filesystem_errors():
+    err = _command_exit("error: cannot open .git/FETCH_HEAD: Permission denied")
+
+    assert is_permission_failure(err) is True
+
+
 def test_is_auth_failure_detects_ssh_publickey_errors():
     err = _command_exit("git@github.com: Permission denied (publickey).")
 
     assert is_auth_failure(err) is True
 
 
-def test_clone_preserves_path_permission_failures():
+class FailingCommands:
+    def __init__(self, err: CommandExitException):
+        self.err = err
+
+    def run(self, *args, **kwargs):
+        raise self.err
+
+
+def test_clone_raises_permission_exception_for_path_permission_failures():
     err = _command_exit(
         "fatal: could not create work tree dir '/home/workspace': Permission denied"
     )
+    git = Git(FailingCommands(err))
 
-    class FailingCommands:
-        def run(self, *args, **kwargs):
-            raise err
-
-    git = Git(FailingCommands())
-
-    with pytest.raises(CommandExitException) as exc:
+    with pytest.raises(GitPermissionException) as exc:
         git.clone("https://github.com/e2b-dev/e2b.git", "/home/workspace")
 
-    assert exc.value is err
+    assert str(exc.value) == build_permission_error_message("clone")
     assert not isinstance(exc.value, GitAuthException)
+
+
+def test_push_raises_permission_exception_for_repository_write_failures():
+    err = _command_exit("error: unable to create '.git/index.lock': Permission denied")
+    git = Git(FailingCommands(err))
+
+    with pytest.raises(GitPermissionException) as exc:
+        git.push("/repo", remote="origin", branch="main")
+
+    assert str(exc.value) == build_permission_error_message("push")
+
+
+def test_pull_raises_permission_exception_for_repository_write_failures():
+    err = _command_exit("error: cannot open .git/FETCH_HEAD: Permission denied")
+    git = Git(FailingCommands(err))
+
+    with pytest.raises(GitPermissionException) as exc:
+        git.pull("/repo", remote="origin", branch="main")
+
+    assert str(exc.value) == build_permission_error_message("pull")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes git error classification and introduces new `GitPermission*` exceptions in both JS and Python SDKs, which can affect downstream error handling and may be a minor breaking behavioral change. Scope is limited to git clone/push/pull failure parsing and messaging.
> 
> **Overview**
> Improves git failure reporting by **separating filesystem write/permission errors from authentication errors**.
> 
> Adds `GitPermissionError` (JS) / `GitPermissionException` (Python) and updates `clone`, `push`, and `pull` to detect common non-auth permission scenarios (e.g. read-only FS, `.git/*.lock`, worktree creation) and throw the new error with a clearer remediation message. Auth detection is tightened to treat SSH publickey/403-style failures as auth errors while avoiding generic `permission denied` matches, and new unit tests cover the new classification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 615dea747af84ab37254e19f430155f7860084e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->