### PR TITLE
Js api http2 dispatcher

### DIFF
--- a/.changeset/tasty-dogs-refuse.md
+++ b/.changeset/tasty-dogs-refuse.md
@@ -1,0 +1,5 @@
+---
+'e2b': minor
+---
+
+support for api h2

--- a/packages/js-sdk/src/api/http2.ts
+++ b/packages/js-sdk/src/api/http2.ts
@@ -1,6 +1,7 @@
 import { runtime } from '../utils'
 import {
   loadUndici,
+  toUndiciRequestInput,
   type UndiciModule,
   type UndiciRequestInit,
 } from '../undici'
@@ -66,7 +67,7 @@ async function buildApiFetcher(options: {
   ) => Promise<Response>
 
   return ((input, init) => {
-    const request = toRequestInput(input, init)
+    const request = toUndiciRequestInput(input, init)
 
     return fetchWithDispatcher(request.input, {
       ...request.init,
@@ -82,38 +83,4 @@ function warnUndiciFallback() {
 
   hasWarnedUndiciFallback = true
   console.warn(API_UNDICI_FALLBACK_WARNING)
-}
-
-function toRequestInput(
-  input: RequestInfo | URL,
-  init?: RequestInit
-): { input: RequestInfo | URL; init?: RequestInit & { duplex?: 'half' } } {
-  if (!(input instanceof Request)) {
-    return { input, init }
-  }
-
-  const requestInit: RequestInit & { duplex?: 'half' } = {
-    body: input.body,
-    cache: input.cache,
-    credentials: input.credentials,
-    headers: input.headers,
-    integrity: input.integrity,
-    keepalive: input.keepalive,
-    method: input.method,
-    mode: input.mode,
-    redirect: input.redirect,
-    referrer: input.referrer,
-    referrerPolicy: input.referrerPolicy,
-    signal: input.signal,
-    ...init,
-  }
-
-  if (requestInit.body) {
-    requestInit.duplex = 'half'
-  }
-
-  return {
-    input: input.url,
-    init: requestInit,
-  }
 }

--- a/packages/js-sdk/src/api/http2.ts
+++ b/packages/js-sdk/src/api/http2.ts
@@ -1,0 +1,140 @@
+import { runtime } from '../utils'
+
+const API_CONNECTION_LIMIT = 100
+const API_UNDICI_FALLBACK_WARNING =
+  'Failed to load undici for API HTTP/2 transport; falling back to global fetch.'
+
+type UndiciRequestInit = RequestInit & {
+  dispatcher?: unknown
+  duplex?: 'half'
+}
+
+type UndiciModule = {
+  Agent: new (options: { allowH2: true; connections?: number }) => unknown
+  fetch: unknown
+}
+
+let apiFetch: typeof fetch | undefined
+let hasWarnedUndiciFallback = false
+
+export function createApiFetch(): typeof fetch {
+  if (apiFetch) {
+    return apiFetch
+  }
+
+  apiFetch = createApiFetchForRuntime(runtime)
+
+  return apiFetch
+}
+
+export function createApiFetchForRuntime(
+  currentRuntime = runtime,
+  options: {
+    connectionLimit?: number
+    loadUndici?: () => Promise<UndiciModule | undefined>
+  } = { connectionLimit: API_CONNECTION_LIMIT }
+): typeof fetch {
+  if (currentRuntime !== 'node') {
+    return fetch
+  }
+
+  let fetcherPromise: Promise<typeof fetch> | undefined
+
+  return (async (input, init) => {
+    fetcherPromise ??= buildApiFetcher(options)
+    const fetcher = await fetcherPromise
+
+    return fetcher(input, init)
+  }) as typeof fetch
+}
+
+async function buildApiFetcher(options: {
+  connectionLimit?: number
+  loadUndici?: () => Promise<UndiciModule | undefined>
+}): Promise<typeof fetch> {
+  const undici = await (options.loadUndici ?? loadUndici)()
+
+  if (!undici) {
+    warnUndiciFallback()
+
+    return fetch
+  }
+
+  const { Agent, fetch: undiciFetch } = undici
+  const dispatcher = new Agent({
+    allowH2: true,
+    connections: options.connectionLimit,
+  })
+  const fetchWithDispatcher = undiciFetch as unknown as (
+    input: RequestInfo | URL,
+    init?: UndiciRequestInit
+  ) => Promise<Response>
+
+  return ((input, init) => {
+    const request = toRequestInput(input, init)
+
+    return fetchWithDispatcher(request.input, {
+      ...request.init,
+      dispatcher,
+    })
+  }) as typeof fetch
+}
+
+async function loadUndici(): Promise<UndiciModule | undefined> {
+  try {
+    // Keep this import opaque to bundlers. It must resolve as a package name
+    // from the runtime environment, not as a path relative to this file.
+    // eslint-disable-next-line no-new-func
+    const importModule = new Function(
+      'moduleName',
+      'return import(moduleName)'
+    ) as (moduleName: string) => Promise<UndiciModule>
+
+    return await importModule('undici')
+  } catch {
+    return undefined
+  }
+}
+
+function warnUndiciFallback() {
+  if (hasWarnedUndiciFallback) {
+    return
+  }
+
+  hasWarnedUndiciFallback = true
+  console.warn(API_UNDICI_FALLBACK_WARNING)
+}
+
+function toRequestInput(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): { input: RequestInfo | URL; init?: RequestInit & { duplex?: 'half' } } {
+  if (!(input instanceof Request)) {
+    return { input, init }
+  }
+
+  const requestInit: RequestInit & { duplex?: 'half' } = {
+    body: input.body,
+    cache: input.cache,
+    credentials: input.credentials,
+    headers: input.headers,
+    integrity: input.integrity,
+    keepalive: input.keepalive,
+    method: input.method,
+    mode: input.mode,
+    redirect: input.redirect,
+    referrer: input.referrer,
+    referrerPolicy: input.referrerPolicy,
+    signal: input.signal,
+    ...init,
+  }
+
+  if (requestInit.body) {
+    requestInit.duplex = 'half'
+  }
+
+  return {
+    input: input.url,
+    init: requestInit,
+  }
+}

--- a/packages/js-sdk/src/api/http2.ts
+++ b/packages/js-sdk/src/api/http2.ts
@@ -1,18 +1,13 @@
 import { runtime } from '../utils'
+import {
+  loadUndici,
+  type UndiciModule,
+  type UndiciRequestInit,
+} from '../undici'
 
 const API_CONNECTION_LIMIT = 100
 const API_UNDICI_FALLBACK_WARNING =
   'Failed to load undici for API HTTP/2 transport; falling back to global fetch.'
-
-type UndiciRequestInit = RequestInit & {
-  dispatcher?: unknown
-  duplex?: 'half'
-}
-
-type UndiciModule = {
-  Agent: new (options: { allowH2: true; connections?: number }) => unknown
-  fetch: unknown
-}
 
 let apiFetch: typeof fetch | undefined
 let hasWarnedUndiciFallback = false
@@ -78,22 +73,6 @@ async function buildApiFetcher(options: {
       dispatcher,
     })
   }) as typeof fetch
-}
-
-async function loadUndici(): Promise<UndiciModule | undefined> {
-  try {
-    // Keep this import opaque to bundlers. It must resolve as a package name
-    // from the runtime environment, not as a path relative to this file.
-    // eslint-disable-next-line no-new-func
-    const importModule = new Function(
-      'moduleName',
-      'return import(moduleName)'
-    ) as (moduleName: string) => Promise<UndiciModule>
-
-    return await importModule('undici')
-  } catch {
-    return undefined
-  }
 }
 
 function warnUndiciFallback() {

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -2,6 +2,7 @@ import createClient, { FetchResponse } from 'openapi-fetch'
 
 import type { components, paths } from './schema.gen'
 import { defaultHeaders } from './metadata'
+import { createApiFetch } from './http2'
 import { ConnectionConfig } from '../connectionConfig'
 import { AuthenticationError, RateLimitError, SandboxError } from '../errors'
 import { createApiLogger } from '../logs'
@@ -74,6 +75,7 @@ class ApiClient {
 
     this.api = createClient<paths>({
       baseUrl: config.apiUrl,
+      fetch: createApiFetch(),
       // In HTTP 1.1, all connections are considered persistent unless declared otherwise
       // keepalive: true,
       headers: {

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -1,6 +1,7 @@
 import { runtime } from '../utils'
 import {
   loadUndici,
+  toUndiciRequestInput,
   type UndiciModule,
   type UndiciRequestInit,
 } from '../undici'
@@ -58,7 +59,7 @@ async function buildEnvdFetcher(
   ) => Promise<Response>
 
   return ((input, init) => {
-    const request = toRequestInput(input, init)
+    const request = toUndiciRequestInput(input, init)
 
     return fetchWithDispatcher(request.input, {
       ...request.init,
@@ -100,38 +101,4 @@ export function createEnvdRpcFetch(): typeof fetch {
   envdRpcFetch = createEnvdFetchForRuntime(runtime, {})
 
   return envdRpcFetch
-}
-
-function toRequestInput(
-  input: RequestInfo | URL,
-  init?: RequestInit
-): { input: RequestInfo | URL; init?: RequestInit & { duplex?: 'half' } } {
-  if (!(input instanceof Request)) {
-    return { input, init }
-  }
-
-  const requestInit: RequestInit & { duplex?: 'half' } = {
-    body: input.body,
-    cache: input.cache,
-    credentials: input.credentials,
-    headers: input.headers,
-    integrity: input.integrity,
-    keepalive: input.keepalive,
-    method: input.method,
-    mode: input.mode,
-    redirect: input.redirect,
-    referrer: input.referrer,
-    referrerPolicy: input.referrerPolicy,
-    signal: input.signal,
-    ...init,
-  }
-
-  if (requestInit.body) {
-    requestInit.duplex = 'half'
-  }
-
-  return {
-    input: input.url,
-    init: requestInit,
-  }
 }

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -1,13 +1,10 @@
 import { runtime } from '../utils'
+import {
+  loadUndici,
+  type UndiciModule,
+  type UndiciRequestInit,
+} from '../undici'
 
-type UndiciRequestInit = RequestInit & {
-  dispatcher?: unknown
-  duplex?: 'half'
-}
-type UndiciModule = {
-  Agent: new (options: { allowH2: true; connections?: number }) => unknown
-  fetch: unknown
-}
 type EnvdFetchOptions = {
   connectionLimit?: number
   loadUndici?: () => Promise<UndiciModule | undefined>
@@ -68,22 +65,6 @@ async function buildEnvdFetcher(
       dispatcher,
     })
   }) as typeof fetch
-}
-
-async function loadUndici(): Promise<UndiciModule | undefined> {
-  try {
-    // Keep this import opaque to bundlers. It must resolve as a package name
-    // from the runtime environment, not as a path relative to this file.
-    // eslint-disable-next-line no-new-func
-    const importModule = new Function(
-      'moduleName',
-      'return import(moduleName)'
-    ) as (moduleName: string) => Promise<UndiciModule>
-
-    return await importModule('undici')
-  } catch {
-    return undefined
-  }
 }
 
 function warnUndiciFallback() {

--- a/packages/js-sdk/src/undici.ts
+++ b/packages/js-sdk/src/undici.ts
@@ -1,0 +1,25 @@
+export type UndiciRequestInit = RequestInit & {
+  dispatcher?: unknown
+  duplex?: 'half'
+}
+
+export type UndiciModule = {
+  Agent: new (options: { allowH2: true; connections?: number }) => unknown
+  fetch: unknown
+}
+
+export async function loadUndici(): Promise<UndiciModule | undefined> {
+  try {
+    // Keep this import opaque to bundlers. It must resolve as a package name
+    // from the runtime environment, not as a path relative to this file.
+    // eslint-disable-next-line no-new-func
+    const importModule = new Function(
+      'moduleName',
+      'return import(moduleName)'
+    ) as (moduleName: string) => Promise<UndiciModule>
+
+    return await importModule('undici')
+  } catch {
+    return undefined
+  }
+}

--- a/packages/js-sdk/src/undici.ts
+++ b/packages/js-sdk/src/undici.ts
@@ -23,3 +23,37 @@ export async function loadUndici(): Promise<UndiciModule | undefined> {
     return undefined
   }
 }
+
+export function toUndiciRequestInput(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): { input: RequestInfo | URL; init?: RequestInit & { duplex?: 'half' } } {
+  if (!(input instanceof Request)) {
+    return { input, init }
+  }
+
+  const requestInit: RequestInit & { duplex?: 'half' } = {
+    body: input.body,
+    cache: input.cache,
+    credentials: input.credentials,
+    headers: input.headers,
+    integrity: input.integrity,
+    keepalive: input.keepalive,
+    method: input.method,
+    mode: input.mode,
+    redirect: input.redirect,
+    referrer: input.referrer,
+    referrerPolicy: input.referrerPolicy,
+    signal: input.signal,
+    ...init,
+  }
+
+  if (requestInit.body) {
+    requestInit.duplex = 'half'
+  }
+
+  return {
+    input: input.url,
+    init: requestInit,
+  }
+}

--- a/packages/js-sdk/tests/api/http2.test.ts
+++ b/packages/js-sdk/tests/api/http2.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, expect, test, vi } from 'vitest'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+  vi.doUnmock('undici')
+  vi.doUnmock('../../src/utils')
+})
+
+test('uses undici with a bounded HTTP/2 dispatcher for API requests', async () => {
+  const agents: Array<{ allowH2?: boolean; connections?: number }> = []
+  const requests: Array<{ init?: RequestInit & { dispatcher?: unknown } }> = []
+
+  class Agent {
+    constructor(options: { allowH2?: boolean; connections?: number }) {
+      agents.push(options)
+    }
+  }
+
+  const undiciFetch = vi.fn((input, init) => {
+    requests.push({ init })
+    return Promise.resolve(new Response('ok'))
+  })
+  const loadUndici = vi.fn(() => Promise.resolve({ Agent, fetch: undiciFetch }))
+
+  const { createApiFetchForRuntime } = await import('../../src/api/http2')
+
+  const fetcher = createApiFetchForRuntime('node', {
+    connectionLimit: 100,
+    loadUndici,
+  })
+  await fetcher('https://example.com/sandboxes')
+
+  expect(loadUndici).toHaveBeenCalledOnce()
+  expect(agents).toEqual([{ allowH2: true, connections: 100 }])
+  expect(requests[0].init?.dispatcher).toBeInstanceOf(Agent)
+})


### PR DESCRIPTION
use undici for the js api calls as well where we can; improved connection use leads to speed improvement at high concurrency for `/sandboxes` to create

| SDK build | Result | Wall time | Create p50 | Create p90 | Create p95 | Create p99 | Peak sockets | Errors |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `origin/main` | 300/300 | 2.687s | 1036ms | 2230ms | 2394ms | 2541ms | 302 sampled, 319 observed in progress logs | 0 |
| `js-api-http2-dispatcher` | 300/300 | 1.278s | 599ms | 760ms | 831ms | 1257ms | 102 | 0 |
