### PR TITLE
fix(js-sdk): forward name param and expose names in createSnapshot

### DIFF
--- a/.changeset/fix-snapshot-name.md
+++ b/.changeset/fix-snapshot-name.md
@@ -1,0 +1,6 @@
+---
+"e2b": patch
+"@e2b/python-sdk": patch
+---
+
+Forward optional `name` parameter in `createSnapshot` / `create_snapshot` and return `names` array in `SnapshotInfo` for both JS and Python SDKs.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ vale-styles
 .vercel
 .vscode
 .DS_Store
+.worktrees
 
 # Logs
 logs

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -62,6 +62,7 @@ export type {
   SandboxInfoLifecycle,
   SnapshotInfo,
   SnapshotListOpts,
+  SnapshotCreateOpts,
   SnapshotPaginator,
 } from './sandbox/sandboxApi'
 

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -20,8 +20,8 @@ import {
   SandboxListOpts,
   SandboxPaginator,
   SandboxBetaCreateOpts,
-  SandboxApiOpts,
   SnapshotListOpts,
+  SnapshotCreateOpts,
   SnapshotInfo,
   SnapshotPaginator,
 } from './sandboxApi'
@@ -621,7 +621,7 @@ export class Sandbox extends SandboxApi {
    * const newSandbox = await Sandbox.create(snapshot.snapshotId)
    * ```
    */
-  async createSnapshot(opts?: SandboxApiOpts): Promise<SnapshotInfo> {
+  async createSnapshot(opts?: SnapshotCreateOpts): Promise<SnapshotInfo> {
     return await SandboxApi.createSnapshot(
       this.sandboxId,
       this.resolveApiOpts(opts)

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -722,7 +722,7 @@ export class SandboxApi {
         },
       },
       body: {
-        ...(opts?.name && { name: opts.name }),
+        ...(opts?.name !== undefined && { name: opts.name }),
       },
       signal: config.getSignal(opts?.requestTimeoutMs),
     })

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -268,6 +268,22 @@ export interface SnapshotListOpts extends SandboxApiOpts {
 }
 
 /**
+ * Options for creating a snapshot.
+ */
+export interface SnapshotCreateOpts extends SandboxApiOpts {
+  /**
+   * Optional human-readable name for the snapshot template.
+   *
+   * If a snapshot template with this name already exists, a new build will be
+   * assigned to the existing template instead of creating a new one.
+   *
+   * The name must be unique within your team. Once assigned, the snapshot can
+   * be used with {@link Sandbox.create} via `team-slug/name`.
+   */
+  name?: string
+}
+
+/**
  * Information about a snapshot.
  */
 export interface SnapshotInfo {
@@ -276,6 +292,13 @@ export interface SnapshotInfo {
    * Can be used with Sandbox.create() to create a new sandbox from this snapshot.
    */
   snapshotId: string
+
+  /**
+   * Full namespaced names assigned to this snapshot (e.g. `["team-slug/my-snapshot:default"]`).
+   * Present when the snapshot was created with a `name` option.
+   * Use any entry with {@link Sandbox.create} to start a sandbox from this snapshot by name.
+   */
+  names: string[]
 }
 
 /**
@@ -687,7 +710,7 @@ export class SandboxApi {
    */
   static async createSnapshot(
     sandboxId: string,
-    opts?: SandboxApiOpts
+    opts?: SnapshotCreateOpts
   ): Promise<SnapshotInfo> {
     const config = new ConnectionConfig(opts)
     const client = new ApiClient(config)
@@ -698,7 +721,9 @@ export class SandboxApi {
           sandboxID: sandboxId,
         },
       },
-      body: {},
+      body: {
+        ...(opts?.name && { name: opts.name }),
+      },
       signal: config.getSignal(opts?.requestTimeoutMs),
     })
 
@@ -713,6 +738,7 @@ export class SandboxApi {
 
     return {
       snapshotId: res.data!.snapshotID,
+      names: res.data!.names,
     }
   }
 
@@ -1038,6 +1064,7 @@ export class SnapshotPaginator extends BasePaginator<SnapshotInfo> {
     return (res.data ?? []).map(
       (snapshot: components['schemas']['SnapshotInfo']) => ({
         snapshotId: snapshot.snapshotID,
+        names: snapshot.names,
       })
     )
   }

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -297,6 +297,9 @@ class SnapshotInfo:
     snapshot_id: str
     """Snapshot identifier — template ID with tag, or namespaced name with tag (e.g. my-snapshot:latest). Can be used with Sandbox.create() to create a new sandbox from this snapshot."""
 
+    names: List[str] = field(default_factory=list)
+    """Full namespaced names assigned to this snapshot (e.g. ["team-slug/my-snapshot:default"]). Present when the snapshot was created with a name. Use any entry with Sandbox.create() to start a sandbox from this snapshot by name."""
+
 
 class PaginatorBase:
     def __init__(

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -694,6 +694,7 @@ class AsyncSandbox(SandboxApi):
     @overload
     async def create_snapshot(
         self,
+        name: Optional[str] = None,
         **opts: Unpack[ApiParams],
     ) -> SnapshotInfo:
         """
@@ -705,7 +706,8 @@ class AsyncSandbox(SandboxApi):
 
         Use the returned `snapshot_id` with `AsyncSandbox.create(snapshot_id)` to create a new sandbox from the snapshot.
 
-        :return: Snapshot information including the snapshot ID
+        :param name: Optional human-readable name for the snapshot template. If a snapshot with this name already exists, a new build is assigned to it instead of creating a new one.
+        :return: Snapshot information including the snapshot ID and names
         """
         ...
 
@@ -713,6 +715,7 @@ class AsyncSandbox(SandboxApi):
     @staticmethod
     async def create_snapshot(
         sandbox_id: str,
+        name: Optional[str] = None,
         **opts: Unpack[ApiParams],
     ) -> SnapshotInfo:
         """
@@ -721,14 +724,15 @@ class AsyncSandbox(SandboxApi):
         The sandbox will be paused while the snapshot is being created.
 
         :param sandbox_id: Sandbox ID
-
-        :return: Snapshot information including the snapshot ID
+        :param name: Optional human-readable name for the snapshot template.
+        :return: Snapshot information including the snapshot ID and names
         """
         ...
 
     @class_method_variant("_cls_create_snapshot")
     async def create_snapshot(
         self,
+        name: Optional[str] = None,
         **opts: Unpack[ApiParams],
     ) -> SnapshotInfo:
         """
@@ -740,10 +744,12 @@ class AsyncSandbox(SandboxApi):
 
         Use the returned `snapshot_id` with `AsyncSandbox.create(snapshot_id)` to create a new sandbox from the snapshot.
 
-        :return: Snapshot information including the snapshot ID
+        :param name: Optional human-readable name for the snapshot template. If a snapshot with this name already exists, a new build is assigned to it instead of creating a new one.
+        :return: Snapshot information including the snapshot ID and names
         """
         return await SandboxApi._cls_create_snapshot(
             sandbox_id=self.sandbox_id,
+            name=name,
             **self.connection_config.get_api_params(**opts),
         )
 

--- a/packages/python-sdk/e2b/sandbox_async/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_async/paginator.py
@@ -121,5 +121,6 @@ class AsyncSnapshotPaginator(SnapshotPaginatorBase):
             raise SandboxException(f"{res.parsed.message}: Request failed")
 
         return [
-            SnapshotInfo(snapshot_id=snapshot.snapshot_id) for snapshot in res.parsed
+            SnapshotInfo(snapshot_id=snapshot.snapshot_id, names=list(snapshot.names))
+            for snapshot in res.parsed
         ]

--- a/packages/python-sdk/e2b/sandbox_async/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_async/paginator.py
@@ -121,6 +121,6 @@ class AsyncSnapshotPaginator(SnapshotPaginatorBase):
             raise SandboxException(f"{res.parsed.message}: Request failed")
 
         return [
-            SnapshotInfo(snapshot_id=snapshot.snapshot_id, names=list(snapshot.names))
+            SnapshotInfo(snapshot_id=snapshot.snapshot_id, names=snapshot.names or [])
             for snapshot in res.parsed
         ]

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -297,6 +297,7 @@ class SandboxApi(SandboxBase):
     async def _cls_create_snapshot(
         cls,
         sandbox_id: str,
+        name: Optional[str] = None,
         **opts: Unpack[ApiParams],
     ) -> SnapshotInfo:
         config = ConnectionConfig(**opts)
@@ -305,7 +306,9 @@ class SandboxApi(SandboxBase):
         res = await post_sandboxes_sandbox_id_snapshots.asyncio_detailed(
             sandbox_id,
             client=api_client,
-            body=PostSandboxesSandboxIDSnapshotsBody(),
+            body=PostSandboxesSandboxIDSnapshotsBody(
+                name=name if name is not None else UNSET,
+            ),
         )
 
         if res.status_code == 404:
@@ -320,7 +323,9 @@ class SandboxApi(SandboxBase):
         if isinstance(res.parsed, Error):
             raise SandboxException(f"{res.parsed.message}: Request failed")
 
-        return SnapshotInfo(snapshot_id=res.parsed.snapshot_id)
+        return SnapshotInfo(
+            snapshot_id=res.parsed.snapshot_id, names=list(res.parsed.names)
+        )
 
     @classmethod
     async def _cls_delete_snapshot(

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -324,7 +324,7 @@ class SandboxApi(SandboxBase):
             raise SandboxException(f"{res.parsed.message}: Request failed")
 
         return SnapshotInfo(
-            snapshot_id=res.parsed.snapshot_id, names=list(res.parsed.names)
+            snapshot_id=res.parsed.snapshot_id, names=res.parsed.names or []
         )
 
     @classmethod

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -691,6 +691,7 @@ class Sandbox(SandboxApi):
     @overload
     def create_snapshot(
         self,
+        name: Optional[str] = None,
         **opts: Unpack[ApiParams],
     ) -> SnapshotInfo:
         """
@@ -702,7 +703,8 @@ class Sandbox(SandboxApi):
 
         Use the returned `snapshot_id` with `Sandbox.create(snapshot_id)` to create a new sandbox from the snapshot.
 
-        :return: Snapshot information including the snapshot ID
+        :param name: Optional human-readable name for the snapshot template. If a snapshot with this name already exists, a new build is assigned to it instead of creating a new one.
+        :return: Snapshot information including the snapshot ID and names
         """
         ...
 
@@ -710,6 +712,7 @@ class Sandbox(SandboxApi):
     @staticmethod
     def create_snapshot(
         sandbox_id: str,
+        name: Optional[str] = None,
         **opts: Unpack[ApiParams],
     ) -> SnapshotInfo:
         """
@@ -718,14 +721,15 @@ class Sandbox(SandboxApi):
         The sandbox will be paused while the snapshot is being created.
 
         :param sandbox_id: Sandbox ID
-
-        :return: Snapshot information including the snapshot ID
+        :param name: Optional human-readable name for the snapshot template.
+        :return: Snapshot information including the snapshot ID and names
         """
         ...
 
     @class_method_variant("_cls_create_snapshot")
     def create_snapshot(
         self,
+        name: Optional[str] = None,
         **opts: Unpack[ApiParams],
     ) -> SnapshotInfo:
         """
@@ -737,10 +741,12 @@ class Sandbox(SandboxApi):
 
         Use the returned `snapshot_id` with `Sandbox.create(snapshot_id)` to create a new sandbox from the snapshot.
 
-        :return: Snapshot information including the snapshot ID
+        :param name: Optional human-readable name for the snapshot template. If a snapshot with this name already exists, a new build is assigned to it instead of creating a new one.
+        :return: Snapshot information including the snapshot ID and names
         """
         return SandboxApi._cls_create_snapshot(
             sandbox_id=self.sandbox_id,
+            name=name,
             **self.connection_config.get_api_params(**opts),
         )
 

--- a/packages/python-sdk/e2b/sandbox_sync/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_sync/paginator.py
@@ -121,6 +121,6 @@ class SnapshotPaginator(SnapshotPaginatorBase):
             raise SandboxException(f"{res.parsed.message}: Request failed")
 
         return [
-            SnapshotInfo(snapshot_id=snapshot.snapshot_id, names=list(snapshot.names))
+            SnapshotInfo(snapshot_id=snapshot.snapshot_id, names=snapshot.names or [])
             for snapshot in res.parsed
         ]

--- a/packages/python-sdk/e2b/sandbox_sync/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_sync/paginator.py
@@ -121,5 +121,6 @@ class SnapshotPaginator(SnapshotPaginatorBase):
             raise SandboxException(f"{res.parsed.message}: Request failed")
 
         return [
-            SnapshotInfo(snapshot_id=snapshot.snapshot_id) for snapshot in res.parsed
+            SnapshotInfo(snapshot_id=snapshot.snapshot_id, names=list(snapshot.names))
+            for snapshot in res.parsed
         ]

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -351,7 +351,7 @@ class SandboxApi(SandboxBase):
             raise SandboxException(f"{res.parsed.message}: Request failed")
 
         return SnapshotInfo(
-            snapshot_id=res.parsed.snapshot_id, names=list(res.parsed.names)
+            snapshot_id=res.parsed.snapshot_id, names=res.parsed.names or []
         )
 
     @classmethod

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -324,6 +324,7 @@ class SandboxApi(SandboxBase):
     def _cls_create_snapshot(
         cls,
         sandbox_id: str,
+        name: Optional[str] = None,
         **opts: Unpack[ApiParams],
     ) -> SnapshotInfo:
         config = ConnectionConfig(**opts)
@@ -332,7 +333,9 @@ class SandboxApi(SandboxBase):
         res = post_sandboxes_sandbox_id_snapshots.sync_detailed(
             sandbox_id,
             client=api_client,
-            body=PostSandboxesSandboxIDSnapshotsBody(),
+            body=PostSandboxesSandboxIDSnapshotsBody(
+                name=name if name is not None else UNSET,
+            ),
         )
 
         if res.status_code == 404:
@@ -347,7 +350,9 @@ class SandboxApi(SandboxBase):
         if isinstance(res.parsed, Error):
             raise SandboxException(f"{res.parsed.message}: Request failed")
 
-        return SnapshotInfo(snapshot_id=res.parsed.snapshot_id)
+        return SnapshotInfo(
+            snapshot_id=res.parsed.snapshot_id, names=list(res.parsed.names)
+        )
 
     @classmethod
     def _cls_delete_snapshot(


### PR DESCRIPTION
## Summary

Closes #1249.

Named snapshots let users write \`Sandbox.create('team/my-snapshot')\` instead of tracking raw template IDs like \`abc123:default\`. But passing \`name\` to \`createSnapshot()\` / \`create_snapshot()\` silently had no effect in both SDKs — the generated REST clients were already correct, but the hand-written wrapper layer never forwarded the value or surfaced the response field.

Three layers had the same gap in both SDKs:

| Layer | Problem |
|---|---|
| Options type | No \`name\` field — callers had nowhere to pass it |
| Request body | \`body: {}\` / \`PostSandboxesSandboxIDSnapshotsBody()\` — \`name\` never included |
| \`SnapshotInfo\` return type | Missing \`names\` field — API response aliases silently dropped |
| Paginators | \`listSnapshots\` / \`list_snapshots\` had the same \`names\` omission |

**JS SDK changes** (\`packages/js-sdk/\`):
- Added \`SnapshotCreateOpts\` interface with \`name?: string\`
- Added \`names: string[]\` to \`SnapshotInfo\`
- Forwarded \`name\` in \`SandboxApi.createSnapshot()\` using \`!== undefined\` guard (preserves \`name: ''\`)
- Fixed \`SnapshotPaginator\` to map \`names\`
- Exported \`SnapshotCreateOpts\` from the package index

**Python SDK changes** (\`packages/python-sdk/\`):
- Added \`names: List[str]\` to \`SnapshotInfo\` dataclass (\`default_factory=list\`)
- Added \`name: Optional[str] = None\` to \`_cls_create_snapshot()\` in both sync and async, forwarded as \`name if name is not None else UNSET\`
- Updated \`create_snapshot()\` overloads and implementations (sync + async)
- Fixed both \`SnapshotPaginator.next_items()\` to map \`names\`

Backwards compatible: \`name\` is optional everywhere, \`names\` defaults to \`[]\`.

## Usage

**JS:**
\`\`\`ts
const snap = await sandbox.createSnapshot({ name: 'my-snapshot' })
console.log(snap.snapshotId)  // 'team-slug/my-snapshot:default'
console.log(snap.names)       // ['team-slug/my-snapshot:default']

// Now usable by name instead of raw ID
const sbx = await Sandbox.create('team-slug/my-snapshot')
\`\`\`

**Python:**
\`\`\`python
snap = sandbox.create_snapshot(name='my-snapshot')
print(snap.snapshot_id)  # 'team-slug/my-snapshot:default'
print(snap.names)        # ['team-slug/my-snapshot:default']

sbx = Sandbox.create('team-slug/my-snapshot')
\`\`\`

## Test plan

- [x] \`pnpm run typecheck\` — zero errors
- [x] \`pnpm run lint\` — zero errors
- [x] Python \`make lint\` (ruff check + ruff format) — all pass
- [x] Changeset added: \`patch\` bump for \`e2b\` (JS) and \`@e2b/python-sdk\`
- [x] Backwards compatible: \`name\` is optional, \`names\` defaults to \`[]\`
- [ ] Live integration: \`createSnapshot({ name: ... })\` returns alias in \`names\` — pending backend round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)