### PR TITLE
feat(js-sdk): support AbortSignal for request cancellation

### DIFF
--- a/.changeset/abort-signal-support.md
+++ b/.changeset/abort-signal-support.md
@@ -1,0 +1,5 @@
+---
+'e2b': minor
+---
+
+Add `signal: AbortSignal` option to JS SDK methods to support cancelling in-flight requests. The signal can be passed to `Sandbox.create`, `Sandbox.connect`, `sandbox.commands.run`, `sandbox.files.*`, volume methods, and other request options. When the signal is aborted, the underlying `fetch` is aborted and the returned promise rejects with an `AbortError`.

--- a/.changeset/abort-signal-support.md
+++ b/.changeset/abort-signal-support.md
@@ -3,3 +3,7 @@
 ---
 
 Add `signal: AbortSignal` option to JS SDK methods to support cancelling in-flight requests. The signal can be passed to `Sandbox.create`, `Sandbox.connect`, `sandbox.commands.run`, `sandbox.files.*`, volume methods, and other request options. When the signal is aborted, the underlying `fetch` is aborted and the returned promise rejects with an `AbortError`.
+
+`SandboxPaginator.nextItems` and `SnapshotPaginator.nextItems` now accept a `SandboxApiOpts` argument (including `signal`) — when provided, the per-call options override the connection options the paginator was constructed with for that single request.
+
+Same change in the Python SDK: `SandboxPaginator.next_items` / `SnapshotPaginator.next_items` (sync and async) now accept `**opts: ApiParams` (e.g. `api_key`, `domain`, `headers`, `request_timeout`); when provided, the per-call options override the ones the paginator was constructed with.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,7 +59,7 @@
     "json2md": "^2.0.1",
     "knip": "^5.43.6",
     "tsup": "^8.4.0",
-    "typescript": "^5.2.2",
+    "typescript": "^5.4.5",
     "vitest": "^3.2.4"
   },
   "files": [

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -71,6 +71,22 @@ export interface ConnectionOpts {
   signal?: AbortSignal
 }
 
+export function combineAbortSignals(signals: AbortSignal[]): AbortSignal {
+  const controller = new AbortController()
+
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason)
+      return controller.signal
+    }
+    signal.addEventListener('abort', () => controller.abort(signal.reason), {
+      once: true,
+    })
+  }
+
+  return controller.signal
+}
+
 /**
  * Configuration for connecting to the API.
  */
@@ -137,7 +153,7 @@ export class ConnectionConfig {
     const timeoutSignal = timeout ? AbortSignal.timeout(timeout) : undefined
 
     if (timeoutSignal && signal) {
-      return AbortSignal.any([timeoutSignal, signal])
+      return combineAbortSignals([timeoutSignal, signal])
     }
 
     return timeoutSignal ?? signal

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -72,6 +72,49 @@ export interface ConnectionOpts {
 }
 
 /**
+ * Set up an internal `AbortController` for a streaming request that:
+ *  - aborts when the optional user signal aborts
+ *  - aborts when the optional request timeout elapses
+ *
+ * Returns the controller plus an idempotent `cleanup` function that detaches
+ * the user-signal listener, clears the timeout, and aborts the controller.
+ *
+ * @internal
+ */
+export function setupRequestController(
+  requestTimeoutMs: number | undefined,
+  userSignal: AbortSignal | undefined
+): { controller: AbortController; cleanup: () => void } {
+  const controller = new AbortController()
+
+  const onUserAbort = () => controller.abort(userSignal?.reason)
+  if (userSignal) {
+    if (userSignal.aborted) {
+      controller.abort(userSignal.reason)
+    } else {
+      userSignal.addEventListener('abort', onUserAbort, { once: true })
+    }
+  }
+
+  const reqTimeout = requestTimeoutMs
+    ? setTimeout(() => controller.abort(), requestTimeoutMs)
+    : undefined
+
+  let cleaned = false
+  const cleanup = () => {
+    if (cleaned) return
+    cleaned = true
+    userSignal?.removeEventListener('abort', onUserAbort)
+    if (reqTimeout) {
+      clearTimeout(reqTimeout)
+    }
+    controller.abort()
+  }
+
+  return { controller, cleanup }
+}
+
+/**
  * Configuration for connecting to the API.
  */
 export class ConnectionConfig {

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -72,6 +72,29 @@ export interface ConnectionOpts {
 }
 
 /**
+ * Build an `AbortSignal` that combines an optional request-timeout signal
+ * (via `AbortSignal.timeout`) with an optional user-provided signal.
+ *
+ * Returns `undefined` when neither input would produce a signal.
+ *
+ * @internal
+ */
+export function buildRequestSignal(
+  requestTimeoutMs: number | undefined,
+  userSignal: AbortSignal | undefined
+): AbortSignal | undefined {
+  const timeoutSignal = requestTimeoutMs
+    ? AbortSignal.timeout(requestTimeoutMs)
+    : undefined
+
+  if (timeoutSignal && userSignal) {
+    return AbortSignal.any([timeoutSignal, userSignal])
+  }
+
+  return timeoutSignal ?? userSignal
+}
+
+/**
  * Set up an internal `AbortController` for a streaming request.
  *
  * Until `clearStartTimeout` is called, the controller aborts when either
@@ -109,7 +132,16 @@ export function setupRequestController(
   }
 
   let reqTimeout: ReturnType<typeof setTimeout> | undefined = requestTimeoutMs
-    ? setTimeout(() => controller.abort(), requestTimeoutMs)
+    ? setTimeout(
+        () =>
+          controller.abort(
+            new DOMException(
+              `Request handshake timed out after ${requestTimeoutMs}ms`,
+              'TimeoutError'
+            )
+          ),
+        requestTimeoutMs
+      )
     : undefined
 
   const clearStartTimeout = () => {
@@ -193,14 +225,7 @@ export class ConnectionConfig {
   }
 
   getSignal(requestTimeoutMs?: number, signal?: AbortSignal) {
-    const timeout = requestTimeoutMs ?? this.requestTimeoutMs
-    const timeoutSignal = timeout ? AbortSignal.timeout(timeout) : undefined
-
-    if (timeoutSignal && signal) {
-      return AbortSignal.any([timeoutSignal, signal])
-    }
-
-    return timeoutSignal ?? signal
+    return buildRequestSignal(requestTimeoutMs ?? this.requestTimeoutMs, signal)
   }
 
   getSandboxUrl(

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -72,19 +72,31 @@ export interface ConnectionOpts {
 }
 
 /**
- * Set up an internal `AbortController` for a streaming request that:
- *  - aborts when the optional user signal aborts
- *  - aborts when the optional request timeout elapses
+ * Set up an internal `AbortController` for a streaming request.
  *
- * Returns the controller plus an idempotent `cleanup` function that detaches
- * the user-signal listener, clears the timeout, and aborts the controller.
+ * Until `clearStartTimeout` is called, the controller aborts when either
+ *  - the optional user signal aborts, or
+ *  - the optional request timeout elapses (used to bound the initial
+ *    handshake; long-lived streams should call `clearStartTimeout` once
+ *    the handshake succeeds).
+ *
+ * The user-signal listener stays attached for the full stream lifetime
+ * so the caller can cancel a long-running stream by aborting the signal.
+ *
+ * `cleanup` is idempotent and detaches the listener, clears the handshake
+ * timer (if still pending), and aborts the controller. Call it when the
+ * stream finishes or when startup fails.
  *
  * @internal
  */
 export function setupRequestController(
   requestTimeoutMs: number | undefined,
   userSignal: AbortSignal | undefined
-): { controller: AbortController; cleanup: () => void } {
+): {
+  controller: AbortController
+  clearStartTimeout: () => void
+  cleanup: () => void
+} {
   const controller = new AbortController()
 
   const onUserAbort = () => controller.abort(userSignal?.reason)
@@ -96,22 +108,27 @@ export function setupRequestController(
     }
   }
 
-  const reqTimeout = requestTimeoutMs
+  let reqTimeout: ReturnType<typeof setTimeout> | undefined = requestTimeoutMs
     ? setTimeout(() => controller.abort(), requestTimeoutMs)
     : undefined
+
+  const clearStartTimeout = () => {
+    if (reqTimeout) {
+      clearTimeout(reqTimeout)
+      reqTimeout = undefined
+    }
+  }
 
   let cleaned = false
   const cleanup = () => {
     if (cleaned) return
     cleaned = true
     userSignal?.removeEventListener('abort', onUserAbort)
-    if (reqTimeout) {
-      clearTimeout(reqTimeout)
-    }
+    clearStartTimeout()
     controller.abort()
   }
 
-  return { controller, cleanup }
+  return { controller, clearStartTimeout, cleanup }
 }
 
 /**

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -62,6 +62,13 @@ export interface ConnectionOpts {
    * Additional headers to send with the request.
    */
   headers?: Record<string, string>
+
+  /**
+   * An optional `AbortSignal` that can be used to cancel the in-flight request.
+   * When the signal is aborted, the underlying `fetch` is aborted and the
+   * returned promise rejects with an `AbortError`.
+   */
+  signal?: AbortSignal
 }
 
 /**
@@ -125,10 +132,15 @@ export class ConnectionConfig {
     return getEnvVar('E2B_ACCESS_TOKEN')
   }
 
-  getSignal(requestTimeoutMs?: number) {
+  getSignal(requestTimeoutMs?: number, signal?: AbortSignal) {
     const timeout = requestTimeoutMs ?? this.requestTimeoutMs
+    const timeoutSignal = timeout ? AbortSignal.timeout(timeout) : undefined
 
-    return timeout ? AbortSignal.timeout(timeout) : undefined
+    if (timeoutSignal && signal) {
+      return AbortSignal.any([timeoutSignal, signal])
+    }
+
+    return timeoutSignal ?? signal
   }
 
   getSandboxUrl(

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -71,22 +71,6 @@ export interface ConnectionOpts {
   signal?: AbortSignal
 }
 
-export function combineAbortSignals(signals: AbortSignal[]): AbortSignal {
-  const controller = new AbortController()
-
-  for (const signal of signals) {
-    if (signal.aborted) {
-      controller.abort(signal.reason)
-      return controller.signal
-    }
-    signal.addEventListener('abort', () => controller.abort(signal.reason), {
-      once: true,
-    })
-  }
-
-  return controller.signal
-}
-
 /**
  * Configuration for connecting to the API.
  */
@@ -153,7 +137,7 @@ export class ConnectionConfig {
     const timeoutSignal = timeout ? AbortSignal.timeout(timeout) : undefined
 
     if (timeoutSignal && signal) {
-      return combineAbortSignals([timeoutSignal, signal])
+      return AbortSignal.any([timeoutSignal, signal])
     }
 
     return timeoutSignal ?? signal

--- a/packages/js-sdk/src/sandbox/commands/commandHandle.ts
+++ b/packages/js-sdk/src/sandbox/commands/commandHandle.ts
@@ -236,11 +236,7 @@ export class CommandHandle
     } catch (e) {
       this.iterationError = handleRpcError(e)
     } finally {
-      try {
-        this.handleDisconnect()
-      } catch {
-        // handleDisconnect runs cleanup (idempotent); ignore any errors.
-      }
+      this.handleDisconnect()
     }
   }
 }

--- a/packages/js-sdk/src/sandbox/commands/commandHandle.ts
+++ b/packages/js-sdk/src/sandbox/commands/commandHandle.ts
@@ -235,6 +235,12 @@ export class CommandHandle
       }
     } catch (e) {
       this.iterationError = handleRpcError(e)
+    } finally {
+      try {
+        this.handleDisconnect()
+      } catch {
+        // handleDisconnect runs cleanup (idempotent); ignore any errors.
+      }
     }
   }
 }

--- a/packages/js-sdk/src/sandbox/commands/index.ts
+++ b/packages/js-sdk/src/sandbox/commands/index.ts
@@ -29,7 +29,7 @@ export { Pty } from './pty'
  * Options for sending a command request.
  */
 export interface CommandRequestOpts
