### PR TITLE
Bug e2b 2195 throws dynamic usage of require is not eng 4003

### DIFF
--- a/.changeset/wild-lions-call.md
+++ b/.changeset/wild-lions-call.md
@@ -1,0 +1,5 @@
+---
+'e2b': minor
+---
+
+Compatibility for turbopack

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -2,7 +2,7 @@ import { runtime } from '../utils'
 
 type UndiciDispatcher = unknown
 type UndiciRequestInit = RequestInit & {
-  dispatcher: UndiciDispatcher
+  dispatcher?: UndiciDispatcher
   duplex?: 'half'
 }
 type UndiciModule = {
@@ -11,17 +11,19 @@ type UndiciModule = {
 }
 type EnvdFetchOptions = {
   connectionLimit?: number
+  loadUndici?: () => Promise<UndiciModule | undefined>
 }
 type EnvdFetchClient = {
-  dispatcher: UndiciDispatcher
+  dispatcher?: UndiciDispatcher
   fetchWithDispatcher: (
     input: RequestInfo | URL,
-    init?: UndiciRequestInit
+    init?: RequestInit | UndiciRequestInit
   ) => Promise<Response>
 }
 
 let envdFetch: typeof fetch | undefined
 let envdRpcFetch: typeof fetch | undefined
+let hasWarnedUndiciFallback = false
 
 export function createEnvdFetchForRuntime(
   currentRuntime = runtime,
@@ -38,6 +40,10 @@ export function createEnvdFetchForRuntime(
     const { dispatcher, fetchWithDispatcher } = await clientPromise
     const request = toRequestInput(input, init)
 
+    if (!dispatcher) {
+      return fetchWithDispatcher(request.input, request.init)
+    }
+
     return fetchWithDispatcher(request.input, {
       ...request.init,
       dispatcher,
@@ -48,11 +54,20 @@ export function createEnvdFetchForRuntime(
 async function createUndiciClient(
   options: EnvdFetchOptions
 ): Promise<EnvdFetchClient> {
-  const { Agent, fetch: undiciFetch } = (await import(
-    /* webpackIgnore: true */
-    /* @vite-ignore */
-    'undici'
-  )) as UndiciModule
+  const undici = await (options.loadUndici ?? loadUndici)()
+
+  if (!undici) {
+    warnUndiciFallback()
+
+    return {
+      fetchWithDispatcher: fetch as (
+        input: RequestInfo | URL,
+        init?: RequestInit
+      ) => Promise<Response>,
+    }
+  }
+
+  const { Agent, fetch: undiciFetch } = undici
   const dispatcherOptions: { allowH2: true; connections?: number } = {
     allowH2: true,
   }
@@ -67,6 +82,33 @@ async function createUndiciClient(
       init?: UndiciRequestInit
     ) => Promise<Response>,
   }
+}
+
+async function loadUndici(): Promise<UndiciModule | undefined> {
+  try {
+    // Keep this import opaque to bundlers. It must resolve as a package name
+    // from the runtime environment, not as a path relative to this file.
+    // eslint-disable-next-line no-new-func
+    const importModule = new Function(
+      'moduleName',
+      'return import(moduleName)'
+    ) as (moduleName: string) => Promise<UndiciModule>
+
+    return await importModule('undici')
+  } catch {
+    return undefined
+  }
+}
+
+function warnUndiciFallback() {
+  if (hasWarnedUndiciFallback) {
+    return
+  }
+
+  hasWarnedUndiciFallback = true
+  console.warn(
+    'Failed to load undici for envd HTTP/2 transport; falling back to global fetch.'
+  )
 }
 
 export function createEnvdFetch(): typeof fetch {

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -1,4 +1,4 @@
-import { dynamicImport, runtime } from '../utils'
+import { runtime } from '../utils'
 
 type UndiciDispatcher = unknown
 type UndiciRequestInit = RequestInit & {
@@ -48,8 +48,7 @@ export function createEnvdFetchForRuntime(
 async function createUndiciClient(
   options: EnvdFetchOptions
 ): Promise<EnvdFetchClient> {
-  const { Agent, fetch: undiciFetch } =
-    await dynamicImport<UndiciModule>('undici')
+  const { Agent, fetch: undiciFetch } = (await import('undici')) as UndiciModule
   const dispatcherOptions: { allowH2: true; connections?: number } = {
     allowH2: true,
   }

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -1,8 +1,7 @@
 import { runtime } from '../utils'
 
-type UndiciDispatcher = unknown
 type UndiciRequestInit = RequestInit & {
-  dispatcher?: UndiciDispatcher
+  dispatcher?: unknown
   duplex?: 'half'
 }
 type UndiciModule = {
@@ -12,13 +11,6 @@ type UndiciModule = {
 type EnvdFetchOptions = {
   connectionLimit?: number
   loadUndici?: () => Promise<UndiciModule | undefined>
-}
-type EnvdFetchClient = {
-  dispatcher?: UndiciDispatcher
-  fetchWithDispatcher: (
-    input: RequestInfo | URL,
-    init?: RequestInit | UndiciRequestInit
-  ) => Promise<Response>
 }
 
 let envdFetch: typeof fetch | undefined
@@ -33,38 +25,25 @@ export function createEnvdFetchForRuntime(
     return fetch
   }
 
-  let clientPromise: Promise<EnvdFetchClient> | undefined
+  let fetcherPromise: Promise<typeof fetch> | undefined
 
   return (async (input, init) => {
-    clientPromise ??= createUndiciClient(options)
-    const { dispatcher, fetchWithDispatcher } = await clientPromise
-    const request = toRequestInput(input, init)
+    fetcherPromise ??= buildEnvdFetcher(options)
+    const fetcher = await fetcherPromise
 
-    if (!dispatcher) {
-      return fetchWithDispatcher(request.input, request.init)
-    }
-
-    return fetchWithDispatcher(request.input, {
-      ...request.init,
-      dispatcher,
-    })
+    return fetcher(input, init)
   }) as typeof fetch
 }
 
-async function createUndiciClient(
+async function buildEnvdFetcher(
   options: EnvdFetchOptions
-): Promise<EnvdFetchClient> {
+): Promise<typeof fetch> {
   const undici = await (options.loadUndici ?? loadUndici)()
 
   if (!undici) {
     warnUndiciFallback()
 
-    return {
-      fetchWithDispatcher: fetch as (
-        input: RequestInfo | URL,
-        init?: RequestInit
-      ) => Promise<Response>,
-    }
+    return fetch
   }
 
   const { Agent, fetch: undiciFetch } = undici
@@ -75,13 +54,20 @@ async function createUndiciClient(
     dispatcherOptions.connections = options.connectionLimit
   }
 
-  return {
-    dispatcher: new Agent(dispatcherOptions),
-    fetchWithDispatcher: undiciFetch as unknown as (
-      input: RequestInfo | URL,
-      init?: UndiciRequestInit
-    ) => Promise<Response>,
-  }
+  const dispatcher = new Agent(dispatcherOptions)
+  const fetchWithDispatcher = undiciFetch as unknown as (
+    input: RequestInfo | URL,
+    init?: UndiciRequestInit
+  ) => Promise<Response>
+
+  return ((input, init) => {
+    const request = toRequestInput(input, init)
+
+    return fetchWithDispatcher(request.input, {
+      ...request.init,
+      dispatcher,
+    })
+  }) as typeof fetch
 }
 
 async function loadUndici(): Promise<UndiciModule | undefined> {

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -1,13 +1,23 @@
-import { dynamicRequire, runtime } from '../utils'
+import { dynamicImport, runtime } from '../utils'
 
-type Undici = typeof import('undici')
-type UndiciDispatcher = InstanceType<Undici['Agent']>
+type UndiciDispatcher = unknown
 type UndiciRequestInit = RequestInit & {
   dispatcher: UndiciDispatcher
   duplex?: 'half'
 }
+type UndiciModule = {
+  Agent: new (options: { allowH2: true; connections?: number }) => unknown
+  fetch: unknown
+}
 type EnvdFetchOptions = {
   connectionLimit?: number
+}
+type EnvdFetchClient = {
+  dispatcher: UndiciDispatcher
+  fetchWithDispatcher: (
+    input: RequestInfo | URL,
+    init?: UndiciRequestInit
+  ) => Promise<Response>
 }
 
 let envdFetch: typeof fetch | undefined
@@ -21,20 +31,11 @@ export function createEnvdFetchForRuntime(
     return fetch
   }
 
-  const { Agent, fetch: undiciFetch } = dynamicRequire<Undici>('undici')
-  const dispatcherOptions: { allowH2: true; connections?: number } = {
-    allowH2: true,
-  }
-  if (options.connectionLimit !== undefined) {
-    dispatcherOptions.connections = options.connectionLimit
-  }
-  const dispatcher = new Agent(dispatcherOptions)
-  const fetchWithDispatcher = undiciFetch as unknown as (
-    input: RequestInfo | URL,
-    init?: UndiciRequestInit
-  ) => Promise<Response>
+  let clientPromise: Promise<EnvdFetchClient> | undefined
 
-  return ((input, init) => {
+  return (async (input, init) => {
+    clientPromise ??= createUndiciClient(options)
+    const { dispatcher, fetchWithDispatcher } = await clientPromise
     const request = toRequestInput(input, init)
 
     return fetchWithDispatcher(request.input, {
@@ -42,6 +43,27 @@ export function createEnvdFetchForRuntime(
       dispatcher,
     })
   }) as typeof fetch
+}
+
+async function createUndiciClient(
+  options: EnvdFetchOptions
+): Promise<EnvdFetchClient> {
+  const { Agent, fetch: undiciFetch } =
+    await dynamicImport<UndiciModule>('undici')
+  const dispatcherOptions: { allowH2: true; connections?: number } = {
+    allowH2: true,
+  }
+  if (options.connectionLimit !== undefined) {
+    dispatcherOptions.connections = options.connectionLimit
+  }
+
+  return {
+    dispatcher: new Agent(dispatcherOptions),
+    fetchWithDispatcher: undiciFetch as unknown as (
+      input: RequestInfo | URL,
+      init?: UndiciRequestInit
+    ) => Promise<Response>,
+  }
 }
 
 export function createEnvdFetch(): typeof fetch {

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -48,7 +48,11 @@ export function createEnvdFetchForRuntime(
 async function createUndiciClient(
   options: EnvdFetchOptions
 ): Promise<EnvdFetchClient> {
-  const { Agent, fetch: undiciFetch } = (await import('undici')) as UndiciModule
+  const { Agent, fetch: undiciFetch } = (await import(
+    /* webpackIgnore: true */
+    /* @vite-ignore */
+    'undici'
+  )) as UndiciModule
   const dispatcherOptions: { allowH2: true; connections?: number } = {
     allowH2: true,
   }

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -22,10 +22,12 @@ test('uses undici with HTTP/2 enabled in Node', async () => {
     return Promise.resolve(new Response('ok'))
   })
 
-  vi.doMock('undici', () => ({ Agent, fetch: undiciFetch }))
   const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
 
-  const fetcher = createEnvdFetchForRuntime('node')
+  const fetcher = createEnvdFetchForRuntime('node', {
+    connectionLimit: 1,
+    loadUndici: () => Promise.resolve({ Agent, fetch: undiciFetch }),
+  })
   const res = await fetcher('https://example.com/status')
 
   expect(await res.text()).toBe('ok')
@@ -43,10 +45,12 @@ test('passes Request objects to undici as URL plus init', async () => {
     return Promise.resolve(new Response('ok'))
   })
 
-  vi.doMock('undici', () => ({ Agent, fetch: undiciFetch }))
   const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
 
-  const fetcher = createEnvdFetchForRuntime('node')
+  const fetcher = createEnvdFetchForRuntime('node', {
+    connectionLimit: 1,
+    loadUndici: () => Promise.resolve({ Agent, fetch: undiciFetch }),
+  })
   const body = JSON.stringify({ ok: true })
   await fetcher(
     new Request('https://example.com/rpc', {
@@ -73,10 +77,11 @@ test('can create an uncapped dispatcher for RPC streams', async () => {
 
   const undiciFetch = vi.fn(() => Promise.resolve(new Response('ok')))
 
-  vi.doMock('undici', () => ({ Agent, fetch: undiciFetch }))
   const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
 
-  const fetcher = createEnvdFetchForRuntime('node', {})
+  const fetcher = createEnvdFetchForRuntime('node', {
+    loadUndici: () => Promise.resolve({ Agent, fetch: undiciFetch }),
+  })
   await fetcher('https://example.com/rpc')
 
   expect(agents).toEqual([{ allowH2: true }])
@@ -85,19 +90,46 @@ test('can create an uncapped dispatcher for RPC streams', async () => {
 test('defers loading undici until the first Node request', async () => {
   const Agent = vi.fn()
   const undiciFetch = vi.fn(() => Promise.resolve(new Response('ok')))
+  const loadUndici = vi.fn(() => Promise.resolve({ Agent, fetch: undiciFetch }))
 
-  vi.doMock('undici', () => ({ Agent, fetch: undiciFetch }))
   const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
 
-  const fetcher = createEnvdFetchForRuntime('node')
+  const fetcher = createEnvdFetchForRuntime('node', {
+    connectionLimit: 1,
+    loadUndici,
+  })
 
+  expect(loadUndici).not.toHaveBeenCalled()
   expect(Agent).not.toHaveBeenCalled()
   expect(undiciFetch).not.toHaveBeenCalled()
 
   await fetcher('https://example.com/status')
 
+  expect(loadUndici).toHaveBeenCalledOnce()
   expect(Agent).toHaveBeenCalledOnce()
   expect(undiciFetch).toHaveBeenCalledOnce()
+})
+
+test('falls back to global fetch when undici cannot be loaded', async () => {
+  const fallbackFetch = vi.fn(() =>
+    Promise.resolve(new Response('fallback ok'))
+  ) as unknown as typeof fetch
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.stubGlobal('fetch', fallbackFetch)
+
+  const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
+
+  const fetcher = createEnvdFetchForRuntime('node', {
+    loadUndici: () => Promise.resolve(undefined),
+  })
+  const res = await fetcher('https://example.com/status')
+
+  expect(await res.text()).toBe('fallback ok')
+  expect(fallbackFetch).toHaveBeenCalledWith(
+    'https://example.com/status',
+    undefined
+  )
+  expect(warn).toHaveBeenCalledOnce()
 })
 
 test('uses global fetch outside Node', async () => {

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -22,7 +22,7 @@ test('uses undici with HTTP/2 enabled in Node', async () => {
   })
 
   vi.doMock('../../src/utils', () => ({
-    dynamicRequire: () => ({ Agent, fetch: undiciFetch }),
+    dynamicImport: () => Promise.resolve({ Agent, fetch: undiciFetch }),
     runtime: 'node',
   }))
   const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
@@ -46,7 +46,7 @@ test('passes Request objects to undici as URL plus init', async () => {
   })
 
   vi.doMock('../../src/utils', () => ({
-    dynamicRequire: () => ({ Agent, fetch: undiciFetch }),
+    dynamicImport: () => Promise.resolve({ Agent, fetch: undiciFetch }),
     runtime: 'node',
   }))
   const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
@@ -79,7 +79,7 @@ test('can create an uncapped dispatcher for RPC streams', async () => {
   const undiciFetch = vi.fn(() => Promise.resolve(new Response('ok')))
 
   vi.doMock('../../src/utils', () => ({
-    dynamicRequire: () => ({ Agent, fetch: undiciFetch }),
+    dynamicImport: () => Promise.resolve({ Agent, fetch: undiciFetch }),
     runtime: 'node',
   }))
   const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
@@ -88,6 +88,27 @@ test('can create an uncapped dispatcher for RPC streams', async () => {
   await fetcher('https://example.com/rpc')
 
   expect(agents).toEqual([{ allowH2: true }])
+})
+
+test('defers loading undici until the first Node request', async () => {
+  const Agent = vi.fn()
+  const undiciFetch = vi.fn(() => Promise.resolve(new Response('ok')))
+
+  vi.doMock('../../src/utils', () => ({
+    dynamicImport: () => Promise.resolve({ Agent, fetch: undiciFetch }),
+    runtime: 'node',
+  }))
+  const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
+
+  const fetcher = createEnvdFetchForRuntime('node')
+
+  expect(Agent).not.toHaveBeenCalled()
+  expect(undiciFetch).not.toHaveBeenCalled()
+
+  await fetcher('https://example.com/status')
+
+  expect(Agent).toHaveBeenCalledOnce()
+  expect(undiciFetch).toHaveBeenCalledOnce()
 })
 
 test('uses global fetch outside Node', async () => {

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -3,6 +3,7 @@ import { afterEach, expect, test, vi } from 'vitest'
 afterEach(() => {
   vi.restoreAllMocks()
   vi.resetModules()
+  vi.doUnmock('undici')
   vi.doUnmock('../../src/utils')
 })
 
@@ -21,10 +22,7 @@ test('uses undici with HTTP/2 enabled in Node', async () => {
     return Promise.resolve(new Response('ok'))
   })
 
-  vi.doMock('../../src/utils', () => ({
-    dynamicImport: () => Promise.resolve({ Agent, fetch: undiciFetch }),
-    runtime: 'node',
-  }))
+  vi.doMock('undici', () => ({ Agent, fetch: undiciFetch }))
   const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
 
   const fetcher = createEnvdFetchForRuntime('node')
@@ -45,10 +43,7 @@ test('passes Request objects to undici as URL plus init', async () => {
     return Promise.resolve(new Response('ok'))
   })
 
-  vi.doMock('../../src/utils', () => ({
-    dynamicImport: () => Promise.resolve({ Agent, fetch: undiciFetch }),
-    runtime: 'node',
-  }))
+  vi.doMock('undici', () => ({ Agent, fetch: undiciFetch }))
   const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
 
   const fetcher = createEnvdFetchForRuntime('node')
@@ -78,10 +73,7 @@ test('can create an uncapped dispatcher for RPC streams', async () => {
 
   const undiciFetch = vi.fn(() => Promise.resolve(new Response('ok')))
 
-  vi.doMock('../../src/utils', () => ({
-    dynamicImport: () => Promise.resolve({ Agent, fetch: undiciFetch }),
-    runtime: 'node',
-  }))
+  vi.doMock('undici', () => ({ Agent, fetch: undiciFetch }))
   const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
 
   const fetcher = createEnvdFetchForRuntime('node', {})
@@ -94,10 +86,7 @@ test('defers loading undici until the first Node request', async () => {
   const Agent = vi.fn()
   const undiciFetch = vi.fn(() => Promise.resolve(new Response('ok')))
 
-  vi.doMock('../../src/utils', () => ({
-    dynamicImport: () => Promise.resolve({ Agent, fetch: undiciFetch }),
-    runtime: 'node',
-  }))
+  vi.doMock('undici', () => ({ Agent, fetch: undiciFetch }))
   const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
 
   const fetcher = createEnvdFetchForRuntime('node')

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "dist",
+    "module": "ESNext",
     "target": "es6",
     "lib": [
       "dom",

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "module": "ESNext",
     "target": "es6",
     "lib": [
       "dom",


### PR DESCRIPTION
Fix the JS SDK envd HTTP/2 transport so it works in Next.js/Turbopack production builds.

The HTTP/2 path loaded `undici` through a dynamic require, which Turbopack rewrites to a runtime stub that throws during envd requests. This changes envd to load `undici` lazily at runtime through an import that bundlers cannot statically rewrite. If `undici` cannot be loaded, the SDK falls back to global `fetch`, so Node keeps the HTTP/2 dispatcher path when available without pulling `undici` into browser bundles.

tested node/next/browser
