### PR TITLE
chore(js-sdk): add patch changeset for npm-check-updates removal

### DIFF
--- a/.changeset/drop-npm-check-updates.md
+++ b/.changeset/drop-npm-check-updates.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+drop unused `npm-check-updates` devDependency to clear remaining `tar@6` Dependabot security alerts


### PR DESCRIPTION
## Summary

Adds a patch changeset for the `e2b` JS SDK to cover #1306 (commit bd99b23c1), which removed the unused `npm-check-updates` devDependency to clear the remaining `tar@6` Dependabot security alerts.

The original PR landed without a changeset, so the next release would skip publishing the SDK despite the `package.json` change. This file ensures the dependency cleanup gets a proper patch bump.

## Test plan

- [x] `.changeset/drop-npm-check-updates.md` follows the repo's existing changeset format (frontmatter + summary line)
- [ ] Changesets bot picks up the entry on the PR