### PR TITLE
refactor(sdk): make octet-stream file upload opt-in via useOctetStream

### DIFF
--- a/.changeset/write-octet-stream-override.md
+++ b/.changeset/write-octet-stream-override.md
@@ -3,4 +3,4 @@
 'e2b': patch
 ---
 
-added option to sandbox file write to override the envd version-based default for octet-stream uploads
+added opt-in `useOctetStream` / `use_octet_stream` option to sandbox file write; default is now `multipart/form-data` regardless of envd version

--- a/.changeset/write-octet-stream-override.md
+++ b/.changeset/write-octet-stream-override.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': patch
+'e2b': patch
+---
+
+added option to sandbox file write to override the envd version-based default for octet-stream uploads

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -29,7 +29,6 @@ import type { Timestamp } from '@bufbuild/protobuf/wkt'
 import { compareVersions } from 'compare-versions'
 import {
   ENVD_DEFAULT_USER,
-  ENVD_OCTET_STREAM_UPLOAD,
   ENVD_VERSION_RECURSIVE_WATCH,
 } from '../../envd/versions'
 import {
@@ -175,8 +174,7 @@ export interface FilesystemWriteOpts extends FilesystemRequestOpts {
   /**
    * When true, the upload uses `application/octet-stream` instead of `multipart/form-data`.
    *
-   * Defaults to `true` when the sandbox's envd version supports octet-stream uploads,
-   * and `false` otherwise. Set explicitly to override the version-based default.
+   * Defaults to `false`. Requires envd 0.5.7 or later.
    */
   useOctetStream?: boolean
 }
@@ -422,9 +420,7 @@ export class Filesystem {
       user = defaultUsername
     }
 
-    const useOctetStream =
-      writeOpts?.useOctetStream ??
-      compareVersions(this.envdApi.version, ENVD_OCTET_STREAM_UPLOAD) >= 0
+    const useOctetStream = writeOpts?.useOctetStream ?? false
 
     const results: WriteInfo[] = []
 

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -172,6 +172,13 @@ export interface FilesystemWriteOpts extends FilesystemRequestOpts {
    * When true, the upload will be gzip-compressed.
    */
   gzip?: boolean
+  /**
+   * When true, the upload uses `application/octet-stream` instead of `multipart/form-data`.
+   *
+   * Defaults to `true` when the sandbox's envd version supports octet-stream uploads,
+   * and `false` otherwise. Set explicitly to override the version-based default.
+   */
+  useOctetStream?: boolean
 }
 
 /**
@@ -416,6 +423,7 @@ export class Filesystem {
     }
 
     const useOctetStream =
+      writeOpts?.useOctetStream ??
       compareVersions(this.envdApi.version, ENVD_OCTET_STREAM_UPLOAD) >= 0
 
     const results: WriteInfo[] = []

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -29,6 +29,7 @@ import type { Timestamp } from '@bufbuild/protobuf/wkt'
 import { compareVersions } from 'compare-versions'
 import {
   ENVD_DEFAULT_USER,
+  ENVD_OCTET_STREAM_UPLOAD,
   ENVD_VERSION_RECURSIVE_WATCH,
 } from '../../envd/versions'
 import {
@@ -174,7 +175,8 @@ export interface FilesystemWriteOpts extends FilesystemRequestOpts {
   /**
    * When true, the upload uses `application/octet-stream` instead of `multipart/form-data`.
    *
-   * Defaults to `false`. Requires envd 0.5.7 or later.
+   * Defaults to `false`. Requires envd 0.5.7 or later — when not supported by
+   * the sandbox's envd version, the upload falls back to `multipart/form-data`.
    */
   useOctetStream?: boolean
 }
@@ -420,7 +422,10 @@ export class Filesystem {
       user = defaultUsername
     }
 
-    const useOctetStream = writeOpts?.useOctetStream ?? false
+    const supportsOctetStream =
+      compareVersions(this.envdApi.version, ENVD_OCTET_STREAM_UPLOAD) >= 0
+    const useOctetStream =
+      (writeOpts?.useOctetStream ?? false) && supportsOctetStream
 
     const results: WriteInfo[] = []
 

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
@@ -20,6 +20,7 @@ from e2b.envd.filesystem import filesystem_connect, filesystem_pb2
 from e2b.envd.rpc import authentication_header, handle_rpc_exception
 from e2b.envd.versions import (
     ENVD_DEFAULT_USER,
+    ENVD_OCTET_STREAM_UPLOAD,
     ENVD_VERSION_RECURSIVE_WATCH,
 )
 from e2b.exceptions import (
@@ -209,7 +210,7 @@ class Filesystem:
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request in **seconds**
         :param gzip: Use gzip compression for the request
-        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later.
+        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later — when not supported, the upload falls back to `multipart/form-data`.
 
         :return: Information about the written file
         """
@@ -246,7 +247,7 @@ class Filesystem:
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request
         :param gzip: Use gzip compression for the request
-        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later.
+        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later — when not supported, the upload falls back to `multipart/form-data`.
         :return: Information about the written files
         """
         username = user
@@ -255,6 +256,9 @@ class Filesystem:
 
         if len(files) == 0:
             return []
+
+        supports_octet_stream = self._envd_version >= ENVD_OCTET_STREAM_UPLOAD
+        use_octet_stream = use_octet_stream and supports_octet_stream
 
         results: List[WriteInfo] = []
 

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
@@ -197,6 +197,7 @@ class Filesystem:
         user: Optional[Username] = None,
         request_timeout: Optional[float] = None,
         gzip: bool = False,
+        use_octet_stream: Optional[bool] = None,
     ) -> WriteInfo:
         """
         Write content to a file on the path.
@@ -209,6 +210,7 @@ class Filesystem:
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request in **seconds**
         :param gzip: Use gzip compression for the request
+        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `True` when the sandbox's envd version supports it, `False` otherwise. Set explicitly to override the version-based default.
 
         :return: Information about the written file
         """
