### PR TITLE
fix: move E2b-Sandbox-Id/Port headers from control plane connect to data plane ConnectionConfig

### DIFF
--- a/.changeset/fix-connect-unset-sanitization.md
+++ b/.changeset/fix-connect-unset-sanitization.md
@@ -1,0 +1,5 @@
+---
+'@e2b/python-sdk': patch
+---
+
+fix connect path: move sandbox headers to data plane and sanitize UNSET values

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -861,8 +861,22 @@ class AsyncSandbox(SandboxApi):
         )
 
         sandbox_headers = {}
-        envd_access_token = sandbox.envd_access_token
-        if envd_access_token is not None and not isinstance(envd_access_token, Unset):
+        domain = (
+            sandbox.domain
+            if isinstance(sandbox.domain, str)
+            else None
+        )
+        envd_access_token = (
+            sandbox.envd_access_token
+            if isinstance(sandbox.envd_access_token, str)
+            else None
+        )
+        traffic_access_token = (
+            sandbox.traffic_access_token
+            if isinstance(sandbox.traffic_access_token, str)
+            else None
+        )
+        if envd_access_token is not None:
             sandbox_headers["X-Access-Token"] = envd_access_token
 
         sandbox_headers["E2b-Sandbox-Id"] = sandbox.sandbox_id
@@ -875,10 +889,10 @@ class AsyncSandbox(SandboxApi):
 
         return cls(
             sandbox_id=sandbox.sandbox_id,
-            sandbox_domain=sandbox.domain,
+            sandbox_domain=domain,
             envd_version=Version(sandbox.envd_version),
             envd_access_token=envd_access_token,
-            traffic_access_token=sandbox.traffic_access_token,
+            traffic_access_token=traffic_access_token,
             connection_config=connection_config,
         )
 

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -865,6 +865,9 @@ class AsyncSandbox(SandboxApi):
         if envd_access_token is not None and not isinstance(envd_access_token, Unset):
             sandbox_headers["X-Access-Token"] = envd_access_token
 
+        sandbox_headers["E2b-Sandbox-Id"] = sandbox.sandbox_id
+        sandbox_headers["E2b-Sandbox-Port"] = str(ConnectionConfig.envd_port)
+
         connection_config = ConnectionConfig(
             extra_sandbox_headers=sandbox_headers,
             **opts,

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -385,13 +385,7 @@ class SandboxApi(SandboxBase):
         # Sandbox is not running, resume it
         config = ConnectionConfig(**opts)
 
-        api_client = get_api_client(
-            config,
-            headers={
-                "E2b-Sandbox-Id": sandbox_id,
-                "E2b-Sandbox-Port": str(config.envd_port),
-            },
-        )
+        api_client = get_api_client(config)
         res = await post_sandboxes_sandbox_id_connect.asyncio_detailed(
             sandbox_id,
             client=api_client,

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -860,6 +860,9 @@ class Sandbox(SandboxApi):
         if envd_access_token is not None and not isinstance(envd_access_token, Unset):
             sandbox_headers["X-Access-Token"] = envd_access_token
 
+        sandbox_headers["E2b-Sandbox-Id"] = sandbox.sandbox_id
+        sandbox_headers["E2b-Sandbox-Port"] = str(ConnectionConfig.envd_port)
+
         connection_config = ConnectionConfig(
             extra_sandbox_headers=sandbox_headers,
             **opts,

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -856,8 +856,22 @@ class Sandbox(SandboxApi):
         )
 
         sandbox_headers = {}
-        envd_access_token = sandbox.envd_access_token
-        if envd_access_token is not None and not isinstance(envd_access_token, Unset):
+        domain = (
+            sandbox.domain
+            if isinstance(sandbox.domain, str)
+            else None
+        )
+        envd_access_token = (
+            sandbox.envd_access_token
+            if isinstance(sandbox.envd_access_token, str)
+            else None
+        )
+        traffic_access_token = (
+            sandbox.traffic_access_token
+            if isinstance(sandbox.traffic_access_token, str)
+            else None
+        )
+        if envd_access_token is not None:
             sandbox_headers["X-Access-Token"] = envd_access_token
 
         sandbox_headers["E2b-Sandbox-Id"] = sandbox.sandbox_id
@@ -870,11 +884,11 @@ class Sandbox(SandboxApi):
 
         return cls(
             sandbox_id=sandbox.sandbox_id,
-            sandbox_domain=sandbox.domain,
+            sandbox_domain=domain,
             connection_config=connection_config,
             envd_version=Version(sandbox.envd_version),
             envd_access_token=envd_access_token,
-            traffic_access_token=sandbox.traffic_access_token,
+            traffic_access_token=traffic_access_token,
         )
 
     @classmethod

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -293,13 +293,7 @@ class SandboxApi(SandboxBase):
 
         config = ConnectionConfig(**opts)
 
-        api_client = get_api_client(
-            config,
-            headers={
-                "E2b-Sandbox-Id": sandbox_id,
-                "E2b-Sandbox-Port": str(config.envd_port),
-            },
-        )
+        api_client = get_api_client(config)
         res = post_sandboxes_sandbox_id_connect.sync_detailed(
             sandbox_id,
             client=api_client,


### PR DESCRIPTION
### Problem

The Python SDK's `Sandbox.connect()` currently injects `E2b-Sandbox-Id` and `E2b-Sandbox-Port` headers into the **control plane** request (`POST /sandboxes/{sandboxID}/connect`).

This causes issues for any proxy/gateway that uses these headers to distinguish between control plane and data plane traffic. Since these headers are the canonical signal for "this request targets a specific sandbox instance (data plane)", their presence on a control plane API call causes the proxy to misroute the request to the sandbox's envd endpoint instead of the API server — resulting in authentication failures (401).

The JS/TS SDK does **not** have this problem: `connectSandbox()` sends a clean control plane request without these headers, and only injects them on data plane requests via the sandbox instance's connection config.

### Root Cause

Introduced in [#1013](https://github.com/e2b-dev/E2B/pull/1013) (*Support overriding envd API URL*), the `_cls_connect` method was updated to pass `E2b-Sandbox-Id` / `E2b-Sandbox-Port` directly to `get_api_client()` as extra headers. This means they end up on the **control plane** HTTP client, polluting the `POST /sandboxes/{id}/connect` request with data plane routing signals.

### Fix

Move `E2b-Sandbox-Id` and `E2b-Sandbox-Port` from the control plane API client (`get_api_client()` in `sandbox_api.py`) to `extra_sandbox_headers` in the `ConnectionConfig` (set in `main.py`'s `_cls_connect_sandbox`).

This ensures:

- **Control plane requests** (via `config.headers` → `ApiClient`) do **not** carry these headers
- **Data plane requests** (via `config.sandbox_headers` → filesystem / commands / pty / health) **do** carry them, as intended

The fix applies to both sync and async SDK paths (4 files).

### Why this matters

These two headers serve as a **data plane routing signal** in the E2B protocol. Any transparent proxy, API gateway, or load balancer that multiplexes control plane and data plane traffic on a single endpoint will use their presence/absence to decide where to forward the request.

When a control plane API like `connect` carries these headers, it creates an ambiguous signal — the path says "control plane" but the headers say "data plane". This is not specific to any single proxy implementation; it affects any gateway that follows the protocol semantics.

### Verification

- Confirmed that after this fix, `connect` requests no longer carry `E2b-Sandbox-Id` / `E2b-Sandbox-Port`
- Confirmed that subsequent data plane requests (file ops, commands, health checks) still carry these headers via `sandbox_headers`
- Behavior now matches the JS/TS SDK