### PR TITLE
fix(sdks): make lifecycle.on_timeout and auto_pause precedence consistent

### DIFF
--- a/.changeset/little-webs-drive.md
+++ b/.changeset/little-webs-drive.md
@@ -4,4 +4,5 @@
 ---
 
 - Fix lifecycle and autopause precedence
-- Deprecate auto_pause, use `lifecycle={"on_timeout": "pause"}` instead
+- Deprecate `auto_pause`/`autoPause`; use `lifecycle={"on_timeout": "pause"}` instead. A `DeprecationWarning` (Python) / `console.warn` (JS) is now emitted when the flag is set
+- **Breaking validation change**: passing `auto_resume=true` while the resolved `on_timeout` is `"kill"` now raises `InvalidArgumentException` (Python) / `InvalidArgumentError` (JS)

--- a/.changeset/little-webs-drive.md
+++ b/.changeset/little-webs-drive.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': patch
+'e2b': patch
+---
+
+Fix lifecycle and autopause precedence

--- a/.changeset/little-webs-drive.md
+++ b/.changeset/little-webs-drive.md
@@ -1,6 +1,7 @@
 ---
-'@e2b/python-sdk': patch
-'e2b': patch
+'@e2b/python-sdk': minor
+'e2b': minor
 ---
 
-Fix lifecycle and autopause precedence
+- Fix lifecycle and autopause precedence
+- Deprecate auto_pause, use `lifecycle={"on_timeout": "pause"}` instead

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -423,19 +423,9 @@ export interface SandboxMetrics {
   diskTotal: number
 }
 
-export type ResolvedLifecycle = {
-  /** Effective `onTimeout` after merging `lifecycle` and `autoPause`. */
-  onTimeout: 'pause' | 'kill'
-  /**
-   * Auto-resume value to send to the API, or `undefined` when neither
-   * `lifecycle` nor `autoPause` was provided (omits the field from the body).
-   */
-  autoResumeEnabled: boolean | undefined
-}
-
 export function getLifecycle(
   opts?: Pick<SandboxBetaCreateOpts, 'lifecycle' | 'autoPause'>
-): ResolvedLifecycle {
+): SandboxLifecycle {
   const autoResume = opts?.lifecycle?.autoResume ?? false
   const onTimeout =
     opts?.lifecycle?.onTimeout ?? (opts?.autoPause ? 'pause' : 'kill')
@@ -446,12 +436,9 @@ export function getLifecycle(
     )
   }
 
-  const lifecycleProvided =
-    opts?.lifecycle !== undefined || opts?.autoPause !== undefined
-
   return {
     onTimeout,
-    autoResumeEnabled: lifecycleProvided ? autoResume : undefined,
+    autoResume: opts?.lifecycle?.autoResume,
   }
 }
 
