### PR TITLE
fix(cli): use latest Template.build API with name parameter

### DIFF
--- a/.changeset/template-init-name-syntax.md
+++ b/.changeset/template-init-name-syntax.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+fix(cli): use `name` parameter instead of deprecated `alias` in template init generated code

--- a/packages/cli/src/commands/template/generators/handlebars.ts
+++ b/packages/cli/src/commands/template/generators/handlebars.ts
@@ -108,7 +108,7 @@ export async function transformTemplateData(
  */
 export async function generateTypeScriptCode(
   template: TemplateClass,
-  alias: string,
+  name: string,
   cpuCount?: number,
   memoryMB?: number
 ): Promise<{ templateContent: string; buildContent: string }> {
@@ -138,7 +138,7 @@ export async function generateTypeScriptCode(
   const templateContent = generateTemplateSource(templateData)
 
   const buildContent = generateBuildSource({
-    alias,
+    name,
     cpuCount,
     memoryMB,
   })
@@ -154,7 +154,7 @@ export async function generateTypeScriptCode(
  */
 export async function generatePythonCode(
   template: TemplateClass,
-  alias: string,
+  name: string,
   cpuCount?: number,
   memoryMB?: number,
   isAsync: boolean = false
@@ -184,7 +184,7 @@ export async function generatePythonCode(
   })
 
   const buildContent = generateBuildSource({
-    alias,
+    name,
     cpuCount,
     memoryMB,
   })
@@ -199,7 +199,7 @@ export async function generatePythonCode(
  * Generate README.md content using Handlebars
  */
 export async function generateReadmeContent(
-  alias: string,
+  name: string,
   templateDir: string,
   generatedFiles: GeneratedFiles
 ): Promise<string> {
@@ -216,7 +216,7 @@ export async function generateReadmeContent(
 
   // Prepare template data
   const templateData = {
-    alias,
+    name,
     templateDir,
     templateFile: generatedFiles.templateFile,
     buildDevFile: generatedFiles.buildDevFile,

--- a/packages/cli/src/commands/template/generators/template-generator.ts
+++ b/packages/cli/src/commands/template/generators/template-generator.ts
@@ -10,7 +10,7 @@ import { TemplateClass } from 'e2b'
  */
 export async function generateAndWriteTemplateFiles(
   root: string,
-  alias: string,
+  name: string,
   language: Language,
   template: TemplateClass,
   cpuCount?: number,
@@ -21,13 +21,13 @@ export async function generateAndWriteTemplateFiles(
       const { templateContent, buildContent: buildDevContent } =
         await generateTypeScriptCode(
           template,
-          `${alias}-dev`,
+          `${name}-dev`,
           cpuCount,
           memoryMB
         )
       const { buildContent: buildProdContent } = await generateTypeScriptCode(
         template,
-        alias,
+        name,
         cpuCount,
         memoryMB
       )
@@ -57,14 +57,14 @@ export async function generateAndWriteTemplateFiles(
       const { templateContent, buildContent: buildDevContent } =
         await generatePythonCode(
           template,
-          `${alias}-dev`,
+          `${name}-dev`,
           cpuCount,
           memoryMB,
           isAsync
         )
       const { buildContent: buildProdContent } = await generatePythonCode(
         template,
-        alias,
+        name,
         cpuCount,
         memoryMB,
         isAsync

--- a/packages/cli/src/commands/template/init.ts
+++ b/packages/cli/src/commands/template/init.ts
@@ -22,7 +22,7 @@ const DEFAULT_TEMPLATE_NAME = 'my-template'
  */
 async function generateTemplateFiles(
   root: string,
-  alias: string,
+  name: string,
   language: Language,
   cpuCount?: number,
   memoryMB?: number
@@ -31,7 +31,7 @@ async function generateTemplateFiles(
 
   return generateAndWriteTemplateFiles(
     root,
-    alias,
+    name,
     language,
     template,
     cpuCount,
@@ -158,7 +158,7 @@ function validateTemplateName(name: string) {
 export const initCommand = new commander.Command('init')
   .description('initialize a new sandbox template using the SDK')
   .addOption(pathOption)
-  .option('-n, --name <name>', 'template name (alias)', (value) => {
+  .option('-n, --name <name>', 'template name', (value) => {
     try {
       validateTemplateName(value)
     } catch (err) {
@@ -197,7 +197,7 @@ export const initCommand = new commander.Command('init')
         let templateName: string = opts.name ?? DEFAULT_TEMPLATE_NAME
         if (opts.name === undefined) {
           templateName = await input({
-            message: 'Enter template name (alias):',
+            message: 'Enter template name:',
             default: DEFAULT_TEMPLATE_NAME,
             validate: (input: string) => {
               try {

--- a/packages/cli/src/commands/template/migrate.ts
+++ b/packages/cli/src/commands/template/migrate.ts
@@ -66,15 +66,15 @@ async function migrateToLanguage(
     parsedTemplate = baseTemplate.setReadyCmd(config.ready_cmd)
   }
 
-  const alias = config.template_name || config.template_id
-  if (!alias) {
+  const name = config.template_name || config.template_id
+  if (!name) {
     throw new Error('Template name or ID is required')
   }
 
   // Generate code for the target language using shared functionality
   await generateAndWriteTemplateFiles(
     root,
-    alias,
+    name,
     language,
     parsedTemplate,
     config.cpu_count,

--- a/packages/cli/src/templates/python-build-async.hbs
+++ b/packages/cli/src/templates/python-build-async.hbs
@@ -6,7 +6,7 @@ from .template import template
 async def main():
     await AsyncTemplate.build(
         template,
-        "{{alias}}",
+        "{{name}}",
 {{#if cpuCount}}
         cpu_count={{cpuCount}},
 {{/if}}

--- a/packages/cli/src/templates/python-build-sync.hbs
+++ b/packages/cli/src/templates/python-build-sync.hbs
@@ -5,7 +5,7 @@ from .template import template
 if __name__ == "__main__":
     Template.build(
         template,
-        "{{alias}}",
+        "{{name}}",
     {{#if cpuCount}}
         cpu_count={{cpuCount}},
     {{/if}}

--- a/packages/cli/src/templates/readme.hbs
+++ b/packages/cli/src/templates/readme.hbs
@@ -1,4 +1,4 @@
-# {{alias}} - E2B Sandbox Template
+# {{name}} - E2B Sandbox Template
 
 This is an E2B sandbox template that allows you to run code in a controlled environment.
 
@@ -53,7 +53,7 @@ Once your template is built, you can use it in your E2B sandbox:
 import { Sandbox } from 'e2b'
 
 // Create a new sandbox instance
-const sandbox = await Sandbox.create('{{alias}}')
+const sandbox = await Sandbox.create('{{name}}')
 
 // Your sandbox is ready to use!
 console.log('Sandbox created successfully')
@@ -63,7 +63,7 @@ console.log('Sandbox created successfully')
 from e2b import Sandbox
 
 # Create a new sandbox instance
-sandbox = Sandbox.create('{{alias}}')
+sandbox = Sandbox.create('{{name}}')
 
 # Your sandbox is ready to use!
 print('Sandbox created successfully')
@@ -75,7 +75,7 @@ import asyncio
 
 async def main():
     # Create a new sandbox instance
-    sandbox = await AsyncSandbox.create('{{alias}}')
+    sandbox = await AsyncSandbox.create('{{name}}')
     
     # Your sandbox is ready to use!
     print('Sandbox created successfully')

--- a/packages/cli/src/templates/typescript-build.hbs
+++ b/packages/cli/src/templates/typescript-build.hbs
@@ -2,7 +2,7 @@ import { Template, defaultBuildLogger } from 'e2b'
 import { template } from './template'
 
 async function main() {
-  await Template.build(template, '{{alias}}', {
+  await Template.build(template, '{{name}}', {
     {{#if cpuCount}}
     cpuCount: {{cpuCount}},
     {{/if}}


### PR DESCRIPTION
## Summary
- Updates `e2b template init` to generate code using the current Template.build() API with the `name` parameter
- Replaces deprecated `alias` parameter usage throughout build templates and generator code
- Maintains support for all languages (TypeScript, Python sync/async)

## Changes
- Renamed `alias` to `name` in generator functions and templates (8 files)
- Updated CLI option description and prompts to reference "template name" consistently
- Added changeset for patch release

## Testing
All 79 template init tests pass, including validation of generated build files.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI template-code generation and user-facing prompts, primarily a rename from deprecated `alias` to `name` in generated build/README templates.
> 
> **Overview**
> Updates `e2b template init`/`migrate` code generation to pass a `name` parameter (and `name-dev` for dev builds) instead of the deprecated `alias`, across the Handlebars generator APIs and the TypeScript/Python build and README templates.
> 
> Cleans up CLI UX copy to consistently refer to *template name* (option help text and interactive prompt), and adds a changeset for a patch release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6e291df259a62efa4e59244b44ef8b4044d26dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->