### PR TITLE
fix: pass apiKey from connectionConfig to pause() method

### DIFF
--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -585,14 +585,14 @@ export class Sandbox extends SandboxApi {
    * ```
    */
   async pause(opts?: ConnectionOpts): Promise<boolean> {
-    return await SandboxApi.pause(this.sandboxId, opts)
+    return await SandboxApi.pause(this.sandboxId, { ...this.connectionConfig, ...opts })
   }
 
   /**
    * @deprecated Use {@link Sandbox.pause} instead.
    */
   async betaPause(opts?: ConnectionOpts): Promise<boolean> {
-    return await SandboxApi.betaPause(this.sandboxId, opts)
+    return await SandboxApi.betaPause(this.sandboxId, { ...this.connectionConfig, ...opts })
   }
 
   /**


### PR DESCRIPTION
When using Sandbox.connect() with an apiKey, the pause() method was not passing the apiKey to the API call, causing auth failures. This fix ensures pause() (and deprecated betaPause()) use the same pattern as kill() - merging connectionConfig with provided opts.

Fixes: #1215