### PR TITLE
fix(js-sdk): pass connection config to pause() and betaPause()

### DIFF
--- a/.changeset/fix-pause-credentials.md
+++ b/.changeset/fix-pause-credentials.md
@@ -1,0 +1,10 @@
+---
+"e2b": patch
+---
+
+fix(js-sdk): pass connection config to pause() and betaPause()
+
+The pause() and betaPause() methods were not using the connection config
+(including API key) passed to Sandbox.connect(), unlike kill() which
+correctly passed the connection config. This caused authentication errors
+when calling pause() after connecting to a sandbox with explicit credentials.

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -585,14 +585,14 @@ export class Sandbox extends SandboxApi {
    * ```
    */
   async pause(opts?: ConnectionOpts): Promise<boolean> {
-    return await SandboxApi.pause(this.sandboxId, opts)
+    return await SandboxApi.pause(this.sandboxId, { ...this.connectionConfig, ...opts })
   }
 
   /**
    * @deprecated Use {@link Sandbox.pause} instead.
    */
   async betaPause(opts?: ConnectionOpts): Promise<boolean> {
-    return await SandboxApi.betaPause(this.sandboxId, opts)
+    return await SandboxApi.betaPause(this.sandboxId, { ...this.connectionConfig, ...opts })
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes #1215

The `pause()` and `betaPause()` methods were not using the connection config passed to `Sandbox.connect()`, unlike `kill()` which correctly uses it.

This caused authentication failures when calling `pause()` after connecting to a sandbox with explicit credentials (e.g., via `apiKey` option).

### Changes

- Modified `pause()` to pass `{ ...this.connectionConfig, ...opts }` to `SandboxApi.pause()`
- Modified `betaPause()` to pass `{ ...this.connectionConfig, ...opts }` to `SandboxApi.betaPause()`

This aligns the behavior with `kill()`, which already correctly uses the connection config.

### Before

```ts
const mySandbox = Sandbox.connect(externalId, { apiKey })
mySandbox.kill() // Works ✓
mySandbox.pause() // Fails with auth issue ✗
```

### After

```ts
const mySandbox = Sandbox.connect(externalId, { apiKey })
mySandbox.kill() // Works ✓
mySandbox.pause() // Works ✓
```