### PR TITLE
Remove e2b-docs from changeset ignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,9 +3,7 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "ignore": [
-    "e2b-docs"
-  ],
+  "ignore": [],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
Removes e2b-docs from the changeset ignore configuration in .changeset/config.json.

This change allows e2b-docs to trigger changelog generation during the release process.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects release/changelog generation behavior by including `e2b-docs` in Changesets processing.
> 
> **Overview**
> Removes `e2b-docs` from the Changesets `ignore` list by setting `ignore` to an empty array in `.changeset/config.json`, so changes in `e2b-docs` will now be considered during versioning/changelog generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afe51b41ac9d4f9e6e629886d6cd0ccd1d1e1de3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->