### PR TITLE
docs: update self-hosting cloud provider support wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get i
 Read the [self-hosting guide](https://github.com/e2b-dev/infra/blob/main/self-host.md) to learn how to set up the [E2B infrastructure](https://github.com/e2b-dev/infra) on your own. The infrastructure is deployed using Terraform. 
 
 Supported cloud providers:
-- 🟢 GCP
-- 🚧 AWS
+- 🟢 AWS
+- 🟢 Google Cloud (GCP)
 - [ ] Azure
-- [ ] General linux machine
+- [ ] General Linux machine


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update the self-hosting cloud provider list in `README.md`
- explicitly mark Google Cloud (GCP) as supported
- align provider list formatting/capitalization (`General Linux machine`)

## Validation
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test` *(fails in existing python async tests: `tests/async/sandbox_async/test_create.py::test_auto_pause_without_auto_resume_requires_connect` with `AsyncApiClient` missing `raise_on_unexpected_status`)*
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://e2b-team.slack.com/archives/C080PPTP2DP/p1773953026690659?thread_ts=1773953026.690659&cid=C080PPTP2DP)

<div><a href="https://cursor.com/agents/bc-3a9b191f-6491-5746-bf8e-ba09a270b1e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a9b191f-6491-5746-bf8e-ba09a270b1e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

