### PR TITLE
Keep sandbox after disconnecting terminal

### DIFF
--- a/.changeset/fresh-lands-talk.md
+++ b/.changeset/fresh-lands-talk.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+keep sandbox running after disconnecting terminal

--- a/packages/cli/src/commands/sandbox/create.ts
+++ b/packages/cli/src/commands/sandbox/create.ts
@@ -113,8 +113,7 @@ export async function connectSandbox({
     await spawnConnectedTerminal(sandbox)
   } finally {
     clearInterval(intervalId)
-    await pendingKeepAlive.catch(() => {})
-    await sandbox.setTimeout(1_000)
+    await pendingKeepAlive.catch(() => { })
     console.log(
       `Closing terminal connection to template ${asFormattedSandboxTemplate(
         template


### PR DESCRIPTION

```
e2b sbx spawn base
Warning: The 'spawn' command is deprecated and will be removed in future releases. Please use 'e2b sandbox create' instead.

Use the following link to inspect this Sandbox live inside the E2B Dashboard:
↪ https://e2b.dev/dashboard/inspect/sandbox/ia0qewmopiizke0bn3o83

Terminal connecting to template base with sandbox ID ia0qewmopiizke0bn3o83
user@e2b:~$ ^C
user@e2b:~$
logout
Terminal session was killed by user

Closing terminal connection to template base with sandbox ID ia0qewmopiizke0bn3o83

mish@Mishs-MacBook-Pro e2b-task % e2b sbx ls
No sandboxes found
```