### PR TITLE
fix: cli info handles not found without showing error message

### DIFF
--- a/.changeset/icy-eggs-change.md
+++ b/.changeset/icy-eggs-change.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': minor
+---
+
+Handle sandbox not found on cli info

--- a/packages/cli/src/commands/sandbox/info.ts
+++ b/packages/cli/src/commands/sandbox/info.ts
@@ -1,5 +1,5 @@
 import * as commander from 'commander'
-import { Sandbox } from 'e2b'
+import { NotFoundError, Sandbox } from 'e2b'
 
 import { ensureAPIKey } from 'src/api'
 import { asBold } from 'src/utils/format'
@@ -62,6 +62,11 @@ export const infoCommand = new commander.Command('info')
         process.exit(1)
       }
     } catch (err: any) {
+      if (err instanceof NotFoundError) {
+        console.error(`Sandbox ${asBold(sandboxID)} wasn't found`)
+        process.exit(1)
+        return
+      }
       console.error(err)
       process.exit(1)
     }


### PR DESCRIPTION
Handles sandbox not found on cli info

## Prior Behavior: 

(searching for nonexistant iqe4cs0bcml3lf3hp5e3eef)

$ e2b sandbox info iqe4cs0bcml3lf3hp5e3eef
qr [SandboxNotFoundError]: Sandbox iqe4cs0bcml3lf3hp5e3eef not found
    at Function.getFullInfo (/.../v20.20.0/lib/node_modules/@e2b/js-sdk/src/sandbox/sandboxApi.ts:565:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async t.<anonymous> (/.../node/v20.20.0/lib/node_modules/@e2b/cli/src/commands/sandbox/info.ts:53:20)
    at async t.parseAsync (/.../node/v20.20.0/lib/node_modules/node_modules/.pnpm/commander@11.1.0/node_modules/commander/lib/command.js:936:5)
    at async EIe (/.../versions/node/v20.20.0/lib/node_modules/@e2b/cli/src/index.ts:36:3

## Fixed: 
$ e2b sandbox info iqe4cs0bcml3lf3hp5e3eef
Sandbox iqe4cs0bcml3lf3hp5e3eef wasn't found