@@ -217,6 +219,7 @@ class Filesystem:
             user,
             request_timeout,
             gzip,
+            use_octet_stream,
         )
 
         if len(result) != 1:
@@ -230,6 +233,7 @@ class Filesystem:
         user: Optional[Username] = None,
         request_timeout: Optional[float] = None,
         gzip: bool = False,
+        use_octet_stream: Optional[bool] = None,
     ) -> List[WriteInfo]:
         """
         Writes multiple files.
@@ -243,6 +247,7 @@ class Filesystem:
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request
         :param gzip: Use gzip compression for the request
+        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `True` when the sandbox's envd version supports it, `False` otherwise. Set explicitly to override the version-based default.
         :return: Information about the written files
         """
         username = user
@@ -252,7 +257,8 @@ class Filesystem:
         if len(files) == 0:
             return []
 
-        use_octet_stream = self._envd_version >= ENVD_OCTET_STREAM_UPLOAD
+        if use_octet_stream is None:
+            use_octet_stream = self._envd_version >= ENVD_OCTET_STREAM_UPLOAD
 
         results: List[WriteInfo] = []
 

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
@@ -20,7 +20,6 @@ from e2b.envd.filesystem import filesystem_connect, filesystem_pb2
 from e2b.envd.rpc import authentication_header, handle_rpc_exception
 from e2b.envd.versions import (
     ENVD_DEFAULT_USER,
-    ENVD_OCTET_STREAM_UPLOAD,
     ENVD_VERSION_RECURSIVE_WATCH,
 )
 from e2b.exceptions import (
@@ -197,7 +196,7 @@ class Filesystem:
         user: Optional[Username] = None,
         request_timeout: Optional[float] = None,
         gzip: bool = False,
-        use_octet_stream: Optional[bool] = None,
+        use_octet_stream: bool = False,
     ) -> WriteInfo:
         """
         Write content to a file on the path.
@@ -210,7 +209,7 @@ class Filesystem:
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request in **seconds**
         :param gzip: Use gzip compression for the request
-        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `True` when the sandbox's envd version supports it, `False` otherwise. Set explicitly to override the version-based default.
+        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later.
 
         :return: Information about the written file
         """
@@ -233,7 +232,7 @@ class Filesystem:
         user: Optional[Username] = None,
         request_timeout: Optional[float] = None,
         gzip: bool = False,
-        use_octet_stream: Optional[bool] = None,
+        use_octet_stream: bool = False,
     ) -> List[WriteInfo]:
         """
         Writes multiple files.
@@ -247,7 +246,7 @@ class Filesystem:
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request
         :param gzip: Use gzip compression for the request
-        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `True` when the sandbox's envd version supports it, `False` otherwise. Set explicitly to override the version-based default.
+        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later.
         :return: Information about the written files
         """
         username = user
@@ -256,9 +255,6 @@ class Filesystem:
 
         if len(files) == 0:
             return []
-
-        if use_octet_stream is None:
-            use_octet_stream = self._envd_version >= ENVD_OCTET_STREAM_UPLOAD
 
         results: List[WriteInfo] = []
 

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -195,6 +195,7 @@ class Filesystem:
         user: Optional[Username] = None,
         request_timeout: Optional[float] = None,
         gzip: bool = False,
+        use_octet_stream: Optional[bool] = None,
     ) -> WriteInfo:
         """
         Write content to a file on the path.
@@ -207,6 +208,7 @@ class Filesystem:
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request in **seconds**
         :param gzip: Use gzip compression for the request
+        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `True` when the sandbox's envd version supports it, `False` otherwise. Set explicitly to override the version-based default.
 
         :return: Information about the written file
         """
@@ -215,6 +217,7 @@ class Filesystem:
             user=user,
             request_timeout=request_timeout,
             gzip=gzip,
+            use_octet_stream=use_octet_stream,
         )
 
         if len(result) != 1:
@@ -228,6 +231,7 @@ class Filesystem:
         user: Optional[Username] = None,
         request_timeout: Optional[float] = None,
         gzip: bool = False,
+        use_octet_stream: Optional[bool] = None,
     ) -> List[WriteInfo]:
         """
         Writes a list of files to the filesystem.
@@ -239,6 +243,7 @@ class Filesystem:
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request
         :param gzip: Use gzip compression for the request
+        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `True` when the sandbox's envd version supports it, `False` otherwise. Set explicitly to override the version-based default.
         :return: Information about the written files
         """
         username = user