-  extends Partial<Pick<ConnectionOpts, 'requestTimeoutMs'>> {}
+  extends Partial<Pick<ConnectionOpts, 'requestTimeoutMs' | 'signal'>> {}
 
 /**
  * Options for starting a new command.
@@ -160,7 +160,10 @@ export class Commands {
       const res = await this.rpc.list(
         {},
         {
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
 
@@ -209,7 +212,10 @@ export class Commands {
           },
         },
         {
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
     } catch (err) {
@@ -239,7 +245,10 @@ export class Commands {
           },
         },
         {
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
     } catch (err) {
@@ -269,7 +278,10 @@ export class Commands {
           signal: Signal.SIGKILL,
         },
         {
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
 
@@ -303,6 +315,15 @@ export class Commands {
 
     const controller = new AbortController()
 
+    const onUserAbort = () => controller.abort(opts?.signal?.reason)
+    if (opts?.signal) {
+      if (opts.signal.aborted) {
+        controller.abort(opts.signal.reason)
+      } else {
+        opts.signal.addEventListener('abort', onUserAbort, { once: true })
+      }
+    }
+
     const reqTimeout = requestTimeoutMs
       ? setTimeout(() => {
           controller.abort()
@@ -334,7 +355,10 @@ export class Commands {
 
       return new CommandHandle(
         pid,
-        () => controller.abort(),
+        () => {
+          opts?.signal?.removeEventListener('abort', onUserAbort)
+          controller.abort()
+        },
         () => this.kill(pid),
         events,
         opts?.onStdout,
@@ -342,6 +366,7 @@ export class Commands {
         undefined
       )
     } catch (err) {
+      opts?.signal?.removeEventListener('abort', onUserAbort)
       throw handleRpcError(err)
     }
   }
@@ -407,6 +432,15 @@ export class Commands {
 
     const controller = new AbortController()
 
+    const onUserAbort = () => controller.abort(opts?.signal?.reason)
+    if (opts?.signal) {
+      if (opts.signal.aborted) {
+        controller.abort(opts.signal.reason)
+      } else {
+        opts.signal.addEventListener('abort', onUserAbort, { once: true })
+      }
+    }
+
     const reqTimeout = requestTimeoutMs
       ? setTimeout(() => {
           controller.abort()
@@ -449,7 +483,10 @@ export class Commands {
 
       return new CommandHandle(
         pid,
-        () => controller.abort(),
+        () => {
+          opts?.signal?.removeEventListener('abort', onUserAbort)
+          controller.abort()
+        },
         () => this.kill(pid),
         events,
         opts?.onStdout,
@@ -457,6 +494,7 @@ export class Commands {
         undefined
       )
     } catch (err) {
+      opts?.signal?.removeEventListener('abort', onUserAbort)
       throw handleRpcError(err)
     }
   }

--- a/packages/js-sdk/src/sandbox/commands/index.ts
+++ b/packages/js-sdk/src/sandbox/commands/index.ts
@@ -314,7 +314,7 @@ export class Commands {
     const requestTimeoutMs =
       opts?.requestTimeoutMs ?? this.connectionConfig.requestTimeoutMs
 
-    const { controller, cleanup } = setupRequestController(
+    const { controller, clearStartTimeout, cleanup } = setupRequestController(
       requestTimeoutMs,
       opts?.signal
     )
@@ -339,6 +339,7 @@ export class Commands {
 
     try {
       const pid = await handleProcessStartEvent(events)
+      clearStartTimeout()
 
       return new CommandHandle(
         pid,
@@ -423,7 +424,7 @@ export class Commands {
     const requestTimeoutMs =
       opts?.requestTimeoutMs ?? this.connectionConfig.requestTimeoutMs
 
-    const { controller, cleanup } = setupRequestController(
+    const { controller, clearStartTimeout, cleanup } = setupRequestController(
       requestTimeoutMs,
       opts?.signal
     )
@@ -450,6 +451,7 @@ export class Commands {
 
     try {
       const pid = await handleProcessStartEvent(events)
+      clearStartTimeout()
 
       return new CommandHandle(
         pid,

--- a/packages/js-sdk/src/sandbox/commands/index.ts
+++ b/packages/js-sdk/src/sandbox/commands/index.ts
@@ -12,6 +12,7 @@ import {
   ConnectionOpts,
   KEEPALIVE_PING_HEADER,
   KEEPALIVE_PING_INTERVAL_SEC,
+  setupRequestController,
   Username,
 } from '../../connectionConfig'
 import { handleProcessStartEvent } from '../../envd/api'
@@ -313,22 +314,10 @@ export class Commands {
     const requestTimeoutMs =
       opts?.requestTimeoutMs ?? this.connectionConfig.requestTimeoutMs
 
-    const controller = new AbortController()
-
-    const onUserAbort = () => controller.abort(opts?.signal?.reason)
-    if (opts?.signal) {
-      if (opts.signal.aborted) {
-        controller.abort(opts.signal.reason)
-      } else {
-        opts.signal.addEventListener('abort', onUserAbort, { once: true })
-      }
-    }
-
-    const reqTimeout = requestTimeoutMs
-      ? setTimeout(() => {
-          controller.abort()
-        }, requestTimeoutMs)
-      : undefined
+    const { controller, cleanup } = setupRequestController(
+      requestTimeoutMs,
+      opts?.signal
+    )
 
     const events = this.rpc.connect(
       {
@@ -351,14 +340,9 @@ export class Commands {
     try {
       const pid = await handleProcessStartEvent(events)
 
-      clearTimeout(reqTimeout)
-
       return new CommandHandle(
         pid,
-        () => {
-          opts?.signal?.removeEventListener('abort', onUserAbort)
-          controller.abort()
-        },
+        cleanup,
         () => this.kill(pid),
         events,
         opts?.onStdout,
@@ -366,7 +350,7 @@ export class Commands {
         undefined
       )
     } catch (err) {
-      opts?.signal?.removeEventListener('abort', onUserAbort)
+      cleanup()
       throw handleRpcError(err)
     }
   }
@@ -427,26 +411,6 @@ export class Commands {
     cmd: string,
     opts?: CommandStartOpts
   ): Promise<CommandHandle> {
-    const requestTimeoutMs =
-      opts?.requestTimeoutMs ?? this.connectionConfig.requestTimeoutMs
-
-    const controller = new AbortController()
-
-    const onUserAbort = () => controller.abort(opts?.signal?.reason)
-    if (opts?.signal) {
-      if (opts.signal.aborted) {
-        controller.abort(opts.signal.reason)
-      } else {
-        opts.signal.addEventListener('abort', onUserAbort, { once: true })
-      }
-    }
-
-    const reqTimeout = requestTimeoutMs
-      ? setTimeout(() => {
-          controller.abort()
-        }, requestTimeoutMs)
-      : undefined
-
     if (
       opts?.stdin === false &&
       compareVersions(this.envdVersion, ENVD_COMMANDS_STDIN) < 0
@@ -455,6 +419,14 @@ export class Commands {
         `Sandbox envd version ${this.envdVersion} can't specify stdin, it's always turned on. Please rebuild your template if you need this feature.`
       )
     }
+
+    const requestTimeoutMs =
+      opts?.requestTimeoutMs ?? this.connectionConfig.requestTimeoutMs
+
+    const { controller, cleanup } = setupRequestController(
+      requestTimeoutMs,
+      opts?.signal
+    )
 
     const events = this.rpc.start(
       {
@@ -479,14 +451,9 @@ export class Commands {
     try {
       const pid = await handleProcessStartEvent(events)
 
-      clearTimeout(reqTimeout)
-
       return new CommandHandle(
         pid,
-        () => {
-          opts?.signal?.removeEventListener('abort', onUserAbort)
-          controller.abort()
-        },
+        cleanup,
         () => this.kill(pid),
         events,
         opts?.onStdout,
@@ -494,7 +461,7 @@ export class Commands {
         undefined
       )
     } catch (err) {
-      opts?.signal?.removeEventListener('abort', onUserAbort)
+      cleanup()
       throw handleRpcError(err)
     }
   }

--- a/packages/js-sdk/src/sandbox/commands/pty.ts
+++ b/packages/js-sdk/src/sandbox/commands/pty.ts
@@ -16,6 +16,7 @@ import {
   Username,
   KEEPALIVE_PING_HEADER,
   KEEPALIVE_PING_INTERVAL_SEC,
+  setupRequestController,
 } from '../../connectionConfig'
 import { CommandHandle } from './commandHandle'
 import { authenticationHeader, handleRpcError } from '../../envd/rpc'
@@ -101,20 +102,11 @@ export class Pty {
     envs.TERM = envs.TERM ?? 'xterm-256color'
     envs.LANG = envs.LANG ?? 'C.UTF-8'
     envs.LC_ALL = envs.LC_ALL ?? 'C.UTF-8'
-    const controller = new AbortController()
 
-    const onUserAbort = () => controller.abort(opts?.signal?.reason)
-    if (opts?.signal) {
-      if (opts.signal.aborted) {
-        controller.abort(opts.signal.reason)
-      } else {
-        opts.signal.addEventListener('abort', onUserAbort, { once: true })
-      }
-    }
-
-    const reqTimeout = setTimeout(() => {
-      controller.abort()
-    }, requestTimeoutMs)
+    const { controller, cleanup } = setupRequestController(
+      requestTimeoutMs,
+      opts?.signal
+    )
 
     const events = this.rpc.start(
       {
@@ -144,14 +136,9 @@ export class Pty {
     try {
       const pid = await handleProcessStartEvent(events)
 
-      clearTimeout(reqTimeout)
-
       return new CommandHandle(
         pid,
-        () => {
-          opts?.signal?.removeEventListener('abort', onUserAbort)
-          controller.abort()
-        },
+        cleanup,
         () => this.kill(pid),
         events,
         undefined,
@@ -159,7 +146,7 @@ export class Pty {
         opts.onData
       )
     } catch (err) {
-      opts?.signal?.removeEventListener('abort', onUserAbort)
+      cleanup()
       throw handleRpcError(err)
     }
   }
@@ -176,22 +163,10 @@ export class Pty {
     const requestTimeoutMs =
       opts?.requestTimeoutMs ?? this.connectionConfig.requestTimeoutMs
 
-    const controller = new AbortController()
-
-    const onUserAbort = () => controller.abort(opts?.signal?.reason)
-    if (opts?.signal) {
-      if (opts.signal.aborted) {
-        controller.abort(opts.signal.reason)
-      } else {
-        opts.signal.addEventListener('abort', onUserAbort, { once: true })
-      }
-    }
-
-    const reqTimeout = requestTimeoutMs
-      ? setTimeout(() => {
-          controller.abort()
-        }, requestTimeoutMs)
-      : undefined
+    const { controller, cleanup } = setupRequestController(
+      requestTimeoutMs,
+      opts?.signal
+    )
 
     const events = this.rpc.connect(
       {
@@ -214,14 +189,9 @@ export class Pty {
     try {
       const pid = await handleProcessStartEvent(events)
 
-      clearTimeout(reqTimeout)
-
       return new CommandHandle(
         pid,
-        () => {
-          opts?.signal?.removeEventListener('abort', onUserAbort)
-          controller.abort()
-        },
+        cleanup,
         () => this.kill(pid),
         events,
         undefined,
@@ -229,7 +199,7 @@ export class Pty {
         opts?.onData
       )
     } catch (err) {
-      opts?.signal?.removeEventListener('abort', onUserAbort)
+      cleanup()
       throw handleRpcError(err)
     }
   }

--- a/packages/js-sdk/src/sandbox/commands/pty.ts
+++ b/packages/js-sdk/src/sandbox/commands/pty.ts
@@ -103,7 +103,7 @@ export class Pty {
     envs.LANG = envs.LANG ?? 'C.UTF-8'
     envs.LC_ALL = envs.LC_ALL ?? 'C.UTF-8'
 
-    const { controller, cleanup } = setupRequestController(
+    const { controller, clearStartTimeout, cleanup } = setupRequestController(
       requestTimeoutMs,
       opts?.signal
     )
@@ -135,6 +135,7 @@ export class Pty {
 
     try {
       const pid = await handleProcessStartEvent(events)
+      clearStartTimeout()
 
       return new CommandHandle(
         pid,
@@ -163,7 +164,7 @@ export class Pty {
     const requestTimeoutMs =
       opts?.requestTimeoutMs ?? this.connectionConfig.requestTimeoutMs
 
-    const { controller, cleanup } = setupRequestController(
+    const { controller, clearStartTimeout, cleanup } = setupRequestController(
       requestTimeoutMs,
       opts?.signal
     )
@@ -188,6 +189,7 @@ export class Pty {
 
     try {
       const pid = await handleProcessStartEvent(events)
+      clearStartTimeout()
 
       return new CommandHandle(
         pid,

--- a/packages/js-sdk/src/sandbox/commands/pty.ts
+++ b/packages/js-sdk/src/sandbox/commands/pty.ts
@@ -22,7 +22,7 @@ import { authenticationHeader, handleRpcError } from '../../envd/rpc'
 import { handleProcessStartEvent } from '../../envd/api'
 
 export interface PtyCreateOpts
-  extends Pick<ConnectionOpts, 'requestTimeoutMs'> {
+  extends Pick<ConnectionOpts, 'requestTimeoutMs' | 'signal'> {
   /**
    * Number of columns for the PTY.
    */
