### PR TITLE
fix: resolve TypeScript deprecated configs and improve type support

### DIFF
--- a/.changeset/typescript-config-fix.md
+++ b/.changeset/typescript-config-fix.md
@@ -1,0 +1,39 @@
+---
+"@e2b/cli": patch
+"e2b": patch
+---
+
+fix: resolve TypeScript deprecated configs and improve type support
+
+## What changed
+
+Updated TypeScript compiler options in both CLI and JS-SDK packages to remove deprecated settings that will stop working in TypeScript 7.0:
+
+### CLI Package (`packages/cli/tsconfig.json`)
+- Changed `moduleResolution` from `"node"` to `"bundler"` (modern recommended approach)
+- Removed `downlevelIteration` option (deprecated, no longer needed)
+- Added `types: ["node"]` to properly resolve Node.js type definitions
+
+### JS-SDK Package (`packages/js-sdk/tsconfig.json`)
+- Changed `moduleResolution` from `"node"` to `"bundler"` (modern recommended approach)
+- Fixed JSON syntax error (removed trailing comma)
+
+### Dependencies
+- Added `@types/node ^20.19.19` as a dev dependency to provide type definitions for Node.js built-in modules (os, path, fs, process)
+
+## Why this change was made
+
+The current TypeScript configuration uses deprecated compiler options that will stop functioning in TypeScript 7.0. This change ensures:
+- Forward compatibility with TypeScript 7.0+
+- Proper type checking for Node.js modules used in the CLI package
+- Modern module resolution strategy that better supports both ESM and CommonJS
+
+## How to verify
+
+All changes have been tested and verified:
+- ✅ `pnpm run typecheck` - All TypeScript compilation errors resolved
+- ✅ `pnpm run lint` - Code style checks pass
+- ✅ `pnpm run format` - Code formatting is correct
+- ✅ Dependencies installed successfully (584 packages)
+
+No breaking changes for users. This is a maintenance fix to ensure compatibility with future TypeScript versions.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@changesets/read": "^0.6.2"
   },
   "devDependencies": {
+    "@types/node": "^20.19.19",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
     "changeset": "^0.2.6",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -6,7 +6,7 @@
     "allowJs": true,
     "declaration": true,
     "declarationMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
@@ -17,7 +17,6 @@
     "alwaysStrict": true,
     "esModuleInterop": true,
     "preserveSymlinks": true,
-    "downlevelIteration": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
@@ -26,6 +25,7 @@
     "rootDirs": ["src"],
     "paths": {
       "e2b": ["../js-sdk/src"]
-    }
+    },
+    "types": ["node"]
   }
 }

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -14,10 +14,10 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "declaration": true,
+    "declaration": true
   },
   "include": [
     "src"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
         specifier: ^0.6.2
         version: 0.6.2
     devDependencies:
+      '@types/node':
+        specifier: ^20.19.19
+        version: 20.19.19
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.7.2
         version: 6.7.2(@typescript-eslint/parser@6.7.2(eslint@8.57.1)(typescript@5.5.3))(eslint@8.57.1)(typescript@5.5.3)
@@ -887,66 +890,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -1985,7 +2001,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}


### PR DESCRIPTION
## Summary
Fix all deprecated TypeScript configurations in the project:
- Replace `moduleResolution: "node"` with `"bundler"`
- Remove deprecated `downlevelIteration`
- Add `@types/node` for missing Node.js built-in type support
- Fix JSON syntax error in js-sdk/tsconfig.json

## Changes
- Update `packages/cli/tsconfig.json`
- Update `packages/js-sdk/tsconfig.json`
- Add `@types/node` devDependency

## Validation
- ✅ pnpm run typecheck (all packages passed)
- ✅ pnpm run lint
- ✅ pnpm run format
- ✅ pnpm install