### PR TITLE
Fix typos in docs, tests, and helper names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 Use pnpm for node and poetry for python to install and update dependencies.
-Run `pnpm run format`, `pnpm run lint` and `pnpm run typecheck` before commiting changes.
+Run `pnpm run format`, `pnpm run lint` and `pnpm run typecheck` before committing changes.
 To re-generate the API client run `make codegen` in the repository root.
 Run tests on affected codepaths using `pnpm run test`.
 Default credentials are stored in .env.local in the repository root or inside ~/.e2b/config.json.

--- a/packages/cli/src/utils/confirm.ts
+++ b/packages/cli/src/utils/confirm.ts
@@ -1,10 +1,10 @@
-export async function confirm(text: string, defaultAnwser = false) {
+export async function confirm(text: string, defaultAnswer = false) {
   const inquirer = await import('inquirer')
   const confirmAnswers = await inquirer.default.prompt([
     {
       name: 'confirm',
       type: 'confirm',
-      default: defaultAnwser,
+      default: defaultAnswer,
       message: text,
     },
   ])

--- a/packages/cli/src/utils/templatePrompt.ts
+++ b/packages/cli/src/utils/templatePrompt.ts
@@ -8,7 +8,7 @@ export async function getPromptTemplates(
   text: string
 ) {
   const inquirer = await import('inquirer')
-  const templatesAnwsers = await inquirer.default.prompt([
+  const templatesAnswers = await inquirer.default.prompt([
     {
       name: 'templates',
       message: chalk.default.underline(text),
@@ -21,7 +21,7 @@ export async function getPromptTemplates(
     },
   ])
 
-  return templatesAnwsers[
+  return templatesAnswers[
     'templates'
   ] as e2b.components['schemas']['Template'][]
 }

--- a/packages/js-sdk/src/sandbox/git/index.ts
+++ b/packages/js-sdk/src/sandbox/git/index.ts
@@ -937,7 +937,7 @@ export class Git {
   /**
    * Execute a raw shell command while applying default git environment variables.
    * 
-   Note: We can liekly just modify runGit later to allow appending commands to the git but for now it's separate.
+   Note: We can likely just modify runGit later to allow appending commands to the git but for now it's separate.
    */
   private async runShell(
     cmd: string,

--- a/packages/js-sdk/tests/integration/stress.test.ts
+++ b/packages/js-sdk/tests/integration/stress.test.ts
@@ -10,13 +10,13 @@ for (let i = 0; i < view.length; i++) {
 }
 
 const integrationTestTemplate = 'integration-test-v1'
-const sanboxCount = 10
+const sandboxCount = 10
 
 test.skipIf(!isIntegrationTest)(
   'stress test heavy file writes and reads',
   async () => {
     const promises: Array<Promise<string | void>> = []
-    for (let i = 0; i < sanboxCount; i++) {
+    for (let i = 0; i < sandboxCount; i++) {
       promises.push(
         Sandbox.create(integrationTestTemplate, { timeoutMs: 60 })
           .then((sbx) => {
@@ -36,7 +36,7 @@ test.skipIf(!isIntegrationTest)(
 test.skipIf(!isIntegrationTest)('stress requests to nextjs app', async () => {
   const hostPromises: Array<Promise<string | void>> = []
 
-  for (let i = 0; i < sanboxCount; i++) {
+  for (let i = 0; i < sandboxCount; i++) {
     hostPromises.push(
       Sandbox.create(integrationTestTemplate, { timeoutMs: 60_000 }).then(
         (sbx) => {

--- a/packages/js-sdk/tests/integration/template/e2b.Dockerfile
+++ b/packages/js-sdk/tests/integration/template/e2b.Dockerfile
@@ -1,6 +1,6 @@
 FROM e2bdev/code-interpreter:latest
 
-# Install stess-ng, a tool to load and stress computer systems
+# Install stress-ng, a tool to load and stress computer systems
 RUN apt update
 RUN apt install -y stress-ng
 
@@ -9,4 +9,3 @@ RUN npx -y create-next-app@latest basic-nextjs-app --yes --ts --use-npm
 
 # Install dependencies
 RUN cd basic-nextjs-app && npm install
-

--- a/packages/js-sdk/tests/sandbox/timeout.test.ts
+++ b/packages/js-sdk/tests/sandbox/timeout.test.ts
@@ -11,7 +11,7 @@ sandboxTest.skipIf(isDebug)('shorten timeout', async ({ sandbox }) => {
 })
 
 sandboxTest.skipIf(isDebug)(
-  'shorten then lenghten timeout',
+  'shorten then lengthen timeout',
   async ({ sandbox }) => {
     await sandbox.setTimeout(5000)
 

--- a/packages/python-sdk/e2b/sandbox_async/git.py
+++ b/packages/python-sdk/e2b/sandbox_async/git.py
@@ -1002,7 +1002,7 @@ class Git:
         """
         Dangerously authenticate git globally via the credential helper.
 
-        This persists credentials in the credential store and may be accessable to agents running on the sandbox.
+        This persists credentials in the credential store and may be accessible to agents running on the sandbox.
         Prefer short-lived credentials when possible.
 
         :param username: Username for HTTP(S) authentication

--- a/packages/python-sdk/e2b/sandbox_sync/git.py
+++ b/packages/python-sdk/e2b/sandbox_sync/git.py
@@ -979,7 +979,7 @@ class Git:
         """
         Dangerously authenticate git globally via the credential helper.
 
-        This persists credentials in the credential store and may be accessable to agents running on the sandbox.
+        This persists credentials in the credential store and may be accessible to agents running on the sandbox.
         Prefer short-lived credentials when possible.
 
         :param username: Username for HTTP(S) authentication


### PR DESCRIPTION
## Summary

- fix typos in hand-written docs and comments
- rename typoed helper variables in the CLI
- fix typoed test identifiers and descriptions in the JS SDK tests
- fix typoed credential warning text in the Python SDK

## Testing

- not run

Closes #1281