@@ -65,7 +65,7 @@ export interface PtyCreateOpts
  * Options for connecting to a command.
  */
 export type PtyConnectOpts = Pick<PtyCreateOpts, 'onData' | 'timeoutMs'> &
-  Pick<ConnectionOpts, 'requestTimeoutMs'>
+  Pick<ConnectionOpts, 'requestTimeoutMs' | 'signal'>
 
 /**
  * Module for interacting with PTYs (pseudo-terminals) in the sandbox.
@@ -103,6 +103,15 @@ export class Pty {
     envs.LC_ALL = envs.LC_ALL ?? 'C.UTF-8'
     const controller = new AbortController()
 
+    const onUserAbort = () => controller.abort(opts?.signal?.reason)
+    if (opts?.signal) {
+      if (opts.signal.aborted) {
+        controller.abort(opts.signal.reason)
+      } else {
+        opts.signal.addEventListener('abort', onUserAbort, { once: true })
+      }
+    }
+
     const reqTimeout = setTimeout(() => {
       controller.abort()
     }, requestTimeoutMs)
@@ -139,7 +148,10 @@ export class Pty {
 
       return new CommandHandle(
         pid,
-        () => controller.abort(),
+        () => {
+          opts?.signal?.removeEventListener('abort', onUserAbort)
+          controller.abort()
+        },
         () => this.kill(pid),
         events,
         undefined,
@@ -147,6 +159,7 @@ export class Pty {
         opts.onData
       )
     } catch (err) {
+      opts?.signal?.removeEventListener('abort', onUserAbort)
       throw handleRpcError(err)
     }
   }
@@ -164,6 +177,15 @@ export class Pty {
       opts?.requestTimeoutMs ?? this.connectionConfig.requestTimeoutMs
 
     const controller = new AbortController()
+
+    const onUserAbort = () => controller.abort(opts?.signal?.reason)
+    if (opts?.signal) {
+      if (opts.signal.aborted) {
+        controller.abort(opts.signal.reason)
+      } else {
+        opts.signal.addEventListener('abort', onUserAbort, { once: true })
+      }
+    }
 
     const reqTimeout = requestTimeoutMs
       ? setTimeout(() => {
@@ -196,7 +218,10 @@ export class Pty {
 
       return new CommandHandle(
         pid,
-        () => controller.abort(),
+        () => {
+          opts?.signal?.removeEventListener('abort', onUserAbort)
+          controller.abort()
+        },
         () => this.kill(pid),
         events,
         undefined,
@@ -204,6 +229,7 @@ export class Pty {
         opts?.onData
       )
     } catch (err) {
+      opts?.signal?.removeEventListener('abort', onUserAbort)
       throw handleRpcError(err)
     }
   }
@@ -218,7 +244,7 @@ export class Pty {
   async sendInput(
     pid: number,
     data: Uint8Array,
-    opts?: Pick<ConnectionOpts, 'requestTimeoutMs'>
+    opts?: Pick<ConnectionOpts, 'requestTimeoutMs' | 'signal'>
   ): Promise<void> {
     try {
       await this.rpc.sendInput(
@@ -237,7 +263,10 @@ export class Pty {
           },
         },
         {
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
     } catch (err) {
@@ -259,7 +288,7 @@ export class Pty {
       cols: number
       rows: number
     },
-    opts?: Pick<ConnectionOpts, 'requestTimeoutMs'>
+    opts?: Pick<ConnectionOpts, 'requestTimeoutMs' | 'signal'>
   ): Promise<void> {
     try {
       await this.rpc.update(
@@ -275,7 +304,10 @@ export class Pty {
           },
         },
         {
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
     } catch (err) {
@@ -294,7 +326,7 @@ export class Pty {
    */
   async kill(
     pid: number,
-    opts?: Pick<ConnectionOpts, 'requestTimeoutMs'>
+    opts?: Pick<ConnectionOpts, 'requestTimeoutMs' | 'signal'>
   ): Promise<boolean> {
     try {
       await this.rpc.sendSignal(
@@ -308,7 +340,10 @@ export class Pty {
           signal: Signal.SIGKILL,
         },
         {
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
 

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -156,7 +156,7 @@ function mapModifiedTime(modifiedTime: Timestamp | undefined) {
  * Options for the sandbox filesystem operations.
  */
 export interface FilesystemRequestOpts
-  extends Partial<Pick<ConnectionOpts, 'requestTimeoutMs'>> {
+  extends Partial<Pick<ConnectionOpts, 'requestTimeoutMs' | 'signal'>> {
   /**
    * User to use for the operation in the sandbox.
    * This affects the resolution of relative paths and ownership of the created filesystem objects.
@@ -325,7 +325,10 @@ export class Filesystem {
         },
       },
       parseAs: format === 'bytes' ? 'arrayBuffer' : format,
-      signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+      signal: this.connectionConfig.getSignal(
+        opts?.requestTimeoutMs,
+        opts?.signal
+      ),
       headers,
     })
 
@@ -454,7 +457,8 @@ export class Filesystem {
             bodySerializer: () => body,
             headers,
             signal: this.connectionConfig.getSignal(
-              writeOpts?.requestTimeoutMs
+              writeOpts?.requestTimeoutMs,
+              writeOpts?.signal
             ),
             body: {},
           })
@@ -496,7 +500,10 @@ export class Filesystem {
           },
         },
         bodySerializer: () => formData,
-        signal: this.connectionConfig.getSignal(writeOpts?.requestTimeoutMs),
+        signal: this.connectionConfig.getSignal(
+          writeOpts?.requestTimeoutMs,
+          writeOpts?.signal
+        ),
         body: {},
       })
 
@@ -559,7 +566,10 @@ export class Filesystem {
         },
         {
           headers: authenticationHeader(this.envdApi.version, opts?.user),
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
 
@@ -604,7 +614,10 @@ export class Filesystem {
         { path },
         {
           headers: authenticationHeader(this.envdApi.version, opts?.user),
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
 
@@ -642,7 +655,10 @@ export class Filesystem {
         },
         {
           headers: authenticationHeader(this.envdApi.version, opts?.user),
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
 
@@ -680,7 +696,10 @@ export class Filesystem {
         { path },
         {
           headers: authenticationHeader(this.envdApi.version, opts?.user),
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
     } catch (err) {
@@ -702,7 +721,10 @@ export class Filesystem {
         { path },
         {
           headers: authenticationHeader(this.envdApi.version, opts?.user),
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
 
@@ -735,7 +757,10 @@ export class Filesystem {
         { path },
         {
           headers: authenticationHeader(this.envdApi.version, opts?.user),
-          signal: this.connectionConfig.getSignal(opts?.requestTimeoutMs),
+          signal: this.connectionConfig.getSignal(
+            opts?.requestTimeoutMs,
+            opts?.signal
+          ),
         }
       )
 
@@ -794,6 +819,15 @@ export class Filesystem {
 
     const controller = new AbortController()
 
+    const onUserAbort = () => controller.abort(opts?.signal?.reason)
+    if (opts?.signal) {
+      if (opts.signal.aborted) {
+        controller.abort(opts.signal.reason)
+      } else {
+        opts.signal.addEventListener('abort', onUserAbort, { once: true })
+      }
+    }
+
     const reqTimeout = requestTimeoutMs
       ? setTimeout(() => {
           controller.abort()
@@ -821,12 +855,16 @@ export class Filesystem {
       clearTimeout(reqTimeout)
 
       return new WatchHandle(
-        () => controller.abort(),
+        () => {
+          opts?.signal?.removeEventListener('abort', onUserAbort)
+          controller.abort()
+        },
         events,
         onEvent,
         opts?.onExit
       )
     } catch (err) {
+      opts?.signal?.removeEventListener('abort', onUserAbort)
       throw handleFilesystemRpcError(err)
     }
   }

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -818,7 +818,7 @@ export class Filesystem {
     const requestTimeoutMs =
       opts?.requestTimeoutMs ?? this.connectionConfig.requestTimeoutMs
 
-    const { controller, cleanup } = setupRequestController(
+    const { controller, clearStartTimeout, cleanup } = setupRequestController(
       requestTimeoutMs,
       opts?.signal
     )
@@ -840,6 +840,7 @@ export class Filesystem {
 
     try {
       await handleWatchDirStartEvent(events)
+      clearStartTimeout()
 
       return new WatchHandle(cleanup, events, onEvent, opts?.onExit)
     } catch (err) {

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -11,6 +11,7 @@ import {
   defaultUsername,
   KEEPALIVE_PING_HEADER,
   KEEPALIVE_PING_INTERVAL_SEC,
+  setupRequestController,
   Username,
 } from '../../connectionConfig'
 
@@ -817,22 +818,10 @@ export class Filesystem {
     const requestTimeoutMs =
       opts?.requestTimeoutMs ?? this.connectionConfig.requestTimeoutMs
 
-    const controller = new AbortController()
-
-    const onUserAbort = () => controller.abort(opts?.signal?.reason)
-    if (opts?.signal) {
-      if (opts.signal.aborted) {
-        controller.abort(opts.signal.reason)
-      } else {
-        opts.signal.addEventListener('abort', onUserAbort, { once: true })
-      }
-    }
-
-    const reqTimeout = requestTimeoutMs
-      ? setTimeout(() => {
-          controller.abort()
-        }, requestTimeoutMs)
-      : undefined
+    const { controller, cleanup } = setupRequestController(
+      requestTimeoutMs,
+      opts?.signal
+    )
 
     const events = this.rpc.watchDir(
       {
@@ -852,19 +841,9 @@ export class Filesystem {
     try {
       await handleWatchDirStartEvent(events)
 
-      clearTimeout(reqTimeout)
-
-      return new WatchHandle(
-        () => {
-          opts?.signal?.removeEventListener('abort', onUserAbort)
-          controller.abort()
-        },
-        events,
-        onEvent,
-        opts?.onExit
-      )
+      return new WatchHandle(cleanup, events, onEvent, opts?.onExit)
     } catch (err) {
-      opts?.signal?.removeEventListener('abort', onUserAbort)
+      cleanup()
       throw handleFilesystemRpcError(err)
     }
   }

--- a/packages/js-sdk/src/sandbox/filesystem/watchHandle.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/watchHandle.ts
@@ -112,11 +112,7 @@ export class WatchHandle {
     } catch (err) {
       this.onExit?.(err as Error)
     } finally {
-      try {
-        this.handleStop()
-      } catch {
-        // handleStop runs cleanup (idempotent); ignore any errors.
-      }
+      this.handleStop()
     }
   }
 }

--- a/packages/js-sdk/src/sandbox/filesystem/watchHandle.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/watchHandle.ts
@@ -111,6 +111,12 @@ export class WatchHandle {
       this.onExit?.()
     } catch (err) {
       this.onExit?.(err as Error)
+    } finally {
+      try {
+        this.handleStop()
+      } catch {
+        // handleStop runs cleanup (idempotent); ignore any errors.
+      }
     }
   }
 }

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -522,9 +522,12 @@ export class Sandbox extends SandboxApi {
    * ```
    */
   async isRunning(
-    opts?: Pick<ConnectionOpts, 'requestTimeoutMs'>
+    opts?: Pick<ConnectionOpts, 'requestTimeoutMs' | 'signal'>
   ): Promise<boolean> {
-    const signal = this.connectionConfig.getSignal(opts?.requestTimeoutMs)
+    const signal = this.connectionConfig.getSignal(
+      opts?.requestTimeoutMs,
+      opts?.signal
+    )
 
     const res = await this.envdApi.api.GET('/health', {
       signal,
@@ -553,7 +556,7 @@ export class Sandbox extends SandboxApi {
    */
   async setTimeout(
     timeoutMs: number,
-    opts?: Pick<SandboxOpts, 'requestTimeoutMs'>
+    opts?: Pick<SandboxOpts, 'requestTimeoutMs' | 'signal'>
   ) {
     if (this.connectionConfig.debug) {
       // Skip timeout in debug mode
@@ -572,7 +575,7 @@ export class Sandbox extends SandboxApi {
    *
    * @param opts connection options.
    */
-  async kill(opts?: Pick<SandboxOpts, 'requestTimeoutMs'>) {
+  async kill(opts?: Pick<SandboxOpts, 'requestTimeoutMs' | 'signal'>) {
     if (this.connectionConfig.debug) {
       // Skip killing in debug mode
       return
@@ -788,7 +791,7 @@ export class Sandbox extends SandboxApi {
    *
    * @returns information about the sandbox
    */
-  async getInfo(opts?: Pick<SandboxOpts, 'requestTimeoutMs'>) {
+  async getInfo(opts?: Pick<SandboxOpts, 'requestTimeoutMs' | 'signal'>) {
     return await SandboxApi.getInfo(this.sandboxId, this.resolveApiOpts(opts))
   }
 

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -894,14 +894,14 @@ export class SandboxApi {
 }
 
 abstract class BasePaginator<T> {
-  protected readonly opts?: SandboxApiOpts
+  protected readonly config: ConnectionConfig
   protected readonly limit?: number
 
   private _hasNext: boolean
   private _nextToken?: string
 
-  constructor(opts?: SandboxApiOpts, limit?: number, nextToken?: string) {
-    this.opts = opts
+  constructor(config: ConnectionConfig, limit?: number, nextToken?: string) {
+    this.config = config
     this.limit = limit
 
     this._hasNext = true
@@ -959,7 +959,7 @@ export class SandboxPaginator extends BasePaginator<SandboxInfo> {
   private query: SandboxListOpts['query']
 
   constructor(opts?: SandboxListOpts) {
-    super(opts, opts?.limit, opts?.nextToken)
+    super(new ConnectionConfig(opts), opts?.limit, opts?.nextToken)
 
     this.query = opts?.query
   }
@@ -981,7 +981,7 @@ export class SandboxPaginator extends BasePaginator<SandboxInfo> {
       metadata = new URLSearchParams(encodedPairs).toString()
     }
 
-    const config = new ConnectionConfig(opts ?? this.opts)
+    const config = opts ? new ConnectionConfig(opts) : this.config
     const client = new ApiClient(config)
 
     const res = await client.api.GET('/v2/sandboxes', {
@@ -1037,7 +1037,7 @@ export class SnapshotPaginator extends BasePaginator<SnapshotInfo> {
   private readonly sandboxId?: string
 
   constructor(opts?: SnapshotListOpts) {
-    super(opts, opts?.limit, opts?.nextToken)
+    super(new ConnectionConfig(opts), opts?.limit, opts?.nextToken)
 
     this.sandboxId = opts?.sandboxId
   }
@@ -1047,7 +1047,7 @@ export class SnapshotPaginator extends BasePaginator<SnapshotInfo> {
       throw new Error('No more items to fetch')
     }
 
-    const config = new ConnectionConfig(opts ?? this.opts)
+    const config = opts ? new ConnectionConfig(opts) : this.config
     const client = new ApiClient(config)
 
     const res = await client.api.GET('/snapshots', {

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -897,11 +897,17 @@ abstract class BasePaginator<T> {
   protected readonly config: ConnectionConfig
   protected client: ApiClient
   protected readonly limit?: number
+  protected readonly signal?: AbortSignal
 
   private _hasNext: boolean
   private _nextToken?: string
 
-  constructor(config: ConnectionConfig, limit?: number, nextToken?: string) {
+  constructor(
+    config: ConnectionConfig,
+    limit?: number,
+    nextToken?: string,
+    signal?: AbortSignal
+  ) {
     this.config = config
     this.client = new ApiClient(this.config)
 
@@ -909,6 +915,7 @@ abstract class BasePaginator<T> {
     this._nextToken = nextToken
 
     this.limit = limit
+    this.signal = signal
   }
 
   /**
@@ -956,7 +963,12 @@ export class SandboxPaginator extends BasePaginator<SandboxInfo> {
   private query: SandboxListOpts['query']
 
   constructor(opts?: SandboxListOpts) {
-    super(new ConnectionConfig(opts), opts?.limit, opts?.nextToken)
+    super(
+      new ConnectionConfig(opts),
+      opts?.limit,
+      opts?.nextToken,
+      opts?.signal
+    )
 
     this.query = opts?.query
   }
@@ -988,7 +1000,7 @@ export class SandboxPaginator extends BasePaginator<SandboxInfo> {
         },
       },
       // requestTimeoutMs is already passed here via the connectionConfig.
-      signal: this.config.getSignal(),
+      signal: this.config.getSignal(undefined, this.signal),
     })
 
     const err = handleApiError(res)
@@ -1032,7 +1044,12 @@ export class SnapshotPaginator extends BasePaginator<SnapshotInfo> {
   private readonly sandboxId?: string
 
   constructor(opts?: SnapshotListOpts) {
-    super(new ConnectionConfig(opts), opts?.limit, opts?.nextToken)
+    super(
+      new ConnectionConfig(opts),
+      opts?.limit,
+      opts?.nextToken,
+      opts?.signal
+    )
 
     this.sandboxId = opts?.sandboxId
   }
@@ -1050,7 +1067,7 @@ export class SnapshotPaginator extends BasePaginator<SnapshotInfo> {
           nextToken: this.nextToken,
         },
       },
-      signal: this.config.getSignal(),
+      signal: this.config.getSignal(undefined, this.signal),
     })
 
     const err = handleApiError(res)

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -894,14 +894,14 @@ export class SandboxApi {
 }
 
 abstract class BasePaginator<T> {
-  protected readonly config: ConnectionConfig
+  protected readonly opts?: SandboxApiOpts
   protected readonly limit?: number
 
   private _hasNext: boolean
   private _nextToken?: string
 
-  constructor(config: ConnectionConfig, limit?: number, nextToken?: string) {
-    this.config = config
+  constructor(opts?: SandboxApiOpts, limit?: number, nextToken?: string) {
+    this.opts = opts
     this.limit = limit
 
     this._hasNext = true
@@ -959,7 +959,7 @@ export class SandboxPaginator extends BasePaginator<SandboxInfo> {
   private query: SandboxListOpts['query']
 
   constructor(opts?: SandboxListOpts) {
-    super(new ConnectionConfig(opts), opts?.limit, opts?.nextToken)
+    super(opts, opts?.limit, opts?.nextToken)
 
     this.query = opts?.query
   }
@@ -981,7 +981,7 @@ export class SandboxPaginator extends BasePaginator<SandboxInfo> {
       metadata = new URLSearchParams(encodedPairs).toString()
     }
 
-    const config = opts ? new ConnectionConfig(opts) : this.config
+    const config = new ConnectionConfig({ ...this.opts, ...opts })
     const client = new ApiClient(config)
 
     const res = await client.api.GET('/v2/sandboxes', {
@@ -1037,7 +1037,7 @@ export class SnapshotPaginator extends BasePaginator<SnapshotInfo> {
   private readonly sandboxId?: string
 
   constructor(opts?: SnapshotListOpts) {
-    super(new ConnectionConfig(opts), opts?.limit, opts?.nextToken)
+    super(opts, opts?.limit, opts?.nextToken)
 
     this.sandboxId = opts?.sandboxId
   }
@@ -1047,7 +1047,7 @@ export class SnapshotPaginator extends BasePaginator<SnapshotInfo> {
       throw new Error('No more items to fetch')
     }
 
-    const config = opts ? new ConnectionConfig(opts) : this.config
+    const config = new ConnectionConfig({ ...this.opts, ...opts })
     const client = new ApiClient(config)
 
     const res = await client.api.GET('/snapshots', {

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -99,7 +99,7 @@ export interface SandboxApiOpts
   extends Partial<
     Pick<
       ConnectionOpts,
-      'apiKey' | 'headers' | 'debug' | 'domain' | 'requestTimeoutMs'
+      'apiKey' | 'headers' | 'debug' | 'domain' | 'requestTimeoutMs' | 'signal'
     >
   > {}
 
@@ -463,7 +463,7 @@ export class SandboxApi {
           sandboxID: sandboxId,
         },
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.error?.code === 404) {
@@ -525,7 +525,7 @@ export class SandboxApi {
           end,
         },
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     const err = handleApiError(res)
@@ -575,7 +575,7 @@ export class SandboxApi {
       body: {
         timeout: timeoutToSeconds(timeoutMs),
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.error?.code === 404) {
@@ -598,7 +598,7 @@ export class SandboxApi {
           sandboxID: sandboxId,
         },
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.error?.code === 404) {
@@ -667,7 +667,7 @@ export class SandboxApi {
           sandboxID: sandboxId,
         },
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.error?.code === 404) {
@@ -723,7 +723,7 @@ export class SandboxApi {
         },
       },
       body: opts?.name ? { name: opts.name } : {},
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.error?.code === 404) {
@@ -773,7 +773,7 @@ export class SandboxApi {
           templateID: snapshotId,
         },
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.error?.code === 404) {
@@ -828,7 +828,7 @@ export class SandboxApi {
 
     const res = await client.api.POST('/sandboxes', {
       body,
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     const err = handleApiError(res)
@@ -871,7 +871,7 @@ export class SandboxApi {
       body: {
         timeout: timeoutToSeconds(timeoutMs),
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.error?.code === 404) {

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -214,7 +214,7 @@ export type SandboxConnectOpts = ConnectionOpts & {
  */
 export type SandboxState = 'running' | 'paused'
 
-export interface SandboxListOpts extends SandboxApiOpts {
+export interface SandboxListOpts extends Omit<SandboxApiOpts, 'signal'> {
   /**
    * Filter the list of sandboxes, e.g. by metadata `metadata:{"key": "value"}`, if there are multiple filters they are combined with AND.
    *
@@ -239,15 +239,6 @@ export interface SandboxListOpts extends SandboxApiOpts {
    * Token to the next page.
    */
   nextToken?: string
-
-  /**
-   * An optional `AbortSignal` that cancels in-flight page requests.
-   * The signal is stored on the returned paginator and applies to every
-   * subsequent {@link SandboxPaginator.nextItems} call — once aborted,
-   * all further pages reject. Construct a new paginator if you need a
-   * fresh signal.
-   */
-  signal?: AbortSignal
 }
 
 export interface SandboxMetricsOpts extends SandboxApiOpts {
@@ -264,7 +255,7 @@ export interface SandboxMetricsOpts extends SandboxApiOpts {
 /**
  * Options for listing snapshots.
  */
-export interface SnapshotListOpts extends SandboxApiOpts {
+export interface SnapshotListOpts extends Omit<SandboxApiOpts, 'signal'> {
   /**
    * Filter snapshots by source sandbox ID.
    */
@@ -281,15 +272,6 @@ export interface SnapshotListOpts extends SandboxApiOpts {
    * Token to the next page.
    */
   nextToken?: string
-
-  /**
-   * An optional `AbortSignal` that cancels in-flight page requests.
-   * The signal is stored on the returned paginator and applies to every
-   * subsequent {@link SnapshotPaginator.nextItems} call — once aborted,
-   * all further pages reject. Construct a new paginator if you need a
-   * fresh signal.
-   */
-  signal?: AbortSignal
 }
 
 /**
@@ -911,21 +893,27 @@ export class SandboxApi {
   }
 }
 
+/**
+ * Per-call options accepted by {@link BasePaginator.nextItems}.
+ */
+export interface PaginatorNextOpts {
+  /**
+   * An optional `AbortSignal` that cancels this in-flight page request.
+   * Aborting one page does not affect subsequent {@link BasePaginator.nextItems}
+   * calls — pass a fresh signal each call you want to be cancellable.
+   */
+  signal?: AbortSignal
+}
+
 abstract class BasePaginator<T> {
   protected readonly config: ConnectionConfig
   protected client: ApiClient
   protected readonly limit?: number
-  protected readonly signal?: AbortSignal
 
   private _hasNext: boolean
   private _nextToken?: string
 
-  constructor(
-    config: ConnectionConfig,
-    limit?: number,
-    nextToken?: string,
-    signal?: AbortSignal
-  ) {
+  constructor(config: ConnectionConfig, limit?: number, nextToken?: string) {
     this.config = config
     this.client = new ApiClient(this.config)
 
@@ -933,7 +921,6 @@ abstract class BasePaginator<T> {
     this._nextToken = nextToken
 
     this.limit = limit
-    this.signal = signal
   }
 
   /**
@@ -958,11 +945,13 @@ abstract class BasePaginator<T> {
   /**
    * Get the next page of items.
    *
+   * @param opts per-call options (e.g. an `AbortSignal` to cancel this page request).
+   *
    * @throws Error if there are no more items to fetch. Call this method only if `hasNext` is `true`.
    *
    * @returns List of items
    */
-  abstract nextItems(): Promise<T[]>
+  abstract nextItems(opts?: PaginatorNextOpts): Promise<T[]>
 }
 
 /**
@@ -981,17 +970,12 @@ export class SandboxPaginator extends BasePaginator<SandboxInfo> {
   private query: SandboxListOpts['query']
 
   constructor(opts?: SandboxListOpts) {
-    super(
-      new ConnectionConfig(opts),
-      opts?.limit,
-      opts?.nextToken,
-      opts?.signal
-    )
+    super(new ConnectionConfig(opts), opts?.limit, opts?.nextToken)
 
     this.query = opts?.query
   }
 
-  async nextItems(): Promise<SandboxInfo[]> {
+  async nextItems(opts?: PaginatorNextOpts): Promise<SandboxInfo[]> {
     if (!this.hasNext) {
       throw new Error('No more items to fetch')
     }
@@ -1018,7 +1002,7 @@ export class SandboxPaginator extends BasePaginator<SandboxInfo> {
         },
       },
       // requestTimeoutMs is already passed here via the connectionConfig.
-      signal: this.config.getSignal(undefined, this.signal),
+      signal: this.config.getSignal(undefined, opts?.signal),
     })
 
     const err = handleApiError(res)
@@ -1062,17 +1046,12 @@ export class SnapshotPaginator extends BasePaginator<SnapshotInfo> {
   private readonly sandboxId?: string
 
   constructor(opts?: SnapshotListOpts) {
-    super(
-      new ConnectionConfig(opts),
-      opts?.limit,
-      opts?.nextToken,
-      opts?.signal
-    )
+    super(new ConnectionConfig(opts), opts?.limit, opts?.nextToken)
 
     this.sandboxId = opts?.sandboxId
   }
 
-  async nextItems(): Promise<SnapshotInfo[]> {
+  async nextItems(opts?: PaginatorNextOpts): Promise<SnapshotInfo[]> {
     if (!this.hasNext) {
       throw new Error('No more items to fetch')
     }
@@ -1085,7 +1064,7 @@ export class SnapshotPaginator extends BasePaginator<SnapshotInfo> {
           nextToken: this.nextToken,
         },
       },
-      signal: this.config.getSignal(undefined, this.signal),
+      signal: this.config.getSignal(undefined, opts?.signal),
     })
 
     const err = handleApiError(res)

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -893,34 +893,19 @@ export class SandboxApi {
   }
 }
 
-/**
- * Per-call options accepted by {@link BasePaginator.nextItems}.
- */
-export interface PaginatorNextOpts {
-  /**
-   * An optional `AbortSignal` that cancels this in-flight page request.
-   * Aborting one page does not affect subsequent {@link BasePaginator.nextItems}
-   * calls — pass a fresh signal each call you want to be cancellable.
-   */
-  signal?: AbortSignal
-}
-
 abstract class BasePaginator<T> {
-  protected readonly config: ConnectionConfig
-  protected client: ApiClient
+  protected readonly opts?: SandboxApiOpts
   protected readonly limit?: number
 
   private _hasNext: boolean
   private _nextToken?: string
 
-  constructor(config: ConnectionConfig, limit?: number, nextToken?: string) {
-    this.config = config
-    this.client = new ApiClient(this.config)
+  constructor(opts?: SandboxApiOpts, limit?: number, nextToken?: string) {
+    this.opts = opts
+    this.limit = limit
 
     this._hasNext = true
     this._nextToken = nextToken
-
-    this.limit = limit
   }
 
   /**
@@ -945,13 +930,17 @@ abstract class BasePaginator<T> {
   /**
    * Get the next page of items.
    *
-   * @param opts per-call options (e.g. an `AbortSignal` to cancel this page request).
+   * @param opts per-call connection options. When provided, this call uses
+   * these options (e.g. `apiKey`, `domain`, `headers`, `requestTimeoutMs`,
+   * `signal`) instead of the ones the paginator was constructed with.
+   * Aborting a page via `signal` does not affect subsequent {@link BasePaginator.nextItems}
+   * calls — pass a fresh signal each call you want to be cancellable.
    *
    * @throws Error if there are no more items to fetch. Call this method only if `hasNext` is `true`.
    *
    * @returns List of items
    */
-  abstract nextItems(opts?: PaginatorNextOpts): Promise<T[]>
+  abstract nextItems(opts?: SandboxApiOpts): Promise<T[]>
 }
 
 /**
@@ -970,12 +959,12 @@ export class SandboxPaginator extends BasePaginator<SandboxInfo> {
   private query: SandboxListOpts['query']
 
   constructor(opts?: SandboxListOpts) {
-    super(new ConnectionConfig(opts), opts?.limit, opts?.nextToken)
+    super(opts, opts?.limit, opts?.nextToken)
 
     this.query = opts?.query
   }
 
-  async nextItems(opts?: PaginatorNextOpts): Promise<SandboxInfo[]> {
+  async nextItems(opts?: SandboxApiOpts): Promise<SandboxInfo[]> {
     if (!this.hasNext) {
       throw new Error('No more items to fetch')
     }
@@ -992,7 +981,10 @@ export class SandboxPaginator extends BasePaginator<SandboxInfo> {
       metadata = new URLSearchParams(encodedPairs).toString()
     }
 
-    const res = await this.client.api.GET('/v2/sandboxes', {
+    const config = new ConnectionConfig(opts ?? this.opts)
+    const client = new ApiClient(config)
+
+    const res = await client.api.GET('/v2/sandboxes', {
       params: {
         query: {
           metadata,
@@ -1001,8 +993,7 @@ export class SandboxPaginator extends BasePaginator<SandboxInfo> {
           nextToken: this.nextToken,
         },
       },
-      // requestTimeoutMs is already passed here via the connectionConfig.
-      signal: this.config.getSignal(undefined, opts?.signal),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     const err = handleApiError(res)
@@ -1046,17 +1037,20 @@ export class SnapshotPaginator extends BasePaginator<SnapshotInfo> {
   private readonly sandboxId?: string
 
   constructor(opts?: SnapshotListOpts) {
-    super(new ConnectionConfig(opts), opts?.limit, opts?.nextToken)
+    super(opts, opts?.limit, opts?.nextToken)
 
     this.sandboxId = opts?.sandboxId
   }
 
-  async nextItems(opts?: PaginatorNextOpts): Promise<SnapshotInfo[]> {
+  async nextItems(opts?: SandboxApiOpts): Promise<SnapshotInfo[]> {
     if (!this.hasNext) {
       throw new Error('No more items to fetch')
     }
 
-    const res = await this.client.api.GET('/snapshots', {
+    const config = new ConnectionConfig(opts ?? this.opts)
+    const client = new ApiClient(config)
+
+    const res = await client.api.GET('/snapshots', {
       params: {
         query: {
           sandboxID: this.sandboxId,
@@ -1064,7 +1058,7 @@ export class SnapshotPaginator extends BasePaginator<SnapshotInfo> {
           nextToken: this.nextToken,
         },
       },
-      signal: this.config.getSignal(undefined, opts?.signal),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     const err = handleApiError(res)

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -239,6 +239,15 @@ export interface SandboxListOpts extends SandboxApiOpts {
    * Token to the next page.
    */
   nextToken?: string
+
+  /**
+   * An optional `AbortSignal` that cancels in-flight page requests.
+   * The signal is stored on the returned paginator and applies to every
+   * subsequent {@link SandboxPaginator.nextItems} call — once aborted,
+   * all further pages reject. Construct a new paginator if you need a
+   * fresh signal.
+   */
+  signal?: AbortSignal
 }
 
 export interface SandboxMetricsOpts extends SandboxApiOpts {
@@ -272,6 +281,15 @@ export interface SnapshotListOpts extends SandboxApiOpts {
    * Token to the next page.
    */
   nextToken?: string
+
+  /**
+   * An optional `AbortSignal` that cancels in-flight page requests.
+   * The signal is stored on the returned paginator and applies to every
+   * subsequent {@link SnapshotPaginator.nextItems} call — once aborted,
+   * all further pages reject. Construct a new paginator if you need a
+   * fresh signal.
+   */
+  signal?: AbortSignal
 }
 
 /**

--- a/packages/js-sdk/src/volume/client.ts
+++ b/packages/js-sdk/src/volume/client.ts
@@ -2,6 +2,7 @@ import createClient from 'openapi-fetch'
 
 import type { components, paths } from './schema.gen'
 import { defaultHeaders, getEnvVar } from '../api/metadata'
+import { buildRequestSignal } from '../connectionConfig'
 import { createApiLogger, Logger } from '../logs'
 import type { Volume } from './index'
 
@@ -91,14 +92,7 @@ export class VolumeConnectionConfig {
   }
 
   getSignal(requestTimeoutMs?: number, signal?: AbortSignal) {
-    const timeout = requestTimeoutMs ?? this.requestTimeoutMs
-    const timeoutSignal = timeout ? AbortSignal.timeout(timeout) : undefined
-
-    if (timeoutSignal && signal) {
-      return AbortSignal.any([timeoutSignal, signal])
-    }
-
-    return timeoutSignal ?? signal
+    return buildRequestSignal(requestTimeoutMs ?? this.requestTimeoutMs, signal)
   }
 }
 

--- a/packages/js-sdk/src/volume/client.ts
+++ b/packages/js-sdk/src/volume/client.ts
@@ -47,6 +47,13 @@ export interface VolumeApiOpts {
    * Additional headers to send with the request.
    */
   headers?: Record<string, string>
+
+  /**
+   * An optional `AbortSignal` that can be used to cancel the in-flight request.
+   * When the signal is aborted, the underlying `fetch` is aborted and the
+   * returned promise rejects with an `AbortError`.
+   */
+  signal?: AbortSignal
 }
 
 export class VolumeConnectionConfig {
@@ -83,10 +90,15 @@ export class VolumeConnectionConfig {
     return getEnvVar('E2B_VOLUME_API_URL')
   }
 
-  getSignal(requestTimeoutMs?: number) {
+  getSignal(requestTimeoutMs?: number, signal?: AbortSignal) {
     const timeout = requestTimeoutMs ?? this.requestTimeoutMs
+    const timeoutSignal = timeout ? AbortSignal.timeout(timeout) : undefined
 
-    return timeout ? AbortSignal.timeout(timeout) : undefined
+    if (timeoutSignal && signal) {
+      return AbortSignal.any([timeoutSignal, signal])
+    }
+
+    return timeoutSignal ?? signal
   }
 }
 

--- a/packages/js-sdk/src/volume/client.ts
+++ b/packages/js-sdk/src/volume/client.ts
@@ -2,7 +2,6 @@ import createClient from 'openapi-fetch'
 
 import type { components, paths } from './schema.gen'
 import { defaultHeaders, getEnvVar } from '../api/metadata'
-import { combineAbortSignals } from '../connectionConfig'
 import { createApiLogger, Logger } from '../logs'
 import type { Volume } from './index'
 
@@ -96,7 +95,7 @@ export class VolumeConnectionConfig {
     const timeoutSignal = timeout ? AbortSignal.timeout(timeout) : undefined
 
     if (timeoutSignal && signal) {
-      return combineAbortSignals([timeoutSignal, signal])
+      return AbortSignal.any([timeoutSignal, signal])
     }
 
     return timeoutSignal ?? signal

--- a/packages/js-sdk/src/volume/client.ts
+++ b/packages/js-sdk/src/volume/client.ts
@@ -2,6 +2,7 @@ import createClient from 'openapi-fetch'
 
 import type { components, paths } from './schema.gen'
 import { defaultHeaders, getEnvVar } from '../api/metadata'
+import { combineAbortSignals } from '../connectionConfig'
 import { createApiLogger, Logger } from '../logs'
 import type { Volume } from './index'
 
@@ -95,7 +96,7 @@ export class VolumeConnectionConfig {
     const timeoutSignal = timeout ? AbortSignal.timeout(timeout) : undefined
 
     if (timeoutSignal && signal) {
-      return AbortSignal.any([timeoutSignal, signal])
+      return combineAbortSignals([timeoutSignal, signal])
     }
 
     return timeoutSignal ?? signal

--- a/packages/js-sdk/src/volume/index.ts
+++ b/packages/js-sdk/src/volume/index.ts
@@ -104,7 +104,7 @@ export class Volume {
       body: {
         name,
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     const err = handleApiError(res, VolumeError)
@@ -163,7 +163,7 @@ export class Volume {
           volumeID: volumeId,
         },
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.response.status === 404) {
@@ -194,7 +194,7 @@ export class Volume {
     const client = new ApiClient(config)
 
     const res = await client.api.GET('/volumes', {
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     const err = handleApiError(res, VolumeError)
@@ -227,7 +227,7 @@ export class Volume {
           volumeID: volumeId,
         },
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.response.status === 404) {
@@ -268,7 +268,7 @@ export class Volume {
           depth: opts?.depth,
         },
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.response.status === 404) {
@@ -312,7 +312,7 @@ export class Volume {
           force: opts?.force,
         },
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.response.status === 404) {
@@ -354,7 +354,7 @@ export class Volume {
           path,
         },
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.response.status === 404) {
@@ -429,7 +429,7 @@ export class Volume {
         gid: metadata.gid,
         mode: metadata.mode,
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.response.status === 404) {
@@ -530,7 +530,10 @@ export class Volume {
         },
       },
       parseAs: format === 'bytes' ? 'arrayBuffer' : format,
-      signal: config.getSignal(opts?.requestTimeoutMs ?? FILE_TIMEOUT_MS),
+      signal: config.getSignal(
+        opts?.requestTimeoutMs ?? FILE_TIMEOUT_MS,
+        opts?.signal
+      ),
     })
 
     if (res.response.status === 404) {
@@ -599,7 +602,10 @@ export class Volume {
       headers: {
         'Content-Type': 'application/octet-stream',
       },
-      signal: config.getSignal(opts?.requestTimeoutMs ?? FILE_TIMEOUT_MS),
+      signal: config.getSignal(
+        opts?.requestTimeoutMs ?? FILE_TIMEOUT_MS,
+        opts?.signal
+      ),
     })
 
     if (res.response.status === 404) {
@@ -639,7 +645,7 @@ export class Volume {
           path,
         },
       },
-      signal: config.getSignal(opts?.requestTimeoutMs),
+      signal: config.getSignal(opts?.requestTimeoutMs, opts?.signal),
     })
 
     if (res.response.status === 404) {

--- a/packages/js-sdk/tests/connectionConfig.test.ts
+++ b/packages/js-sdk/tests/connectionConfig.test.ts
@@ -119,3 +119,31 @@ test('setupRequestController cleanup removes the user-signal listener', () => {
   userController.abort()
   cleanup()
 })
+
+test('setupRequestController clearStartTimeout stops the handshake timer', async () => {
+  const { controller, clearStartTimeout } = setupRequestController(
+    20,
+    undefined
+  )
+  clearStartTimeout()
+  await new Promise((resolve) => setTimeout(resolve, 40))
+  assert.equal(controller.signal.aborted, false)
+})
+
+test('setupRequestController handshake timer aborts when not cleared', async () => {
+  const { controller } = setupRequestController(20, undefined)
+  await new Promise((resolve) => setTimeout(resolve, 40))
+  assert.equal(controller.signal.aborted, true)
+})
+
+test('setupRequestController user signal still cancels after clearStartTimeout', () => {
+  const userController = new AbortController()
+  const { controller, clearStartTimeout } = setupRequestController(
+    60_000,
+    userController.signal
+  )
+  clearStartTimeout()
+  assert.equal(controller.signal.aborted, false)
+  userController.abort()
+  assert.equal(controller.signal.aborted, true)
+})

--- a/packages/js-sdk/tests/connectionConfig.test.ts
+++ b/packages/js-sdk/tests/connectionConfig.test.ts
@@ -51,3 +51,33 @@ test('api_url has correct priority', () => {
   const config = new ConnectionConfig({ apiUrl: 'http://localhost:8080' })
   assert.equal(config.apiUrl, 'http://localhost:8080')
 })
+
+test('getSignal returns user signal when no timeout is set', () => {
+  const config = new ConnectionConfig({ requestTimeoutMs: 0 })
+  const controller = new AbortController()
+  const signal = config.getSignal(0, controller.signal)
+  assert.strictEqual(signal, controller.signal)
+})
+
+test('getSignal aborts when user signal is aborted', () => {
+  const config = new ConnectionConfig({ requestTimeoutMs: 60_000 })
+  const controller = new AbortController()
+  const signal = config.getSignal(undefined, controller.signal)
+  assert.ok(signal)
+  assert.equal(signal!.aborted, false)
+  controller.abort()
+  assert.equal(signal!.aborted, true)
+})
+
+test('getSignal returns timeout signal when no user signal is provided', () => {
+  const config = new ConnectionConfig({ requestTimeoutMs: 60_000 })
+  const signal = config.getSignal()
+  assert.ok(signal)
+  assert.equal(signal!.aborted, false)
+})
+
+test('getSignal returns undefined when no timeout and no signal', () => {
+  const config = new ConnectionConfig({ requestTimeoutMs: 0 })
+  const signal = config.getSignal(0)
+  assert.equal(signal, undefined)
+})

--- a/packages/js-sdk/tests/connectionConfig.test.ts
+++ b/packages/js-sdk/tests/connectionConfig.test.ts
@@ -1,5 +1,8 @@
 import { assert, test, beforeEach, afterEach } from 'vitest'
-import { ConnectionConfig } from '../src/connectionConfig'
+import {
+  ConnectionConfig,
+  setupRequestController,
+} from '../src/connectionConfig'
 
 // Store original env vars to restore after tests
 let originalEnv: { [key: string]: string | undefined }
@@ -80,4 +83,39 @@ test('getSignal returns undefined when no timeout and no signal', () => {
   const config = new ConnectionConfig({ requestTimeoutMs: 0 })
   const signal = config.getSignal(0)
   assert.equal(signal, undefined)
+})
+
+test('setupRequestController aborts when user signal aborts', () => {
+  const userController = new AbortController()
+  const { controller } = setupRequestController(0, userController.signal)
+
+  assert.equal(controller.signal.aborted, false)
+  userController.abort()
+  assert.equal(controller.signal.aborted, true)
+})
+
+test('setupRequestController is already aborted when user signal was pre-aborted', () => {
+  const userController = new AbortController()
+  userController.abort()
+
+  const { controller } = setupRequestController(0, userController.signal)
+  assert.equal(controller.signal.aborted, true)
+})
+
+test('setupRequestController cleanup removes the user-signal listener', () => {
+  const userController = new AbortController()
+  const { controller, cleanup } = setupRequestController(
+    0,
+    userController.signal
+  )
+
+  cleanup()
+  // Internal controller is aborted by cleanup, so it stays aborted.
+  assert.equal(controller.signal.aborted, true)
+
+  // After cleanup the listener is detached — a subsequent abort on the
+  // user signal must not propagate (verified indirectly: cleanup is
+  // idempotent and no error is thrown).
+  userController.abort()
+  cleanup()
 })

--- a/packages/js-sdk/tests/connectionConfig.test.ts
+++ b/packages/js-sdk/tests/connectionConfig.test.ts
@@ -136,6 +136,14 @@ test('setupRequestController handshake timer aborts when not cleared', async () 
   assert.equal(controller.signal.aborted, true)
 })
 
+test('setupRequestController handshake timeout aborts with TimeoutError reason', async () => {
+  const { controller } = setupRequestController(20, undefined)
+  await new Promise((resolve) => setTimeout(resolve, 40))
+  assert.equal(controller.signal.aborted, true)
+  assert.ok(controller.signal.reason instanceof DOMException)
+  assert.equal((controller.signal.reason as DOMException).name, 'TimeoutError')
+})
+
 test('setupRequestController user signal still cancels after clearStartTimeout', () => {
   const userController = new AbortController()
   const { controller, clearStartTimeout } = setupRequestController(

--- a/packages/js-sdk/tests/sandbox/abortSignal.test.ts
+++ b/packages/js-sdk/tests/sandbox/abortSignal.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { Sandbox } from '../../src'
+import { apiUrl } from '../setup'
+
+const restHandlers = [
+  http.post(apiUrl('/sandboxes'), async ({ request }) => {
+    // Hold the request open until the caller aborts (or the test times out).
+    await new Promise<void>((_, reject) => {
+      request.signal.addEventListener('abort', () =>
+        reject(new DOMException('aborted', 'AbortError'))
+      )
+    })
+    return HttpResponse.json({})
+  }),
+  http.delete(apiUrl('/sandboxes/:sandboxID'), async ({ request }) => {
+    await new Promise<void>((_, reject) => {
+      request.signal.addEventListener('abort', () =>
+        reject(new DOMException('aborted', 'AbortError'))
+      )
+    })
+    return HttpResponse.json({})
+  }),
+]
+
+const server = setupServer(...restHandlers)
+
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'bypass',
+  })
+)
+
+afterAll(() => server.close())
+
+afterEach(() => server.resetHandlers())
+
+test('Sandbox.create rejects when AbortSignal is aborted', async () => {
+  const controller = new AbortController()
+
+  const promise = Sandbox.create('base', {
+    apiKey: 'test-key',
+    signal: controller.signal,
+  })
+
+  // Abort soon after the request starts.
+  setTimeout(() => controller.abort(), 25)
+
+  await expect(promise).rejects.toThrow()
+})
+
+test('Sandbox.create rejects immediately when signal is already aborted', async () => {
+  const controller = new AbortController()
+  controller.abort()
+
+  await expect(
+    Sandbox.create('base', {
+      apiKey: 'test-key',
+      signal: controller.signal,
+    })
+  ).rejects.toThrow()
+})
+
+test('Sandbox.kill rejects when AbortSignal is aborted', async () => {
+  const controller = new AbortController()
+
+  const promise = Sandbox.kill('some-sandbox', {
+    apiKey: 'test-key',
+    signal: controller.signal,
+  })
+
+  setTimeout(() => controller.abort(), 25)
+
+  await expect(promise).rejects.toThrow()
+})

--- a/packages/js-sdk/tests/sandbox/abortSignal.test.ts
+++ b/packages/js-sdk/tests/sandbox/abortSignal.test.ts
@@ -5,30 +5,31 @@ import { setupServer } from 'msw/node'
 import { Sandbox } from '../../src'
 import { apiUrl } from '../setup'
 
+// Hold the request open until the caller aborts. If the signal is already
+// aborted by the time the handler runs, `addEventListener('abort', …)` would
+// never fire — so check `aborted` first to avoid hanging.
+function holdUntilAborted(signal: AbortSignal): Promise<never> {
+  return new Promise<never>((_, reject) => {
+    const abort = () => reject(new DOMException('aborted', 'AbortError'))
+    if (signal.aborted) {
+      abort()
+      return
+    }
+    signal.addEventListener('abort', abort, { once: true })
+  })
+}
+
 const restHandlers = [
   http.post(apiUrl('/sandboxes'), async ({ request }) => {
-    // Hold the request open until the caller aborts (or the test times out).
-    await new Promise<void>((_, reject) => {
-      request.signal.addEventListener('abort', () =>
-        reject(new DOMException('aborted', 'AbortError'))
-      )
-    })
+    await holdUntilAborted(request.signal)
     return HttpResponse.json({})
   }),
   http.delete(apiUrl('/sandboxes/:sandboxID'), async ({ request }) => {
-    await new Promise<void>((_, reject) => {
-      request.signal.addEventListener('abort', () =>
-        reject(new DOMException('aborted', 'AbortError'))
-      )
-    })
+    await holdUntilAborted(request.signal)
     return HttpResponse.json({})
   }),
   http.get(apiUrl('/v2/sandboxes'), async ({ request }) => {
-    await new Promise<void>((_, reject) => {
-      request.signal.addEventListener('abort', () =>
-        reject(new DOMException('aborted', 'AbortError'))
-      )
-    })
+    await holdUntilAborted(request.signal)
     return HttpResponse.json([])
   }),
 ]
@@ -45,16 +46,29 @@ afterAll(() => server.close())
 
 afterEach(() => server.resetHandlers())
 
+// Resolves once MSW has dispatched the next request, so tests can abort
+// deterministically instead of guessing with `setTimeout`.
+function nextRequestStart(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const listener = () => {
+      server.events.removeListener('request:start', listener)
+      resolve()
+    }
+    server.events.on('request:start', listener)
+  })
+}
+
 test('Sandbox.create rejects when AbortSignal is aborted', async () => {
   const controller = new AbortController()
+  const requestStarted = nextRequestStart()
 
   const promise = Sandbox.create('base', {
     apiKey: 'test-key',
     signal: controller.signal,
   })
 
-  // Abort soon after the request starts.
-  setTimeout(() => controller.abort(), 25)
+  await requestStarted
+  controller.abort()
 
   await expect(promise).rejects.toThrow()
 })
@@ -73,24 +87,28 @@ test('Sandbox.create rejects immediately when signal is already aborted', async 
 
 test('Sandbox.kill rejects when AbortSignal is aborted', async () => {
   const controller = new AbortController()
+  const requestStarted = nextRequestStart()
 
   const promise = Sandbox.kill('some-sandbox', {
     apiKey: 'test-key',
     signal: controller.signal,
   })
 
-  setTimeout(() => controller.abort(), 25)
+  await requestStarted
+  controller.abort()
 
   await expect(promise).rejects.toThrow()
 })
 
 test('SandboxPaginator.nextItems rejects when per-call AbortSignal is aborted', async () => {
   const controller = new AbortController()
+  const requestStarted = nextRequestStart()
 
   const paginator = Sandbox.list({ apiKey: 'test-key' })
-
   const promise = paginator.nextItems({ signal: controller.signal })
-  setTimeout(() => controller.abort(), 25)
+
+  await requestStarted
+  controller.abort()
 
   await expect(promise).rejects.toThrow()
 })

--- a/packages/js-sdk/tests/sandbox/abortSignal.test.ts
+++ b/packages/js-sdk/tests/sandbox/abortSignal.test.ts
@@ -84,15 +84,12 @@ test('Sandbox.kill rejects when AbortSignal is aborted', async () => {
   await expect(promise).rejects.toThrow()
 })
 
-test('SandboxPaginator.nextItems rejects when AbortSignal is aborted', async () => {
+test('SandboxPaginator.nextItems rejects when per-call AbortSignal is aborted', async () => {
   const controller = new AbortController()
 
-  const paginator = Sandbox.list({
-    apiKey: 'test-key',
-    signal: controller.signal,
-  })
+  const paginator = Sandbox.list({ apiKey: 'test-key' })
 
-  const promise = paginator.nextItems()
+  const promise = paginator.nextItems({ signal: controller.signal })
   setTimeout(() => controller.abort(), 25)
 
   await expect(promise).rejects.toThrow()

--- a/packages/js-sdk/tests/sandbox/abortSignal.test.ts
+++ b/packages/js-sdk/tests/sandbox/abortSignal.test.ts
@@ -23,6 +23,14 @@ const restHandlers = [
     })
     return HttpResponse.json({})
   }),
+  http.get(apiUrl('/v2/sandboxes'), async ({ request }) => {
+    await new Promise<void>((_, reject) => {
+      request.signal.addEventListener('abort', () =>
+        reject(new DOMException('aborted', 'AbortError'))
+      )
+    })
+    return HttpResponse.json([])
+  }),
 ]
 
 const server = setupServer(...restHandlers)
@@ -71,6 +79,20 @@ test('Sandbox.kill rejects when AbortSignal is aborted', async () => {
     signal: controller.signal,
   })
 
+  setTimeout(() => controller.abort(), 25)
+
+  await expect(promise).rejects.toThrow()
+})
+
+test('SandboxPaginator.nextItems rejects when AbortSignal is aborted', async () => {
+  const controller = new AbortController()
+
+  const paginator = Sandbox.list({
+    apiKey: 'test-key',
+    signal: controller.signal,
+  })
+
+  const promise = paginator.nextItems()
   setTimeout(() => controller.abort(), 25)
 
   await expect(promise).rejects.toThrow()

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Literal, Optional, TypedDict, Union, cast
 
 from typing_extensions import NotRequired, Unpack
 
-from e2b import ConnectionConfig
 from e2b.api.client.models import (
     ListedSandbox,
     SandboxDetail,
@@ -307,7 +306,7 @@ class PaginatorBase:
         next_token: Optional[str] = None,
         **opts: Unpack[ApiParams],
     ):
-        self._config = ConnectionConfig(**opts)
+        self._opts: ApiParams = opts
         self.limit = limit
         self._has_next = True
         self._next_token = next_token

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Literal, Optional, TypedDict, Union, cast
 
 from typing_extensions import NotRequired, Unpack
 
+from e2b import ConnectionConfig
 from e2b.api.client.models import (
     ListedSandbox,
     SandboxDetail,
@@ -306,7 +307,7 @@ class PaginatorBase:
         next_token: Optional[str] = None,
         **opts: Unpack[ApiParams],
     ):
-        self._opts: ApiParams = opts
+        self._config = ConnectionConfig(**opts)
         self.limit = limit
         self._has_next = True
         self._next_token = next_token

--- a/packages/python-sdk/e2b/sandbox_async/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_async/paginator.py
@@ -57,7 +57,7 @@ class AsyncSandboxPaginator(SandboxPaginatorBase):
             }
             metadata = urllib.parse.urlencode(quoted_metadata)
 
-        config = ConnectionConfig(**(opts if opts else self._opts))
+        config = ConnectionConfig(**opts) if opts else self._config
         api_client = get_api_client(config)
         res = await get_v2_sandboxes.asyncio_detailed(
             client=api_client,
@@ -112,7 +112,7 @@ class AsyncSnapshotPaginator(SnapshotPaginatorBase):
         if not self.has_next:
             raise Exception("No more items to fetch")
 
-        config = ConnectionConfig(**(opts if opts else self._opts))
+        config = ConnectionConfig(**opts) if opts else self._config
         api_client = get_api_client(config)
         res = await get_snapshots.asyncio_detailed(
             client=api_client,

--- a/packages/python-sdk/e2b/sandbox_async/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_async/paginator.py
@@ -1,9 +1,12 @@
 import urllib.parse
 from typing import Optional, List
 
+from typing_extensions import Unpack
+
 from e2b.api.client.api.sandboxes import get_v2_sandboxes
 from e2b.api.client.api.snapshots import get_snapshots
 from e2b.api.client.types import UNSET
+from e2b.connection_config import ApiParams, ConnectionConfig
 from e2b.exceptions import SandboxException
 from e2b.sandbox.sandbox_api import (
     SandboxPaginatorBase,
@@ -30,11 +33,15 @@ class AsyncSandboxPaginator(SandboxPaginatorBase):
     ```
     """
 
-    async def next_items(self) -> List[SandboxInfo]:
+    async def next_items(self, **opts: Unpack[ApiParams]) -> List[SandboxInfo]:
         """
         Returns the next page of sandboxes.
 
         Call this method only if `has_next` is `True`, otherwise it will raise an exception.
+
+        :param opts: Per-call connection options (e.g. `api_key`, `domain`,
+            `headers`, `request_timeout`). When provided, this call uses these
+            options instead of the ones the paginator was constructed with.
 
         :returns: List of sandboxes
         """
@@ -50,7 +57,8 @@ class AsyncSandboxPaginator(SandboxPaginatorBase):
             }
             metadata = urllib.parse.urlencode(quoted_metadata)
 
-        api_client = get_api_client(self._config)
+        config = ConnectionConfig(**(opts if opts else self._opts))
+        api_client = get_api_client(config)
         res = await get_v2_sandboxes.asyncio_detailed(
             client=api_client,
             metadata=metadata if metadata else UNSET,
@@ -89,18 +97,23 @@ class AsyncSnapshotPaginator(SnapshotPaginatorBase):
     ```
     """
 
-    async def next_items(self) -> List[SnapshotInfo]:
+    async def next_items(self, **opts: Unpack[ApiParams]) -> List[SnapshotInfo]:
         """
         Returns the next page of snapshots.
 
         Call this method only if `has_next` is `True`, otherwise it will raise an exception.
+
+        :param opts: Per-call connection options (e.g. `api_key`, `domain`,
+            `headers`, `request_timeout`). When provided, this call uses these
+            options instead of the ones the paginator was constructed with.
 
         :returns: List of snapshots
         """
         if not self.has_next:
             raise Exception("No more items to fetch")
 
-        api_client = get_api_client(self._config)
+        config = ConnectionConfig(**(opts if opts else self._opts))
+        api_client = get_api_client(config)
         res = await get_snapshots.asyncio_detailed(
             client=api_client,
             sandbox_id=self.sandbox_id if self.sandbox_id else UNSET,

--- a/packages/python-sdk/e2b/sandbox_async/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_async/paginator.py
@@ -57,7 +57,7 @@ class AsyncSandboxPaginator(SandboxPaginatorBase):
             }
             metadata = urllib.parse.urlencode(quoted_metadata)
 
-        config = ConnectionConfig(**opts) if opts else self._config
+        config = ConnectionConfig(**{**self._opts, **opts})
         api_client = get_api_client(config)
         res = await get_v2_sandboxes.asyncio_detailed(
             client=api_client,
@@ -112,7 +112,7 @@ class AsyncSnapshotPaginator(SnapshotPaginatorBase):
         if not self.has_next:
             raise Exception("No more items to fetch")
 
-        config = ConnectionConfig(**opts) if opts else self._config
+        config = ConnectionConfig(**{**self._opts, **opts})
         api_client = get_api_client(config)
         res = await get_snapshots.asyncio_detailed(
             client=api_client,

--- a/packages/python-sdk/e2b/sandbox_sync/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_sync/paginator.py
@@ -57,7 +57,7 @@ class SandboxPaginator(SandboxPaginatorBase):
             }
             metadata = urllib.parse.urlencode(quoted_metadata)
 
-        config = ConnectionConfig(**(opts if opts else self._opts))
+        config = ConnectionConfig(**opts) if opts else self._config
         api_client = get_api_client(config)
         res = get_v2_sandboxes.sync_detailed(
             client=api_client,
@@ -112,7 +112,7 @@ class SnapshotPaginator(SnapshotPaginatorBase):
         if not self.has_next:
             raise Exception("No more items to fetch")
 
-        config = ConnectionConfig(**(opts if opts else self._opts))
+        config = ConnectionConfig(**opts) if opts else self._config
         api_client = get_api_client(config)
         res = get_snapshots.sync_detailed(
             client=api_client,

--- a/packages/python-sdk/e2b/sandbox_sync/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_sync/paginator.py
@@ -57,7 +57,7 @@ class SandboxPaginator(SandboxPaginatorBase):
             }
             metadata = urllib.parse.urlencode(quoted_metadata)
 
-        config = ConnectionConfig(**opts) if opts else self._config
+        config = ConnectionConfig(**{**self._opts, **opts})
         api_client = get_api_client(config)
         res = get_v2_sandboxes.sync_detailed(
             client=api_client,
@@ -112,7 +112,7 @@ class SnapshotPaginator(SnapshotPaginatorBase):
         if not self.has_next:
             raise Exception("No more items to fetch")
 
-        config = ConnectionConfig(**opts) if opts else self._config
+        config = ConnectionConfig(**{**self._opts, **opts})
         api_client = get_api_client(config)
         res = get_snapshots.sync_detailed(
             client=api_client,

--- a/packages/python-sdk/e2b/sandbox_sync/paginator.py
+++ b/packages/python-sdk/e2b/sandbox_sync/paginator.py
@@ -1,11 +1,14 @@
 import urllib.parse
 from typing import Optional, List
 
+from typing_extensions import Unpack
+
 from e2b.api import handle_api_exception
 from e2b.api.client.api.sandboxes import get_v2_sandboxes
 from e2b.api.client.api.snapshots import get_snapshots
 from e2b.api.client.models.error import Error
 from e2b.api.client.types import UNSET
+from e2b.connection_config import ApiParams, ConnectionConfig
 from e2b.exceptions import SandboxException
 from e2b.sandbox.sandbox_api import (
     SandboxPaginatorBase,
@@ -30,11 +33,15 @@ class SandboxPaginator(SandboxPaginatorBase):
     ```
     """
 
-    def next_items(self) -> List[SandboxInfo]:
+    def next_items(self, **opts: Unpack[ApiParams]) -> List[SandboxInfo]:
         """
         Returns the next page of sandboxes.
 
         Call this method only if `has_next` is `True`, otherwise it will raise an exception.
+
+        :param opts: Per-call connection options (e.g. `api_key`, `domain`,
+            `headers`, `request_timeout`). When provided, this call uses these
+            options instead of the ones the paginator was constructed with.
 
         :returns: List of sandboxes
         """
@@ -50,7 +57,8 @@ class SandboxPaginator(SandboxPaginatorBase):
             }
             metadata = urllib.parse.urlencode(quoted_metadata)
 
-        api_client = get_api_client(self._config)
+        config = ConnectionConfig(**(opts if opts else self._opts))
+        api_client = get_api_client(config)
         res = get_v2_sandboxes.sync_detailed(
             client=api_client,
             metadata=metadata if metadata else UNSET,
@@ -89,18 +97,23 @@ class SnapshotPaginator(SnapshotPaginatorBase):
     ```
     """
 
-    def next_items(self) -> List[SnapshotInfo]:
+    def next_items(self, **opts: Unpack[ApiParams]) -> List[SnapshotInfo]:
         """
         Returns the next page of snapshots.
 
         Call this method only if `has_next` is `True`, otherwise it will raise an exception.
+
+        :param opts: Per-call connection options (e.g. `api_key`, `domain`,
+            `headers`, `request_timeout`). When provided, this call uses these
+            options instead of the ones the paginator was constructed with.
 
         :returns: List of snapshots
         """
         if not self.has_next:
             raise Exception("No more items to fetch")
 
-        api_client = get_api_client(self._config)
+        config = ConnectionConfig(**(opts if opts else self._opts))
+        api_client = get_api_client(config)
         res = get_snapshots.sync_detailed(
             client=api_client,
             sandbox_id=self.sandbox_id if self.sandbox_id else UNSET,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,16 +135,16 @@ importers:
         version: 2.0.1
       knip:
         specifier: ^5.43.6
-        version: 5.43.6(@types/node@20.19.19)(typescript@5.2.2)
+        version: 5.43.6(@types/node@20.19.19)(typescript@5.5.3)
       tsup:
         specifier: ^8.4.0
-        version: 8.4.0(jiti@2.4.2)(postcss@8.5.12)(typescript@5.2.2)
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.12)(typescript@5.5.3)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.5
+        version: 5.5.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.14(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0)
+        version: 3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(terser@5.46.0)
 
   packages/js-sdk:
     dependencies:
@@ -3412,11 +3412,6 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.5.3:
     resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
     engines: {node: '>=14.17'}
@@ -4690,26 +4685,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.2.4(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.2.2))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@3.2.4)':
-    dependencies:
-      '@testing-library/dom': 10.4.0
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.4(msw@2.12.14(@types/node@20.19.19)(typescript@5.2.2))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
-      '@vitest/utils': 3.2.4
-      magic-string: 0.30.17
-      sirv: 3.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.14(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0)
-      ws: 8.19.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-    optionalDependencies:
-      playwright: 1.55.1
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/browser@3.2.4(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
@@ -4744,9 +4719,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.14(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0)
+      vitest: 3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(terser@5.46.0)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.2.2))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -4757,15 +4732,6 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.2.0
       tinyrainbow: 2.0.0
-
-  '@vitest/mocker@3.2.4(msw@2.12.14(@types/node@20.19.19)(typescript@5.2.2))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      msw: 2.12.14(@types/node@20.19.19)(typescript@5.2.2)
-      vite: 6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)
 
   '@vitest/mocker@3.2.4(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))':
     dependencies:
@@ -6037,27 +6003,6 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knip@5.43.6(@types/node@20.19.19)(typescript@5.2.2):
-    dependencies:
-      '@nodelib/fs.walk': 3.0.1
-      '@snyk/github-codeowners': 1.1.0
-      '@types/node': 20.19.19
-      easy-table: 1.2.0
-      enhanced-resolve: 5.18.1
-      fast-glob: 3.3.3
-      jiti: 2.4.2
-      js-yaml: 4.1.1
-      minimist: 1.2.8
-      picocolors: 1.1.1
-      picomatch: 4.0.4
-      pretty-ms: 9.1.0
-      smol-toml: 1.6.1
-      strip-json-comments: 5.0.1
-      summary: 2.1.0
-      typescript: 5.2.2
-      zod: 3.22.4
-      zod-validation-error: 3.4.0(zod@3.22.4)
-
   knip@5.43.6(@types/node@20.19.19)(typescript@5.5.3):
     dependencies:
       '@nodelib/fs.walk': 3.0.1
@@ -6187,32 +6132,6 @@ snapshots:
   ms@2.1.2: {}
 
   ms@2.1.3: {}
-
-  msw@2.12.14(@types/node@20.19.19)(typescript@5.2.2):
-    dependencies:
-      '@inquirer/confirm': 5.1.19(@types/node@20.19.19)
-      '@mswjs/interceptors': 0.41.3
-      '@open-draft/deferred-promise': 2.2.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.12.0
-      headers-polyfill: 4.0.3
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.10.1
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.0
-      type-fest: 5.2.0
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3):
     dependencies:
@@ -7016,33 +6935,6 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.4.0(jiti@2.4.2)(postcss@8.5.12)(typescript@5.2.2):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.0)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.0
-      esbuild: 0.25.0
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.12)
-      resolve-from: 5.0.0
-      rollup: 4.60.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.13
-      tree-kill: 1.2.2
-    optionalDependencies:
-      postcss: 8.5.12
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
   tsup@8.4.0(jiti@2.4.2)(postcss@8.5.12)(typescript@5.5.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.0)
@@ -7116,8 +7008,6 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
-
-  typescript@5.2.2: {}
 
   typescript@5.5.3: {}
 
@@ -7215,48 +7105,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
-
-  vitest@3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.14(@types/node@20.19.19)(typescript@5.2.2))(terser@5.46.0):
-    dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.14(@types/node@20.19.19)(typescript@5.2.2))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.2.0
-      debug: 4.4.3(supports-color@10.2.2)
-      expect-type: 1.2.1
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)
-      vite-node: 3.2.4(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 20.19.19
-      '@vitest/browser': 3.2.4(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.2.2))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@3.2.4)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vitest@3.2.4(@types/node@20.19.19)(@vitest/browser@3.2.4)(jiti@2.4.2)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(terser@5.46.0):
     dependencies:


### PR DESCRIPTION
## Summary
- Adds an optional `signal: AbortSignal` to SDK request options across `Sandbox`, `Commands`, `Pty`, `Filesystem`, and `Volume` methods.
- `ConnectionConfig.getSignal()` (and `VolumeConnectionConfig.getSignal()`) delegate to a shared `buildRequestSignal()` helper that combines the user signal with the existing request-timeout signal via `AbortSignal.any()`.
- Streaming RPCs (`commands.run`/`connect`, `pty.create`/`connect`, `watchDir`) route through a shared `setupRequestController()` that bridges the user signal into the internal `AbortController` and exposes `clearStartTimeout` + idempotent `cleanup`. Handshake timer is cleared after start succeeds (so long-running streams aren't aborted at `requestTimeoutMs`), and `CommandHandle`/`WatchHandle` call cleanup in a `finally` so the user-signal listener is always detached.
- Handshake timeout aborts with `DOMException('Request handshake timed out …', 'TimeoutError')` so callers can distinguish from user aborts.
- `SandboxPaginator.nextItems` / `SnapshotPaginator.nextItems` now accept a per-call `SandboxApiOpts` (incl. `signal`, `apiKey`, `domain`, `headers`, `requestTimeoutMs`); the per-call options are merged with the constructor opts (per-call values win) so passing e.g. `{ signal }` does not drop the constructor's `apiKey`.
- **Python SDK parity**: `SandboxPaginator.next_items` / `SnapshotPaginator.next_items` (sync + async) now accept `**opts: Unpack[ApiParams]` with the same merge semantics.
- Bumps the CLI's TypeScript range to `^5.4.5` so its dom lib includes `AbortSignal.any`.

Fixes #1312

Usage:
\`\`\`ts
const ctrl = new AbortController()
await Sandbox.create(template, { apiKey, signal: ctrl.signal })
await sandbox.commands.run('long-running', { signal: ctrl.signal })
await sandbox.files.write('/tmp/x', 'hi', { signal: ctrl.signal })

const paginator = Sandbox.list({ apiKey })
// per-call opts merge with constructor opts — apiKey is preserved:
await paginator.nextItems({ signal: ctrl.signal })
// override fields individually:
await paginator.nextItems({ apiKey: otherKey, signal: ctrl.signal })
\`\`\`

\`\`\`python
# Python
paginator = Sandbox.list(api_key=api_key)
paginator.next_items(request_timeout=10.0)  # api_key still applied
\`\`\`

## Test plan
- [x] \`pnpm run typecheck\` (js-sdk + cli)
- [x] \`pnpm run lint\`
- [x] \`pnpm run format\`
- [x] \`pnpm exec vitest run tests/sandbox/abortSignal.test.ts tests/connectionConfig.test.ts\` (19/19 pass — covers \`Sandbox.create\`/\`kill\`, paginator per-call signal, \`getSignal\`, \`setupRequestController\` lifecycle, \`TimeoutError\` reason)
- [x] \`poetry run make typecheck\` / \`make lint\` (python-sdk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)