@@ -811,7 +798,8 @@ export class SandboxApi {
   ) {
     const config = new ConnectionConfig(opts)
     const client = new ApiClient(config)
-    const { autoResumeEnabled } = getLifecycle(opts)
+    const { onTimeout, autoResume } = getLifecycle(opts)
+    const autoPause = onTimeout === 'pause'
 
     const body: components['schemas']['NewSandbox'] = {
       templateID: template,
@@ -822,8 +810,9 @@ export class SandboxApi {
       secure: opts?.secure ?? true,
       allow_internet_access: opts?.allowInternetAccess ?? true,
       network: opts?.network,
-      ...(autoResumeEnabled !== undefined
-        ? { autoResume: { enabled: autoResumeEnabled } }
+      autoPause,
+      ...(autoResume !== undefined
+        ? { autoResume: { enabled: autoResume } }
         : {}),
     }
 

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -422,20 +422,20 @@ export interface SandboxMetrics {
 function getLifecycle(
   opts?: Pick<SandboxBetaCreateOpts, 'lifecycle' | 'autoPause'>
 ): SandboxLifecycle {
-  if (opts?.lifecycle) {
+  if (opts?.lifecycle?.onTimeout) {
     return opts.lifecycle
   }
 
   if (opts?.autoPause) {
     return {
       onTimeout: 'pause',
-      autoResume: false,
+      autoResume: opts.lifecycle?.autoResume ?? false,
     }
   }
 
   return {
     onTimeout: 'kill',
-    autoResume: false,
+    autoResume: opts?.lifecycle?.autoResume ?? false,
   }
 }
 

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -421,15 +421,9 @@ export interface SandboxMetrics {
 
 function getLifecycle(
   opts?: Pick<SandboxBetaCreateOpts, 'lifecycle' | 'autoPause'>
-): SandboxLifecycle | undefined {
-  if (opts?.lifecycle === undefined && opts?.autoPause === undefined) {
-    return undefined
-  }
-  // Spread `opts.lifecycle` so new fields flow through automatically;
-  // `onTimeout` falls back to the legacy `autoPause` flag if missing.
+): SandboxLifecycle {
   return {
-    autoResume: false,
-    ...opts?.lifecycle,
+    autoResume: opts?.lifecycle?.autoResume ?? false,
     onTimeout:
       opts?.lifecycle?.onTimeout ?? (opts?.autoPause ? 'pause' : 'kill'),
   }
@@ -792,9 +786,8 @@ export class SandboxApi {
     const config = new ConnectionConfig(opts)
     const client = new ApiClient(config)
     const lifecycle = getLifecycle(opts)
-    const autoPause = lifecycle ? lifecycle.onTimeout === 'pause' : undefined
-    const autoResumeEnabled =
-      lifecycle?.onTimeout === 'pause' ? lifecycle.autoResume : undefined
+    const autoPause = lifecycle.onTimeout === 'pause'
+    const autoResumeEnabled = lifecycle.autoResume
 
     const body: components['schemas']['NewSandbox'] = {
       templateID: template,

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -787,7 +787,7 @@ export class SandboxApi {
     const client = new ApiClient(config)
     const lifecycle = getLifecycle(opts)
     const autoPause = lifecycle.onTimeout === 'pause'
-    const autoResumeEnabled = lifecycle.autoResume
+    const autoResumeEnabled = opts?.lifecycle ? lifecycle.autoResume : undefined
 
     const body: components['schemas']['NewSandbox'] = {
       templateID: template,

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -5,7 +5,11 @@ import {
   DEFAULT_SANDBOX_TIMEOUT_MS,
 } from '../connectionConfig'
 import { compareVersions } from 'compare-versions'
-import { SandboxNotFoundError, TemplateError } from '../errors'
+import {
+  InvalidArgumentError,
+  SandboxNotFoundError,
+  TemplateError,
+} from '../errors'
 import { timeoutToSeconds } from '../utils'
 import type { Volume } from '../volume'
 import type { McpServer as BaseMcpServer } from './mcp'
@@ -419,13 +423,35 @@ export interface SandboxMetrics {
   diskTotal: number
 }
 
+export type ResolvedLifecycle = {
+  /** Effective `onTimeout` after merging `lifecycle` and `autoPause`. */
+  onTimeout: 'pause' | 'kill'
+  /**
+   * Auto-resume value to send to the API, or `undefined` when neither
+   * `lifecycle` nor `autoPause` was provided (omits the field from the body).
+   */
+  autoResumeEnabled: boolean | undefined
+}
+
 export function getLifecycle(
   opts?: Pick<SandboxBetaCreateOpts, 'lifecycle' | 'autoPause'>
-): SandboxLifecycle {
+): ResolvedLifecycle {
+  const autoResume = opts?.lifecycle?.autoResume ?? false
+  const onTimeout =
+    opts?.lifecycle?.onTimeout ?? (opts?.autoPause ? 'pause' : 'kill')
+
+  if (autoResume && onTimeout !== 'pause') {
+    throw new InvalidArgumentError(
+      "autoResume can only be true when onTimeout is 'pause' (or autoPause is true)."
+    )
+  }
+
+  const lifecycleProvided =
+    opts?.lifecycle !== undefined || opts?.autoPause !== undefined
+
   return {
-    autoResume: opts?.lifecycle?.autoResume ?? false,
-    onTimeout:
-      opts?.lifecycle?.onTimeout ?? (opts?.autoPause ? 'pause' : 'kill'),
+    onTimeout,
+    autoResumeEnabled: lifecycleProvided ? autoResume : undefined,
   }
 }
 
@@ -785,12 +811,7 @@ export class SandboxApi {
   ) {
     const config = new ConnectionConfig(opts)
     const client = new ApiClient(config)
-    const lifecycle = getLifecycle(opts)
-    const autoPause = lifecycle.onTimeout === 'pause'
-    const autoResumeEnabled =
-      opts?.lifecycle !== undefined || opts?.autoPause
-        ? lifecycle.autoResume
-        : undefined
+    const { autoResumeEnabled } = getLifecycle(opts)
 
     const body: components['schemas']['NewSandbox'] = {
       templateID: template,
@@ -801,7 +822,6 @@ export class SandboxApi {
       secure: opts?.secure ?? true,
       allow_internet_access: opts?.allowInternetAccess ?? true,
       network: opts?.network,
-      ...(autoPause !== undefined ? { autoPause } : {}),
       ...(autoResumeEnabled !== undefined
         ? { autoResume: { enabled: autoResumeEnabled } }
         : {}),

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -422,16 +422,10 @@ export interface SandboxMetrics {
 function getLifecycle(
   opts?: Pick<SandboxBetaCreateOpts, 'lifecycle' | 'autoPause'>
 ): SandboxLifecycle {
-  if (opts?.lifecycle) {
-    return {
-      onTimeout: opts.lifecycle.onTimeout ?? 'kill',
-      autoResume: opts.lifecycle.autoResume ?? false,
-    }
-  }
-
   return {
-    onTimeout: opts?.autoPause ? 'pause' : 'kill',
-    autoResume: false,
+    onTimeout:
+      opts?.lifecycle?.onTimeout ?? (opts?.autoPause ? 'pause' : 'kill'),
+    autoResume: opts?.lifecycle?.autoResume ?? false,
   }
 }
 

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -426,13 +426,18 @@ export interface SandboxMetrics {
 export function getLifecycle(
   opts?: Pick<SandboxBetaCreateOpts, 'lifecycle' | 'autoPause'>
 ): SandboxLifecycle {
-  const autoResume = opts?.lifecycle?.autoResume ?? false
+  if (opts?.autoPause !== undefined) {
+    console.warn(
+      "`autoPause` is deprecated; use `lifecycle: { onTimeout: 'pause' }` instead."
+    )
+  }
+
   const onTimeout =
     opts?.lifecycle?.onTimeout ?? (opts?.autoPause ? 'pause' : 'kill')
 
-  if (autoResume && onTimeout !== 'pause') {
+  if (opts?.lifecycle?.autoResume === true && onTimeout !== 'pause') {
     throw new InvalidArgumentError(
-      "autoResume can only be true when onTimeout is 'pause' (or autoPause is true)."
+      "autoResume can only be true when the resolved onTimeout is 'pause'."
     )
   }
 

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -419,7 +419,7 @@ export interface SandboxMetrics {
   diskTotal: number
 }
 
-function getLifecycle(
+export function getLifecycle(
   opts?: Pick<SandboxBetaCreateOpts, 'lifecycle' | 'autoPause'>
 ): SandboxLifecycle {
   return {

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -422,20 +422,16 @@ export interface SandboxMetrics {
 function getLifecycle(
   opts?: Pick<SandboxBetaCreateOpts, 'lifecycle' | 'autoPause'>
 ): SandboxLifecycle {
-  if (opts?.lifecycle?.onTimeout) {
-    return opts.lifecycle
-  }
-
-  if (opts?.autoPause) {
+  if (opts?.lifecycle) {
     return {
-      onTimeout: 'pause',
-      autoResume: opts.lifecycle?.autoResume ?? false,
+      onTimeout: opts.lifecycle.onTimeout ?? 'kill',
+      autoResume: opts.lifecycle.autoResume ?? false,
     }
   }
 
   return {
-    onTimeout: 'kill',
-    autoResume: opts?.lifecycle?.autoResume ?? false,
+    onTimeout: opts?.autoPause ? 'pause' : 'kill',
+    autoResume: false,
   }
 }
 

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -425,10 +425,13 @@ function getLifecycle(
   if (opts?.lifecycle === undefined && opts?.autoPause === undefined) {
     return undefined
   }
+  // Spread `opts.lifecycle` so new fields flow through automatically;
+  // `onTimeout` falls back to the legacy `autoPause` flag if missing.
   return {
+    autoResume: false,
+    ...opts?.lifecycle,
     onTimeout:
       opts?.lifecycle?.onTimeout ?? (opts?.autoPause ? 'pause' : 'kill'),
-    autoResume: opts?.lifecycle?.autoResume ?? false,
   }
 }
 

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -421,7 +421,10 @@ export interface SandboxMetrics {
 
 function getLifecycle(
   opts?: Pick<SandboxBetaCreateOpts, 'lifecycle' | 'autoPause'>
-): SandboxLifecycle {
+): SandboxLifecycle | undefined {
+  if (opts?.lifecycle === undefined && opts?.autoPause === undefined) {
+    return undefined
+  }
   return {
     onTimeout:
       opts?.lifecycle?.onTimeout ?? (opts?.autoPause ? 'pause' : 'kill'),
@@ -786,11 +789,9 @@ export class SandboxApi {
     const config = new ConnectionConfig(opts)
     const client = new ApiClient(config)
     const lifecycle = getLifecycle(opts)
-    const autoPause = lifecycle.onTimeout === 'pause'
+    const autoPause = lifecycle ? lifecycle.onTimeout === 'pause' : undefined
     const autoResumeEnabled =
-      lifecycle.onTimeout === 'pause'
-        ? (lifecycle.autoResume ?? false)
-        : undefined
+      lifecycle?.onTimeout === 'pause' ? lifecycle.autoResume : undefined
 
     const body: components['schemas']['NewSandbox'] = {
       templateID: template,

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -787,7 +787,10 @@ export class SandboxApi {
     const client = new ApiClient(config)
     const lifecycle = getLifecycle(opts)
     const autoPause = lifecycle.onTimeout === 'pause'
-    const autoResumeEnabled = opts?.lifecycle ? lifecycle.autoResume : undefined
+    const autoResumeEnabled =
+      opts?.lifecycle !== undefined || opts?.autoPause
+        ? lifecycle.autoResume
+        : undefined
 
     const body: components['schemas']['NewSandbox'] = {
       templateID: template,

--- a/packages/js-sdk/tests/sandbox/getLifecycle.test.ts
+++ b/packages/js-sdk/tests/sandbox/getLifecycle.test.ts
@@ -7,14 +7,14 @@ describe('getLifecycle', () => {
   test('returns defaults when no opts are provided', () => {
     assert.deepEqual(getLifecycle(), {
       onTimeout: 'kill',
-      autoResumeEnabled: undefined,
+      autoResume: undefined,
     })
   })
 
   test('returns defaults when opts is empty', () => {
     assert.deepEqual(getLifecycle({}), {
       onTimeout: 'kill',
-      autoResumeEnabled: undefined,
+      autoResume: undefined,
     })
   })
 
@@ -23,7 +23,7 @@ describe('getLifecycle', () => {
       getLifecycle({ lifecycle: { onTimeout: 'kill' }, autoPause: true }),
       {
         onTimeout: 'kill',
-        autoResumeEnabled: false,
+        autoResume: undefined,
       }
     )
   })
@@ -33,7 +33,7 @@ describe('getLifecycle', () => {
       getLifecycle({ lifecycle: { onTimeout: 'pause' }, autoPause: false }),
       {
         onTimeout: 'pause',
-        autoResumeEnabled: false,
+        autoResume: undefined,
       }
     )
   })
@@ -46,21 +46,21 @@ describe('getLifecycle', () => {
     }
     assert.deepEqual(getLifecycle({ lifecycle, autoPause: true }), {
       onTimeout: 'pause',
-      autoResumeEnabled: true,
+      autoResume: true,
     })
   })
 
   test('autoPause=true with no lifecycle maps to onTimeout=pause', () => {
     assert.deepEqual(getLifecycle({ autoPause: true }), {
       onTimeout: 'pause',
-      autoResumeEnabled: false,
+      autoResume: undefined,
     })
   })
 
   test('autoPause=false with no lifecycle maps to onTimeout=kill', () => {
     assert.deepEqual(getLifecycle({ autoPause: false }), {
       onTimeout: 'kill',
-      autoResumeEnabled: false,
+      autoResume: undefined,
     })
   })
 
@@ -69,33 +69,28 @@ describe('getLifecycle', () => {
       getLifecycle({ lifecycle: { onTimeout: 'pause', autoResume: true } }),
       {
         onTimeout: 'pause',
-        autoResumeEnabled: true,
+        autoResume: true,
       }
     )
     assert.deepEqual(
       getLifecycle({ lifecycle: { onTimeout: 'pause', autoResume: false } }),
       {
         onTimeout: 'pause',
-        autoResumeEnabled: false,
+        autoResume: false,
       }
     )
   })
 
-  test('autoResume defaults to false when omitted from lifecycle', () => {
+  test('autoResume is undefined when omitted from lifecycle', () => {
     assert.deepEqual(getLifecycle({ lifecycle: { onTimeout: 'pause' } }), {
       onTimeout: 'pause',
-      autoResumeEnabled: false,
+      autoResume: undefined,
     })
   })
 
-  test('autoResumeEnabled is undefined when neither lifecycle nor autoPause provided', () => {
-    assert.equal(getLifecycle().autoResumeEnabled, undefined)
-    assert.equal(getLifecycle({}).autoResumeEnabled, undefined)
-  })
-
-  test('autoResumeEnabled is set (false) when only autoPause is provided', () => {
-    assert.equal(getLifecycle({ autoPause: true }).autoResumeEnabled, false)
-    assert.equal(getLifecycle({ autoPause: false }).autoResumeEnabled, false)
+  test('autoResume is undefined when only autoPause is provided', () => {
+    assert.equal(getLifecycle({ autoPause: true }).autoResume, undefined)
+    assert.equal(getLifecycle({ autoPause: false }).autoResume, undefined)
   })
 
   test('throws when autoResume=true and onTimeout=kill', () => {

--- a/packages/js-sdk/tests/sandbox/getLifecycle.test.ts
+++ b/packages/js-sdk/tests/sandbox/getLifecycle.test.ts
@@ -1,19 +1,20 @@
 import { assert, describe, test } from 'vitest'
 
+import { InvalidArgumentError } from '../../src'
 import { getLifecycle } from '../../src/sandbox/sandboxApi'
 
 describe('getLifecycle', () => {
   test('returns defaults when no opts are provided', () => {
     assert.deepEqual(getLifecycle(), {
-      autoResume: false,
       onTimeout: 'kill',
+      autoResumeEnabled: undefined,
     })
   })
 
   test('returns defaults when opts is empty', () => {
     assert.deepEqual(getLifecycle({}), {
-      autoResume: false,
       onTimeout: 'kill',
+      autoResumeEnabled: undefined,
     })
   })
 
@@ -21,8 +22,8 @@ describe('getLifecycle', () => {
     assert.deepEqual(
       getLifecycle({ lifecycle: { onTimeout: 'kill' }, autoPause: true }),
       {
-        autoResume: false,
         onTimeout: 'kill',
+        autoResumeEnabled: false,
       }
     )
   })
@@ -31,8 +32,8 @@ describe('getLifecycle', () => {
     assert.deepEqual(
       getLifecycle({ lifecycle: { onTimeout: 'pause' }, autoPause: false }),
       {
-        autoResume: false,
         onTimeout: 'pause',
+        autoResumeEnabled: false,
       }
     )
   })
@@ -44,26 +45,22 @@ describe('getLifecycle', () => {
       autoResume?: boolean
     }
     assert.deepEqual(getLifecycle({ lifecycle, autoPause: true }), {
-      autoResume: true,
       onTimeout: 'pause',
-    })
-    assert.deepEqual(getLifecycle({ lifecycle, autoPause: false }), {
-      autoResume: true,
-      onTimeout: 'kill',
+      autoResumeEnabled: true,
     })
   })
 
   test('autoPause=true with no lifecycle maps to onTimeout=pause', () => {
     assert.deepEqual(getLifecycle({ autoPause: true }), {
-      autoResume: false,
       onTimeout: 'pause',
+      autoResumeEnabled: false,
     })
   })
 
   test('autoPause=false with no lifecycle maps to onTimeout=kill', () => {
     assert.deepEqual(getLifecycle({ autoPause: false }), {
-      autoResume: false,
       onTimeout: 'kill',
+      autoResumeEnabled: false,
     })
   })
 
@@ -71,34 +68,64 @@ describe('getLifecycle', () => {
     assert.deepEqual(
       getLifecycle({ lifecycle: { onTimeout: 'pause', autoResume: true } }),
       {
-        autoResume: true,
         onTimeout: 'pause',
+        autoResumeEnabled: true,
       }
     )
     assert.deepEqual(
       getLifecycle({ lifecycle: { onTimeout: 'pause', autoResume: false } }),
       {
-        autoResume: false,
         onTimeout: 'pause',
+        autoResumeEnabled: false,
       }
     )
   })
 
   test('autoResume defaults to false when omitted from lifecycle', () => {
     assert.deepEqual(getLifecycle({ lifecycle: { onTimeout: 'pause' } }), {
-      autoResume: false,
       onTimeout: 'pause',
+      autoResumeEnabled: false,
     })
   })
 
-  test('autoResume is independent of onTimeout (decoupled from auto-pause)', () => {
-    // Per design: autoResume can be set even when onTimeout is 'kill'.
-    assert.deepEqual(
-      getLifecycle({ lifecycle: { onTimeout: 'kill', autoResume: true } }),
-      {
-        autoResume: true,
-        onTimeout: 'kill',
-      }
+  test('autoResumeEnabled is undefined when neither lifecycle nor autoPause provided', () => {
+    assert.equal(getLifecycle().autoResumeEnabled, undefined)
+    assert.equal(getLifecycle({}).autoResumeEnabled, undefined)
+  })
+
+  test('autoResumeEnabled is set (false) when only autoPause is provided', () => {
+    assert.equal(getLifecycle({ autoPause: true }).autoResumeEnabled, false)
+    assert.equal(getLifecycle({ autoPause: false }).autoResumeEnabled, false)
+  })
+
+  test('throws when autoResume=true and onTimeout=kill', () => {
+    assert.throws(
+      () =>
+        getLifecycle({
+          lifecycle: { onTimeout: 'kill', autoResume: true },
+        }),
+      InvalidArgumentError
     )
+  })
+
+  test('throws when autoResume=true and effective onTimeout resolves to kill', () => {
+    // partial lifecycle with autoResume=true; no onTimeout; autoPause falsy.
+    const lifecycle = { autoResume: true } as unknown as {
+      onTimeout: 'pause' | 'kill'
+      autoResume?: boolean
+    }
+    assert.throws(() => getLifecycle({ lifecycle }), InvalidArgumentError)
+    assert.throws(
+      () => getLifecycle({ lifecycle, autoPause: false }),
+      InvalidArgumentError
+    )
+  })
+
+  test('does not throw when autoResume=true and autoPause=true (no explicit onTimeout)', () => {
+    const lifecycle = { autoResume: true } as unknown as {
+      onTimeout: 'pause' | 'kill'
+      autoResume?: boolean
+    }
+    assert.doesNotThrow(() => getLifecycle({ lifecycle, autoPause: true }))
   })
 })

--- a/packages/js-sdk/tests/sandbox/getLifecycle.test.ts
+++ b/packages/js-sdk/tests/sandbox/getLifecycle.test.ts
@@ -1,0 +1,104 @@
+import { assert, describe, test } from 'vitest'
+
+import { getLifecycle } from '../../src/sandbox/sandboxApi'
+
+describe('getLifecycle', () => {
+  test('returns defaults when no opts are provided', () => {
+    assert.deepEqual(getLifecycle(), {
+      autoResume: false,
+      onTimeout: 'kill',
+    })
+  })
+
+  test('returns defaults when opts is empty', () => {
+    assert.deepEqual(getLifecycle({}), {
+      autoResume: false,
+      onTimeout: 'kill',
+    })
+  })
+
+  test('lifecycle.onTimeout takes precedence over autoPause=true', () => {
+    assert.deepEqual(
+      getLifecycle({ lifecycle: { onTimeout: 'kill' }, autoPause: true }),
+      {
+        autoResume: false,
+        onTimeout: 'kill',
+      }
+    )
+  })
+
+  test('lifecycle.onTimeout=pause takes precedence over autoPause=false', () => {
+    assert.deepEqual(
+      getLifecycle({ lifecycle: { onTimeout: 'pause' }, autoPause: false }),
+      {
+        autoResume: false,
+        onTimeout: 'pause',
+      }
+    )
+  })
+
+  test('falls back to autoPause when lifecycle.onTimeout is missing', () => {
+    // partial lifecycle without onTimeout (possible at runtime despite TS typing)
+    const lifecycle = { autoResume: true } as unknown as {
+      onTimeout: 'pause' | 'kill'
+      autoResume?: boolean
+    }
+    assert.deepEqual(getLifecycle({ lifecycle, autoPause: true }), {
+      autoResume: true,
+      onTimeout: 'pause',
+    })
+    assert.deepEqual(getLifecycle({ lifecycle, autoPause: false }), {
+      autoResume: true,
+      onTimeout: 'kill',
+    })
+  })
+
+  test('autoPause=true with no lifecycle maps to onTimeout=pause', () => {
+    assert.deepEqual(getLifecycle({ autoPause: true }), {
+      autoResume: false,
+      onTimeout: 'pause',
+    })
+  })
+
+  test('autoPause=false with no lifecycle maps to onTimeout=kill', () => {
+    assert.deepEqual(getLifecycle({ autoPause: false }), {
+      autoResume: false,
+      onTimeout: 'kill',
+    })
+  })
+
+  test('preserves autoResume from lifecycle', () => {
+    assert.deepEqual(
+      getLifecycle({ lifecycle: { onTimeout: 'pause', autoResume: true } }),
+      {
+        autoResume: true,
+        onTimeout: 'pause',
+      }
+    )
+    assert.deepEqual(
+      getLifecycle({ lifecycle: { onTimeout: 'pause', autoResume: false } }),
+      {
+        autoResume: false,
+        onTimeout: 'pause',
+      }
+    )
+  })
+
+  test('autoResume defaults to false when omitted from lifecycle', () => {
+    assert.deepEqual(getLifecycle({ lifecycle: { onTimeout: 'pause' } }), {
+      autoResume: false,
+      onTimeout: 'pause',
+    })
+  })
+
+  test('autoResume is independent of onTimeout (decoupled from auto-pause)', () => {
+    // Per design: autoResume can be set even when onTimeout is 'kill'.
+    assert.deepEqual(
+      getLifecycle({ lifecycle: { onTimeout: 'kill', autoResume: true } }),
+      {
+        autoResume: true,
+        onTimeout: 'kill',
+      }
+    )
+  })
+})

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -13,6 +13,7 @@ from e2b.api.client.models import (
 )
 from e2b.api.client.types import Unset
 from e2b.connection_config import ApiParams
+from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.mcp import McpServer as BaseMcpServer
 
 
@@ -121,6 +122,33 @@ def get_auto_resume_enabled(lifecycle: Optional[SandboxLifecycle]) -> Optional[b
         return None
 
     return lifecycle.get("auto_resume", False)
+
+
+def validate_lifecycle(
+    lifecycle: Optional[SandboxLifecycle],
+    auto_pause: Optional[bool],
+) -> None:
+    """
+    Validate that auto_resume is only enabled when the effective on_timeout
+    resolves to "pause" (either via lifecycle.on_timeout or auto_pause=True).
+    """
+    if lifecycle is None:
+        return
+
+    auto_resume = lifecycle.get("auto_resume", False)
+    if not auto_resume:
+        return
+
+    on_timeout = lifecycle.get("on_timeout")
+    effective_on_timeout = (
+        on_timeout if on_timeout is not None else ("pause" if auto_pause else "kill")
+    )
+
+    if effective_on_timeout != "pause":
+        raise InvalidArgumentException(
+            "auto_resume can only be True when on_timeout is 'pause' "
+            "(or auto_pause is True)."
+        )
 
 
 def from_client_network_config(

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -116,26 +116,11 @@ class SandboxInfoLifecycle(TypedDict):
     """
 
 
-def get_effective_lifecycle(
-    lifecycle: Optional[SandboxLifecycle], auto_pause: Optional[bool]
-) -> Optional[SandboxLifecycle]:
-    """
-    Merge `lifecycle` with the legacy `auto_pause` flag. Returns `None`
-    when neither is set. Fields from `lifecycle` always win; `auto_pause`
-    only fills in a missing `on_timeout`. Unknown fields on `lifecycle`
-    are passed through, so adding new lifecycle fields does not require
-    updating this helper.
-    """
-    if lifecycle is None and auto_pause is None:
+def get_auto_resume_enabled(lifecycle: Optional[SandboxLifecycle]) -> Optional[bool]:
+    if lifecycle is None:
         return None
 
-    on_timeout = (lifecycle or {}).get("on_timeout") or (
-        "pause" if auto_pause else "kill"
-    )
-    return cast(
-        SandboxLifecycle,
-        {"auto_resume": False, **(lifecycle or {}), "on_timeout": on_timeout},
-    )
+    return lifecycle.get("auto_resume", False)
 
 
 def from_client_network_config(

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -7,9 +7,13 @@ from typing_extensions import NotRequired, Unpack
 from e2b.api.client.models import (
     ListedSandbox,
     SandboxDetail,
-    SandboxLifecycle as ClientSandboxLifecycle,
-    SandboxNetworkConfig as ClientSandboxNetworkConfig,
     SandboxState,
+)
+from e2b.api.client.models import (
+    SandboxLifecycle as ClientSandboxLifecycle,
+)
+from e2b.api.client.models import (
+    SandboxNetworkConfig as ClientSandboxNetworkConfig,
 )
 from e2b.api.client.types import Unset
 from e2b.connection_config import ApiParams
@@ -117,38 +121,37 @@ class SandboxInfoLifecycle(TypedDict):
     """
 
 
-def get_auto_resume_enabled(lifecycle: Optional[SandboxLifecycle]) -> Optional[bool]:
-    if lifecycle is None:
-        return None
-
-    return lifecycle.get("auto_resume", False)
-
-
-def validate_lifecycle(
+def get_lifecycle(
     lifecycle: Optional[SandboxLifecycle],
     auto_pause: Optional[bool],
-) -> None:
+) -> SandboxLifecycle:
     """
-    Validate that auto_resume is only enabled when the effective on_timeout
-    resolves to "pause" (either via lifecycle.on_timeout or auto_pause=True).
+    Resolve the effective sandbox lifecycle from `lifecycle` and the deprecated
+    `auto_pause` flag, and validate that `auto_resume=True` is only used when
+    the effective `on_timeout` is `"pause"`.
+
+    Mirrors the JS SDK `getLifecycle` helper: `auto_resume` is preserved
+    verbatim from the input lifecycle (omitted when the caller did not set it).
     """
-    if lifecycle is None:
-        return
+    auto_resume = lifecycle.get("auto_resume") if lifecycle is not None else None
 
-    auto_resume = lifecycle.get("auto_resume", False)
-    if not auto_resume:
-        return
-
-    on_timeout = lifecycle.get("on_timeout")
-    effective_on_timeout = (
-        on_timeout if on_timeout is not None else ("pause" if auto_pause else "kill")
+    explicit_on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
+    on_timeout: Literal["pause", "kill"] = (
+        explicit_on_timeout
+        if explicit_on_timeout is not None
+        else ("pause" if auto_pause else "kill")
     )
 
-    if effective_on_timeout != "pause":
+    if auto_resume and on_timeout != "pause":
         raise InvalidArgumentException(
             "auto_resume can only be True when on_timeout is 'pause' "
             "(or auto_pause is True)."
         )
+
+    resolved: SandboxLifecycle = {"on_timeout": on_timeout}
+    if auto_resume is not None:
+        resolved["auto_resume"] = auto_resume
+    return resolved
 
 
 def from_client_network_config(

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -136,8 +136,7 @@ def get_lifecycle(
 
     if auto_resume and on_timeout != "pause":
         raise InvalidArgumentException(
-            "auto_resume can only be True when on_timeout is 'pause' "
-            "(or auto_pause is True)."
+            "auto_resume can only be True when the resolved on_timeout is 'pause'."
         )
 
     resolved = SandboxLifecycle(on_timeout=on_timeout)

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -116,6 +116,28 @@ class SandboxInfoLifecycle(TypedDict):
     """
 
 
+def get_effective_lifecycle(
+    lifecycle: Optional[SandboxLifecycle], auto_pause: Optional[bool]
+) -> Optional[SandboxLifecycle]:
+    """
+    Merge `lifecycle` with the legacy `auto_pause` flag. Returns `None`
+    when neither is set. Fields from `lifecycle` always win; `auto_pause`
+    only fills in a missing `on_timeout`. Unknown fields on `lifecycle`
+    are passed through, so adding new lifecycle fields does not require
+    updating this helper.
+    """
+    if lifecycle is None and auto_pause is None:
+        return None
+
+    on_timeout = (lifecycle or {}).get("on_timeout") or (
+        "pause" if auto_pause else "kill"
+    )
+    return cast(
+        SandboxLifecycle,
+        {"auto_resume": False, **(lifecycle or {}), "on_timeout": on_timeout},
+    )
+
+
 def from_client_network_config(
     network: Union[Unset, ClientSandboxNetworkConfig],
 ) -> Optional[SandboxNetworkOpts]:

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -125,14 +125,6 @@ def get_lifecycle(
     lifecycle: Optional[SandboxLifecycle],
     auto_pause: Optional[bool],
 ) -> SandboxLifecycle:
-    """
-    Resolve the effective sandbox lifecycle from `lifecycle` and the deprecated
-    `auto_pause` flag, and validate that `auto_resume=True` is only used when
-    the effective `on_timeout` is `"pause"`.
-
-    Mirrors the JS SDK `getLifecycle` helper: `auto_resume` is preserved
-    verbatim from the input lifecycle (omitted when the caller did not set it).
-    """
     auto_resume = lifecycle.get("auto_resume") if lifecycle is not None else None
 
     explicit_on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
@@ -148,9 +140,10 @@ def get_lifecycle(
             "(or auto_pause is True)."
         )
 
-    resolved: SandboxLifecycle = {"on_timeout": on_timeout}
+    resolved = SandboxLifecycle(on_timeout= on_timeout)
     if auto_resume is not None:
         resolved["auto_resume"] = auto_resume
+
     return resolved
 
 

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -116,13 +116,6 @@ class SandboxInfoLifecycle(TypedDict):
     """
 
 
-def get_auto_resume_enabled(lifecycle: Optional[SandboxLifecycle]) -> Optional[bool]:
-    if lifecycle is None or lifecycle.get("on_timeout") != "pause":
-        return None
-
-    return lifecycle.get("auto_resume", False)
-
-
 def from_client_network_config(
     network: Union[Unset, ClientSandboxNetworkConfig],
 ) -> Optional[SandboxNetworkOpts]:

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -140,7 +140,7 @@ def get_lifecycle(
             "(or auto_pause is True)."
         )
 
-    resolved = SandboxLifecycle(on_timeout= on_timeout)
+    resolved = SandboxLifecycle(on_timeout=on_timeout)
     if auto_resume is not None:
         resolved["auto_resume"] = auto_resume
 

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -3,6 +3,7 @@ import json
 import logging
 import shlex
 import uuid
+import warnings
 from typing import Dict, List, Optional, Union, overload
 
 import httpx
@@ -551,13 +552,14 @@ class AsyncSandbox(SandboxApi):
         cls,
         template: Optional[str] = None,
         timeout: Optional[int] = None,
-        auto_pause: bool = False,
+        auto_pause: Optional[bool] = None,
         metadata: Optional[Dict[str, str]] = None,
         envs: Optional[Dict[str, str]] = None,
         secure: bool = True,
         allow_internet_access: bool = True,
         mcp: Optional[McpServer] = None,
         volume_mounts: Optional[SandboxAsyncVolumeMount] = None,
+        lifecycle: Optional[SandboxLifecycle] = None,
         **opts: Unpack[ApiParams],
     ) -> Self:
         """
@@ -569,19 +571,27 @@ class AsyncSandbox(SandboxApi):
 
         :param template: Sandbox template name or ID
         :param timeout: Timeout for the sandbox in **seconds**, default to 300 seconds. The maximum time a sandbox can be kept alive is 24 hours (86_400 seconds) for Pro users and 1 hour (3_600 seconds) for Hobby users.
-        :param auto_pause: Automatically pause the sandbox after the timeout expires. Defaults to `False`.
-            :deprecated: Use `lifecycle={"on_timeout": "pause"}` instead.
+        :param auto_pause: **Deprecated**: use ``lifecycle={"on_timeout": "pause"}`` instead.
+            Automatically pause the sandbox after the timeout expires. Defaults to ``False``.
         :param metadata: Custom metadata for the sandbox
         :param envs: Custom environment variables for the sandbox
         :param secure: Envd is secured with access token and cannot be used without it, defaults to `True`.
         :param allow_internet_access: Allow sandbox to access the internet, defaults to `True`.
         :param mcp: MCP server to enable in the sandbox
         :param volume_mounts: Dictionary mapping mount paths to AsyncVolume instances or volume names
+        :param lifecycle: Sandbox lifecycle configuration; controls timeout behavior and auto-resume.
 
         :return: A Sandbox instance for the new sandbox
 
         Use this method instead of using the constructor to create a new sandbox.
         """
+        if auto_pause is not None:
+            warnings.warn(
+                "`auto_pause` is deprecated; use `lifecycle={'on_timeout': 'pause'}` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         if not template and mcp is not None:
             template = cls.default_mcp_template
         elif not template:
@@ -606,9 +616,7 @@ class AsyncSandbox(SandboxApi):
             secure=secure,
             allow_internet_access=allow_internet_access,
             mcp=mcp,
-            lifecycle=(
-                {"on_timeout": "pause", "auto_resume": False} if auto_pause else None
-            ),
+            lifecycle=lifecycle,
             volume_mounts=transformed_mounts,
             **opts,
         )

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -570,6 +570,7 @@ class AsyncSandbox(SandboxApi):
         :param template: Sandbox template name or ID
         :param timeout: Timeout for the sandbox in **seconds**, default to 300 seconds. The maximum time a sandbox can be kept alive is 24 hours (86_400 seconds) for Pro users and 1 hour (3_600 seconds) for Hobby users.
         :param auto_pause: Automatically pause the sandbox after the timeout expires. Defaults to `False`.
+            :deprecated: Use `lifecycle={"on_timeout": "pause"}` instead.
         :param metadata: Custom metadata for the sandbox
         :param envs: Custom environment variables for the sandbox
         :param secure: Envd is secured with access token and cannot be used without it, defaults to `True`.

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -25,8 +25,6 @@ from e2b.api.client.models import (
     Sandbox,
     SandboxAutoResumeConfig,
     SandboxNetworkConfig,
-)
-from e2b.api.client.models import (
     SandboxVolumeMount as SandboxVolumeMountAPI,
 )
 from e2b.api.client.types import UNSET

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -177,9 +177,10 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
-        on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
         should_auto_pause = (
-            on_timeout == "pause" if on_timeout is not None else auto_pause
+            lifecycle.get("on_timeout") == "pause"
+            if lifecycle is not None
+            else auto_pause
         )
         auto_resume_enabled = get_auto_resume_enabled(lifecycle)
         body = NewSandbox(

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -45,6 +45,7 @@ from e2b.sandbox.sandbox_api import (
     SandboxNetworkOpts,
     SandboxQuery,
     SnapshotInfo,
+    validate_lifecycle,
 )
 from e2b.sandbox_async.paginator import AsyncSandboxPaginator
 
@@ -177,14 +178,11 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
-        on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
-        should_auto_pause = (
-            on_timeout == "pause" if on_timeout is not None else auto_pause
-        )
+        validate_lifecycle(lifecycle, auto_pause)
+
         auto_resume_enabled = get_auto_resume_enabled(lifecycle)
         body = NewSandbox(
             template_id=template,
-            auto_pause=(should_auto_pause if should_auto_pause is not None else UNSET),
             metadata=metadata or {},
             timeout=timeout,
             env_vars=env_vars or {},

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -25,6 +25,8 @@ from e2b.api.client.models import (
     Sandbox,
     SandboxAutoResumeConfig,
     SandboxNetworkConfig,
+)
+from e2b.api.client.models import (
     SandboxVolumeMount as SandboxVolumeMountAPI,
 )
 from e2b.api.client.types import UNSET
@@ -37,15 +39,14 @@ from e2b.exceptions import (
 )
 from e2b.sandbox.main import SandboxBase
 from e2b.sandbox.sandbox_api import (
-    SandboxLifecycle,
-    get_auto_resume_enabled,
     McpServer,
     SandboxInfo,
+    SandboxLifecycle,
     SandboxMetrics,
     SandboxNetworkOpts,
     SandboxQuery,
     SnapshotInfo,
-    validate_lifecycle,
+    get_lifecycle,
 )
 from e2b.sandbox_async.paginator import AsyncSandboxPaginator
 
@@ -178,11 +179,10 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
-        validate_lifecycle(lifecycle, auto_pause)
-
-        auto_resume_enabled = get_auto_resume_enabled(lifecycle)
+        lifecycle = get_lifecycle(lifecycle, auto_pause)
         body = NewSandbox(
             template_id=template,
+            auto_pause=lifecycle["on_timeout"] == "pause",
             metadata=metadata or {},
             timeout=timeout,
             env_vars=env_vars or {},
@@ -192,8 +192,8 @@ class SandboxApi(SandboxBase):
             network=SandboxNetworkConfig(**network) if network else UNSET,
             volume_mounts=volume_mounts if volume_mounts else UNSET,
         )
-        if auto_resume_enabled is not None:
-            body.auto_resume = SandboxAutoResumeConfig(enabled=auto_resume_enabled)
+        if "auto_resume" in lifecycle:
+            body.auto_resume = SandboxAutoResumeConfig(enabled=lifecycle["auto_resume"])
 
         api_client = get_api_client(config)
         res = await post_sandboxes.asyncio_detailed(

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -38,7 +38,6 @@ from e2b.exceptions import (
 from e2b.sandbox.main import SandboxBase
 from e2b.sandbox.sandbox_api import (
     SandboxLifecycle,
-    get_auto_resume_enabled,
     McpServer,
     SandboxInfo,
     SandboxMetrics,
@@ -181,7 +180,11 @@ class SandboxApi(SandboxBase):
         should_auto_pause = (
             on_timeout == "pause" if on_timeout is not None else auto_pause
         )
-        auto_resume_enabled = get_auto_resume_enabled(lifecycle)
+        auto_resume_enabled = (
+            (lifecycle.get("auto_resume", False) if lifecycle is not None else False)
+            if should_auto_pause
+            else None
+        )
         body = NewSandbox(
             template_id=template,
             auto_pause=(should_auto_pause if should_auto_pause is not None else UNSET),

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -38,7 +38,7 @@ from e2b.exceptions import (
 from e2b.sandbox.main import SandboxBase
 from e2b.sandbox.sandbox_api import (
     SandboxLifecycle,
-    get_effective_lifecycle,
+    get_auto_resume_enabled,
     McpServer,
     SandboxInfo,
     SandboxMetrics,
@@ -177,17 +177,11 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
-        effective_lifecycle = get_effective_lifecycle(lifecycle, auto_pause)
+        on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
         should_auto_pause = (
-            effective_lifecycle["on_timeout"] == "pause"
-            if effective_lifecycle is not None
-            else None
+            on_timeout == "pause" if on_timeout is not None else auto_pause
         )
-        auto_resume_enabled = (
-            effective_lifecycle.get("auto_resume", False)
-            if effective_lifecycle is not None and should_auto_pause
-            else None
-        )
+        auto_resume_enabled = get_auto_resume_enabled(lifecycle)
         body = NewSandbox(
             template_id=template,
             auto_pause=(should_auto_pause if should_auto_pause is not None else UNSET),

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -177,8 +177,9 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
+        on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
         should_auto_pause = (
-            lifecycle["on_timeout"] == "pause" if lifecycle is not None else auto_pause
+            on_timeout == "pause" if on_timeout is not None else auto_pause
         )
         auto_resume_enabled = get_auto_resume_enabled(lifecycle)
         body = NewSandbox(

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -177,10 +177,9 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
+        on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
         should_auto_pause = (
-            lifecycle.get("on_timeout") == "pause"
-            if lifecycle is not None
-            else auto_pause
+            on_timeout == "pause" if on_timeout is not None else auto_pause
         )
         auto_resume_enabled = get_auto_resume_enabled(lifecycle)
         body = NewSandbox(

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -38,6 +38,7 @@ from e2b.exceptions import (
 from e2b.sandbox.main import SandboxBase
 from e2b.sandbox.sandbox_api import (
     SandboxLifecycle,
+    get_effective_lifecycle,
     McpServer,
     SandboxInfo,
     SandboxMetrics,
@@ -176,13 +177,15 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
-        on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
+        effective_lifecycle = get_effective_lifecycle(lifecycle, auto_pause)
         should_auto_pause = (
-            on_timeout == "pause" if on_timeout is not None else auto_pause
+            effective_lifecycle["on_timeout"] == "pause"
+            if effective_lifecycle is not None
+            else None
         )
         auto_resume_enabled = (
-            (lifecycle.get("auto_resume", False) if lifecycle is not None else False)
-            if should_auto_pause
+            effective_lifecycle.get("auto_resume", False)
+            if effective_lifecycle is not None and should_auto_pause
             else None
         )
         body = NewSandbox(

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -571,6 +571,7 @@ class Sandbox(SandboxApi):
         :param template: Sandbox template name or ID
         :param timeout: Timeout for the sandbox in **seconds**, default to 300 seconds. The maximum time a sandbox can be kept alive is 24 hours (86_400 seconds) for Pro users and 1 hour (3_600 seconds) for Hobby users.
         :param auto_pause: Automatically pause the sandbox after the timeout expires. Defaults to `False`.
+            :deprecated: Use `lifecycle={"on_timeout": "pause"}` instead.
         :param metadata: Custom metadata for the sandbox
         :param envs: Custom environment variables for the sandbox
         :param secure: Envd is secured with access token and cannot be used without it, defaults to `True`.

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -3,6 +3,7 @@ import json
 import logging
 import shlex
 import uuid
+import warnings
 from typing import Dict, List, Optional, Union, overload
 
 import httpx
@@ -552,13 +553,14 @@ class Sandbox(SandboxApi):
         cls,
         template: Optional[str] = None,
         timeout: Optional[int] = None,
-        auto_pause: bool = False,
+        auto_pause: Optional[bool] = None,
         metadata: Optional[Dict[str, str]] = None,
         envs: Optional[Dict[str, str]] = None,
         secure: bool = True,
         allow_internet_access: bool = True,
         mcp: Optional[McpServer] = None,
         volume_mounts: Optional[SandboxVolumeMount] = None,
+        lifecycle: Optional[SandboxLifecycle] = None,
         **opts: Unpack[ApiParams],
     ) -> Self:
         """
@@ -570,19 +572,27 @@ class Sandbox(SandboxApi):
 
         :param template: Sandbox template name or ID
         :param timeout: Timeout for the sandbox in **seconds**, default to 300 seconds. The maximum time a sandbox can be kept alive is 24 hours (86_400 seconds) for Pro users and 1 hour (3_600 seconds) for Hobby users.
-        :param auto_pause: Automatically pause the sandbox after the timeout expires. Defaults to `False`.
-            :deprecated: Use `lifecycle={"on_timeout": "pause"}` instead.
+        :param auto_pause: **Deprecated**: use ``lifecycle={"on_timeout": "pause"}`` instead.
+            Automatically pause the sandbox after the timeout expires. Defaults to ``False``.
         :param metadata: Custom metadata for the sandbox
         :param envs: Custom environment variables for the sandbox
         :param secure: Envd is secured with access token and cannot be used without it, defaults to `True`.
         :param allow_internet_access: Allow sandbox to access the internet, defaults to `True`.
         :param mcp: MCP server to enable in the sandbox
         :param volume_mounts: Dictionary mapping mount paths to Volume instances or volume names
+        :param lifecycle: Sandbox lifecycle configuration; controls timeout behavior and auto-resume.
 
         :return: A Sandbox instance for the new sandbox
 
         Use this method instead of using the constructor to create a new sandbox.
         """
+        if auto_pause is not None:
+            warnings.warn(
+                "`auto_pause` is deprecated; use `lifecycle={'on_timeout': 'pause'}` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         if not template and mcp is not None:
             template = cls.default_mcp_template
         elif not template:
@@ -607,9 +617,7 @@ class Sandbox(SandboxApi):
             secure=secure,
             allow_internet_access=allow_internet_access,
             mcp=mcp,
-            lifecycle=(
-                {"on_timeout": "pause", "auto_resume": False} if auto_pause else None
-            ),
+            lifecycle=lifecycle,
             volume_mounts=transformed_mounts,
             **opts,
         )

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -44,6 +44,7 @@ from e2b.sandbox.sandbox_api import (
     SandboxNetworkOpts,
     SandboxQuery,
     SnapshotInfo,
+    validate_lifecycle,
 )
 from e2b.sandbox_sync.paginator import SandboxPaginator, get_api_client
 
@@ -176,14 +177,11 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
-        on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
-        should_auto_pause = (
-            on_timeout == "pause" if on_timeout is not None else auto_pause
-        )
+        validate_lifecycle(lifecycle, auto_pause)
+
         auto_resume_enabled = get_auto_resume_enabled(lifecycle)
         body = NewSandbox(
             template_id=template,
-            auto_pause=(should_auto_pause if should_auto_pause is not None else UNSET),
             metadata=metadata or {},
             timeout=timeout,
             env_vars=env_vars or {},

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -176,9 +176,10 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
-        on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
         should_auto_pause = (
-            on_timeout == "pause" if on_timeout is not None else auto_pause
+            lifecycle.get("on_timeout") == "pause"
+            if lifecycle is not None
+            else auto_pause
         )
         auto_resume_enabled = get_auto_resume_enabled(lifecycle)
         body = NewSandbox(

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -176,10 +176,9 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
+        on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
         should_auto_pause = (
-            lifecycle.get("on_timeout") == "pause"
-            if lifecycle is not None
-            else auto_pause
+            on_timeout == "pause" if on_timeout is not None else auto_pause
         )
         auto_resume_enabled = get_auto_resume_enabled(lifecycle)
         body = NewSandbox(

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -37,7 +37,6 @@ from e2b.exceptions import (
 from e2b.sandbox.main import SandboxBase
 from e2b.sandbox.sandbox_api import (
     SandboxLifecycle,
-    get_auto_resume_enabled,
     McpServer,
     SandboxInfo,
     SandboxMetrics,
@@ -180,7 +179,11 @@ class SandboxApi(SandboxBase):
         should_auto_pause = (
             on_timeout == "pause" if on_timeout is not None else auto_pause
         )
-        auto_resume_enabled = get_auto_resume_enabled(lifecycle)
+        auto_resume_enabled = (
+            (lifecycle.get("auto_resume", False) if lifecycle is not None else False)
+            if should_auto_pause
+            else None
+        )
         body = NewSandbox(
             template_id=template,
             auto_pause=(should_auto_pause if should_auto_pause is not None else UNSET),

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -37,6 +37,7 @@ from e2b.exceptions import (
 from e2b.sandbox.main import SandboxBase
 from e2b.sandbox.sandbox_api import (
     SandboxLifecycle,
+    get_effective_lifecycle,
     McpServer,
     SandboxInfo,
     SandboxMetrics,
@@ -175,13 +176,15 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
-        on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
+        effective_lifecycle = get_effective_lifecycle(lifecycle, auto_pause)
         should_auto_pause = (
-            on_timeout == "pause" if on_timeout is not None else auto_pause
+            effective_lifecycle["on_timeout"] == "pause"
+            if effective_lifecycle is not None
+            else None
         )
         auto_resume_enabled = (
-            (lifecycle.get("auto_resume", False) if lifecycle is not None else False)
-            if should_auto_pause
+            effective_lifecycle.get("auto_resume", False)
+            if effective_lifecycle is not None and should_auto_pause
             else None
         )
         body = NewSandbox(

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -37,14 +37,13 @@ from e2b.exceptions import (
 from e2b.sandbox.main import SandboxBase
 from e2b.sandbox.sandbox_api import (
     SandboxLifecycle,
-    get_auto_resume_enabled,
+    get_lifecycle,
     McpServer,
     SandboxInfo,
     SandboxMetrics,
     SandboxNetworkOpts,
     SandboxQuery,
     SnapshotInfo,
-    validate_lifecycle,
 )
 from e2b.sandbox_sync.paginator import SandboxPaginator, get_api_client
 
@@ -177,11 +176,10 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
-        validate_lifecycle(lifecycle, auto_pause)
-
-        auto_resume_enabled = get_auto_resume_enabled(lifecycle)
+        lifecycle = get_lifecycle(lifecycle, auto_pause)
         body = NewSandbox(
             template_id=template,
+            auto_pause=lifecycle["on_timeout"] == "pause",
             metadata=metadata or {},
             timeout=timeout,
             env_vars=env_vars or {},
@@ -191,8 +189,8 @@ class SandboxApi(SandboxBase):
             network=SandboxNetworkConfig(**network) if network else UNSET,
             volume_mounts=volume_mounts if volume_mounts else UNSET,
         )
-        if auto_resume_enabled is not None:
-            body.auto_resume = SandboxAutoResumeConfig(enabled=auto_resume_enabled)
+        if "auto_resume" in lifecycle:
+            body.auto_resume = SandboxAutoResumeConfig(enabled=lifecycle["auto_resume"])
 
         api_client = get_api_client(config)
         res = post_sandboxes.sync_detailed(

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -37,7 +37,7 @@ from e2b.exceptions import (
 from e2b.sandbox.main import SandboxBase
 from e2b.sandbox.sandbox_api import (
     SandboxLifecycle,
-    get_effective_lifecycle,
+    get_auto_resume_enabled,
     McpServer,
     SandboxInfo,
     SandboxMetrics,
@@ -176,17 +176,11 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
-        effective_lifecycle = get_effective_lifecycle(lifecycle, auto_pause)
+        on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
         should_auto_pause = (
-            effective_lifecycle["on_timeout"] == "pause"
-            if effective_lifecycle is not None
-            else None
+            on_timeout == "pause" if on_timeout is not None else auto_pause
         )
-        auto_resume_enabled = (
-            effective_lifecycle.get("auto_resume", False)
-            if effective_lifecycle is not None and should_auto_pause
-            else None
-        )
+        auto_resume_enabled = get_auto_resume_enabled(lifecycle)
         body = NewSandbox(
             template_id=template,
             auto_pause=(should_auto_pause if should_auto_pause is not None else UNSET),

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -176,8 +176,9 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
+        on_timeout = lifecycle.get("on_timeout") if lifecycle is not None else None
         should_auto_pause = (
-            lifecycle["on_timeout"] == "pause" if lifecycle is not None else auto_pause
+            on_timeout == "pause" if on_timeout is not None else auto_pause
         )
         auto_resume_enabled = get_auto_resume_enabled(lifecycle)
         body = NewSandbox(

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -8,6 +8,7 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
+from e2b.sandbox.sandbox_api import get_auto_resume_enabled
 
 
 @pytest.mark.skip_debug()
@@ -32,6 +33,31 @@ async def test_metadata(async_sandbox_factory):
             break
     else:
         assert False, "Sandbox not found"
+
+
+def test_get_auto_resume_enabled_returns_none_when_lifecycle_missing():
+    assert get_auto_resume_enabled(None) is None
+
+
+def test_get_auto_resume_enabled_uses_auto_resume_from_lifecycle():
+    assert get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": True}) is True
+    assert (
+        get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": False}) is False
+    )
+
+
+def test_get_auto_resume_enabled_defaults_to_false_when_missing_in_lifecycle():
+    # Lifecycle present but no auto_resume key -> defaults to False.
+    assert get_auto_resume_enabled({"on_timeout": "pause"}) is False
+    assert get_auto_resume_enabled({"on_timeout": "kill"}) is False
+
+
+def test_get_auto_resume_enabled_decoupled_from_on_timeout():
+    # auto_resume is independent of on_timeout (per design).
+    assert get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": True}) is True
+    assert (
+        get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": False}) is False
+    )
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -8,7 +8,6 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
-from e2b.sandbox.sandbox_api import get_auto_resume_enabled
 
 
 @pytest.mark.skip_debug()
@@ -33,19 +32,6 @@ async def test_metadata(async_sandbox_factory):
             break
     else:
         assert False, "Sandbox not found"
-
-
-def test_lifecycle_auto_resume_enabled_mapping():
-    assert get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": True}) is True
-    assert (
-        get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": False}) is False
-    )
-    assert get_auto_resume_enabled({"on_timeout": "pause"}) is False
-    assert (
-        get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": False}) is False
-    )
-    assert get_auto_resume_enabled({"on_timeout": "kill"}) is False
-    assert get_auto_resume_enabled(None) is None
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -8,7 +8,6 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
-from e2b.sandbox.sandbox_api import get_auto_resume_enabled
 
 
 @pytest.mark.skip_debug()
@@ -33,17 +32,6 @@ async def test_metadata(async_sandbox_factory):
             break
     else:
         assert False, "Sandbox not found"
-
-
-def test_lifecycle_auto_resume_enabled_mapping():
-    assert get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": True}) is True
-    assert (
-        get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": False}) is False
-    )
-    assert get_auto_resume_enabled({"on_timeout": "pause"}) is False
-    assert get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": False}) is None
-    assert get_auto_resume_enabled({"on_timeout": "kill"}) is None
-    assert get_auto_resume_enabled(None) is None
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -8,8 +8,6 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
-from e2b.exceptions import InvalidArgumentException
-from e2b.sandbox.sandbox_api import get_lifecycle
 
 
 @pytest.mark.skip_debug()
@@ -34,72 +32,6 @@ async def test_metadata(async_sandbox_factory):
             break
     else:
         assert False, "Sandbox not found"
-
-
-def test_get_lifecycle_returns_defaults_when_nothing_provided():
-    assert get_lifecycle(None, None) == {"on_timeout": "kill"}
-
-
-def test_get_lifecycle_on_timeout_takes_precedence_over_auto_pause():
-    assert get_lifecycle({"on_timeout": "kill"}, True) == {"on_timeout": "kill"}
-    assert get_lifecycle({"on_timeout": "pause"}, False) == {"on_timeout": "pause"}
-
-
-def test_get_lifecycle_falls_back_to_auto_pause_when_on_timeout_missing():
-    # partial lifecycle without on_timeout (possible at runtime despite typing).
-    assert get_lifecycle({"auto_resume": True}, True) == {  # type: ignore[typeddict-item]
-        "on_timeout": "pause",
-        "auto_resume": True,
-    }
-
-
-def test_get_lifecycle_auto_pause_only_maps_to_on_timeout():
-    assert get_lifecycle(None, True) == {"on_timeout": "pause"}
-    assert get_lifecycle(None, False) == {"on_timeout": "kill"}
-
-
-def test_get_lifecycle_preserves_auto_resume_from_lifecycle():
-    assert get_lifecycle({"on_timeout": "pause", "auto_resume": True}, None) == {
-        "on_timeout": "pause",
-        "auto_resume": True,
-    }
-    assert get_lifecycle({"on_timeout": "pause", "auto_resume": False}, None) == {
-        "on_timeout": "pause",
-        "auto_resume": False,
-    }
-
-
-def test_get_lifecycle_omits_auto_resume_when_not_set_in_lifecycle():
-    # Lifecycle present but auto_resume not specified -> key omitted in result.
-    assert "auto_resume" not in get_lifecycle({"on_timeout": "pause"}, None)
-
-
-def test_get_lifecycle_omits_auto_resume_when_only_auto_pause_provided():
-    # auto_resume is preserved verbatim from lifecycle input; bare auto_pause
-    # does not introduce one.
-    assert "auto_resume" not in get_lifecycle(None, True)
-    assert "auto_resume" not in get_lifecycle(None, False)
-
-
-def test_get_lifecycle_raises_when_auto_resume_true_with_kill():
-    with pytest.raises(InvalidArgumentException):
-        get_lifecycle({"on_timeout": "kill", "auto_resume": True}, None)
-
-
-def test_get_lifecycle_raises_when_auto_resume_true_and_effective_is_kill():
-    # No on_timeout, auto_pause falsy -> effective kill -> error.
-    with pytest.raises(InvalidArgumentException):
-        get_lifecycle({"auto_resume": True}, None)  # type: ignore[typeddict-item]
-    with pytest.raises(InvalidArgumentException):
-        get_lifecycle({"auto_resume": True}, False)  # type: ignore[typeddict-item]
-
-
-def test_get_lifecycle_does_not_raise_when_auto_resume_true_with_auto_pause():
-    # Partial lifecycle with auto_resume=True and auto_pause=True is valid.
-    assert get_lifecycle(
-        {"auto_resume": True},  # type: ignore[typeddict-item]
-        True,
-    ) == {"on_timeout": "pause", "auto_resume": True}
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -8,7 +8,8 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
-from e2b.sandbox.sandbox_api import get_auto_resume_enabled
+from e2b.exceptions import InvalidArgumentException
+from e2b.sandbox.sandbox_api import get_auto_resume_enabled, validate_lifecycle
 
 
 @pytest.mark.skip_debug()
@@ -58,6 +59,41 @@ def test_get_auto_resume_enabled_decoupled_from_on_timeout():
     assert (
         get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": False}) is False
     )
+
+
+def test_validate_lifecycle_allows_none_lifecycle():
+    validate_lifecycle(None, None)
+    validate_lifecycle(None, True)
+    validate_lifecycle(None, False)
+
+
+def test_validate_lifecycle_allows_auto_resume_with_pause():
+    validate_lifecycle({"on_timeout": "pause", "auto_resume": True}, None)
+    validate_lifecycle({"on_timeout": "pause", "auto_resume": True}, False)
+    validate_lifecycle({"on_timeout": "pause", "auto_resume": True}, True)
+
+
+def test_validate_lifecycle_allows_auto_resume_with_auto_pause_fallback():
+    # No on_timeout but auto_pause=True -> effective pause -> OK.
+    validate_lifecycle({"auto_resume": True}, True)  # type: ignore[typeddict-item]
+
+
+def test_validate_lifecycle_allows_auto_resume_false_with_kill():
+    validate_lifecycle({"on_timeout": "kill", "auto_resume": False}, None)
+    validate_lifecycle({"on_timeout": "kill"}, None)
+
+
+def test_validate_lifecycle_raises_when_auto_resume_true_with_kill():
+    with pytest.raises(InvalidArgumentException):
+        validate_lifecycle({"on_timeout": "kill", "auto_resume": True}, None)
+
+
+def test_validate_lifecycle_raises_when_auto_resume_true_and_effective_is_kill():
+    # No on_timeout, auto_pause falsy -> effective kill -> error.
+    with pytest.raises(InvalidArgumentException):
+        validate_lifecycle({"auto_resume": True}, None)  # type: ignore[typeddict-item]
+    with pytest.raises(InvalidArgumentException):
+        validate_lifecycle({"auto_resume": True}, False)  # type: ignore[typeddict-item]
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -8,6 +8,7 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
+from e2b.sandbox.sandbox_api import get_auto_resume_enabled
 
 
 @pytest.mark.skip_debug()
@@ -32,6 +33,19 @@ async def test_metadata(async_sandbox_factory):
             break
     else:
         assert False, "Sandbox not found"
+
+
+def test_lifecycle_auto_resume_enabled_mapping():
+    assert get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": True}) is True
+    assert (
+        get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": False}) is False
+    )
+    assert get_auto_resume_enabled({"on_timeout": "pause"}) is False
+    assert (
+        get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": False}) is False
+    )
+    assert get_auto_resume_enabled({"on_timeout": "kill"}) is False
+    assert get_auto_resume_enabled(None) is None
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -9,7 +9,7 @@ from e2b.api.client.models import (
     SandboxAutoResumeConfig,
 )
 from e2b.exceptions import InvalidArgumentException
-from e2b.sandbox.sandbox_api import get_auto_resume_enabled, validate_lifecycle
+from e2b.sandbox.sandbox_api import get_lifecycle
 
 
 @pytest.mark.skip_debug()
@@ -36,64 +36,70 @@ async def test_metadata(async_sandbox_factory):
         assert False, "Sandbox not found"
 
 
-def test_get_auto_resume_enabled_returns_none_when_lifecycle_missing():
-    assert get_auto_resume_enabled(None) is None
+def test_get_lifecycle_returns_defaults_when_nothing_provided():
+    assert get_lifecycle(None, None) == {"on_timeout": "kill"}
 
 
-def test_get_auto_resume_enabled_uses_auto_resume_from_lifecycle():
-    assert get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": True}) is True
-    assert (
-        get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": False}) is False
-    )
+def test_get_lifecycle_on_timeout_takes_precedence_over_auto_pause():
+    assert get_lifecycle({"on_timeout": "kill"}, True) == {"on_timeout": "kill"}
+    assert get_lifecycle({"on_timeout": "pause"}, False) == {"on_timeout": "pause"}
 
 
-def test_get_auto_resume_enabled_defaults_to_false_when_missing_in_lifecycle():
-    # Lifecycle present but no auto_resume key -> defaults to False.
-    assert get_auto_resume_enabled({"on_timeout": "pause"}) is False
-    assert get_auto_resume_enabled({"on_timeout": "kill"}) is False
+def test_get_lifecycle_falls_back_to_auto_pause_when_on_timeout_missing():
+    # partial lifecycle without on_timeout (possible at runtime despite typing).
+    assert get_lifecycle({"auto_resume": True}, True) == {  # type: ignore[typeddict-item]
+        "on_timeout": "pause",
+        "auto_resume": True,
+    }
 
 
-def test_get_auto_resume_enabled_decoupled_from_on_timeout():
-    # auto_resume is independent of on_timeout (per design).
-    assert get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": True}) is True
-    assert (
-        get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": False}) is False
-    )
+def test_get_lifecycle_auto_pause_only_maps_to_on_timeout():
+    assert get_lifecycle(None, True) == {"on_timeout": "pause"}
+    assert get_lifecycle(None, False) == {"on_timeout": "kill"}
 
 
-def test_validate_lifecycle_allows_none_lifecycle():
-    validate_lifecycle(None, None)
-    validate_lifecycle(None, True)
-    validate_lifecycle(None, False)
+def test_get_lifecycle_preserves_auto_resume_from_lifecycle():
+    assert get_lifecycle({"on_timeout": "pause", "auto_resume": True}, None) == {
+        "on_timeout": "pause",
+        "auto_resume": True,
+    }
+    assert get_lifecycle({"on_timeout": "pause", "auto_resume": False}, None) == {
+        "on_timeout": "pause",
+        "auto_resume": False,
+    }
 
 
-def test_validate_lifecycle_allows_auto_resume_with_pause():
-    validate_lifecycle({"on_timeout": "pause", "auto_resume": True}, None)
-    validate_lifecycle({"on_timeout": "pause", "auto_resume": True}, False)
-    validate_lifecycle({"on_timeout": "pause", "auto_resume": True}, True)
+def test_get_lifecycle_omits_auto_resume_when_not_set_in_lifecycle():
+    # Lifecycle present but auto_resume not specified -> key omitted in result.
+    assert "auto_resume" not in get_lifecycle({"on_timeout": "pause"}, None)
 
 
-def test_validate_lifecycle_allows_auto_resume_with_auto_pause_fallback():
-    # No on_timeout but auto_pause=True -> effective pause -> OK.
-    validate_lifecycle({"auto_resume": True}, True)  # type: ignore[typeddict-item]
+def test_get_lifecycle_omits_auto_resume_when_only_auto_pause_provided():
+    # auto_resume is preserved verbatim from lifecycle input; bare auto_pause
+    # does not introduce one.
+    assert "auto_resume" not in get_lifecycle(None, True)
+    assert "auto_resume" not in get_lifecycle(None, False)
 
 
-def test_validate_lifecycle_allows_auto_resume_false_with_kill():
-    validate_lifecycle({"on_timeout": "kill", "auto_resume": False}, None)
-    validate_lifecycle({"on_timeout": "kill"}, None)
-
-
-def test_validate_lifecycle_raises_when_auto_resume_true_with_kill():
+def test_get_lifecycle_raises_when_auto_resume_true_with_kill():
     with pytest.raises(InvalidArgumentException):
-        validate_lifecycle({"on_timeout": "kill", "auto_resume": True}, None)
+        get_lifecycle({"on_timeout": "kill", "auto_resume": True}, None)
 
 
-def test_validate_lifecycle_raises_when_auto_resume_true_and_effective_is_kill():
+def test_get_lifecycle_raises_when_auto_resume_true_and_effective_is_kill():
     # No on_timeout, auto_pause falsy -> effective kill -> error.
     with pytest.raises(InvalidArgumentException):
-        validate_lifecycle({"auto_resume": True}, None)  # type: ignore[typeddict-item]
+        get_lifecycle({"auto_resume": True}, None)  # type: ignore[typeddict-item]
     with pytest.raises(InvalidArgumentException):
-        validate_lifecycle({"auto_resume": True}, False)  # type: ignore[typeddict-item]
+        get_lifecycle({"auto_resume": True}, False)  # type: ignore[typeddict-item]
+
+
+def test_get_lifecycle_does_not_raise_when_auto_resume_true_with_auto_pause():
+    # Partial lifecycle with auto_resume=True and auto_pause=True is valid.
+    assert get_lifecycle(
+        {"auto_resume": True},  # type: ignore[typeddict-item]
+        True,
+    ) == {"on_timeout": "pause", "auto_resume": True}
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -8,7 +8,12 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
-from e2b.sandbox.sandbox_api import SandboxQuery, get_auto_resume_enabled
+from e2b.exceptions import InvalidArgumentException
+from e2b.sandbox.sandbox_api import (
+    SandboxQuery,
+    get_auto_resume_enabled,
+    validate_lifecycle,
+)
 
 
 @pytest.mark.skip_debug()
@@ -58,6 +63,41 @@ def test_get_auto_resume_enabled_decoupled_from_on_timeout():
     assert (
         get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": False}) is False
     )
+
+
+def test_validate_lifecycle_allows_none_lifecycle():
+    validate_lifecycle(None, None)
+    validate_lifecycle(None, True)
+    validate_lifecycle(None, False)
+
+
+def test_validate_lifecycle_allows_auto_resume_with_pause():
+    validate_lifecycle({"on_timeout": "pause", "auto_resume": True}, None)
+    validate_lifecycle({"on_timeout": "pause", "auto_resume": True}, False)
+    validate_lifecycle({"on_timeout": "pause", "auto_resume": True}, True)
+
+
+def test_validate_lifecycle_allows_auto_resume_with_auto_pause_fallback():
+    # No on_timeout but auto_pause=True -> effective pause -> OK.
+    validate_lifecycle({"auto_resume": True}, True)  # type: ignore[typeddict-item]
+
+
+def test_validate_lifecycle_allows_auto_resume_false_with_kill():
+    validate_lifecycle({"on_timeout": "kill", "auto_resume": False}, None)
+    validate_lifecycle({"on_timeout": "kill"}, None)
+
+
+def test_validate_lifecycle_raises_when_auto_resume_true_with_kill():
+    with pytest.raises(InvalidArgumentException):
+        validate_lifecycle({"on_timeout": "kill", "auto_resume": True}, None)
+
+
+def test_validate_lifecycle_raises_when_auto_resume_true_and_effective_is_kill():
+    # No on_timeout, auto_pause falsy -> effective kill -> error.
+    with pytest.raises(InvalidArgumentException):
+        validate_lifecycle({"auto_resume": True}, None)  # type: ignore[typeddict-item]
+    with pytest.raises(InvalidArgumentException):
+        validate_lifecycle({"auto_resume": True}, False)  # type: ignore[typeddict-item]
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -8,7 +8,7 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
-from e2b.sandbox.sandbox_api import SandboxQuery
+from e2b.sandbox.sandbox_api import SandboxQuery, get_auto_resume_enabled
 
 
 @pytest.mark.skip_debug()
@@ -33,6 +33,19 @@ def test_metadata(sandbox_factory):
             break
     else:
         assert False, "Sandbox not found"
+
+
+def test_lifecycle_auto_resume_enabled_mapping():
+    assert get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": True}) is True
+    assert (
+        get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": False}) is False
+    )
+    assert get_auto_resume_enabled({"on_timeout": "pause"}) is False
+    assert (
+        get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": False}) is False
+    )
+    assert get_auto_resume_enabled({"on_timeout": "kill"}) is False
+    assert get_auto_resume_enabled(None) is None
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -11,8 +11,7 @@ from e2b.api.client.models import (
 from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.sandbox_api import (
     SandboxQuery,
-    get_auto_resume_enabled,
-    validate_lifecycle,
+    get_lifecycle,
 )
 
 
@@ -40,64 +39,70 @@ def test_metadata(sandbox_factory):
         assert False, "Sandbox not found"
 
 
-def test_get_auto_resume_enabled_returns_none_when_lifecycle_missing():
-    assert get_auto_resume_enabled(None) is None
+def test_get_lifecycle_returns_defaults_when_nothing_provided():
+    assert get_lifecycle(None, None) == {"on_timeout": "kill"}
 
 
-def test_get_auto_resume_enabled_uses_auto_resume_from_lifecycle():
-    assert get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": True}) is True
-    assert (
-        get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": False}) is False
-    )
+def test_get_lifecycle_on_timeout_takes_precedence_over_auto_pause():
+    assert get_lifecycle({"on_timeout": "kill"}, True) == {"on_timeout": "kill"}
+    assert get_lifecycle({"on_timeout": "pause"}, False) == {"on_timeout": "pause"}
 
 
-def test_get_auto_resume_enabled_defaults_to_false_when_missing_in_lifecycle():
-    # Lifecycle present but no auto_resume key -> defaults to False.
-    assert get_auto_resume_enabled({"on_timeout": "pause"}) is False
-    assert get_auto_resume_enabled({"on_timeout": "kill"}) is False
+def test_get_lifecycle_falls_back_to_auto_pause_when_on_timeout_missing():
+    # partial lifecycle without on_timeout (possible at runtime despite typing).
+    assert get_lifecycle({"auto_resume": True}, True) == {  # type: ignore[typeddict-item]
+        "on_timeout": "pause",
+        "auto_resume": True,
+    }
 
 
-def test_get_auto_resume_enabled_decoupled_from_on_timeout():
-    # auto_resume is independent of on_timeout (per design).
-    assert get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": True}) is True
-    assert (
-        get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": False}) is False
-    )
+def test_get_lifecycle_auto_pause_only_maps_to_on_timeout():
+    assert get_lifecycle(None, True) == {"on_timeout": "pause"}
+    assert get_lifecycle(None, False) == {"on_timeout": "kill"}
 
 
-def test_validate_lifecycle_allows_none_lifecycle():
-    validate_lifecycle(None, None)
-    validate_lifecycle(None, True)
-    validate_lifecycle(None, False)
+def test_get_lifecycle_preserves_auto_resume_from_lifecycle():
+    assert get_lifecycle({"on_timeout": "pause", "auto_resume": True}, None) == {
+        "on_timeout": "pause",
+        "auto_resume": True,
+    }
+    assert get_lifecycle({"on_timeout": "pause", "auto_resume": False}, None) == {
+        "on_timeout": "pause",
+        "auto_resume": False,
+    }
 
 
-def test_validate_lifecycle_allows_auto_resume_with_pause():
-    validate_lifecycle({"on_timeout": "pause", "auto_resume": True}, None)
-    validate_lifecycle({"on_timeout": "pause", "auto_resume": True}, False)
-    validate_lifecycle({"on_timeout": "pause", "auto_resume": True}, True)
+def test_get_lifecycle_omits_auto_resume_when_not_set_in_lifecycle():
+    # Lifecycle present but auto_resume not specified -> key omitted in result.
+    assert "auto_resume" not in get_lifecycle({"on_timeout": "pause"}, None)
 
 
-def test_validate_lifecycle_allows_auto_resume_with_auto_pause_fallback():
-    # No on_timeout but auto_pause=True -> effective pause -> OK.
-    validate_lifecycle({"auto_resume": True}, True)  # type: ignore[typeddict-item]
+def test_get_lifecycle_omits_auto_resume_when_only_auto_pause_provided():
+    # auto_resume is preserved verbatim from lifecycle input; bare auto_pause
+    # does not introduce one.
+    assert "auto_resume" not in get_lifecycle(None, True)
+    assert "auto_resume" not in get_lifecycle(None, False)
 
 
-def test_validate_lifecycle_allows_auto_resume_false_with_kill():
-    validate_lifecycle({"on_timeout": "kill", "auto_resume": False}, None)
-    validate_lifecycle({"on_timeout": "kill"}, None)
-
-
-def test_validate_lifecycle_raises_when_auto_resume_true_with_kill():
+def test_get_lifecycle_raises_when_auto_resume_true_with_kill():
     with pytest.raises(InvalidArgumentException):
-        validate_lifecycle({"on_timeout": "kill", "auto_resume": True}, None)
+        get_lifecycle({"on_timeout": "kill", "auto_resume": True}, None)
 
 
-def test_validate_lifecycle_raises_when_auto_resume_true_and_effective_is_kill():
+def test_get_lifecycle_raises_when_auto_resume_true_and_effective_is_kill():
     # No on_timeout, auto_pause falsy -> effective kill -> error.
     with pytest.raises(InvalidArgumentException):
-        validate_lifecycle({"auto_resume": True}, None)  # type: ignore[typeddict-item]
+        get_lifecycle({"auto_resume": True}, None)  # type: ignore[typeddict-item]
     with pytest.raises(InvalidArgumentException):
-        validate_lifecycle({"auto_resume": True}, False)  # type: ignore[typeddict-item]
+        get_lifecycle({"auto_resume": True}, False)  # type: ignore[typeddict-item]
+
+
+def test_get_lifecycle_does_not_raise_when_auto_resume_true_with_auto_pause():
+    # Partial lifecycle with auto_resume=True and auto_pause=True is valid.
+    assert get_lifecycle(
+        {"auto_resume": True},  # type: ignore[typeddict-item]
+        True,
+    ) == {"on_timeout": "pause", "auto_resume": True}
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -8,7 +8,7 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
-from e2b.sandbox.sandbox_api import SandboxQuery, get_auto_resume_enabled
+from e2b.sandbox.sandbox_api import SandboxQuery
 
 
 @pytest.mark.skip_debug()
@@ -33,17 +33,6 @@ def test_metadata(sandbox_factory):
             break
     else:
         assert False, "Sandbox not found"
-
-
-def test_lifecycle_auto_resume_enabled_mapping():
-    assert get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": True}) is True
-    assert (
-        get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": False}) is False
-    )
-    assert get_auto_resume_enabled({"on_timeout": "pause"}) is False
-    assert get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": False}) is None
-    assert get_auto_resume_enabled({"on_timeout": "kill"}) is None
-    assert get_auto_resume_enabled(None) is None
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -8,7 +8,7 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
-from e2b.sandbox.sandbox_api import SandboxQuery, get_auto_resume_enabled
+from e2b.sandbox.sandbox_api import SandboxQuery
 
 
 @pytest.mark.skip_debug()
@@ -33,19 +33,6 @@ def test_metadata(sandbox_factory):
             break
     else:
         assert False, "Sandbox not found"
-
-
-def test_lifecycle_auto_resume_enabled_mapping():
-    assert get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": True}) is True
-    assert (
-        get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": False}) is False
-    )
-    assert get_auto_resume_enabled({"on_timeout": "pause"}) is False
-    assert (
-        get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": False}) is False
-    )
-    assert get_auto_resume_enabled({"on_timeout": "kill"}) is False
-    assert get_auto_resume_enabled(None) is None
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -8,11 +8,7 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
-from e2b.exceptions import InvalidArgumentException
-from e2b.sandbox.sandbox_api import (
-    SandboxQuery,
-    get_lifecycle,
-)
+from e2b.sandbox.sandbox_api import SandboxQuery
 
 
 @pytest.mark.skip_debug()
@@ -37,72 +33,6 @@ def test_metadata(sandbox_factory):
             break
     else:
         assert False, "Sandbox not found"
-
-
-def test_get_lifecycle_returns_defaults_when_nothing_provided():
-    assert get_lifecycle(None, None) == {"on_timeout": "kill"}
-
-
-def test_get_lifecycle_on_timeout_takes_precedence_over_auto_pause():
-    assert get_lifecycle({"on_timeout": "kill"}, True) == {"on_timeout": "kill"}
-    assert get_lifecycle({"on_timeout": "pause"}, False) == {"on_timeout": "pause"}
-
-
-def test_get_lifecycle_falls_back_to_auto_pause_when_on_timeout_missing():
-    # partial lifecycle without on_timeout (possible at runtime despite typing).
-    assert get_lifecycle({"auto_resume": True}, True) == {  # type: ignore[typeddict-item]
-        "on_timeout": "pause",
-        "auto_resume": True,
-    }
-
-
-def test_get_lifecycle_auto_pause_only_maps_to_on_timeout():
-    assert get_lifecycle(None, True) == {"on_timeout": "pause"}
-    assert get_lifecycle(None, False) == {"on_timeout": "kill"}
-
-
-def test_get_lifecycle_preserves_auto_resume_from_lifecycle():
-    assert get_lifecycle({"on_timeout": "pause", "auto_resume": True}, None) == {
-        "on_timeout": "pause",
-        "auto_resume": True,
-    }
-    assert get_lifecycle({"on_timeout": "pause", "auto_resume": False}, None) == {
-        "on_timeout": "pause",
-        "auto_resume": False,
-    }
-
-
-def test_get_lifecycle_omits_auto_resume_when_not_set_in_lifecycle():
-    # Lifecycle present but auto_resume not specified -> key omitted in result.
-    assert "auto_resume" not in get_lifecycle({"on_timeout": "pause"}, None)
-
-
-def test_get_lifecycle_omits_auto_resume_when_only_auto_pause_provided():
-    # auto_resume is preserved verbatim from lifecycle input; bare auto_pause
-    # does not introduce one.
-    assert "auto_resume" not in get_lifecycle(None, True)
-    assert "auto_resume" not in get_lifecycle(None, False)
-
-
-def test_get_lifecycle_raises_when_auto_resume_true_with_kill():
-    with pytest.raises(InvalidArgumentException):
-        get_lifecycle({"on_timeout": "kill", "auto_resume": True}, None)
-
-
-def test_get_lifecycle_raises_when_auto_resume_true_and_effective_is_kill():
-    # No on_timeout, auto_pause falsy -> effective kill -> error.
-    with pytest.raises(InvalidArgumentException):
-        get_lifecycle({"auto_resume": True}, None)  # type: ignore[typeddict-item]
-    with pytest.raises(InvalidArgumentException):
-        get_lifecycle({"auto_resume": True}, False)  # type: ignore[typeddict-item]
-
-
-def test_get_lifecycle_does_not_raise_when_auto_resume_true_with_auto_pause():
-    # Partial lifecycle with auto_resume=True and auto_pause=True is valid.
-    assert get_lifecycle(
-        {"auto_resume": True},  # type: ignore[typeddict-item]
-        True,
-    ) == {"on_timeout": "pause", "auto_resume": True}
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -8,7 +8,7 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
-from e2b.sandbox.sandbox_api import SandboxQuery
+from e2b.sandbox.sandbox_api import SandboxQuery, get_auto_resume_enabled
 
 
 @pytest.mark.skip_debug()
@@ -33,6 +33,31 @@ def test_metadata(sandbox_factory):
             break
     else:
         assert False, "Sandbox not found"
+
+
+def test_get_auto_resume_enabled_returns_none_when_lifecycle_missing():
+    assert get_auto_resume_enabled(None) is None
+
+
+def test_get_auto_resume_enabled_uses_auto_resume_from_lifecycle():
+    assert get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": True}) is True
+    assert (
+        get_auto_resume_enabled({"on_timeout": "pause", "auto_resume": False}) is False
+    )
+
+
+def test_get_auto_resume_enabled_defaults_to_false_when_missing_in_lifecycle():
+    # Lifecycle present but no auto_resume key -> defaults to False.
+    assert get_auto_resume_enabled({"on_timeout": "pause"}) is False
+    assert get_auto_resume_enabled({"on_timeout": "kill"}) is False
+
+
+def test_get_auto_resume_enabled_decoupled_from_on_timeout():
+    # auto_resume is independent of on_timeout (per design).
+    assert get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": True}) is True
+    assert (
+        get_auto_resume_enabled({"on_timeout": "kill", "auto_resume": False}) is False
+    )
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/test_sandbox_api.py
+++ b/packages/python-sdk/tests/test_sandbox_api.py
@@ -1,0 +1,70 @@
+import pytest
+
+from e2b.exceptions import InvalidArgumentException
+from e2b.sandbox.sandbox_api import get_lifecycle
+
+
+def test_get_lifecycle_returns_defaults_when_nothing_provided():
+    assert get_lifecycle(None, None) == {"on_timeout": "kill"}
+
+
+def test_get_lifecycle_on_timeout_takes_precedence_over_auto_pause():
+    assert get_lifecycle({"on_timeout": "kill"}, True) == {"on_timeout": "kill"}
+    assert get_lifecycle({"on_timeout": "pause"}, False) == {"on_timeout": "pause"}
+
+
+def test_get_lifecycle_falls_back_to_auto_pause_when_on_timeout_missing():
+    # partial lifecycle without on_timeout (possible at runtime despite typing).
+    assert get_lifecycle({"auto_resume": True}, True) == {  # type: ignore[typeddict-item]
+        "on_timeout": "pause",
+        "auto_resume": True,
+    }
+
+
+def test_get_lifecycle_auto_pause_only_maps_to_on_timeout():
+    assert get_lifecycle(None, True) == {"on_timeout": "pause"}
+    assert get_lifecycle(None, False) == {"on_timeout": "kill"}
+
+
+def test_get_lifecycle_preserves_auto_resume_from_lifecycle():
+    assert get_lifecycle({"on_timeout": "pause", "auto_resume": True}, None) == {
+        "on_timeout": "pause",
+        "auto_resume": True,
+    }
+    assert get_lifecycle({"on_timeout": "pause", "auto_resume": False}, None) == {
+        "on_timeout": "pause",
+        "auto_resume": False,
+    }
+
+
+def test_get_lifecycle_omits_auto_resume_when_not_set_in_lifecycle():
+    # Lifecycle present but auto_resume not specified -> key omitted in result.
+    assert "auto_resume" not in get_lifecycle({"on_timeout": "pause"}, None)
+
+
+def test_get_lifecycle_omits_auto_resume_when_only_auto_pause_provided():
+    # auto_resume is preserved verbatim from lifecycle input; bare auto_pause
+    # does not introduce one.
+    assert "auto_resume" not in get_lifecycle(None, True)
+    assert "auto_resume" not in get_lifecycle(None, False)
+
+
+def test_get_lifecycle_raises_when_auto_resume_true_with_kill():
+    with pytest.raises(InvalidArgumentException):
+        get_lifecycle({"on_timeout": "kill", "auto_resume": True}, None)
+
+
+def test_get_lifecycle_raises_when_auto_resume_true_and_effective_is_kill():
+    # No on_timeout, auto_pause falsy -> effective kill -> error.
+    with pytest.raises(InvalidArgumentException):
+        get_lifecycle({"auto_resume": True}, None)  # type: ignore[typeddict-item]
+    with pytest.raises(InvalidArgumentException):
+        get_lifecycle({"auto_resume": True}, False)  # type: ignore[typeddict-item]
+
+
+def test_get_lifecycle_does_not_raise_when_auto_resume_true_with_auto_pause():
+    # Partial lifecycle with auto_resume=True and auto_pause=True is valid.
+    assert get_lifecycle(
+        {"auto_resume": True},  # type: ignore[typeddict-item]
+        True,
+    ) == {"on_timeout": "pause", "auto_resume": True}


### PR DESCRIPTION
## Summary

When `lifecycle.on_timeout` is set it wins; otherwise we fall back to the `auto_pause` argument.

Previously the Python SDKs subscripted `lifecycle["on_timeout"]`, which raised `KeyError` if a caller passed a `lifecycle` dict missing that key (TypedDict is not enforced at runtime). The JS SDK silently used the whole `lifecycle` object even when `onTimeout` was undefined. In both cases, mixing `lifecycle` and `auto_pause` had inconsistent and surprising behavior across the public surfaces (`create` vs `beta_create`).

Now both SDKs use `.get`/optional chaining on `on_timeout` and only treat `lifecycle` as authoritative when that field is actually present.

Touched files:
- `packages/python-sdk/e2b/sandbox_async/sandbox_api.py`
- `packages/python-sdk/e2b/sandbox_sync/sandbox_api.py`
- `packages/js-sdk/src/sandbox/sandboxApi.ts`