### PR TITLE
docs(cli): add sandbox command usage examples

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,7 +4,7 @@
 
 # E2B CLI
 
-This CLI tool allows you to build manager your running E2B sandbox and sandbox templates. Learn more in [our documentation](https://e2b.dev/docs).
+This CLI tool allows you to manage your running E2B sandboxes and sandbox templates. Learn more in [our documentation](https://e2b.dev/docs).
 
 ### 1. Install the CLI
 
@@ -79,6 +79,24 @@ Connect an interactive terminal to a running sandbox:
 e2b sandbox connect <sandboxID>
 ```
 
+Pause a running sandbox:
+
+```bash
+e2b sandbox pause <sandboxID>
+```
+
+Resume a paused sandbox:
+
+```bash
+e2b sandbox resume <sandboxID>
+```
+
+Kill a sandbox you no longer need:
+
+```bash
+e2b sandbox kill <sandboxID>
+```
+
 Stream sandbox logs until the sandbox closes:
 
 ```bash
@@ -105,6 +123,8 @@ e2b sandbox exec <sandboxID> -- pwd
 e2b sandbox exec <sandboxID> -- python -V
 ```
 
+Use `--` before the remote command to clearly separate CLI flags from the command being executed inside the sandbox.
+
 Pass environment variables to a sandbox command:
 
 ```bash
@@ -117,8 +137,61 @@ Pipe stdin into a sandbox command:
 cat script.py | e2b sandbox exec <sandboxID> -- python
 ```
 
-Use `--` before the remote command when you want to clearly separate CLI flags from the command being executed inside the sandbox.
+### 4. Common template commands
 
-### 4. Check out docs
+Build a template from the current project:
+
+```bash
+e2b template build
+```
+
+Build a template and assign it a specific template name:
+
+```bash
+e2b template build --name my-template
+```
+
+Build a template from a specific path:
+
+```bash
+e2b template build --path ./my-template
+```
+
+List available templates:
+
+```bash
+e2b template list
+```
+
+Create a new template project:
+
+```bash
+e2b template init
+```
+
+Delete a template you no longer need:
+
+```bash
+e2b template delete <template>
+```
+
+Publish a previously built template to make it available for creating sandboxes:
+
+```bash
+e2b template publish
+```
+
+### 5. Explore more options
+
+Use `--help` to inspect available subcommands and flags:
+
+```bash
+e2b --help
+e2b sandbox --help
+e2b sandbox logs --help
+e2b template --help
+```
+
+### 6. Check out docs
 
 Visit our [CLI documentation](https://e2b.dev/docs) to learn more.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,6 +35,90 @@ e2b auth login
 > [!IMPORTANT]  
 > Note the distinction between `E2B_ACCESS_TOKEN` and `E2B_API_KEY`.
 
-### 3. Check out docs
+### 3. Common sandbox commands
+
+Create a sandbox from the default template:
+
+```bash
+e2b sandbox create
+```
+
+Create a sandbox from a specific template without attaching a terminal:
+
+```bash
+e2b sandbox create my-template --detach
+```
+
+List running sandboxes:
+
+```bash
+e2b sandbox list
+```
+
+List running and paused sandboxes, limited to 20 results:
+
+```bash
+e2b sandbox list --state running,paused --limit 20
+```
+
+Filter sandboxes by metadata and print JSON:
+
+```bash
+e2b sandbox list --metadata owner=agent --format json
+```
+
+Inspect a sandbox:
+
+```bash
+e2b sandbox info <sandboxID>
+```
+
+Connect an interactive terminal to a running sandbox:
+
+```bash
+e2b sandbox connect <sandboxID>
+```
+
+Stream sandbox logs until the sandbox closes:
+
+```bash
+e2b sandbox logs <sandboxID> --follow
+```
+
+Filter logs by level or logger prefix:
+
+```bash
+e2b sandbox logs <sandboxID> --follow --level warn
+e2b sandbox logs <sandboxID> --format json --loggers Envd,Kernel
+```
+
+View live resource metrics:
+
+```bash
+e2b sandbox metrics <sandboxID> --follow
+```
+
+Run a command in a running sandbox:
+
+```bash
+e2b sandbox exec <sandboxID> -- pwd
+e2b sandbox exec <sandboxID> -- python -V
+```
+
+Pass environment variables to a sandbox command:
+
+```bash
+e2b sandbox exec <sandboxID> -e FOO=bar -- sh -lc 'echo $FOO'
+```
+
+Pipe stdin into a sandbox command:
+
+```bash
+cat script.py | e2b sandbox exec <sandboxID> -- python
+```
+
+Use `--` before the remote command when you want to clearly separate CLI flags from the command being executed inside the sandbox.
+
+### 4. Check out docs
 
 Visit our [CLI documentation](https://e2b.dev/docs) to learn more.


### PR DESCRIPTION
## Summary
- add a `Common sandbox commands` section to the CLI README
- document common `sandbox` workflows with concrete examples
- keep this guidance in docs instead of expanding command-level help text

## Changes
- document `sandbox create`, `list`, `info`, `connect`, `logs`, `metrics`, and `exec`
- include examples for `--detach`, state and metadata filters, JSON output, and `--follow`
- clarify `sandbox exec` usage with `--`, environment variables, and piped stdin

Closes #1289
