### PR TITLE
fix: correct write_files docstring about directory auto-creation

### DIFF
--- a/.changeset/fix-write-files-docstring.md
+++ b/.changeset/fix-write-files-docstring.md
@@ -1,0 +1,5 @@
+---
+'@e2b/python-sdk': patch
+---
+
+fix write_files docstring to correctly state that parent directories are auto-created

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
@@ -237,7 +237,7 @@ class Filesystem:
         Writes a list of files to the filesystem.
         When writing to a file that doesn't exist, the file will get created.
         When writing to a file that already exists, the file will get overwritten.
-        When writing to a file that's in a directory that doesn't exist, you'll get an error.
+        When writing to a file at path that doesn't exist, the necessary directories will be created.
 
         :param files: list of files to write as `WriteEntry` objects, each containing `path` and `data`
         :param user: Run the operation as this user

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -233,7 +233,7 @@ class Filesystem:
         Writes a list of files to the filesystem.
         When writing to a file that doesn't exist, the file will get created.
         When writing to a file that already exists, the file will get overwritten.
-        When writing to a file that's in a directory that doesn't exist, you'll get an error.
+        When writing to a file at path that doesn't exist, the necessary directories will be created.
 
         :param files: list of files to write as `WriteEntry` objects, each containing `path` and `data`
         :param user: Run the operation as this user


### PR DESCRIPTION
## Summary
- Fixes the Python SDK `write_files` docstring (both sync and async) which incorrectly stated that writing to a non-existing directory would produce an error
- The backend actually auto-creates parent directories, consistent with the `write()` docstring and existing tests (`test_write_to_non_existing_directory`)

## Test plan
- [x] Verified behavior with a test script — both `write()` and `write_files()` auto-create nested directories
- [x] Existing tests pass (`test_write_to_non_existing_directory`, `writeFiles creates parent directories`)