### PR TITLE
fix: ensure streaming requests have default timeout when request_timeout is None

### DIFF
--- a/packages/python-sdk/e2b_connect/client.py
+++ b/packages/python-sdk/e2b_connect/client.py
@@ -327,6 +327,13 @@ class Client:
             timeout_ext["connect"] = request_timeout
             timeout_ext["pool"] = request_timeout
             timeout_ext["write"] = request_timeout
+        elif timeout is not None:
+            # Fall back to timeout for connect/pool/write when request_timeout is not set.
+            # This ensures streaming calls have a default timeout instead of hanging
+            # indefinitely when the sandbox is unreachable.
+            timeout_ext["connect"] = timeout
+            timeout_ext["pool"] = timeout
+            timeout_ext["write"] = timeout
         if timeout:
             # This is not actually timeout for the whole stream read, but timeout from the last read chunk.
             # At worst then, the timeout of a hanging stream could be 2 * timeout (reading body until timeout-ϵ, then waiting for the read timeout).

--- a/packages/python-sdk/tests/e2b_connect/test_client.py
+++ b/packages/python-sdk/tests/e2b_connect/test_client.py
@@ -132,3 +132,45 @@ async def test_async_with_multiple_await_calls():
     result = await f()
     assert result is True
     assert total == 2
+
+
+def test_server_stream_request_timeout_fallback():
+    """Test that streaming requests get default timeouts when request_timeout is None.
+
+    Regression test for https://github.com/e2b-dev/E2B/issues/1128
+    When request_timeout is None (the default), streaming requests should fall
+    back to the timeout parameter for connect/pool/write to prevent indefinite hangs.
+    """
+    from e2b_connect.client import Client
+    from unittest.mock import MagicMock
+
+    # Use JSON codec to avoid protobuf dependency
+    client = Client(
+        url="http://localhost:8080",
+        response_type=MagicMock,
+        json=True,
+    )
+
+    # Create a minimal protobuf-like message
+    class FakeMsg:
+        def SerializeToString(self):
+            return b""
+
+    # Case 1: request_timeout=None, timeout=60 -> all four timeouts should be set
+    result = client._prepare_server_stream_request(
+        FakeMsg(), request_timeout=None, timeout=60
+    )
+    assert result["extensions"] is not None
+    assert result["extensions"]["timeout"]["connect"] == 60
+    assert result["extensions"]["timeout"]["pool"] == 60
+    assert result["extensions"]["timeout"]["write"] == 60
+    assert result["extensions"]["timeout"]["read"] == 60
+
+    # Case 2: request_timeout=30, timeout=60 -> request_timeout wins for connect/pool/write
+    result = client._prepare_server_stream_request(
+        FakeMsg(), request_timeout=30, timeout=60
+    )
+    assert result["extensions"]["timeout"]["connect"] == 30
+    assert result["extensions"]["timeout"]["pool"] == 30
+    assert result["extensions"]["timeout"]["write"] == 30
+    assert result["extensions"]["timeout"]["read"] == 60


### PR DESCRIPTION
## Summary

Fixes #1128 — streaming requests hang indefinitely when sandbox is unreachable

When calling streaming RPC methods (e.g. `commands.run`) without an explicit `request_timeout`, the request would hang indefinitely if the sandbox became unreachable - because only `connect`/`pool` timeouts were set, not `read`/`write`.

The fix makes streaming requests fall back to the per-command `timeout` parameter (which defaults to 60s) for `connect`/`pool`/`write` when `request_timeout` is not set. This matches the behavior of unary RPC calls which already set all four timeout types.

## Changes

In `e2b_connect/client.py`, `_prepare_server_stream_request`:
- When `request_timeout` is `None` (the default), fall back to `timeout` for `connect`/`pool`/`write` timeouts
- When `request_timeout` is explicitly provided, it still takes precedence (existing behavior)

Added unit test verifying both cases.