### PR TITLE
Use stable sandbox host in SDKs

### DIFF
--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -38,7 +38,7 @@ export interface ConnectionOpts {
   /**
    * Sandbox Url to use for the API.
    * @internal
-   * @default E2B_SANDBOX_URL // environment variable or `https://${port}-${sandboxID}.${domain}`
+   * @default E2B_SANDBOX_URL // environment variable, `https://sandbox.e2b.app` in production, or `https://${port}-${sandboxID}.${domain}`
    */
   sandboxUrl?: string
   /**
@@ -236,7 +236,16 @@ export class ConnectionConfig {
       return this.sandboxUrl
     }
 
-    return `${this.debug ? 'http' : 'https'}://${this.getHost(sandboxId, opts.envdPort, opts.sandboxDomain)}`
+    if (this.debug) {
+      return `http://${this.getHost(sandboxId, opts.envdPort, opts.sandboxDomain)}`
+    }
+
+    const sandboxDomain = opts.sandboxDomain ?? this.domain
+    if (sandboxDomain === 'e2b.app') {
+      return 'https://sandbox.e2b.app'
+    }
+
+    return `https://${this.getHost(sandboxId, opts.envdPort, sandboxDomain)}`
   }
 
   getHost(sandboxId: string, port: number, sandboxDomain: string) {

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -14,6 +14,7 @@ type EnvdFetchOptions = {
 let envdFetch: typeof fetch | undefined
 let envdRpcFetch: typeof fetch | undefined
 let hasWarnedUndiciFallback = false
+const ENVD_RPC_CONNECTION_LIMIT = 100
 
 export function createEnvdFetchForRuntime(
   currentRuntime = runtime,
@@ -96,9 +97,9 @@ export function createEnvdRpcFetch(): typeof fetch {
     return envdRpcFetch
   }
 
-  // RPC streams can stay open while follow-up RPCs run against the same
-  // sandbox, so they cannot share the REST client's single-connection cap.
-  envdRpcFetch = createEnvdFetchForRuntime(runtime, {})
+  envdRpcFetch = createEnvdFetchForRuntime(runtime, {
+    connectionLimit: ENVD_RPC_CONNECTION_LIMIT,
+  })
 
   return envdRpcFetch
 }

--- a/packages/js-sdk/tests/connectionConfig.test.ts
+++ b/packages/js-sdk/tests/connectionConfig.test.ts
@@ -11,6 +11,7 @@ beforeEach(() => {
   originalEnv = {
     E2B_API_URL: process.env.E2B_API_URL,
     E2B_DOMAIN: process.env.E2B_DOMAIN,
+    E2B_SANDBOX_URL: process.env.E2B_SANDBOX_URL,
     E2B_DEBUG: process.env.E2B_DEBUG,
   }
 })
@@ -53,6 +54,80 @@ test('api_url has correct priority', () => {
 
   const config = new ConnectionConfig({ apiUrl: 'http://localhost:8080' })
   assert.equal(config.apiUrl, 'http://localhost:8080')
+})
+
+test('sandbox_url defaults to stable sandbox host in production', () => {
+  delete process.env.E2B_SANDBOX_URL
+  delete process.env.E2B_DOMAIN
+  delete process.env.E2B_DEBUG
+
+  const config = new ConnectionConfig()
+
+  assert.equal(
+    config.getSandboxUrl('sbx-test', {
+      sandboxDomain: 'e2b.app',
+      envdPort: 49983,
+    }),
+    'https://sandbox.e2b.app'
+  )
+})
+
+test('sandbox_url keeps per-sandbox host outside production', () => {
+  delete process.env.E2B_SANDBOX_URL
+  delete process.env.E2B_DEBUG
+
+  const config = new ConnectionConfig({ domain: 'e2b.dev' })
+
+  assert.equal(
+    config.getSandboxUrl('sbx-test', {
+      sandboxDomain: 'sandbox.e2b.dev',
+      envdPort: 49983,
+    }),
+    'https://49983-sbx-test.sandbox.e2b.dev'
+  )
+})
+
+test('sandbox_url in args has priority', () => {
+  process.env.E2B_SANDBOX_URL = 'https://sandbox.from-env'
+
+  const config = new ConnectionConfig({ sandboxUrl: 'https://sandbox.custom' })
+
+  assert.equal(
+    config.getSandboxUrl('sbx-test', {
+      sandboxDomain: 'e2b.app',
+      envdPort: 49983,
+    }),
+    'https://sandbox.custom'
+  )
+})
+
+test('sandbox_url in env var overrides default', () => {
+  process.env.E2B_SANDBOX_URL = 'https://sandbox.from-env'
+
+  const config = new ConnectionConfig()
+
+  assert.equal(
+    config.getSandboxUrl('sbx-test', {
+      sandboxDomain: 'e2b.app',
+      envdPort: 49983,
+    }),
+    'https://sandbox.from-env'
+  )
+})
+
+test('sandbox_url stays localhost in debug mode', () => {
+  delete process.env.E2B_SANDBOX_URL
+  process.env.E2B_DEBUG = 'true'
+
+  const config = new ConnectionConfig()
+
+  assert.equal(
+    config.getSandboxUrl('sbx-test', {
+      sandboxDomain: 'e2b.app',
+      envdPort: 49983,
+    }),
+    'http://localhost:49983'
+  )
 })
 
 test('getSignal returns user signal when no timeout is set', () => {

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -66,7 +66,7 @@ test('passes Request objects to undici as URL plus init', async () => {
   expect(requests[0].init?.body).toBeInstanceOf(ReadableStream)
 })
 
-test('can create an uncapped dispatcher for RPC streams', async () => {
+test('can create a bounded dispatcher for RPC streams', async () => {
   const agents: Array<{ allowH2?: boolean; connections?: number }> = []
 
   class Agent {
@@ -80,11 +80,12 @@ test('can create an uncapped dispatcher for RPC streams', async () => {
   const { createEnvdFetchForRuntime } = await import('../../src/envd/http2')
 
   const fetcher = createEnvdFetchForRuntime('node', {
+    connectionLimit: 100,
     loadUndici: () => Promise.resolve({ Agent, fetch: undiciFetch }),
   })
   await fetcher('https://example.com/rpc')
 
-  expect(agents).toEqual([{ allowH2: true }])
+  expect(agents).toEqual([{ allowH2: true, connections: 100 }])
 })
 
 test('defers loading undici until the first Node request', async () => {

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -140,7 +140,13 @@ class ConnectionConfig:
         if self._sandbox_url:
             return self._sandbox_url  # type: ignore[return-value]
 
-        return f"{'http' if self.debug else 'https'}://{self.get_host(sandbox_id, sandbox_domain, self.envd_port)}"
+        if self.debug:
+            return f"http://{self.get_host(sandbox_id, sandbox_domain, self.envd_port)}"
+
+        if sandbox_domain == "e2b.app":
+            return "https://sandbox.e2b.app"
+
+        return f"https://{self.get_host(sandbox_id, sandbox_domain, self.envd_port)}"
 
     def get_host(self, sandbox_id: str, sandbox_domain: str, port: int) -> str:
         """

--- a/packages/python-sdk/tests/test_connection_config.py
+++ b/packages/python-sdk/tests/test_connection_config.py
@@ -2,6 +2,7 @@ from e2b import ConnectionConfig
 
 
 def test_api_url_defaults_correctly(monkeypatch):
+    monkeypatch.delenv("E2B_API_URL", raising=False)
     monkeypatch.setenv("E2B_DOMAIN", "")
 
     config = ConnectionConfig()
@@ -25,3 +26,54 @@ def test_api_url_has_correct_priority(monkeypatch):
 
     config = ConnectionConfig(api_url="http://localhost:8080")
     assert config.api_url == "http://localhost:8080"
+
+
+def test_sandbox_url_defaults_to_stable_sandbox_host_in_production(monkeypatch):
+    monkeypatch.delenv("E2B_SANDBOX_URL", raising=False)
+    monkeypatch.delenv("E2B_DOMAIN", raising=False)
+    monkeypatch.delenv("E2B_DEBUG", raising=False)
+
+    config = ConnectionConfig()
+
+    assert config.get_sandbox_url("sbx-test", "e2b.app") == "https://sandbox.e2b.app"
+
+
+def test_sandbox_url_keeps_per_sandbox_host_outside_production(monkeypatch):
+    monkeypatch.delenv("E2B_SANDBOX_URL", raising=False)
+    monkeypatch.delenv("E2B_DEBUG", raising=False)
+
+    config = ConnectionConfig(domain="e2b.dev")
+
+    assert (
+        config.get_sandbox_url("sbx-test", "sandbox.e2b.dev")
+        == "https://49983-sbx-test.sandbox.e2b.dev"
+    )
+
+
+def test_sandbox_url_in_args_has_priority(monkeypatch):
+    monkeypatch.setenv("E2B_SANDBOX_URL", "https://sandbox.from-env")
+
+    config = ConnectionConfig(sandbox_url="https://sandbox.custom")
+
+    assert (
+        config.get_sandbox_url("sbx-test", "e2b.app") == "https://sandbox.custom"
+    )
+
+
+def test_sandbox_url_in_env_var_overrides_default(monkeypatch):
+    monkeypatch.setenv("E2B_SANDBOX_URL", "https://sandbox.from-env")
+
+    config = ConnectionConfig()
+
+    assert (
+        config.get_sandbox_url("sbx-test", "e2b.app") == "https://sandbox.from-env"
+    )
+
+
+def test_sandbox_url_stays_localhost_in_debug_mode(monkeypatch):
+    monkeypatch.delenv("E2B_SANDBOX_URL", raising=False)
+    monkeypatch.setenv("E2B_DEBUG", "true")
+
+    config = ConnectionConfig()
+
+    assert config.get_sandbox_url("sbx-test", "e2b.app") == "http://localhost:49983"


### PR DESCRIPTION
| SDK | Route | Created | Executed | Exec wall time | Exec p50 | Exec p90 | Exec p95 | Exec p99 | Peak exec conns | Peak exec hosts | Errors |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| JS | old per-sandbox host | 300/300 | 300/300 | 3.281s | 1270ms | 2883ms | n/a | 3238ms | 302 | 300 | 0 |
| JS | stable `sandbox.e2b.app` + RPC cap 100 | 300/300 | 300/300 | 0.459s | 354ms | 409ms | 415ms | 424ms | 102 | 1 | 0 |
| Python sync | old per-sandbox host | 300/300 | 300/300 | 3.919s | 1648ms | 2847ms | n/a | 3190ms | 300 | 300 | 0 |
| Python sync | stable `sandbox.e2b.app` | 300/300 | 196/300 | 0.605s | 478ms | 549ms | 559ms | 560ms | 2 | 2 | 100x `Errno 35`, 4x `Max outbound streams is 100` |
| Python async | old per-sandbox host | 300/300 | 295/300 | 3.479s | 1368ms | 3049ms | n/a | 3420ms | 300 | 300 | 5 |
| Python async | stable `sandbox.e2b.app` | 300/300 | 300/300 | 0.471s | 338ms | 423ms | 438ms | 448ms | 2 | 2 | 0 |
