### PR TITLE
feat(python-sdk): add py.typed marker for PEP 561 type checking support

### DIFF
--- a/.changeset/python-sdk-py-typed.md
+++ b/.changeset/python-sdk-py-typed.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+add py.typed marker for PEP 561 type checking support

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ vale-styles
 .vercel
 .vscode
 .DS_Store
+.worktrees
 
 # Logs
 logs

--- a/packages/python-sdk/tests/async/template_async/test_stacktrace.py
+++ b/packages/python-sdk/tests/async/template_async/test_stacktrace.py
@@ -182,9 +182,9 @@ async def test_traces_on_copyItems(async_build):
 @pytest.mark.skip_debug()
 async def test_traces_on_copy_absolute_path():
     await _expect_to_throw_and_check_trace(
-        lambda: AsyncTemplate()
-        .from_base_image()
-        .copy("/absolute/path", "/absolute/path"),
+        lambda: (
+            AsyncTemplate().from_base_image().copy("/absolute/path", "/absolute/path")
+        ),
         "copy",
     )
 
@@ -192,9 +192,11 @@ async def test_traces_on_copy_absolute_path():
 @pytest.mark.skip_debug()
 async def test_traces_on_copyItems_absolute_path():
     await _expect_to_throw_and_check_trace(
-        lambda: AsyncTemplate()
-        .from_base_image()
-        .copy_items([CopyItem(src="/absolute/path", dest="/absolute/path")]),
+        lambda: (
+            AsyncTemplate()
+            .from_base_image()
+            .copy_items([CopyItem(src="/absolute/path", dest="/absolute/path")])
+        ),
         "copy_items",
     )
 


### PR DESCRIPTION
## Context

Python packages can opt into PEP 561 by shipping a `py.typed` marker file alongside their source. Without it, type checkers like `mypy --strict` and `pyright` treat the package as untyped and suppress all type errors at the import boundary — meaning users get no type safety from `e2b` even though the SDK ships full annotations.

Issue: #888

## Investigation

The `e2b` Python SDK already ships complete type annotations across all public APIs (`sandbox/`, `sandbox_async/`, `sandbox_sync/`, etc.). The only missing piece was the `py.typed` marker file that signals to type checkers that the package is typed.

Checked `pyproject.toml` — no additional configuration needed. The existing:

```toml
packages = [{ include = "e2b" }, { include = "e2b_connect" }]
```

tells Poetry to include the entire `e2b/` directory recursively in the built wheel, which picks up `py.typed` automatically.

## Fix

Added an empty `py.typed` marker file at `packages/python-sdk/e2b/py.typed` per the PEP 561 spec. No `pyproject.toml` or `__init__.py` changes required.

Also includes a pre-existing `ruff` formatting fix in `test_stacktrace.py` surfaced by `make format`.

## Test Plan

- [x] `make lint` (`ruff check` + `ruff format --check`) — passes
- [ ] `make typecheck` — local Poetry venv has a broken Python 3.13 dylib (pre-existing env issue unrelated to this change); CI should confirm
- [ ] Downstream verification: add `e2b` to a `mypy --strict` or `pyright` project and confirm no `Cannot find implementation or library stub` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)