### PR TITLE
fix(python-sdk): close gRPC streams on watcher/command teardown

### DIFF
--- a/.changeset/fix-async-stream-leak.md
+++ b/.changeset/fix-async-stream-leak.md
@@ -1,0 +1,7 @@
+---
+"@e2b/python-sdk": patch
+---
+
+fix(python-sdk): close gRPC streams on `AsyncWatchHandle.stop()` and `AsyncCommandHandle.disconnect()`
+
+`stop()` / `disconnect()` previously only cancelled the consumer task and left the underlying server-streaming RPC open (the `await self._events.aclose()` was commented out as a Python 3.8 workaround). On long-lived sandboxes this leaked file descriptors and eventually produced `Code.internal: error creating watcher: too many open files`. Python 3.8 is no longer supported (`pyproject.toml` pins `^3.10`), so the workaround is removed and the streams are now closed explicitly.

--- a/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
+++ b/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
@@ -137,8 +137,14 @@ class AsyncCommandHandle:
         You can reconnect to the command using `sandbox.commands.connect` method.
         """
         self._wait.cancel()
-        # BUG: In Python 3.8 closing async generator can throw RuntimeError.
-        # await self._events.aclose()
+        try:
+            await self._wait
+        except BaseException:
+            pass
+        try:
+            await self._events.aclose()
+        except Exception:
+            pass
 
     async def _handle_events(self):
         try:

--- a/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
+++ b/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
@@ -137,10 +137,7 @@ class AsyncCommandHandle:
         You can reconnect to the command using `sandbox.commands.connect` method.
         """
         self._wait.cancel()
-        try:
-            await self._wait
-        except BaseException:
-            pass
+        await asyncio.wait([self._wait])
         try:
             await self._events.aclose()
         except Exception:

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/watch_handle.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/watch_handle.py
@@ -33,8 +33,14 @@ class AsyncWatchHandle:
         Stop watching the directory.
         """
         self._wait.cancel()
-        # BUG: In Python 3.8 closing async generator can throw RuntimeError.
-        # await self._events.aclose()
+        try:
+            await self._wait
+        except BaseException:
+            pass
+        try:
+            await self._events.aclose()
+        except Exception:
+            pass
 
     async def _iterate_events(self):
         try:

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/watch_handle.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/watch_handle.py
@@ -33,10 +33,7 @@ class AsyncWatchHandle:
         Stop watching the directory.
         """
         self._wait.cancel()
-        try:
-            await self._wait
-        except BaseException:
-            pass
+        await asyncio.wait([self._wait])
         try:
             await self._events.aclose()
         except Exception:


### PR DESCRIPTION
## Summary
- `AsyncWatchHandle.stop()` and `AsyncCommandHandle.disconnect()` previously only cancelled the consumer task and left the underlying server-streaming gRPC call open — the `await self._events.aclose()` was commented out as a Python 3.8 `RuntimeError` workaround. On long-lived sandboxes this leaks one stream per call and eventually produces `Code.internal: error creating watcher: too many open files`.
- The SDK now pins `python = "^3.10"`, so the workaround is removed. `stop()`/`disconnect()` cancel the consumer task, await it, then `aclose()` the async generator. The JS SDK already aborts the underlying request via `AbortController`, so no JS change is needed.

## Test plan
- [ ] CI: `pnpm run format`, `pnpm run lint`, `pnpm run typecheck` (passed locally)
- [ ] CI: `tests/async/sandbox_async/files/test_watch.py` and async command tests still pass
- [ ] Reproduce the leak: in a long-lived async sandbox, repeatedly create+stop a watcher and confirm fd count no longer climbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)