### PR TITLE
fix(js-sdk): buffer template upload to avoid S3 chunked PUT 501

### DIFF
--- a/.changeset/fix-js-sdk-upload-content-length.md
+++ b/.changeset/fix-js-sdk-upload-content-length.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+fix(js-sdk): buffer template tar archive before upload so `fetch` sets `Content-Length` instead of falling back to `Transfer-Encoding: chunked`. S3 presigned PUT URLs reject chunked requests with `501 NotImplemented`, breaking template uploads in self-hosted deployments backed by S3-compatible storage. Aligns the JS SDK with the Python SDK, which already buffers via `io.BytesIO`.

--- a/packages/js-sdk/src/template/buildApi.ts
+++ b/packages/js-sdk/src/template/buildApi.ts
@@ -1,3 +1,4 @@
+import { buffer } from 'node:stream/consumers'
 import { ApiClient, handleApiError, paths, components } from '../api'
 import { stripAnsi } from '../utils'
 import { BuildError, FileUploadError, TemplateError } from '../errors'
@@ -119,12 +120,16 @@ export async function uploadFile(
       resolveSymlinks
     )
 
-    // The compiler assumes this is Web fetch API, but it's actually Node.js fetch API
+    // Buffer the archive before uploading so fetch sets Content-Length.
+    // S3 presigned PUT URLs reject Transfer-Encoding: chunked with 501
+    // NotImplemented, which is what Node's fetch falls back to when the
+    // body is a Readable without a known length. See e2b-dev/e2b#1243.
+    // The Python SDK takes the same approach (build_api.py:upload_file).
+    const uploadBody = await buffer(uploadStream)
+
     const res = await fetch(url, {
       method: 'PUT',
-      // @ts-expect-error
-      body: uploadStream,
-      duplex: 'half',
+      body: uploadBody,
     })
 
     if (!res.ok) {

--- a/packages/js-sdk/src/template/buildApi.ts
+++ b/packages/js-sdk/src/template/buildApi.ts
@@ -1,6 +1,5 @@
-import { buffer } from 'node:stream/consumers'
 import { ApiClient, handleApiError, paths, components } from '../api'
-import { stripAnsi } from '../utils'
+import { dynamicImport, stripAnsi } from '../utils'
 import { BuildError, FileUploadError, TemplateError } from '../errors'
 import { LogEntry } from './logger'
 import { getBuildStepIndex, tarFileStreamUpload } from './utils'
@@ -125,9 +124,13 @@ export async function uploadFile(
     // NotImplemented, which is what Node's fetch falls back to when the
     // body is a Readable without a known length. See e2b-dev/e2b#1243.
     // The Python SDK takes the same approach (build_api.py:upload_file).
+    // Dynamically import so the browser bundle doesn't pull in node:stream.
     // tar's Pack extends Minipass and is iterable as AsyncIterable<Buffer> at
     // runtime, but the cli's tsconfig (preserveSymlinks) doesn't surface that
     // through the type chain — cast via unknown.
+    const { buffer } = await dynamicImport<typeof import('node:stream/consumers')>(
+      'node:stream/consumers'
+    )
     const uploadBody = await buffer(
       uploadStream as unknown as AsyncIterable<Buffer>
     )

--- a/packages/js-sdk/src/template/buildApi.ts
+++ b/packages/js-sdk/src/template/buildApi.ts
@@ -125,7 +125,12 @@ export async function uploadFile(
     // NotImplemented, which is what Node's fetch falls back to when the
     // body is a Readable without a known length. See e2b-dev/e2b#1243.
     // The Python SDK takes the same approach (build_api.py:upload_file).
-    const uploadBody = await buffer(uploadStream)
+    // tar's Pack extends Minipass and is iterable as AsyncIterable<Buffer> at
+    // runtime, but the cli's tsconfig (preserveSymlinks) doesn't surface that
+    // through the type chain — cast via unknown.
+    const uploadBody = await buffer(
+      uploadStream as unknown as AsyncIterable<Buffer>
+    )
 
     const res = await fetch(url, {
       method: 'PUT',

--- a/packages/js-sdk/src/template/buildApi.ts
+++ b/packages/js-sdk/src/template/buildApi.ts
@@ -128,9 +128,9 @@ export async function uploadFile(
     // tar's Pack extends Minipass and is iterable as AsyncIterable<Buffer> at
     // runtime, but the cli's tsconfig (preserveSymlinks) doesn't surface that
     // through the type chain — cast via unknown.
-    const { buffer } = await dynamicImport<typeof import('node:stream/consumers')>(
-      'node:stream/consumers'
-    )
+    const { buffer } = await dynamicImport<
+      typeof import('node:stream/consumers')
+    >('node:stream/consumers')
     const uploadBody = await buffer(
       uploadStream as unknown as AsyncIterable<Buffer>
     )

--- a/packages/js-sdk/tests/template/uploadFile.test.ts
+++ b/packages/js-sdk/tests/template/uploadFile.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect, beforeEach, afterEach } from 'vitest'
-import { writeFile, mkdir, rm } from 'fs/promises'
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { writeFile, mkdtemp, rm } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { createServer, type IncomingMessage, type Server } from 'http'
@@ -14,16 +14,12 @@ describe('uploadFile transfer encoding', () => {
   let testDir: string
   let server: Server
   let baseUrl: string
-  let capturedHeaders: IncomingMessage['headers']
-  let capturedBodyLength: number
+  let capturedHeaders: IncomingMessage['headers'] = {}
+  let capturedBodyLength = 0
 
-  beforeEach(async () => {
-    testDir = join(tmpdir(), `uploadFile-test-${Date.now()}`)
-    await mkdir(testDir, { recursive: true })
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'uploadFile-test-'))
     await writeFile(join(testDir, 'hello.txt'), 'hello world')
-
-    capturedHeaders = {}
-    capturedBodyLength = 0
 
     server = createServer((req, res) => {
       capturedHeaders = req.headers
@@ -42,7 +38,7 @@ describe('uploadFile transfer encoding', () => {
     baseUrl = `http://127.0.0.1:${port}/upload`
   })
 
-  afterEach(async () => {
+  afterAll(async () => {
     await new Promise<void>((resolve) => server.close(() => resolve()))
     await rm(testDir, { recursive: true, force: true })
   })

--- a/packages/js-sdk/tests/template/uploadFile.test.ts
+++ b/packages/js-sdk/tests/template/uploadFile.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
+import { writeFile, mkdir, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createServer, type IncomingMessage, type Server } from 'http'
+import { AddressInfo } from 'net'
+import { uploadFile } from '../../src/template/buildApi'
+
+// Regression test for e2b-dev/e2b#1243 — uploadFile used to pass a Node
+// Readable directly to fetch, which made undici fall back to
+// Transfer-Encoding: chunked. S3 presigned PUT URLs reject that with 501
+// NotImplemented. The fix buffers the archive first so Content-Length is set.
+describe('uploadFile transfer encoding', () => {
+  let testDir: string
+  let server: Server
+  let baseUrl: string
+  let capturedHeaders: IncomingMessage['headers']
+  let capturedBodyLength: number
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `uploadFile-test-${Date.now()}`)
+    await mkdir(testDir, { recursive: true })
+    await writeFile(join(testDir, 'hello.txt'), 'hello world')
+
+    capturedHeaders = {}
+    capturedBodyLength = 0
+
+    server = createServer((req, res) => {
+      capturedHeaders = req.headers
+      let bytes = 0
+      req.on('data', (chunk: Buffer) => {
+        bytes += chunk.length
+      })
+      req.on('end', () => {
+        capturedBodyLength = bytes
+        res.writeHead(200)
+        res.end()
+      })
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const { port } = server.address() as AddressInfo
+    baseUrl = `http://127.0.0.1:${port}/upload`
+  })
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+    await rm(testDir, { recursive: true, force: true })
+  })
+
+  test('sets Content-Length and does not use chunked transfer encoding', async () => {
+    await uploadFile(
+      {
+        fileName: '*.txt',
+        fileContextPath: testDir,
+        url: baseUrl,
+        ignorePatterns: [],
+        resolveSymlinks: false,
+      },
+      undefined
+    )
+
+    expect(capturedHeaders['content-length']).toBeDefined()
+    const contentLength = Number(capturedHeaders['content-length'])
+    expect(contentLength).toBeGreaterThan(0)
+    expect(contentLength).toBe(capturedBodyLength)
+
+    const transferEncoding = capturedHeaders['transfer-encoding']
+    if (transferEncoding !== undefined) {
+      expect(transferEncoding.toLowerCase()).not.toContain('chunked')
+    }
+  })
+})


### PR DESCRIPTION
Fixes #1243.

`uploadFile` passed the gzipped tar `Readable` directly to `fetch`. With no known `Content-Length`, undici falls back to `Transfer-Encoding: chunked`, which S3 presigned PUT URLs reject with `501 NotImplemented`. Template uploads against S3-compatible storage in self-hosted deployments were broken.

Buffer the archive with `stream/consumers.buffer()` before PUT so `fetch` sets `Content-Length` automatically. This aligns the JS SDK with the Python SDK, which already materializes the tar into `io.BytesIO` and uploads bytes via httpx (`packages/python-sdk/e2b/template_sync/build_api.py:upload_file`).

## Verification

Added `tests/template/uploadFile.test.ts`: spins up a local HTTP server, runs `uploadFile`, asserts `Content-Length` is set and matches the received body length, and asserts no chunked transfer encoding.

Stash-bisected against the fix:

```
# pre-fix (body = Readable)
× expected undefined to be defined  (Content-Length was never sent)

# post-fix (body = Buffer)
✓ sets Content-Length and does not use chunked transfer encoding  (68ms)
```

All 51 JS SDK unit tests (`tests/template/utils` + new file) pass. The 22 failures in the full `tests/template` run are integration tests that require `E2B_API_KEY`; they are unrelated.

## Trade-off note

Like the Python SDK, this materializes the archive in memory before PUT. Template build contexts are bounded (the SDK targets Docker-build-sized payloads) and aligning with the Python SDK keeps behavior consistent across clients. If memory pressure becomes an issue for very large uploads, a streaming alternative would need coordinated changes on both SDKs and the server to compute Content-Length up front.

Issue: https://github.com/e2b-dev/E2B/issues/1243