### PR TITLE
enable http2 for js sdk envd rpc/api traffic

### DIFF
--- a/.changeset/empty-fans-wave.md
+++ b/.changeset/empty-fans-wave.md
@@ -1,5 +1,5 @@
 ---
-'e2b': minor
+'e2b': major
 ---
 
-Use HTTP/2 for JS SDK envd/api requests.
+Use HTTP/2 for JS SDK envd/api requests and require Node.js 20.18.1 or newer.

--- a/.changeset/empty-fans-wave.md
+++ b/.changeset/empty-fans-wave.md
@@ -1,5 +1,5 @@
 ---
-'e2b': major
+'e2b': patch
 ---
 
 Use HTTP/2 for JS SDK envd/api requests and require Node.js 20.18.1 or newer.

--- a/.changeset/empty-fans-wave.md
+++ b/.changeset/empty-fans-wave.md
@@ -1,0 +1,6 @@
+---
+'e2b': minor
+'@e2b/cli': minor
+---
+
+js http2 support

--- a/.changeset/empty-fans-wave.md
+++ b/.changeset/empty-fans-wave.md
@@ -1,6 +1,5 @@
 ---
 'e2b': minor
-'@e2b/cli': minor
 ---
 
-js http2 support
+Use HTTP/2 for JS SDK envd/api requests.

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -96,10 +96,11 @@
     "glob": "^11.1.0",
     "openapi-fetch": "^0.14.1",
     "platform": "^1.3.6",
-    "tar": "^7.5.11"
+    "tar": "^7.5.11",
+    "undici": "^7.25.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20.18.1"
   },
   "browserslist": [
     "defaults"

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -193,11 +193,17 @@ class NodeHttp2Fetch {
                 return
               }
               controller.enqueue(new Uint8Array(chunk))
+              if ((controller.desiredSize ?? 1) <= 0) {
+                stream.pause()
+              }
             })
             stream.once('end', () => closeBody(() => controller.close()))
             stream.once('error', (error) =>
               closeBody(() => controller.error(error))
             )
