### PR TITLE
docs(cli): fix grammar in CLI README intro line

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,7 +4,7 @@
 
 # E2B CLI
 
-This CLI tool allows you to build manager your running E2B sandbox and sandbox templates. Learn more in [our documentation](https://e2b.dev/docs).
+This CLI tool allows you to build and manage your running E2B sandbox and sandbox templates. Learn more in [our documentation](https://e2b.dev/docs).
 
 ### 1. Install the CLI
 


### PR DESCRIPTION
## Summary

`packages/cli/README.md` line 7 currently reads:

> This CLI tool allows you to **build manager** your running E2B sandbox and sandbox templates.

That phrase is ungrammatical. The rest of the README and the CLI's documented commands (\`e2b template build\`, \`e2b sandbox ...\`) make the intent clear: the CLI lets you **build and manage** templates and sandboxes.

## Change

```diff
-This CLI tool allows you to build manager your running E2B sandbox and sandbox templates.
+This CLI tool allows you to build and manage your running E2B sandbox and sandbox templates.
```

Pure prose fix in a single README line. No code, API, or runtime change.

## How to test

Render `packages/cli/README.md` on GitHub and confirm the intro reads cleanly.