@@ -248,7 +253,8 @@ class Filesystem:
         if len(files) == 0:
             return []
 
-        use_octet_stream = self._envd_version >= ENVD_OCTET_STREAM_UPLOAD
+        if use_octet_stream is None:
+            use_octet_stream = self._envd_version >= ENVD_OCTET_STREAM_UPLOAD
 
         results: List[WriteInfo] = []
 

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -20,6 +20,7 @@ from e2b.envd.filesystem import filesystem_connect, filesystem_pb2
 from e2b.envd.rpc import authentication_header, handle_rpc_exception
 from e2b.envd.versions import (
     ENVD_DEFAULT_USER,
+    ENVD_OCTET_STREAM_UPLOAD,
     ENVD_VERSION_RECURSIVE_WATCH,
 )
 from e2b.exceptions import (
@@ -207,7 +208,7 @@ class Filesystem:
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request in **seconds**
         :param gzip: Use gzip compression for the request
-        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later.
+        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later — when not supported, the upload falls back to `multipart/form-data`.
 
         :return: Information about the written file
         """
@@ -242,7 +243,7 @@ class Filesystem:
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request
         :param gzip: Use gzip compression for the request
-        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later.
+        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later — when not supported, the upload falls back to `multipart/form-data`.
         :return: Information about the written files
         """
         username = user
@@ -251,6 +252,9 @@ class Filesystem:
 
         if len(files) == 0:
             return []
+
+        supports_octet_stream = self._envd_version >= ENVD_OCTET_STREAM_UPLOAD
+        use_octet_stream = use_octet_stream and supports_octet_stream
 
         results: List[WriteInfo] = []
 

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -20,7 +20,6 @@ from e2b.envd.filesystem import filesystem_connect, filesystem_pb2
 from e2b.envd.rpc import authentication_header, handle_rpc_exception
 from e2b.envd.versions import (
     ENVD_DEFAULT_USER,
-    ENVD_OCTET_STREAM_UPLOAD,
     ENVD_VERSION_RECURSIVE_WATCH,
 )
 from e2b.exceptions import (
@@ -195,7 +194,7 @@ class Filesystem:
         user: Optional[Username] = None,
         request_timeout: Optional[float] = None,
         gzip: bool = False,
-        use_octet_stream: Optional[bool] = None,
+        use_octet_stream: bool = False,
     ) -> WriteInfo:
         """
         Write content to a file on the path.
@@ -208,7 +207,7 @@ class Filesystem:
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request in **seconds**
         :param gzip: Use gzip compression for the request
-        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `True` when the sandbox's envd version supports it, `False` otherwise. Set explicitly to override the version-based default.
+        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later.
 
         :return: Information about the written file
         """
@@ -231,7 +230,7 @@ class Filesystem:
         user: Optional[Username] = None,
         request_timeout: Optional[float] = None,
         gzip: bool = False,
-        use_octet_stream: Optional[bool] = None,
+        use_octet_stream: bool = False,
     ) -> List[WriteInfo]:
         """
         Writes a list of files to the filesystem.
@@ -243,7 +242,7 @@ class Filesystem:
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request
         :param gzip: Use gzip compression for the request
-        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `True` when the sandbox's envd version supports it, `False` otherwise. Set explicitly to override the version-based default.
+        :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later.
         :return: Information about the written files
         """
         username = user
@@ -252,9 +251,6 @@ class Filesystem:
 
         if len(files) == 0:
             return []
-
-        if use_octet_stream is None:
-            use_octet_stream = self._envd_version >= ENVD_OCTET_STREAM_UPLOAD
 
         results: List[WriteInfo] = []
 


### PR DESCRIPTION
## Summary

- Adds an opt-in `useOctetStream` / `use_octet_stream` flag to sandbox file write — JS on `FilesystemWriteOpts`, Python keyword on `write` / `write_files` (async + sync).
- Changes the default upload path to `multipart/form-data` regardless of envd version. Callers must opt in to `application/octet-stream` (requires envd 0.5.7 or later).

## Example

JS:

```ts
// Default — multipart/form-data
await sandbox.files.write('hello.txt', 'world')

// Opt in to application/octet-stream (envd >= 0.5.7)
await sandbox.files.writeFiles(
  [{ path: 'a.txt', data: 'a' }, { path: 'b.txt', data: 'b' }],
  { useOctetStream: true },
)
```

Python:

```python
# Default — multipart/form-data
sandbox.files.write('hello.txt', 'world')

# Opt in to application/octet-stream (envd >= 0.5.7)
await sandbox.files.write_files(
    [{'path': 'a.txt', 'data': 'a'}, {'path': 'b.txt', 'data': 'b'}],
    use_octet_stream=True,
)
```

## Test plan

- [ ] JS: `pnpm --filter e2b run lint && pnpm --filter e2b run typecheck`
- [ ] Python: `cd packages/python-sdk && poetry run make lint && poetry run make typecheck`
- [ ] Manual write with and without `useOctetStream` / `use_octet_stream` against envd 0.5.7+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
