### PR TITLE
fix: set Content-Length on presigned PUT uploads for S3 compatibility

### DIFF
--- a/.changeset/early-hotels-peel.md
+++ b/.changeset/early-hotels-peel.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': patch
+'e2b': patch
+---
+
+fix: set Content-Length on presigned PUT uploads for S3 compatibility

--- a/packages/js-sdk/src/template/buildApi.ts
+++ b/packages/js-sdk/src/template/buildApi.ts
@@ -123,8 +123,8 @@ export async function uploadFile(
     // S3 presigned PUT URLs do not support Transfer-Encoding: chunked,
     // and the compressed size is unknowable without actually compressing.
     const chunks: Buffer[] = []
-    for await (const chunk of uploadStream) {
-      chunks.push(Buffer.from(chunk))
+    for await (const chunk of uploadStream as unknown as AsyncIterable<Buffer>) {
+      chunks.push(chunk)
     }
     const body = Buffer.concat(chunks)
 

--- a/packages/js-sdk/src/template/buildApi.ts
+++ b/packages/js-sdk/src/template/buildApi.ts
@@ -119,12 +119,21 @@ export async function uploadFile(
       resolveSymlinks
     )
 
-    // The compiler assumes this is Web fetch API, but it's actually Node.js fetch API
+    // Buffer the gzipped tar to determine Content-Length.
+    // S3 presigned PUT URLs do not support Transfer-Encoding: chunked,
+    // and the compressed size is unknowable without actually compressing.
+    const chunks: Buffer[] = []
+    for await (const chunk of uploadStream) {
+      chunks.push(Buffer.from(chunk))
+    }
+    const body = Buffer.concat(chunks)
+
     const res = await fetch(url, {
       method: 'PUT',
-      // @ts-expect-error
-      body: uploadStream,
-      duplex: 'half',
+      body,
+      headers: {
+        'Content-Length': String(body.length),
+      },
     })
 
     if (!res.ok) {

--- a/packages/js-sdk/src/template/buildApi.ts
+++ b/packages/js-sdk/src/template/buildApi.ts
@@ -119,9 +119,9 @@ export async function uploadFile(
       resolveSymlinks
     )
 
-    // Buffer the gzipped tar to determine Content-Length.
-    // S3 presigned PUT URLs do not support Transfer-Encoding: chunked,
-    // and the compressed size is unknowable without actually compressing.
+    // Buffer the gzipped tar so fetch sends it with Content-Length.
+    // S3 presigned PUT URLs reject Transfer-Encoding: chunked (501).
+    // Node.js fetch (undici) auto-sets Content-Length for Buffer bodies.
     let body: Buffer
     {
       const chunks: Buffer[] = []
@@ -134,9 +134,6 @@ export async function uploadFile(
     const res = await fetch(url, {
       method: 'PUT',
       body,
-      headers: {
-        'Content-Length': String(body.length),
-      },
     })
 
     if (!res.ok) {

--- a/packages/js-sdk/src/template/buildApi.ts
+++ b/packages/js-sdk/src/template/buildApi.ts
@@ -122,11 +122,14 @@ export async function uploadFile(
     // Buffer the gzipped tar to determine Content-Length.
     // S3 presigned PUT URLs do not support Transfer-Encoding: chunked,
     // and the compressed size is unknowable without actually compressing.
-    const chunks: Buffer[] = []
-    for await (const chunk of uploadStream as unknown as AsyncIterable<Buffer>) {
-      chunks.push(chunk)
+    let body: Buffer
+    {
+      const chunks: Buffer[] = []
+      for await (const chunk of uploadStream as unknown as AsyncIterable<Buffer>) {
+        chunks.push(chunk)
+      }
+      body = Buffer.concat(chunks)
     }
-    const body = Buffer.concat(chunks)
 
     const res = await fetch(url, {
       method: 'PUT',

--- a/packages/js-sdk/src/template/utils.ts
+++ b/packages/js-sdk/src/template/utils.ts
@@ -385,10 +385,11 @@ export async function tarFileStream(
 }
 
 /**
- * Create a tar stream for upload using chunked transfer encoding.
+ * Create a tar stream for upload.
  *
  * @param fileName Glob pattern for files to include
  * @param fileContextPath Base directory for resolving file paths
+ * @param ignorePatterns Ignore patterns to exclude from the archive
  * @param resolveSymlinks Whether to follow symbolic links
  * @returns A readable stream of the gzipped tar archive
  */

--- a/packages/python-sdk/e2b/template_async/build_api.py
+++ b/packages/python-sdk/e2b/template_async/build_api.py
@@ -107,8 +107,9 @@ async def upload_file(
     stack_trace: Optional[TracebackType],
 ):
     try:
-        tar_buffer = tar_file_stream(
-            file_name, context_path, ignore_patterns, resolve_symlinks
+        loop = asyncio.get_event_loop()
+        tar_buffer = await loop.run_in_executor(
+            None, tar_file_stream, file_name, context_path, ignore_patterns, resolve_symlinks
         )
 
         # Use bytes with explicit Content-Length.

--- a/packages/python-sdk/e2b/template_async/build_api.py
+++ b/packages/python-sdk/e2b/template_async/build_api.py
@@ -111,8 +111,15 @@ async def upload_file(
             file_name, context_path, ignore_patterns, resolve_symlinks
         )
 
+        # Use bytes with explicit Content-Length.
+        # S3 presigned PUT URLs do not support Transfer-Encoding: chunked.
+        body = tar_buffer.getvalue()
         client = api_client.get_async_httpx_client()
-        response = await client.put(url, content=tar_buffer.getvalue())
+        response = await client.put(
+            url,
+            content=body,
+            headers={"Content-Length": str(len(body))},
+        )
         response.raise_for_status()
     except httpx.HTTPStatusError as e:
         raise FileUploadException(f"Failed to upload file: {e}").with_traceback(

--- a/packages/python-sdk/e2b/template_async/build_api.py
+++ b/packages/python-sdk/e2b/template_async/build_api.py
@@ -107,7 +107,7 @@ async def upload_file(
     stack_trace: Optional[TracebackType],
 ):
     try:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         tar_buffer = await loop.run_in_executor(
             None, tar_file_stream, file_name, context_path, ignore_patterns, resolve_symlinks
         )

--- a/packages/python-sdk/e2b/template_async/build_api.py
+++ b/packages/python-sdk/e2b/template_async/build_api.py
@@ -109,7 +109,12 @@ async def upload_file(
     try:
         loop = asyncio.get_running_loop()
         tar_buffer = await loop.run_in_executor(
-            None, tar_file_stream, file_name, context_path, ignore_patterns, resolve_symlinks
+            None,
+            tar_file_stream,
+            file_name,
+            context_path,
+            ignore_patterns,
+            resolve_symlinks,
         )
 
         # Use bytes with explicit Content-Length.

--- a/packages/python-sdk/e2b/template_sync/build_api.py
+++ b/packages/python-sdk/e2b/template_sync/build_api.py
@@ -110,8 +110,16 @@ def upload_file(
         tar_buffer = tar_file_stream(
             file_name, context_path, ignore_patterns, resolve_symlinks
         )
+
+        # Use bytes with explicit Content-Length.
+        # S3 presigned PUT URLs do not support Transfer-Encoding: chunked.
+        body = tar_buffer.getvalue()
         client = api_client.get_httpx_client()
-        response = client.put(url, content=tar_buffer.getvalue())
+        response = client.put(
+            url,
+            content=body,
+            headers={"Content-Length": str(len(body))},
+        )
         response.raise_for_status()
     except httpx.HTTPStatusError as e:
         raise FileUploadException(f"Failed to upload file: {e}").with_traceback(


### PR DESCRIPTION
## Summary

- **JS SDK**: Buffer the gzipped tar stream and set explicit `Content-Length` header instead of streaming with `Transfer-Encoding: chunked` via `fetch`. Removes the `duplex: 'half'` workaround.
- **Python SDK**: Set explicit `Content-Length` header on httpx PUT calls for presigned URL uploads.
- S3 presigned PUT URLs do not support `Transfer-Encoding: chunked`, causing `501 NotImplemented` on self-hosted AWS deployments.

Closes #1235
Closes #1243

## Test plan

- [ ] Build a template with `.copy()` on a self-hosted AWS (S3) deployment
- [ ] Build a template on E2B Cloud (GCS) to verify no regression
- [ ] Verify both JS and Python SDKs

🤖 Generated with [Claude Code](https://claude.com/claude-code)