### PR TITLE
feat(js-sdk): add native wallet/payment support via MPP

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -99,6 +99,14 @@
     "platform": "^1.3.6",
     "tar": "^7.5.11"
   },
+  "peerDependencies": {
+    "mppx": ">=0.0.1"
+  },
+  "peerDependenciesMeta": {
+    "mppx": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=20"
   },

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -30,6 +30,17 @@ export function handleApiError(
     return new AuthenticationError(message)
   }
 
+  if (response.response.status === 402) {
+    const message =
+      'Payment required. Configure payment in SDK options or provide an API key.'
+    const content = response.error?.message ?? response.error
+
+    if (content) {
+      return new AuthenticationError(`${message} - ${content}`)
+    }
+    return new AuthenticationError(message)
+  }
+
   if (response.response.status === 429) {
     const message = 'Rate limit exceeded, please try again later'
     const content = response.error?.message ?? response.error
@@ -57,11 +68,12 @@ class ApiClient {
       requireApiKey?: boolean
     } = { requireAccessToken: false, requireApiKey: false }
   ) {
-    if (opts?.requireApiKey && !config.apiKey) {
+    if (opts?.requireApiKey && !config.apiKey && !config.payment) {
       throw new AuthenticationError(
         'API key is required, please visit the Team tab at https://e2b.dev/dashboard to get your API key. ' +
           'You can either set the environment variable `E2B_API_KEY` ' +
-          "or you can pass it directly to the sandbox like Sandbox.create({ apiKey: 'e2b_...' })"
+          "or you can pass it directly to the sandbox like Sandbox.create({ apiKey: 'e2b_...' })" +
+          " or configure payment: { client: mppx } for pay-per-use access."
       )
     }
 
@@ -90,6 +102,11 @@ class ApiClient {
           explode: false,
         },
       },
+      // Use mppx fetch when payment is configured — it handles the
+      // HTTP 402 challenge/credential flow automatically.
+      ...(config.payment && {
+        fetch: config.payment.client.fetch,
+      }),
     })
 
     if (config.logger) {

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -62,6 +62,30 @@ export interface ConnectionOpts {
    * Additional headers to send with the request.
    */
   headers?: Record<string, string>
+
+  /**
+   * MPP payment configuration for pay-per-use sandbox access.
+   * When provided, the SDK uses the Machine Payments Protocol (HTTP 402)
+   * instead of API key authentication. Requires the `mppx` package.
+   *
+   * @example
+   * ```ts
+   * import { Sandbox } from 'e2b'
+   * import { Mppx, tempo } from 'mppx/client'
+   * import { privateKeyToAccount } from 'viem/accounts'
+   *
+   * const mppx = Mppx.create({
+   *   methods: [tempo({ account: privateKeyToAccount('0x...') })],
+   * })
+   *
+   * const sandbox = await Sandbox.create({
+   *   payment: { client: mppx },
+   * })
+   * ```
+   */
+  payment?: {
+    client: { fetch: typeof fetch }
+  }
 }
 
 /**
@@ -82,6 +106,7 @@ export class ConnectionConfig {
   readonly accessToken?: string
 
   readonly headers?: Record<string, string>
+  readonly payment?: ConnectionOpts['payment']
 
   constructor(opts?: ConnectionOpts) {
     this.apiKey = opts?.apiKey || ConnectionConfig.apiKey
@@ -90,6 +115,7 @@ export class ConnectionConfig {
     this.accessToken = opts?.accessToken || ConnectionConfig.accessToken
     this.requestTimeoutMs = opts?.requestTimeoutMs ?? REQUEST_TIMEOUT_MS
     this.logger = opts?.logger
+    this.payment = opts?.payment
     this.headers = opts?.headers || {}
     this.headers['User-Agent'] = `e2b-js-sdk/${version}`
 


### PR DESCRIPTION
## Summary

Add native wallet support to the E2B JS SDK so AI agents can pay for sandbox usage with crypto instead of API keys.

## Motivation

With [MPP support in the E2B API](https://github.com/e2b-dev/infra/pull/2398), agents can now pay per request via the [Machine Payments Protocol](https://mpp.dev). This PR adds client-side support so the SDK handles the HTTP 402 flow automatically.

## Changes

### `package.json`
- Add `mppx` as optional peer dependency

### `src/connectionConfig.ts`
- Add `payment` option to `ConnectionOpts` — accepts an mppx client instance
- Store payment config on `ConnectionConfig`

### `src/api/index.ts`
- Skip API key requirement when `payment` is configured
- Pass mppx `fetch` to `openapi-fetch` — handles 402 automatically
- Add 402 error handling in `handleApiError`

## Usage

```ts
import { Sandbox } from 'e2b'
import { Mppx, tempo } from 'mppx/client'
import { privateKeyToAccount } from 'viem/accounts'

// Create an mppx client with a Tempo wallet
const mppx = Mppx.create({
  methods: [tempo({ account: privateKeyToAccount('0x...') })],
})

// Create sandbox with crypto payment — no API key needed
const sandbox = await Sandbox.create({
  payment: { client: mppx },
})

await sandbox.commands.run('echo hello')
```

## Backward compatibility

Fully backward compatible. API key auth works exactly as before. The `payment` option is entirely additive and `mppx` is an optional peer dep.

Prompted by: georgios