### PR TITLE
Add HTTPS_PROXY environment variable support to Python and JS SDKs

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -97,7 +97,8 @@
     "glob": "^11.1.0",
     "openapi-fetch": "^0.14.1",
     "platform": "^1.3.6",
-    "tar": "^7.5.11"
+    "tar": "^7.5.11",
+    "undici": "^7.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -5,6 +5,7 @@ import { defaultHeaders } from './metadata'
 import { ConnectionConfig } from '../connectionConfig'
 import { AuthenticationError, RateLimitError, SandboxError } from '../errors'
 import { createApiLogger } from '../logs'
+import { getProxyFetch } from '../proxy'
 
 export function handleApiError(
   response: FetchResponse<any, any, any>,
@@ -74,6 +75,7 @@ class ApiClient {
 
     this.api = createClient<paths>({
       baseUrl: config.apiUrl,
+      fetch: getProxyFetch(),
       // In HTTP 1.1, all connections are considered persistent unless declared otherwise
       // keepalive: true,
       headers: {

--- a/packages/js-sdk/src/envd/api.ts
+++ b/packages/js-sdk/src/envd/api.ts
@@ -3,6 +3,7 @@ import createClient from 'openapi-fetch'
 import type { components, paths } from './schema.gen'
 import { ConnectionConfig } from '../connectionConfig'
 import { createApiLogger } from '../logs'
+import { getProxyFetch } from '../proxy'
 import {
   SandboxError,
   InvalidArgumentError,
@@ -130,7 +131,7 @@ class EnvdApiClient {
   ) {
     this.api = createClient({
       baseUrl: config.apiUrl,
-      fetch: config?.fetch,
+      fetch: config?.fetch ?? getProxyFetch(),
       headers: config?.headers,
       // In HTTP 1.1, all connections are considered persistent unless declared otherwise
       // keepalive: true,

--- a/packages/js-sdk/src/proxy.ts
+++ b/packages/js-sdk/src/proxy.ts
@@ -1,0 +1,41 @@
+import { ProxyAgent } from 'undici'
+
+import { getEnvVar } from './api/metadata'
+import { runtime } from './utils'
+
+function getProxyUrl(): string | undefined {
+  return (
+    getEnvVar('https_proxy') ||
+    getEnvVar('HTTPS_PROXY') ||
+    getEnvVar('http_proxy') ||
+    getEnvVar('HTTP_PROXY') ||
+    getEnvVar('all_proxy') ||
+    getEnvVar('ALL_PROXY') ||
+    undefined
+  )
+}
+
+let cachedProxyFetch: typeof fetch | null = null
+let proxyResolved = false
+
+/**
+ * Returns a proxy-aware fetch function if HTTPS_PROXY/HTTP_PROXY/ALL_PROXY
+ * env vars are set. In browser environments, returns undefined (browsers
+ * handle proxies natively via OS settings).
+ *
+ * Uses undici's ProxyAgent.
+ */
+export function getProxyFetch(): typeof fetch | undefined {
+  if (proxyResolved) return cachedProxyFetch ?? undefined
+  proxyResolved = true
+
+  if (runtime === 'browser') return undefined
+
+  const proxyUrl = getProxyUrl()
+  if (!proxyUrl) return undefined
+
+  const agent = new ProxyAgent(proxyUrl)
+  cachedProxyFetch = ((input: any, init?: any) =>
+    fetch(input, { ...init, dispatcher: agent })) as typeof fetch
+  return cachedProxyFetch
+}

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -9,6 +9,7 @@ import {
 } from '../connectionConfig'
 import { EnvdApiClient, handleEnvdApiError } from '../envd/api'
 import { createRpcLogger } from '../logs'
+import { getProxyFetch } from '../proxy'
 import { Commands, Pty } from './commands'
 import { Filesystem } from './filesystem'
 import { Git } from './git'
@@ -150,6 +151,7 @@ export class Sandbox extends SandboxApi {
       'E2b-Sandbox-Port': this.envdPort.toString(),
     }
 
+    const proxyFetch = getProxyFetch() ?? fetch
     const rpcTransport = createConnectTransport({
       baseUrl: this.envdApiUrl,
       useBinaryFormat: false,
@@ -178,7 +180,7 @@ export class Sandbox extends SandboxApi {
           redirect: 'follow',
         }
 
-        return fetch(url, options)
+        return proxyFetch(url, options)
       },
     })
 

--- a/packages/js-sdk/src/volume/client.ts
+++ b/packages/js-sdk/src/volume/client.ts
@@ -3,6 +3,7 @@ import createClient from 'openapi-fetch'
 import type { components, paths } from './schema.gen'
 import { defaultHeaders, getEnvVar } from '../api/metadata'
 import { createApiLogger, Logger } from '../logs'
+import { getProxyFetch } from '../proxy'
 import type { Volume } from './index'
 
 const FILE_TIMEOUT_MS = 3_600_000 // 1 hour
@@ -99,6 +100,7 @@ class VolumeApiClient {
   constructor(config: VolumeConnectionConfig) {
     this.api = createClient<paths>({
       baseUrl: config.apiUrl,
+      fetch: getProxyFetch(),
       headers: {
         ...defaultHeaders,
         ...(config.token && { Authorization: `Bearer ${config.token}` }),

--- a/packages/python-sdk/e2b/api/client_async/__init__.py
+++ b/packages/python-sdk/e2b/api/client_async/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 from typing import Dict
 
-from e2b.connection_config import ConnectionConfig
+from e2b.connection_config import ConnectionConfig, _resolve_proxy
 from e2b.api import limits, AsyncApiClient
 
 
@@ -45,7 +45,7 @@ def get_transport(config: ConnectionConfig) -> AsyncTransportWithLogger:
 
     transport = AsyncTransportWithLogger(
         limits=limits,
-        proxy=config.proxy,
+        proxy=_resolve_proxy(config.proxy),
     )
     AsyncTransportWithLogger._instances[loop_id] = transport
     return transport

--- a/packages/python-sdk/e2b/api/client_sync/__init__.py
+++ b/packages/python-sdk/e2b/api/client_sync/__init__.py
@@ -4,7 +4,7 @@ import httpx
 import logging
 
 from e2b.api import ApiClient, limits
-from e2b.connection_config import ConnectionConfig
+from e2b.connection_config import ConnectionConfig, _resolve_proxy
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ def get_transport(config: ConnectionConfig) -> TransportWithLogger:
 
     transport = TransportWithLogger(
         limits=limits,
-        proxy=config.proxy,
+        proxy=_resolve_proxy(config.proxy),
     )
     TransportWithLogger.singleton = transport
     return transport

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -208,6 +208,25 @@ class ConnectionConfig:
         }
 
 
+def _resolve_proxy(proxy: Optional[ProxyTypes]) -> Optional[ProxyTypes]:
+    """
+    Resolve the proxy to use for a request.
+    If an explicit proxy is provided, use it. Otherwise, fall back to
+    standard environment variables (HTTPS_PROXY, HTTP_PROXY, ALL_PROXY).
+    """
+    if proxy is not None:
+        return proxy
+
+    return (
+        os.environ.get("https_proxy")
+        or os.environ.get("HTTPS_PROXY")
+        or os.environ.get("http_proxy")
+        or os.environ.get("HTTP_PROXY")
+        or os.environ.get("all_proxy")
+        or os.environ.get("ALL_PROXY")
+    )
+
+
 Username = str
 """
 User used for the operation in the sandbox.

--- a/packages/python-sdk/e2b/volume/client_async/__init__.py
+++ b/packages/python-sdk/e2b/volume/client_async/__init__.py
@@ -8,6 +8,7 @@ from httpx import Limits
 from e2b.api.metadata import default_headers
 from e2b.exceptions import AuthenticationException
 from e2b.volume.client.client import AuthenticatedClient as AsyncVolumeApiClient
+from e2b.connection_config import _resolve_proxy
 from e2b.volume.connection_config import VolumeConnectionConfig
 
 logger = logging.getLogger(__name__)
@@ -63,7 +64,7 @@ def get_transport(config: VolumeConnectionConfig) -> AsyncTransportWithLogger:
 
     transport = AsyncTransportWithLogger(
         limits=limits,
-        proxy=config.proxy,
+        proxy=_resolve_proxy(config.proxy),
     )
     AsyncTransportWithLogger.singleton = transport
     return transport

--- a/packages/python-sdk/e2b/volume/client_sync/__init__.py
+++ b/packages/python-sdk/e2b/volume/client_sync/__init__.py
@@ -8,6 +8,7 @@ from httpx import Limits
 from e2b.api.metadata import default_headers
 from e2b.exceptions import AuthenticationException
 from e2b.volume.client.client import AuthenticatedClient as VolumeApiClient
+from e2b.connection_config import _resolve_proxy
 from e2b.volume.connection_config import VolumeConnectionConfig
 
 logger = logging.getLogger(__name__)
@@ -63,7 +64,7 @@ def get_transport(config: VolumeConnectionConfig) -> TransportWithLogger:
 
     transport = TransportWithLogger(
         limits=limits,
-        proxy=config.proxy,
+        proxy=_resolve_proxy(config.proxy),
     )
     TransportWithLogger.singleton = transport
     return transport

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       tar:
         specifier: ^7.5.11
         version: 7.5.12
+      undici:
+        specifier: ^7.0.0
+        version: 7.25.0
     devDependencies:
       '@testing-library/react':
         specifier: ^16.2.0
@@ -4048,6 +4051,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unique-filename@2.0.1:
     resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
@@ -8568,6 +8575,8 @@ snapshots:
   underscore@1.13.6: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.25.0: {}
 
   unique-filename@2.0.1:
     dependencies:


### PR DESCRIPTION
**tl;dr** Claude Code's web environment passes all requests through the proxy set in the environment variable `HTTPS_PROXY`. Since the E2B SDKs don't respect that variable, Claude Code on the web can't call the E2B APIs.

I've run formatters, linters and tests in both the Python and JS SDKs. As far as I can tell I'm only getting errors unrelated to this PR.

I've tested both the Python SDK and JS SDK in Claude Code web. Without this PR, Claude (on the web) is unable to interact with E2B sandboxes, and with this PR it is able to.

I'm more of a Python programmer. For the JS piece we need the Node official https://github.com/nodejs/undici to get the proxy support -- so it adds an extra dependency to the JS SDK.

This PR adds support for 6(!) different environment variables and I'd usually consider that AI slop, but it does seem to follow what other tools support (cURL, Python, and wget) with lowercase variables taking precedence:  https://superuser.com/a/1690537

The code was generated with Claude Code, but I have read and tested it and made some smaller adjustments to both the JS SDK code and Python SDK code.