### PR TITLE
Default to base e2b SDK in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ const execution = await sandbox.runCode('x = 1; x += 1; x')
 console.log(execution.text)  // outputs 2
 ```
 
-### 4. Check docs
+### 5. Check docs
 Visit [E2B documentation](https://e2b.dev/docs).
 
-### 5. E2B cookbook
+### 6. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.
 
 ## Self-hosting

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -57,8 +57,8 @@ const execution = await sandbox.runCode('x = 1; x += 1; x')
 console.log(execution.text)  // outputs 2
 ```
 
-### 4. Check docs
+### 5. Check docs
 Visit [E2B documentation](https://e2b.dev/docs).
 
-### 5. E2B cookbook
+### 6. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -54,8 +54,8 @@ with Sandbox.create() as sandbox:
     print(execution.text)  # outputs 2
 ```
 
-### 4. Check docs
+### 5. Check docs
 Visit [E2B documentation](https://e2b.dev/docs).
 
-### 5. E2B cookbook
+### 6. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.


### PR DESCRIPTION
## Summary
- Updated root README, js-sdk README, and python-sdk README to show base `e2b` SDK install and usage as the default
- Code-interpreter is now shown as an optional step for when `runCode()`/`run_code()` is actually needed
- SDK links in descriptions now point to base `e2b` packages on npm/PyPI

## Why
The base `e2b` package covers commands, files, git, networking, and sandbox lifecycle. Users who don't need code execution shouldn't be directed to install `@e2b/code-interpreter` / `e2b-code-interpreter` as their first step.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm base SDK examples use correct import syntax
- [ ] Confirm code-interpreter section still shows correct usage for `runCode()`