### PR TITLE
fix(sandbox): enhance pause method to merge connection config with options

### DIFF
--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -585,7 +585,10 @@ export class Sandbox extends SandboxApi {
    * ```
    */
   async pause(opts?: ConnectionOpts): Promise<boolean> {
-    return await SandboxApi.pause(this.sandboxId, opts)
+    return await SandboxApi.pause(this.sandboxId, {
+      ...this.connectionConfig,
+      ...opts,
+    })
   }
 
   /**


### PR DESCRIPTION

Updated the `pause` method in the `Sandbox` class to merge the existing `connectionConfig` with the provided options (`opts`). This change ensures that connection settings are consistently applied when pausing the sandbox, improving flexibility and usability. Just like it is for the `kill` method.

Fixes #1215

Please ignore and close if this behaves like so on purpose.