+          },
+          pull() {
+            stream.resume()
           },
           cancel() {
             closeBody(() => undefined)

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -1,349 +1,41 @@
 import { dynamicRequire, runtime } from '../utils'
 
-const IDLE_SESSION_TIMEOUT_MS = 30_000
-const MAX_REDIRECTS = 20
-
-type Http2 = typeof import('node:http2')
-type ClientHttp2Session = import('node:http2').ClientHttp2Session
-
-class NodeHttp2Fetch {
-  private readonly http2: Http2
-  private readonly idleSessionTimeoutMs: number
-  private readonly sessions = new Map<string, ClientHttp2Session>()
-  private readonly activeStreams = new Map<string, number>()
-  private readonly idleTimers = new Map<string, ReturnType<typeof setTimeout>>()
-
-  constructor(http2: Http2, idleSessionTimeoutMs = IDLE_SESSION_TIMEOUT_MS) {
-    this.http2 = http2
-    this.idleSessionTimeoutMs = idleSessionTimeoutMs
-  }
-
-  fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
-    const request = new Request(input, init)
-    const url = new URL(request.url)
-
-    return this.fetchWithSession(request, url, 0)
-  }
-
-  private async fetchWithSession(
-    request: Request,
-    url: URL,
-    redirectCount: number
-  ): Promise<Response> {
-    const origin = `${url.protocol}//${url.host}`
-    const requestBody =
-      request.method === 'GET' || request.method === 'HEAD'
-        ? undefined
-        : Buffer.from(await request.arrayBuffer())
-    const session = this.getSession(origin)
-    const headers: import('node:http2').OutgoingHttpHeaders = {
-      ':method': request.method,
-      ':scheme': url.protocol.slice(0, -1),
-      ':authority': url.host,
-      ':path': `${url.pathname}${url.search}`,
-    }
-
-    request.headers.forEach((value, key) => {
-      const lower = key.toLowerCase()
-      if (
-        lower === 'connection' ||
-        lower === 'host' ||
-        lower === 'keep-alive' ||
-        lower === 'proxy-connection' ||
-        lower === 'transfer-encoding' ||
-        lower === 'upgrade'
-      ) {
-        return
-      }
-
-      headers[lower] = value
-    })
-
-    const stream = session.request(headers)
-    this.addStream(origin)
-
-    return new Promise((resolve, reject) => {
-      const cancelCode = this.http2.constants.NGHTTP2_CANCEL
-      let settled = false
-      let streamReleased = false
-      let bodyClosed = false
-      let bodyController:
-        | ReadableStreamDefaultController<Uint8Array>
-        | undefined
-
-      const releaseStream = () => {
-        if (streamReleased) {
-          return
-        }
-        streamReleased = true
-        this.removeStream(origin)
-      }
-
-      const closeBody = (handle: () => void) => {
-        if (bodyClosed) {
-          return
-        }
-        bodyClosed = true
-        request.signal.removeEventListener('abort', abort)
-        releaseStream()
-        handle()
-      }
-
-      const fail = (error: Error) => {
-        if (settled) {
-          return
-        }
-        settled = true
-        request.signal.removeEventListener('abort', abort)
-        releaseStream()
-        reject(error)
-      }
-
-      const abortError = () =>
-        new DOMException('The operation was aborted.', 'AbortError')
-
-      const abort = () => {
-        stream.close(cancelCode)
-        const controller = bodyController
-        if (controller) {
-          closeBody(() => controller.error(abortError()))
-        }
-        fail(abortError())
-      }
-
-      if (request.signal.aborted) {
-        abort()
-        return
-      }
-
-      request.signal.addEventListener('abort', abort, { once: true })
-      stream.once('error', fail)
-      stream.once('response', (headers) => {
-        const status = Number(headers[':status'] ?? 0)
-        const responseHeaders = new Headers()
-        for (const [key, value] of Object.entries(headers)) {
-          if (key.startsWith(':') || value === undefined) {
-            continue
-          }
-          if (Array.isArray(value)) {
-            value.forEach((item) => responseHeaders.append(key, String(item)))
-          } else {
-            responseHeaders.set(key, String(value))
-          }
-        }
-
-        settled = true
-
-        if (isRedirect(status) && responseHeaders.has('location')) {
-          if (request.redirect === 'error') {
-            stream.resume()
-            request.signal.removeEventListener('abort', abort)
-            releaseStream()
-            reject(new TypeError('fetch failed'))
-            return
-          }
-
-          if (request.redirect === 'follow') {
-            if (redirectCount >= MAX_REDIRECTS) {
-              stream.resume()
-              request.signal.removeEventListener('abort', abort)
-              releaseStream()
-              reject(new TypeError('fetch failed'))
-              return
-            }
-
-            stream.resume()
-            request.signal.removeEventListener('abort', abort)
-            releaseStream()
-
-            const redirectUrl = new URL(responseHeaders.get('location')!, url)
-            const redirectRequest = createRedirectRequest(
-              request,
-              redirectUrl,
-              status,
-              requestBody
-            )
-
-            resolve(
-              this.fetchWithSession(
-                redirectRequest,
-                redirectUrl,
-                redirectCount + 1
-              )
-            )
-            return
-          }
-        }
-
-        if (request.method === 'HEAD' || status === 204 || status === 205) {
-          stream.resume()
-          request.signal.removeEventListener('abort', abort)
-          releaseStream()
-          resolve(new Response(null, { status, headers: responseHeaders }))
-          return
-        }
-
-        let responseBody = new ReadableStream<Uint8Array>({
-          start(controller) {
-            bodyController = controller
-            stream.on('data', (chunk: Buffer) => {
-              if (bodyClosed) {
-                return
-              }
-              controller.enqueue(new Uint8Array(chunk))
-              if ((controller.desiredSize ?? 1) <= 0) {
-                stream.pause()
-              }
-            })
-            stream.once('end', () => closeBody(() => controller.close()))
-            stream.once('error', (error) =>
-              closeBody(() => controller.error(error))
-            )
-          },
-          pull() {
-            stream.resume()
-          },
-          cancel() {
-            closeBody(() => undefined)
-            stream.close(cancelCode)
-          },
-        })
-        responseBody = decodeResponseBody(responseBody, responseHeaders)
-
-        resolve(
-          new Response(responseBody, { status, headers: responseHeaders })
-        )
-      })
-
-      stream.end(requestBody)
-    })
-  }
-
-  private getSession(origin: string) {
-    const current = this.sessions.get(origin)
-    if (current && !current.closed && !current.destroyed) {
-      current.ref()
-      return current
-    }
-
-    const session = this.http2.connect(origin)
-    session.ref()
-    session.once('close', () => {
-      if (this.sessions.get(origin) === session) {
-        this.sessions.delete(origin)
-      }
-    })
-    session.once('error', () => {
-      session.close()
-    })
-    this.sessions.set(origin, session)
-
-    return session
-  }
-
-  private addStream(origin: string) {
-    const timer = this.idleTimers.get(origin)
-    if (timer) {
-      clearTimeout(timer)
-      this.idleTimers.delete(origin)
-    }
-
-    this.activeStreams.set(origin, (this.activeStreams.get(origin) ?? 0) + 1)
-  }
-
-  private removeStream(origin: string) {
-    const active = Math.max((this.activeStreams.get(origin) ?? 1) - 1, 0)
-    if (active > 0) {
-      this.activeStreams.set(origin, active)
-      return
-    }
-
-    this.activeStreams.delete(origin)
-    const session = this.sessions.get(origin)
-    session?.unref()
-    const timer = setTimeout(() => {
-      if (session && !session.closed && !session.destroyed) {
-        session.close()
-      }
-      this.idleTimers.delete(origin)
-    }, this.idleSessionTimeoutMs)
-    ;(timer as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.()
-    this.idleTimers.set(origin, timer)
-  }
-}
-
-function decodeResponseBody(
-  body: ReadableStream<Uint8Array>,
-  headers: Headers
-) {
-  const encoding = headers.get('content-encoding')?.toLowerCase()
-  if (encoding !== 'gzip' && encoding !== 'deflate') {
-    return body
-  }
-
-  headers.delete('content-encoding')
-  headers.delete('content-length')
-
-  return body.pipeThrough(new DecompressionStream(encoding))
-}
-
-function isRedirect(status: number) {
-  return (
-    status === 301 ||
-    status === 302 ||
-    status === 303 ||
-    status === 307 ||
-    status === 308
-  )
-}
-
-function createRedirectRequest(
-  request: Request,
-  url: URL,
-  status: number,
-  body: Buffer | undefined
-) {
-  const headers = new Headers(request.headers)
-  let method = request.method
-  let redirectBody: Buffer | undefined = body
-
-  if (
-    status === 303 ||
-    ((status === 301 || status === 302) && request.method === 'POST')
-  ) {
-    method = 'GET'
-    redirectBody = undefined
-    headers.delete('content-length')
-    headers.delete('content-type')
-  }
-
-  return new Request(url, {
-    body: redirectBody,
-    headers,
-    method,
-    redirect: request.redirect,
-    signal: request.signal,
-  })
+type Undici = typeof import('undici')
+type UndiciDispatcher = InstanceType<Undici['Agent']>
+type UndiciRequestInit = RequestInit & {
+  dispatcher: UndiciDispatcher
+  duplex?: 'half'
 }
 
 let envdFetch: typeof fetch | undefined
 
-type EnvdFetchOptions = {
-  idleSessionTimeoutMs?: number
-}
-
 export function createEnvdFetchForRuntime(
-  currentRuntime = runtime,
-  options: EnvdFetchOptions = {}
+  currentRuntime = runtime
 ): typeof fetch {
   if (currentRuntime !== 'node') {
     return fetch
   }
 
-  const http2 = dynamicRequire<Http2>('node:http2')
-  const client = new NodeHttp2Fetch(http2, options.idleSessionTimeoutMs)
+  const { Agent, fetch: undiciFetch } = dynamicRequire<Undici>('undici')
+  const dispatcher = new Agent({
+    allowH2: true,
+    // Keep one origin connection for h2 multiplexing. If ALPN falls back to h1,
+    // this favors connection pressure over per-sandbox throughput.
+    connections: 1,
+  })
+  const fetchWithDispatcher = undiciFetch as unknown as (
+    input: RequestInfo | URL,
+    init?: UndiciRequestInit
+  ) => Promise<Response>
 
-  return client.fetch
+  return ((input, init) => {
+    const request = toRequestInput(input, init)
+
+    return fetchWithDispatcher(request.input, {
+      ...request.init,
+      dispatcher,
+    })
+  }) as typeof fetch
 }
 
 export function createEnvdFetch(): typeof fetch {
@@ -354,4 +46,38 @@ export function createEnvdFetch(): typeof fetch {
   envdFetch = createEnvdFetchForRuntime(runtime)
 
   return envdFetch
+}
+
+function toRequestInput(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): { input: RequestInfo | URL; init?: RequestInit & { duplex?: 'half' } } {
+  if (!(input instanceof Request)) {
+    return { input, init }
+  }
+
+  const requestInit: RequestInit & { duplex?: 'half' } = {
+    body: input.body,
+    cache: input.cache,
+    credentials: input.credentials,
+    headers: input.headers,
+    integrity: input.integrity,
+    keepalive: input.keepalive,
+    method: input.method,
+    mode: input.mode,
+    redirect: input.redirect,
+    referrer: input.referrer,
+    referrerPolicy: input.referrerPolicy,
+    signal: input.signal,
+    ...init,
+  }
+
+  if (requestInit.body) {
+    requestInit.duplex = 'half'
+  }
+
+  return {
+    input: input.url,
+    init: requestInit,
+  }
 }

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -7,12 +7,14 @@ type ClientHttp2Session = import('node:http2').ClientHttp2Session
 
 class NodeHttp2Fetch {
   private readonly http2: Http2
+  private readonly idleSessionTimeoutMs: number
   private readonly sessions = new Map<string, ClientHttp2Session>()
   private readonly activeStreams = new Map<string, number>()
   private readonly idleTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
-  constructor(http2: Http2) {
+  constructor(http2: Http2, idleSessionTimeoutMs = IDLE_SESSION_TIMEOUT_MS) {
     this.http2 = http2
+    this.idleSessionTimeoutMs = idleSessionTimeoutMs
   }
 
   fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -60,9 +62,13 @@ class NodeHttp2Fetch {
     const stream = session.request(headers)
 
     return new Promise((resolve, reject) => {
+      const cancelCode = this.http2.constants.NGHTTP2_CANCEL
       let settled = false
       let streamReleased = false
       let bodyClosed = false
+      let bodyController:
+        | ReadableStreamDefaultController<Uint8Array>
+        | undefined
 
       const releaseStream = () => {
         if (streamReleased) {
@@ -77,6 +83,7 @@ class NodeHttp2Fetch {
           return
         }
         bodyClosed = true
+        request.signal.removeEventListener('abort', abort)
         releaseStream()
         handle()
       }
@@ -90,9 +97,16 @@ class NodeHttp2Fetch {
         reject(error)
       }
 
+      const abortError = () =>
+        new DOMException('The operation was aborted.', 'AbortError')
+
       const abort = () => {
-        stream.close(this.http2.constants.NGHTTP2_CANCEL)
-        fail(new DOMException('The operation was aborted.', 'AbortError'))
+        stream.close(cancelCode)
+        const controller = bodyController
+        if (controller) {
+          closeBody(() => controller.error(abortError()))
+        }
+        fail(abortError())
       }
 
       if (request.signal.aborted) {
@@ -117,18 +131,18 @@ class NodeHttp2Fetch {
         }
 
         settled = true
-        request.signal.removeEventListener('abort', abort)
 
         if (request.method === 'HEAD' || status === 204 || status === 205) {
           stream.resume()
+          request.signal.removeEventListener('abort', abort)
           releaseStream()
           resolve(new Response(null, { status, headers: responseHeaders }))
           return
         }
 
-        const cancelCode = this.http2.constants.NGHTTP2_CANCEL
         const body = new ReadableStream<Uint8Array>({
           start(controller) {
+            bodyController = controller
             stream.on('data', (chunk: Buffer) => {
               if (bodyClosed) {
                 return
@@ -146,7 +160,6 @@ class NodeHttp2Fetch {
           },
         })
 
-        releaseStream()
         resolve(new Response(body, { status, headers: responseHeaders }))
       })
 
@@ -201,7 +214,7 @@ class NodeHttp2Fetch {
         session.close()
       }
       this.idleTimers.delete(origin)
-    }, IDLE_SESSION_TIMEOUT_MS)
+    }, this.idleSessionTimeoutMs)
     ;(timer as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.()
     this.idleTimers.set(origin, timer)
   }
@@ -209,21 +222,30 @@ class NodeHttp2Fetch {
 
 let envdFetch: typeof fetch | undefined
 
-export function createEnvdFetch(currentRuntime = runtime): typeof fetch {
-  if (currentRuntime === runtime && envdFetch) {
-    return envdFetch
-  }
+type EnvdFetchOptions = {
+  idleSessionTimeoutMs?: number
+}
 
+export function createEnvdFetchForRuntime(
+  currentRuntime = runtime,
+  options: EnvdFetchOptions = {}
+): typeof fetch {
   if (currentRuntime !== 'node') {
     return fetch
   }
 
   const http2 = dynamicRequire<Http2>('node:http2')
-  const client = new NodeHttp2Fetch(http2)
-  const fetcher = client.fetch
-  if (currentRuntime === runtime) {
-    envdFetch = fetcher
+  const client = new NodeHttp2Fetch(http2, options.idleSessionTimeoutMs)
+
+  return client.fetch
+}
+
+export function createEnvdFetch(): typeof fetch {
+  if (envdFetch) {
+    return envdFetch
   }
 
-  return fetcher
+  envdFetch = createEnvdFetchForRuntime(runtime)
+
+  return envdFetch
 }

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -1,6 +1,7 @@
 import { dynamicRequire, runtime } from '../utils'
 
 const IDLE_SESSION_TIMEOUT_MS = 30_000
+const MAX_REDIRECTS = 20
 
 type Http2 = typeof import('node:http2')
 type ClientHttp2Session = import('node:http2').ClientHttp2Session
@@ -22,15 +23,16 @@ class NodeHttp2Fetch {
     const url = new URL(request.url)
     const origin = `${url.protocol}//${url.host}`
 
-    return this.fetchWithSession(origin, request, url)
+    return this.fetchWithSession(origin, request, url, 0)
   }
 
   private async fetchWithSession(
     origin: string,
     request: Request,
-    url: URL
+    url: URL,
+    redirectCount: number
   ): Promise<Response> {
-    const body =
+    const requestBody =
       request.method === 'GET' || request.method === 'HEAD'
         ? undefined
         : Buffer.from(await request.arrayBuffer())
@@ -133,6 +135,48 @@ class NodeHttp2Fetch {
 
         settled = true
 
+        if (isRedirect(status) && responseHeaders.has('location')) {
+          if (request.redirect === 'error') {
+            stream.resume()
+            request.signal.removeEventListener('abort', abort)
+            releaseStream()
+            reject(new TypeError('fetch failed'))
+            return
+          }
+
+          if (request.redirect === 'follow') {
+            if (redirectCount >= MAX_REDIRECTS) {
+              stream.resume()
+              request.signal.removeEventListener('abort', abort)
+              releaseStream()
+              reject(new TypeError('fetch failed'))
+              return
+            }
+
+            stream.resume()
+            request.signal.removeEventListener('abort', abort)
+            releaseStream()
+
+            const redirectUrl = new URL(responseHeaders.get('location')!, url)
+            const redirectRequest = createRedirectRequest(
+              request,
+              redirectUrl,
+              status,
+              requestBody
+            )
+
+            resolve(
+              this.fetchWithSession(
+                `${redirectUrl.protocol}//${redirectUrl.host}`,
+                redirectRequest,
+                redirectUrl,
+                redirectCount + 1
+              )
+            )
+            return
+          }
+        }
+
         if (request.method === 'HEAD' || status === 204 || status === 205) {
           stream.resume()
           request.signal.removeEventListener('abort', abort)
@@ -141,7 +185,7 @@ class NodeHttp2Fetch {
           return
         }
 
-        const body = new ReadableStream<Uint8Array>({
+        const responseBody = new ReadableStream<Uint8Array>({
           start(controller) {
             bodyController = controller
             stream.on('data', (chunk: Buffer) => {
@@ -161,10 +205,10 @@ class NodeHttp2Fetch {
           },
         })
 
-        resolve(new Response(body, { status, headers: responseHeaders }))
+        resolve(new Response(responseBody, { status, headers: responseHeaders }))
       })
 
-      stream.end(body)
+      stream.end(requestBody)
     })
   }
 
@@ -219,6 +263,45 @@ class NodeHttp2Fetch {
     ;(timer as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.()
     this.idleTimers.set(origin, timer)
   }
+}
+
+function isRedirect(status: number) {
+  return (
+    status === 301 ||
+    status === 302 ||
+    status === 303 ||
+    status === 307 ||
+    status === 308
+  )
+}
+
+function createRedirectRequest(
+  request: Request,
+  url: URL,
+  status: number,
+  body: Buffer | undefined
+) {
+  const headers = new Headers(request.headers)
+  let method = request.method
+  let redirectBody: Buffer | undefined = body
+
+  if (
+    status === 303 ||
+    ((status === 301 || status === 302) && request.method === 'POST')
+  ) {
+    method = 'GET'
+    redirectBody = undefined
+    headers.delete('content-length')
+    headers.delete('content-type')
+  }
+
+  return new Request(url, {
+    body: redirectBody,
+    headers,
+    method,
+    redirect: request.redirect,
+    signal: request.signal,
+  })
 }
 
 let envdFetch: typeof fetch | undefined

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -183,7 +183,7 @@ class NodeHttp2Fetch {
           return
         }
 
-        const responseBody = new ReadableStream<Uint8Array>({
+        let responseBody = new ReadableStream<Uint8Array>({
           start(controller) {
             bodyController = controller
             stream.on('data', (chunk: Buffer) => {
@@ -208,6 +208,7 @@ class NodeHttp2Fetch {
             stream.close(cancelCode)
           },
         })
+        responseBody = decodeResponseBody(responseBody, responseHeaders)
 
         resolve(
           new Response(responseBody, { status, headers: responseHeaders })
@@ -269,6 +270,21 @@ class NodeHttp2Fetch {
     ;(timer as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.()
     this.idleTimers.set(origin, timer)
   }
+}
+
+function decodeResponseBody(
+  body: ReadableStream<Uint8Array>,
+  headers: Headers
+) {
+  const encoding = headers.get('content-encoding')?.toLowerCase()
+  if (encoding !== 'gzip' && encoding !== 'deflate') {
+    return body
+  }
+
+  headers.delete('content-encoding')
+  headers.delete('content-length')
+
+  return body.pipeThrough(new DecompressionStream(encoding))
 }
 
 function isRedirect(status: number) {

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -1,6 +1,6 @@
 import { dynamicRequire, runtime } from '../utils'
 
-const MAX_CONCURRENT_STREAMS = 80
+const IDLE_SESSION_TIMEOUT_MS = 30_000
 
 type Http2 = typeof import('node:http2')
 type ClientHttp2Session = import('node:http2').ClientHttp2Session
@@ -9,7 +9,7 @@ class NodeHttp2Fetch {
   private readonly http2: Http2
   private readonly sessions = new Map<string, ClientHttp2Session>()
   private readonly activeStreams = new Map<string, number>()
-  private readonly streamWaiters = new Map<string, Array<() => void>>()
+  private readonly idleTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
   constructor(http2: Http2) {
     this.http2 = http2
@@ -20,16 +20,19 @@ class NodeHttp2Fetch {
     const url = new URL(request.url)
     const origin = `${url.protocol}//${url.host}`
 
-    return this.withStreamSlot(origin, () =>
-      this.fetchWithSlot(origin, request, url)
-    )
+    return this.fetchWithSession(origin, request, url)
   }
 
-  private async fetchWithSlot(
+  private async fetchWithSession(
     origin: string,
     request: Request,
     url: URL
   ): Promise<Response> {
+    const body =
+      request.method === 'GET' || request.method === 'HEAD'
+        ? undefined
+        : Buffer.from(await request.arrayBuffer())
+    this.addStream(origin)
     const session = this.getSession(origin)
     const headers: import('node:http2').OutgoingHttpHeaders = {
       ':method': request.method,
@@ -55,19 +58,35 @@ class NodeHttp2Fetch {
     })
 
     const stream = session.request(headers)
-    const body =
-      request.method === 'GET' || request.method === 'HEAD'
-        ? undefined
-        : Buffer.from(await request.arrayBuffer())
 
     return new Promise((resolve, reject) => {
       let settled = false
+      let streamReleased = false
+      let bodyClosed = false
+
+      const releaseStream = () => {
+        if (streamReleased) {
+          return
+        }
+        streamReleased = true
+        this.removeStream(origin)
+      }
+
+      const closeBody = (handle: () => void) => {
+        if (bodyClosed) {
+          return
+        }
+        bodyClosed = true
+        releaseStream()
+        handle()
+      }
 
       const fail = (error: Error) => {
         if (settled) {
           return
         }
         settled = true
+        releaseStream()
         reject(error)
       }
 
@@ -102,6 +121,7 @@ class NodeHttp2Fetch {
 
         if (request.method === 'HEAD' || status === 204 || status === 205) {
           stream.resume()
+          releaseStream()
           resolve(new Response(null, { status, headers: responseHeaders }))
           return
         }
@@ -110,16 +130,23 @@ class NodeHttp2Fetch {
         const body = new ReadableStream<Uint8Array>({
           start(controller) {
             stream.on('data', (chunk: Buffer) => {
+              if (bodyClosed) {
+                return
+              }
               controller.enqueue(new Uint8Array(chunk))
             })
-            stream.once('end', () => controller.close())
-            stream.once('error', (error) => controller.error(error))
+            stream.once('end', () => closeBody(() => controller.close()))
+            stream.once('error', (error) =>
+              closeBody(() => controller.error(error))
+            )
           },
           cancel() {
+            closeBody(() => undefined)
             stream.close(cancelCode)
           },
         })
 
+        releaseStream()
         resolve(new Response(body, { status, headers: responseHeaders }))
       })
 
@@ -130,10 +157,12 @@ class NodeHttp2Fetch {
   private getSession(origin: string) {
     const current = this.sessions.get(origin)
     if (current && !current.closed && !current.destroyed) {
+      current.ref()
       return current
     }
 
     const session = this.http2.connect(origin)
+    session.ref()
     session.once('close', () => {
       if (this.sessions.get(origin) === session) {
         this.sessions.delete(origin)
@@ -147,40 +176,54 @@ class NodeHttp2Fetch {
     return session
   }
 
-  private async withStreamSlot<T>(origin: string, fn: () => Promise<T>) {
-    while ((this.activeStreams.get(origin) ?? 0) >= MAX_CONCURRENT_STREAMS) {
-      await new Promise<void>((resolve) => {
-        const waiters = this.streamWaiters.get(origin) ?? []
-        waiters.push(resolve)
-        this.streamWaiters.set(origin, waiters)
-      })
+  private addStream(origin: string) {
+    const timer = this.idleTimers.get(origin)
+    if (timer) {
+      clearTimeout(timer)
+      this.idleTimers.delete(origin)
     }
 
     this.activeStreams.set(origin, (this.activeStreams.get(origin) ?? 0) + 1)
-    try {
-      return await fn()
-    } finally {
-      this.activeStreams.set(origin, (this.activeStreams.get(origin) ?? 1) - 1)
-      this.streamWaiters.get(origin)?.shift()?.()
+  }
+
+  private removeStream(origin: string) {
+    const active = Math.max((this.activeStreams.get(origin) ?? 1) - 1, 0)
+    if (active > 0) {
+      this.activeStreams.set(origin, active)
+      return
     }
+
+    this.activeStreams.delete(origin)
+    const session = this.sessions.get(origin)
+    session?.unref()
+    const timer = setTimeout(() => {
+      if (session && !session.closed && !session.destroyed) {
+        session.close()
+      }
+      this.idleTimers.delete(origin)
+    }, IDLE_SESSION_TIMEOUT_MS)
+    ;(timer as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.()
+    this.idleTimers.set(origin, timer)
   }
 }
 
 let envdFetch: typeof fetch | undefined
 
-export function createEnvdFetch(): typeof fetch {
-  if (envdFetch) {
+export function createEnvdFetch(currentRuntime = runtime): typeof fetch {
+  if (currentRuntime === runtime && envdFetch) {
     return envdFetch
   }
 
-  if (runtime !== 'node') {
-    envdFetch = fetch
-    return envdFetch
+  if (currentRuntime !== 'node') {
+    return fetch
   }
 
   const http2 = dynamicRequire<Http2>('node:http2')
   const client = new NodeHttp2Fetch(http2)
-  envdFetch = client.fetch
+  const fetcher = client.fetch
+  if (currentRuntime === runtime) {
+    envdFetch = fetcher
+  }
 
-  return envdFetch
+  return fetcher
 }

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -1,0 +1,186 @@
+import { dynamicRequire, runtime } from '../utils'
+
+const MAX_CONCURRENT_STREAMS = 80
+
+type Http2 = typeof import('node:http2')
+type ClientHttp2Session = import('node:http2').ClientHttp2Session
+
+class NodeHttp2Fetch {
+  private readonly http2: Http2
+  private readonly sessions = new Map<string, ClientHttp2Session>()
+  private readonly activeStreams = new Map<string, number>()
+  private readonly streamWaiters = new Map<string, Array<() => void>>()
+
+  constructor(http2: Http2) {
+    this.http2 = http2
+  }
+
+  fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init)
+    const url = new URL(request.url)
+    const origin = `${url.protocol}//${url.host}`
+
+    return this.withStreamSlot(origin, () =>
+      this.fetchWithSlot(origin, request, url)
+    )
+  }
+
+  private async fetchWithSlot(
+    origin: string,
+    request: Request,
+    url: URL
+  ): Promise<Response> {
+    const session = this.getSession(origin)
+    const headers: import('node:http2').OutgoingHttpHeaders = {
+      ':method': request.method,
+      ':scheme': url.protocol.slice(0, -1),
+      ':authority': url.host,
+      ':path': `${url.pathname}${url.search}`,
+    }
+
+    request.headers.forEach((value, key) => {
+      const lower = key.toLowerCase()
+      if (
+        lower === 'connection' ||
+        lower === 'host' ||
+        lower === 'keep-alive' ||
+        lower === 'proxy-connection' ||
+        lower === 'transfer-encoding' ||
+        lower === 'upgrade'
+      ) {
+        return
+      }
+
+      headers[lower] = value
+    })
+
+    const stream = session.request(headers)
+    const body =
+      request.method === 'GET' || request.method === 'HEAD'
+        ? undefined
+        : Buffer.from(await request.arrayBuffer())
+
+    return new Promise((resolve, reject) => {
+      let settled = false
+
+      const fail = (error: Error) => {
+        if (settled) {
+          return
+        }
+        settled = true
+        reject(error)
+      }
+
+      const abort = () => {
+        stream.close(this.http2.constants.NGHTTP2_CANCEL)
+        fail(new DOMException('The operation was aborted.', 'AbortError'))
+      }
+
+      if (request.signal.aborted) {
+        abort()
+        return
+      }
+
+      request.signal.addEventListener('abort', abort, { once: true })
+      stream.once('error', fail)
+      stream.once('response', (headers) => {
+        const status = Number(headers[':status'] ?? 0)
+        const responseHeaders = new Headers()
+        for (const [key, value] of Object.entries(headers)) {
+          if (key.startsWith(':') || value === undefined) {
+            continue
+          }
+          if (Array.isArray(value)) {
+            value.forEach((item) => responseHeaders.append(key, String(item)))
+          } else {
+            responseHeaders.set(key, String(value))
+          }
+        }
+
+        settled = true
+        request.signal.removeEventListener('abort', abort)
+
+        if (request.method === 'HEAD' || status === 204 || status === 205) {
+          stream.resume()
+          resolve(new Response(null, { status, headers: responseHeaders }))
+          return
+        }
+
+        const cancelCode = this.http2.constants.NGHTTP2_CANCEL
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            stream.on('data', (chunk: Buffer) => {
+              controller.enqueue(new Uint8Array(chunk))
+            })
+            stream.once('end', () => controller.close())
+            stream.once('error', (error) => controller.error(error))
+          },
+          cancel() {
+            stream.close(cancelCode)
+          },
+        })
+
+        resolve(new Response(body, { status, headers: responseHeaders }))
+      })
+
+      stream.end(body)
+    })
+  }
+
+  private getSession(origin: string) {
+    const current = this.sessions.get(origin)
+    if (current && !current.closed && !current.destroyed) {
+      return current
+    }
+
+    const session = this.http2.connect(origin)
+    session.once('close', () => {
+      if (this.sessions.get(origin) === session) {
+        this.sessions.delete(origin)
+      }
+    })
+    session.once('error', () => {
+      session.close()
+    })
+    this.sessions.set(origin, session)
+
+    return session
+  }
+
+  private async withStreamSlot<T>(origin: string, fn: () => Promise<T>) {
+    while ((this.activeStreams.get(origin) ?? 0) >= MAX_CONCURRENT_STREAMS) {
+      await new Promise<void>((resolve) => {
+        const waiters = this.streamWaiters.get(origin) ?? []
+        waiters.push(resolve)
+        this.streamWaiters.set(origin, waiters)
+      })
+    }
+
+    this.activeStreams.set(origin, (this.activeStreams.get(origin) ?? 0) + 1)
+    try {
+      return await fn()
+    } finally {
+      this.activeStreams.set(origin, (this.activeStreams.get(origin) ?? 1) - 1)
+      this.streamWaiters.get(origin)?.shift()?.()
+    }
+  }
+}
+
+let envdFetch: typeof fetch | undefined
+
+export function createEnvdFetch(): typeof fetch {
+  if (envdFetch) {
+    return envdFetch
+  }
+
+  if (runtime !== 'node') {
+    envdFetch = fetch
+    return envdFetch
+  }
+
+  const http2 = dynamicRequire<Http2>('node:http2')
+  const client = new NodeHttp2Fetch(http2)
+  envdFetch = client.fetch
+
+  return envdFetch
+}

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -6,23 +6,29 @@ type UndiciRequestInit = RequestInit & {
   dispatcher: UndiciDispatcher
   duplex?: 'half'
 }
+type EnvdFetchOptions = {
+  connectionLimit?: number
+}
 
 let envdFetch: typeof fetch | undefined
+let envdRpcFetch: typeof fetch | undefined
 
 export function createEnvdFetchForRuntime(
-  currentRuntime = runtime
+  currentRuntime = runtime,
+  options: EnvdFetchOptions = { connectionLimit: 1 }
 ): typeof fetch {
   if (currentRuntime !== 'node') {
     return fetch
   }
 
   const { Agent, fetch: undiciFetch } = dynamicRequire<Undici>('undici')
-  const dispatcher = new Agent({
+  const dispatcherOptions: { allowH2: true; connections?: number } = {
     allowH2: true,
-    // Keep one origin connection for h2 multiplexing. If ALPN falls back to h1,
-    // this favors connection pressure over per-sandbox throughput.
-    connections: 1,
-  })
+  }
+  if (options.connectionLimit !== undefined) {
+    dispatcherOptions.connections = options.connectionLimit
+  }
+  const dispatcher = new Agent(dispatcherOptions)
   const fetchWithDispatcher = undiciFetch as unknown as (
     input: RequestInfo | URL,
     init?: UndiciRequestInit
@@ -43,9 +49,23 @@ export function createEnvdFetch(): typeof fetch {
     return envdFetch
   }
 
+  // Keep one origin connection for short envd REST calls. If ALPN falls back
+  // to h1, this favors connection pressure over per-sandbox throughput.
   envdFetch = createEnvdFetchForRuntime(runtime)
 
   return envdFetch
+}
+
+export function createEnvdRpcFetch(): typeof fetch {
+  if (envdRpcFetch) {
+    return envdRpcFetch
+  }
+
+  // RPC streams can stay open while follow-up RPCs run against the same
+  // sandbox, so they cannot share the REST client's single-connection cap.
+  envdRpcFetch = createEnvdFetchForRuntime(runtime, {})
+
+  return envdRpcFetch
 }
 
 function toRequestInput(

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -34,7 +34,6 @@ class NodeHttp2Fetch {
       request.method === 'GET' || request.method === 'HEAD'
         ? undefined
         : Buffer.from(await request.arrayBuffer())
-    this.addStream(origin)
     const session = this.getSession(origin)
     const headers: import('node:http2').OutgoingHttpHeaders = {
       ':method': request.method,
@@ -60,6 +59,7 @@ class NodeHttp2Fetch {
     })
 
     const stream = session.request(headers)
+    this.addStream(origin)
 
     return new Promise((resolve, reject) => {
       const cancelCode = this.http2.constants.NGHTTP2_CANCEL

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -93,6 +93,7 @@ class NodeHttp2Fetch {
           return
         }
         settled = true
+        request.signal.removeEventListener('abort', abort)
         releaseStream()
         reject(error)
       }

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -209,7 +209,9 @@ class NodeHttp2Fetch {
           },
         })
 
-        resolve(new Response(responseBody, { status, headers: responseHeaders }))
+        resolve(
+          new Response(responseBody, { status, headers: responseHeaders })
+        )
       })
 
       stream.end(requestBody)

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -21,17 +21,16 @@ class NodeHttp2Fetch {
   fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = new Request(input, init)
     const url = new URL(request.url)
-    const origin = `${url.protocol}//${url.host}`
 
-    return this.fetchWithSession(origin, request, url, 0)
+    return this.fetchWithSession(request, url, 0)
   }
 
   private async fetchWithSession(
-    origin: string,
     request: Request,
     url: URL,
     redirectCount: number
   ): Promise<Response> {
+    const origin = `${url.protocol}//${url.host}`
     const requestBody =
       request.method === 'GET' || request.method === 'HEAD'
         ? undefined
@@ -167,7 +166,6 @@ class NodeHttp2Fetch {
 
             resolve(
               this.fetchWithSession(
-                `${redirectUrl.protocol}//${redirectUrl.host}`,
                 redirectRequest,
                 redirectUrl,
                 redirectCount + 1

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -8,6 +8,7 @@ import {
   Username,
 } from '../connectionConfig'
 import { EnvdApiClient, handleEnvdApiError } from '../envd/api'
+import { createEnvdFetch } from '../envd/http2'
 import { createRpcLogger } from '../logs'
 import { Commands, Pty } from './commands'
 import { Filesystem } from './filesystem'
@@ -150,6 +151,7 @@ export class Sandbox extends SandboxApi {
       'E2b-Sandbox-Id': this.sandboxId,
       'E2b-Sandbox-Port': this.envdPort.toString(),
     }
+    const envdFetch = createEnvdFetch()
 
     const rpcTransport = createConnectTransport({
       baseUrl: this.envdApiUrl,
@@ -179,7 +181,7 @@ export class Sandbox extends SandboxApi {
           redirect: 'follow',
         }
 
-        return fetch(url, options)
+        return envdFetch(url, options)
       },
     })
 
@@ -195,6 +197,7 @@ export class Sandbox extends SandboxApi {
             ? { 'X-Access-Token': this.envdAccessToken }
             : {}),
         },
+        fetch: (request) => envdFetch(request),
       },
       {
         version: opts.envdVersion,

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -8,7 +8,7 @@ import {
   Username,
 } from '../connectionConfig'
 import { EnvdApiClient, handleEnvdApiError } from '../envd/api'
-import { createEnvdFetch } from '../envd/http2'
+import { createEnvdFetch, createEnvdRpcFetch } from '../envd/http2'
 import { createRpcLogger } from '../logs'
 import { Commands, Pty } from './commands'
 import { Filesystem } from './filesystem'
@@ -152,6 +152,7 @@ export class Sandbox extends SandboxApi {
       'E2b-Sandbox-Port': this.envdPort.toString(),
     }
     const envdFetch = createEnvdFetch()
+    const envdRpcFetch = createEnvdRpcFetch()
 
     const rpcTransport = createConnectTransport({
       baseUrl: this.envdApiUrl,
@@ -181,7 +182,7 @@ export class Sandbox extends SandboxApi {
           redirect: 'follow',
         }
 
-        return fetch(url, options)
+        return envdRpcFetch(url, options)
       },
     })
 

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -181,7 +181,7 @@ export class Sandbox extends SandboxApi {
           redirect: 'follow',
         }
 
-        return envdFetch(url, options)
+        return fetch(url, options)
       },
     })
 

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -67,6 +67,29 @@ test('passes Request objects to undici as URL plus init', async () => {
   expect(requests[0].init?.body).toBeInstanceOf(ReadableStream)
 })
 
+test('can create an uncapped dispatcher for RPC streams', async () => {
+  const agents: Array<{ allowH2?: boolean; connections?: number }> = []
+
+  class Agent {
+    constructor(options: { allowH2?: boolean; connections?: number }) {
+      agents.push(options)
+    }
+  }
+
+  const undiciFetch = vi.fn(() => Promise.resolve(new Response('ok')))
+
+  vi.doMock('../../src/utils', () => ({
+    dynamicRequire: () => ({ Agent, fetch: undiciFetch }),
+    runtime: 'node',
+  }))
+  const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
+
+  const fetcher = createEnvdFetchForRuntime('node', {})
+  await fetcher('https://example.com/rpc')
+
+  expect(agents).toEqual([{ allowH2: true }])
+})
+
 test('uses global fetch outside Node', async () => {
   const fallbackFetch = vi.fn() as unknown as typeof fetch
   vi.stubGlobal('fetch', fallbackFetch)

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -141,6 +141,45 @@ test('body cancel is safe', async () => {
   await expect(res.body!.cancel()).resolves.toBeUndefined()
 })
 
+test('pauses streaming response bodies when the reader is behind', async () => {
+  const calls = { pause: 0, resume: 0 }
+  const connect = http2.connect
+  vi.spyOn(http2, 'connect').mockImplementation((...args) => {
+    const session = connect(...args)
+    const request = session.request.bind(session)
+    vi.spyOn(session, 'request').mockImplementation((...requestArgs) => {
+      const stream = request(...requestArgs)
+      const pause = stream.pause.bind(stream)
+      const resume = stream.resume.bind(stream)
+      vi.spyOn(stream, 'pause').mockImplementation(() => {
+        calls.pause += 1
+        return pause()
+      })
+      vi.spyOn(stream, 'resume').mockImplementation(() => {
+        calls.resume += 1
+        return resume()
+      })
+
+      return stream
+    })
+
+    return session
+  })
+  const origin = await startServer((stream) => {
+    stream.respond({ ':status': 200 })
+    stream.write('first')
+    stream.write('second')
+    setTimeout(() => stream.end(), 20)
+  })
+
+  const res = await createEnvdFetchForRuntime('node')(`${origin}/stream`)
+  await new Promise((resolve) => setTimeout(resolve, 10))
+
+  expect(calls.pause).toBeGreaterThan(0)
+  await expect(res.text()).resolves.toBe('firstsecond')
+  expect(calls.resume).toBeGreaterThan(0)
+})
+
 test('keeps session open while response body is streaming', async () => {
   const origin = await startServer((stream) => {
     stream.respond({ ':status': 200 })

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -1,211 +1,78 @@
-import http2 from 'node:http2'
-import { AddressInfo } from 'node:net'
-import { gzipSync } from 'node:zlib'
-import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 
-import { createEnvdFetchForRuntime } from '../../src/envd/http2'
-
-let server: http2.Http2Server | undefined
-let serverSessions: Set<http2.ServerHttp2Session>
-
-async function startServer(
-  handle: (
-    stream: http2.ServerHttp2Stream,
-    headers: http2.IncomingHttpHeaders
-  ) => void
-) {
-  server = http2.createServer()
-  server.on('session', (session) => {
-    serverSessions.add(session)
-    session.once('close', () => serverSessions.delete(session))
-  })
-  server.on('stream', handle)
-  await new Promise<void>((resolve) => server!.listen(0, resolve))
-  const address = server.address() as AddressInfo
-
-  return `http://127.0.0.1:${address.port}`
-}
-
-beforeEach(() => {
-  server = undefined
-  serverSessions = new Set()
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+  vi.doUnmock('../../src/utils')
 })
 
-afterEach(async () => {
-  vi.restoreAllMocks()
-  if (!server) {
-    return
+test('uses undici with HTTP/2 enabled in Node', async () => {
+  const agents: Array<{ allowH2?: boolean; connections?: number }> = []
+  const requests: Array<{ init?: RequestInit & { dispatcher?: unknown } }> = []
+
+  class Agent {
+    constructor(options: { allowH2?: boolean; connections?: number }) {
+      agents.push(options)
+    }
   }
 
-  serverSessions.forEach((session) => session.destroy())
-  await new Promise<void>((resolve, reject) => {
-    server!.close((error) => {
-      if (error) {
-        reject(error)
-        return
-      }
-      resolve()
+  const undiciFetch = vi.fn((input, init) => {
+    requests.push({ init })
+    return Promise.resolve(new Response('ok'))
+  })
+
+  vi.doMock('../../src/utils', () => ({
+    dynamicRequire: () => ({ Agent, fetch: undiciFetch }),
+    runtime: 'node',
+  }))
+  const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
+
+  const fetcher = createEnvdFetchForRuntime('node')
+  const res = await fetcher('https://example.com/status')
+
+  expect(await res.text()).toBe('ok')
+  expect(agents).toEqual([{ allowH2: true, connections: 1 }])
+  expect(requests[0].init?.dispatcher).toBeInstanceOf(Agent)
+})
+
+test('passes Request objects to undici as URL plus init', async () => {
+  const requests: Array<{ input: RequestInfo | URL; init?: RequestInit }> = []
+
+  class Agent {}
+
+  const undiciFetch = vi.fn((input, init) => {
+    requests.push({ input, init })
+    return Promise.resolve(new Response('ok'))
+  })
+
+  vi.doMock('../../src/utils', () => ({
+    dynamicRequire: () => ({ Agent, fetch: undiciFetch }),
+    runtime: 'node',
+  }))
+  const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
+
+  const fetcher = createEnvdFetchForRuntime('node')
+  const body = JSON.stringify({ ok: true })
+  await fetcher(
+    new Request('https://example.com/rpc', {
+      body,
+      headers: { 'content-type': 'application/json' },
+      method: 'POST',
     })
-  })
+  )
+
+  expect(requests[0].input).toBe('https://example.com/rpc')
+  expect(requests[0].init?.method).toBe('POST')
+  expect(requests[0].init?.headers).toBeInstanceOf(Headers)
+  expect(requests[0].init?.body).toBeInstanceOf(ReadableStream)
 })
 
-test('uses HTTP/2 in Node', async () => {
-  const origin = await startServer((stream, headers) => {
-    expect(headers[':method']).toBe('GET')
-    stream.respond({ ':status': 200, 'content-type': 'application/json' })
-    stream.end(JSON.stringify({ protocol: 'h2' }))
-  })
-
-  const res = await createEnvdFetchForRuntime('node')(`${origin}/status`)
-
-  expect(res.status).toBe(200)
-  await expect(res.json()).resolves.toEqual({ protocol: 'h2' })
-})
-
-test('uses global fetch outside Node', () => {
-  const originalFetch = globalThis.fetch
+test('uses global fetch outside Node', async () => {
   const fallbackFetch = vi.fn() as unknown as typeof fetch
-  globalThis.fetch = fallbackFetch
+  vi.stubGlobal('fetch', fallbackFetch)
+
+  const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
 
   expect(createEnvdFetchForRuntime('browser')).toBe(fallbackFetch)
   expect(createEnvdFetchForRuntime('vercel-edge')).toBe(fallbackFetch)
-
-  globalThis.fetch = originalFetch
-})
-
-test('rejects aborted requests', async () => {
-  const origin = await startServer(() => undefined)
-  const controller = new AbortController()
-  const promise = createEnvdFetchForRuntime('node')(`${origin}/wait`, {
-    signal: controller.signal,
-  })
-
-  controller.abort()
-
-  await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
-})
-
-test('follows redirects', async () => {
-  const origin = await startServer((stream, headers) => {
-    if (headers[':path'] === '/redirect') {
-      stream.respond({ ':status': 302, location: '/done' })
-      stream.end()
-      return
-    }
-
-    stream.respond({ ':status': 200 })
-    stream.end('ok')
-  })
-
-  const res = await createEnvdFetchForRuntime('node')(`${origin}/redirect`)
-
-  expect(res.status).toBe(200)
-  await expect(res.text()).resolves.toBe('ok')
-})
-
-test('rejects redirects when redirect mode is error', async () => {
-  const origin = await startServer((stream) => {
-    stream.respond({ ':status': 302, location: '/done' })
-    stream.end()
-  })
-
-  const res = createEnvdFetchForRuntime('node')(`${origin}/redirect`, {
-    redirect: 'error',
-  })
-
-  await expect(res).rejects.toThrow(TypeError)
-})
-
-test('aborts streaming response bodies', async () => {
-  const origin = await startServer((stream) => {
-    stream.respond({ ':status': 200 })
-    stream.write('chunk')
-  })
-  const controller = new AbortController()
-  const res = await createEnvdFetchForRuntime('node')(`${origin}/stream`, {
-    signal: controller.signal,
-  })
-
-  controller.abort()
-
-  await expect(res.text()).rejects.toMatchObject({ name: 'AbortError' })
-})
-
-test('body cancel is safe', async () => {
-  const origin = await startServer((stream) => {
-    stream.respond({ ':status': 200 })
-    stream.write('chunk')
-  })
-
-  const res = await createEnvdFetchForRuntime('node')(`${origin}/stream`)
-
-  await expect(res.body!.cancel()).resolves.toBeUndefined()
-})
-
-test('decodes gzip responses', async () => {
-  const origin = await startServer((stream) => {
-    stream.respond({ ':status': 200, 'content-encoding': 'gzip' })
-    stream.end(gzipSync('compressed'))
-  })
-
-  const res = await createEnvdFetchForRuntime('node')(`${origin}/gzip`)
-
-  expect(res.headers.has('content-encoding')).toBe(false)
-  await expect(res.text()).resolves.toBe('compressed')
-})
-
-test('pauses streaming response bodies when the reader is behind', async () => {
-  const calls = { pause: 0, resume: 0 }
-  const connect = http2.connect
-  vi.spyOn(http2, 'connect').mockImplementation((...args) => {
-    const session = connect(...args)
-    const request = session.request.bind(session)
-    vi.spyOn(session, 'request').mockImplementation((...requestArgs) => {
-      const stream = request(...requestArgs)
-      const pause = stream.pause.bind(stream)
-      const resume = stream.resume.bind(stream)
-      vi.spyOn(stream, 'pause').mockImplementation(() => {
-        calls.pause += 1
-        return pause()
-      })
-      vi.spyOn(stream, 'resume').mockImplementation(() => {
-        calls.resume += 1
-        return resume()
-      })
-
-      return stream
-    })
-
-    return session
-  })
-  const origin = await startServer((stream) => {
-    stream.respond({ ':status': 200 })
-    stream.write('first')
-    stream.write('second')
-    setTimeout(() => stream.end(), 20)
-  })
-
-  const res = await createEnvdFetchForRuntime('node')(`${origin}/stream`)
-  await new Promise((resolve) => setTimeout(resolve, 10))
-
-  expect(calls.pause).toBeGreaterThan(0)
-  await expect(res.text()).resolves.toBe('firstsecond')
-  expect(calls.resume).toBeGreaterThan(0)
-})
-
-test('keeps session open while response body is streaming', async () => {
-  const origin = await startServer((stream) => {
-    stream.respond({ ':status': 200 })
-    stream.write('start')
-    setTimeout(() => {
-      stream.end('end')
-    }, 50)
-  })
-
-  const envdFetch = createEnvdFetchForRuntime('node', {
-    idleSessionTimeoutMs: 10,
-  })
-  const res = await envdFetch(`${origin}/stream`)
-
-  await expect(res.text()).resolves.toBe('startend')
 })

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -84,6 +84,37 @@ test('rejects aborted requests', async () => {
   await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
 })
 
+test('follows redirects', async () => {
+  const origin = await startServer((stream, headers) => {
+    if (headers[':path'] === '/redirect') {
+      stream.respond({ ':status': 302, location: '/done' })
+      stream.end()
+      return
+    }
+
+    stream.respond({ ':status': 200 })
+    stream.end('ok')
+  })
+
+  const res = await createEnvdFetchForRuntime('node')(`${origin}/redirect`)
+
+  expect(res.status).toBe(200)
+  await expect(res.text()).resolves.toBe('ok')
+})
+
+test('rejects redirects when redirect mode is error', async () => {
+  const origin = await startServer((stream) => {
+    stream.respond({ ':status': 302, location: '/done' })
+    stream.end()
+  })
+
+  const res = createEnvdFetchForRuntime('node')(`${origin}/redirect`, {
+    redirect: 'error',
+  })
+
+  await expect(res).rejects.toThrow(TypeError)
+})
+
 test('aborts streaming response bodies', async () => {
   const origin = await startServer((stream) => {
     stream.respond({ ':status': 200 })

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -1,0 +1,96 @@
+import http2 from 'node:http2'
+import { AddressInfo } from 'node:net'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+
+import { createEnvdFetch } from '../../src/envd/http2'
+
+let server: http2.Http2Server | undefined
+let serverSessions: Set<http2.ServerHttp2Session>
+
+async function startServer(
+  handle: (
+    stream: http2.ServerHttp2Stream,
+    headers: http2.IncomingHttpHeaders
+  ) => void
+) {
+  server = http2.createServer()
+  server.on('session', (session) => {
+    serverSessions.add(session)
+    session.once('close', () => serverSessions.delete(session))
+  })
+  server.on('stream', handle)
+  await new Promise<void>((resolve) => server!.listen(0, resolve))
+  const address = server.address() as AddressInfo
+
+  return `http://127.0.0.1:${address.port}`
+}
+
+beforeEach(() => {
+  server = undefined
+  serverSessions = new Set()
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  if (!server) {
+    return
+  }
+
+  serverSessions.forEach((session) => session.destroy())
+  await new Promise<void>((resolve, reject) => {
+    server!.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+})
+
+test('uses HTTP/2 in Node', async () => {
+  const origin = await startServer((stream, headers) => {
+    expect(headers[':method']).toBe('GET')
+    stream.respond({ ':status': 200, 'content-type': 'application/json' })
+    stream.end(JSON.stringify({ protocol: 'h2' }))
+  })
+
+  const res = await createEnvdFetch('node')(`${origin}/status`)
+
+  expect(res.status).toBe(200)
+  await expect(res.json()).resolves.toEqual({ protocol: 'h2' })
+})
+
+test('uses global fetch outside Node', () => {
+  const originalFetch = globalThis.fetch
+  const fallbackFetch = vi.fn() as unknown as typeof fetch
+  globalThis.fetch = fallbackFetch
+
+  expect(createEnvdFetch('browser')).toBe(fallbackFetch)
+  expect(createEnvdFetch('vercel-edge')).toBe(fallbackFetch)
+
+  globalThis.fetch = originalFetch
+})
+
+test('rejects aborted requests', async () => {
+  const origin = await startServer(() => undefined)
+  const controller = new AbortController()
+  const promise = createEnvdFetch('node')(`${origin}/wait`, {
+    signal: controller.signal,
+  })
+
+  controller.abort()
+
+  await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+})
+
+test('body cancel is safe', async () => {
+  const origin = await startServer((stream) => {
+    stream.respond({ ':status': 200 })
+    stream.write('chunk')
+  })
+
+  const res = await createEnvdFetch('node')(`${origin}/stream`)
+
+  await expect(res.body!.cancel()).resolves.toBeUndefined()
+})

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -2,7 +2,7 @@ import http2 from 'node:http2'
 import { AddressInfo } from 'node:net'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
-import { createEnvdFetch } from '../../src/envd/http2'
+import { createEnvdFetchForRuntime } from '../../src/envd/http2'
 
 let server: http2.Http2Server | undefined
 let serverSessions: Set<http2.ServerHttp2Session>
@@ -55,7 +55,7 @@ test('uses HTTP/2 in Node', async () => {
     stream.end(JSON.stringify({ protocol: 'h2' }))
   })
 
-  const res = await createEnvdFetch('node')(`${origin}/status`)
+  const res = await createEnvdFetchForRuntime('node')(`${origin}/status`)
 
   expect(res.status).toBe(200)
   await expect(res.json()).resolves.toEqual({ protocol: 'h2' })
@@ -66,8 +66,8 @@ test('uses global fetch outside Node', () => {
   const fallbackFetch = vi.fn() as unknown as typeof fetch
   globalThis.fetch = fallbackFetch
 
-  expect(createEnvdFetch('browser')).toBe(fallbackFetch)
-  expect(createEnvdFetch('vercel-edge')).toBe(fallbackFetch)
+  expect(createEnvdFetchForRuntime('browser')).toBe(fallbackFetch)
+  expect(createEnvdFetchForRuntime('vercel-edge')).toBe(fallbackFetch)
 
   globalThis.fetch = originalFetch
 })
@@ -75,7 +75,7 @@ test('uses global fetch outside Node', () => {
 test('rejects aborted requests', async () => {
   const origin = await startServer(() => undefined)
   const controller = new AbortController()
-  const promise = createEnvdFetch('node')(`${origin}/wait`, {
+  const promise = createEnvdFetchForRuntime('node')(`${origin}/wait`, {
     signal: controller.signal,
   })
 
@@ -84,13 +84,45 @@ test('rejects aborted requests', async () => {
   await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
 })
 
+test('aborts streaming response bodies', async () => {
+  const origin = await startServer((stream) => {
+    stream.respond({ ':status': 200 })
+    stream.write('chunk')
+  })
+  const controller = new AbortController()
+  const res = await createEnvdFetchForRuntime('node')(`${origin}/stream`, {
+    signal: controller.signal,
+  })
+
+  controller.abort()
+
+  await expect(res.text()).rejects.toMatchObject({ name: 'AbortError' })
+})
+
 test('body cancel is safe', async () => {
   const origin = await startServer((stream) => {
     stream.respond({ ':status': 200 })
     stream.write('chunk')
   })
 
-  const res = await createEnvdFetch('node')(`${origin}/stream`)
+  const res = await createEnvdFetchForRuntime('node')(`${origin}/stream`)
 
   await expect(res.body!.cancel()).resolves.toBeUndefined()
+})
+
+test('keeps session open while response body is streaming', async () => {
+  const origin = await startServer((stream) => {
+    stream.respond({ ':status': 200 })
+    stream.write('start')
+    setTimeout(() => {
+      stream.end('end')
+    }, 50)
+  })
+
+  const envdFetch = createEnvdFetchForRuntime('node', {
+    idleSessionTimeoutMs: 10,
+  })
+  const res = await envdFetch(`${origin}/stream`)
+
+  await expect(res.text()).resolves.toBe('startend')
 })

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -1,5 +1,6 @@
 import http2 from 'node:http2'
 import { AddressInfo } from 'node:net'
+import { gzipSync } from 'node:zlib'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
 import { createEnvdFetchForRuntime } from '../../src/envd/http2'
@@ -139,6 +140,18 @@ test('body cancel is safe', async () => {
   const res = await createEnvdFetchForRuntime('node')(`${origin}/stream`)
 
   await expect(res.body!.cancel()).resolves.toBeUndefined()
+})
+
+test('decodes gzip responses', async () => {
+  const origin = await startServer((stream) => {
+    stream.respond({ ':status': 200, 'content-encoding': 'gzip' })
+    stream.end(gzipSync('compressed'))
+  })
+
+  const res = await createEnvdFetchForRuntime('node')(`${origin}/gzip`)
+
+  expect(res.headers.has('content-encoding')).toBe(false)
+  await expect(res.text()).resolves.toBe('compressed')
 })
 
 test('pauses streaming response bodies when the reader is behind', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       tar:
         specifier: ^7.5.11
         version: 7.5.12
+      undici:
+        specifier: ^7.25.0
+        version: 7.25.0
     devDependencies:
       '@testing-library/react':
         specifier: ^16.2.0
@@ -3436,6 +3439,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -7129,6 +7136,8 @@ snapshots:
   underscore@1.13.6: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.25.0: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
<img width="2085" height="1197" alt="image" src="https://github.com/user-attachments/assets/c99c9413-e9b0-4522-950c-fe3e7b02671b" />

Enables HTTP/2 for JS SDK sandbox envd traffic in Node by routing envd RPC/API requests through undici with an HTTP/2-enabled dispatcher.

Non-Node runtimes continue to use global fetch. Management API and volume clients are unchanged.

Requires bumping node from >=20 to >= 20.18.1 for undici