### PR TITLE
feat: allow passing template as option in Sandbox.create()

### DIFF
--- a/.changeset/sandbox-template-option.md
+++ b/.changeset/sandbox-template-option.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+allow passing template as an option in Sandbox.create()

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -273,9 +273,11 @@ export class Sandbox extends SandboxApi {
             sandboxOpts: opts,
           }
         : {
-            template: templateOrOpts?.mcp
-              ? this.defaultMcpTemplate
-              : this.defaultTemplate,
+            template:
+              templateOrOpts?.template ??
+              (templateOrOpts?.mcp
+                ? this.defaultMcpTemplate
+                : this.defaultTemplate),
             sandboxOpts: templateOrOpts,
           }
 
@@ -368,9 +370,11 @@ export class Sandbox extends SandboxApi {
             sandboxOpts: opts,
           }
         : {
-            template: templateOrOpts?.mcp
-              ? this.defaultMcpTemplate
-              : this.defaultTemplate,
+            template:
+              templateOrOpts?.template ??
+              (templateOrOpts?.mcp
+                ? this.defaultMcpTemplate
+                : this.defaultTemplate),
             sandboxOpts: templateOrOpts,
           }
 

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -110,7 +110,7 @@ export interface SandboxOpts extends ConnectionOpts {
   /**
    * Sandbox template name or ID.
    *
-   * @default 'base'
+   * @default 'base' (or 'mcp-gateway' when `mcp` option is set)
    */
   template?: string
 

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -108,6 +108,13 @@ export interface SandboxApiOpts
  */
 export interface SandboxOpts extends ConnectionOpts {
   /**
+   * Sandbox template name or ID.
+   *
+   * @default 'base'
+   */
+  template?: string
+
+  /**
    * Custom metadata for the sandbox.
    *
    * @default {}


### PR DESCRIPTION
## Summary
- Adds `template` as an optional property on `SandboxOpts` in the JS SDK, enabling `Sandbox.create({ template: 'my-template' })` syntax
- Updates both `create` and `betaCreate` to check `opts.template` before falling back to the default template
- Python SDK already supports `Sandbox.create(template='template')` via named parameters, so no changes needed there

## Test plan
- [ ] Verify `Sandbox.create({ template: 'base' })` works
- [ ] Verify `Sandbox.create('base')` still works (backwards compatible)
- [ ] Verify `Sandbox.create()` still defaults to `'base'`
- [ ] Verify MCP template fallback still works when no template is specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)