### PR TITLE
test: reduce test_sbx_metrics flakiness by extending polling window

### DIFF
--- a/packages/js-sdk/tests/sandbox/metrics.test.ts
+++ b/packages/js-sdk/tests/sandbox/metrics.test.ts
@@ -9,12 +9,12 @@ sandboxTest.skipIf(isDebug)(
   async ({ sandbox }) => {
     const now = new Date()
     let metrics: SandboxMetrics[]
-    for (let i = 0; i < 30; i++) {
+    for (let i = 0; i < 60; i++) {
       metrics = await sandbox.getMetrics()
       if (metrics.length > 0) {
         break
       }
-      await wait(1_000)
+      await wait(500)
     }
 
     expect(metrics.length).toBeGreaterThan(0)

--- a/packages/js-sdk/tests/sandbox/metrics.test.ts
+++ b/packages/js-sdk/tests/sandbox/metrics.test.ts
@@ -3,26 +3,30 @@ import { expect } from 'vitest'
 import { SandboxMetrics } from '../../src'
 import { sandboxTest, isDebug, wait } from '../setup.js'
 
-sandboxTest.skipIf(isDebug)('sbx metrics', async ({ sandbox }) => {
-  const now = new Date()
-  let metrics: SandboxMetrics[]
-  for (let i = 0; i < 15; i++) {
-    metrics = await sandbox.getMetrics()
-    if (metrics.length > 0) {
-      break
+sandboxTest.skipIf(isDebug)(
+  'sbx metrics',
+  { timeout: 60_000 },
+  async ({ sandbox }) => {
+    const now = new Date()
+    let metrics: SandboxMetrics[]
+    for (let i = 0; i < 30; i++) {
+      metrics = await sandbox.getMetrics()
+      if (metrics.length > 0) {
+        break
+      }
+      await wait(1_000)
     }
-    await wait(1_000)
+
+    expect(metrics.length).toBeGreaterThan(0)
+    const metric = metrics[0]
+    expect(metric.diskTotal).toBeDefined()
+    expect(metric.diskUsed).toBeDefined()
+    expect(metric.memTotal).toBeDefined()
+    expect(metric.memUsed).toBeDefined()
+    expect(metric.cpuUsedPct).toBeDefined()
+    expect(metric.cpuCount).toBeDefined()
+
+    metrics = await sandbox.getMetrics({ start: now, end: new Date() })
+    expect(metrics.length).toBeGreaterThan(0)
   }
-
-  expect(metrics.length).toBeGreaterThan(0)
-  const metric = metrics[0]
-  expect(metric.diskTotal).toBeDefined()
-  expect(metric.diskUsed).toBeDefined()
-  expect(metric.memTotal).toBeDefined()
-  expect(metric.memUsed).toBeDefined()
-  expect(metric.cpuUsedPct).toBeDefined()
-  expect(metric.cpuCount).toBeDefined()
-
-  metrics = await sandbox.getMetrics({ start: now, end: new Date() })
-  expect(metrics.length).toBeGreaterThan(0)
-})
+)

--- a/packages/python-sdk/tests/async/sandbox_async/test_metrics.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_metrics.py
@@ -5,13 +5,14 @@ import pytest
 
 
 @pytest.mark.skip_debug()
+@pytest.mark.timeout(60)
 async def test_sbx_metrics(async_sandbox_factory):
     start_time = datetime.datetime.now()
-    sbx = await async_sandbox_factory(timeout=20)
+    sbx = await async_sandbox_factory(timeout=60)
 
     # Wait for the sandbox to have some metrics
     metrics = []
-    for _ in range(15):
+    for _ in range(30):
         metrics = await sbx.get_metrics()
         if len(metrics) > 0:
             break

--- a/packages/python-sdk/tests/async/sandbox_async/test_metrics.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_metrics.py
@@ -12,11 +12,11 @@ async def test_sbx_metrics(async_sandbox_factory):
 
     # Wait for the sandbox to have some metrics
     metrics = []
-    for _ in range(30):
+    for _ in range(60):
         metrics = await sbx.get_metrics()
         if len(metrics) > 0:
             break
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.5)
 
     assert len(metrics) > 0
 

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_metrics.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_metrics.py
@@ -5,12 +5,13 @@ import pytest
 
 
 @pytest.mark.skip_debug()
+@pytest.mark.timeout(60)
 def test_sbx_metrics(sandbox_factory) -> None:
     start_time = datetime.datetime.now()
     sbx = sandbox_factory(timeout=60)
     # Wait for the sandbox to have some metrics
     metrics = []
-    for _ in range(15):
+    for _ in range(30):
         metrics = sbx.get_metrics()
         if len(metrics) > 0:
             break

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_metrics.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_metrics.py
@@ -11,11 +11,11 @@ def test_sbx_metrics(sandbox_factory) -> None:
     sbx = sandbox_factory(timeout=60)
     # Wait for the sandbox to have some metrics
     metrics = []
-    for _ in range(30):
+    for _ in range(60):
         metrics = sbx.get_metrics()
         if len(metrics) > 0:
             break
-        time.sleep(1)
+        time.sleep(0.5)
 
     assert len(metrics) > 0
 


### PR DESCRIPTION
## Summary
- Bumps metrics polling from 15s to 30s in Python async/sync and JS SDK tests so the backend has enough headroom to populate metrics under load — this test was the new #1 CI offender (5/9 Python runs and 4/10 JS runs failed).
- Raises the async Python sandbox timeout from 20s to 60s for parity with sync, and adds per-test timeout overrides (`@pytest.mark.timeout(60)` / `{ timeout: 60_000 }`) so polling can complete under the default 30s pytest/vitest cap.
- Happy path is unchanged: the loop still breaks as soon as metrics appear.

## Test plan
- [x] `pnpm run format`, `pnpm run lint`, `pnpm run typecheck` pass
- [x] `test_sbx_metrics` (Python async) passed locally in 8.4s
- [x] `test_sbx_metrics` (Python sync) passed locally in 15.6s
- [x] `metrics.test.ts` (JS) passed locally in 20.7s

🤖 Generated with [Claude Code](https://claude.com/claude-code)