### PR TITLE
chore(js): add max concurrency limits

### DIFF
--- a/.changeset/cool-camels-remain.md
+++ b/.changeset/cool-camels-remain.md
@@ -1,0 +1,5 @@
+---
+'e2b': minor
+---
+
+Limit max number of inflight connections

--- a/packages/js-sdk/src/api/http2.ts
+++ b/packages/js-sdk/src/api/http2.ts
@@ -1,4 +1,6 @@
 import { runtime } from '../utils'
+import { getEnvVar } from './metadata'
+import { limitConcurrency } from './inflight'
 import {
   loadUndici,
   toUndiciRequestInput,
@@ -6,7 +8,10 @@ import {
   type UndiciRequestInit,
 } from '../undici'
 
-const API_CONNECTION_LIMIT = 100
+const DEFAULT_API_CONNECTION_LIMIT = 100
+// 1000 = ~10 streams per connection (with the 100-conn default).
+// Override via env if your workload needs different.
+const DEFAULT_API_INFLIGHT_LIMIT = 1000
 const API_UNDICI_FALLBACK_WARNING =
   'Failed to load undici for API HTTP/2 transport; falling back to global fetch.'
 
@@ -27,8 +32,9 @@ export function createApiFetchForRuntime(
   currentRuntime = runtime,
   options: {
     connectionLimit?: number
+    inflightLimit?: number
     loadUndici?: () => Promise<UndiciModule | undefined>
-  } = { connectionLimit: API_CONNECTION_LIMIT }
+  } = {}
 ): typeof fetch {
   if (currentRuntime !== 'node') {
     return fetch
@@ -46,6 +52,7 @@ export function createApiFetchForRuntime(
 
 async function buildApiFetcher(options: {
   connectionLimit?: number
+  inflightLimit?: number
   loadUndici?: () => Promise<UndiciModule | undefined>
 }): Promise<typeof fetch> {
   const undici = await (options.loadUndici ?? loadUndici)()
@@ -53,20 +60,20 @@ async function buildApiFetcher(options: {
   if (!undici) {
     warnUndiciFallback()
 
-    return fetch
+    return applyInflightLimit(fetch, options.inflightLimit)
   }
 
   const { Agent, fetch: undiciFetch } = undici
   const dispatcher = new Agent({
     allowH2: true,
-    connections: options.connectionLimit,
+    connections: options.connectionLimit ?? getApiConnectionLimit(),
   })
   const fetchWithDispatcher = undiciFetch as unknown as (
     input: RequestInfo | URL,
     init?: UndiciRequestInit
   ) => Promise<Response>
 
-  return ((input, init) => {
+  const wrapped: typeof fetch = ((input, init) => {
     const request = toUndiciRequestInput(input, init)
 
     return fetchWithDispatcher(request.input, {
@@ -74,6 +81,46 @@ async function buildApiFetcher(options: {
       dispatcher,
     })
   }) as typeof fetch
+
+  return applyInflightLimit(wrapped, options.inflightLimit)
+}
+
+function applyInflightLimit(
+  fetcher: typeof fetch,
+  override: number | undefined
+): typeof fetch {
+  const limit = override ?? getApiInflightLimit()
+  if (limit == null) return fetcher
+  return limitConcurrency(fetcher, limit)
+}
+
+export function getApiConnectionLimit(): number {
+  const raw = getEnvVar('E2B_API_CONNECTIONS')
+  if (!raw) return DEFAULT_API_CONNECTION_LIMIT
+
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 1)
+    return DEFAULT_API_CONNECTION_LIMIT
+
+  return parsed
+}
+
+/**
+ * Returns the configured max number of API requests that can be in flight at
+ * once, or `null` to disable the cap.
+ *
+ * Defaults to {@link DEFAULT_API_INFLIGHT_LIMIT} ({@link 1000}). Override via
+ * `E2B_API_INFLIGHT_REQUESTS` env var; set to `0` (or any non-positive value)
+ * to disable the cap entirely.
+ */
+export function getApiInflightLimit(): number | null {
+  const raw = getEnvVar('E2B_API_INFLIGHT_REQUESTS')
+  if (!raw) return DEFAULT_API_INFLIGHT_LIMIT
+
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 1) return null
+
+  return parsed
 }
 
 function warnUndiciFallback() {

--- a/packages/js-sdk/src/api/http2.ts
+++ b/packages/js-sdk/src/api/http2.ts
@@ -1,5 +1,5 @@
 import { runtime } from '../utils'
-import { getEnvVar } from './metadata'
+import { parseInflightLimitEnv, parsePositiveIntEnv } from './metadata'
 import { limitConcurrency } from './inflight'
 import {
   loadUndici,
@@ -56,11 +56,12 @@ async function buildApiFetcher(options: {
   loadUndici?: () => Promise<UndiciModule | undefined>
 }): Promise<typeof fetch> {
   const undici = await (options.loadUndici ?? loadUndici)()
+  const inflightLimit = options.inflightLimit ?? getApiInflightLimit()
 
   if (!undici) {
     warnUndiciFallback()
 
-    return applyInflightLimit(fetch, options.inflightLimit)
+    return limitConcurrency(fetch, inflightLimit)
   }
 
   const { Agent, fetch: undiciFetch } = undici
@@ -82,45 +83,28 @@ async function buildApiFetcher(options: {
     })
   }) as typeof fetch
 
-  return applyInflightLimit(wrapped, options.inflightLimit)
-}
-
-function applyInflightLimit(
-  fetcher: typeof fetch,
-  override: number | undefined
-): typeof fetch {
-  const limit = override ?? getApiInflightLimit()
-  if (limit == null) return fetcher
-  return limitConcurrency(fetcher, limit)
+  return limitConcurrency(wrapped, inflightLimit)
 }
 
 export function getApiConnectionLimit(): number {
-  const raw = getEnvVar('E2B_API_CONNECTIONS')
-  if (!raw) return DEFAULT_API_CONNECTION_LIMIT
-
-  const parsed = Number.parseInt(raw, 10)
-  if (!Number.isFinite(parsed) || parsed < 1)
-    return DEFAULT_API_CONNECTION_LIMIT
-
-  return parsed
+  return parsePositiveIntEnv(
+    'E2B_API_CONNECTIONS',
+    DEFAULT_API_CONNECTION_LIMIT
+  )
 }
 
 /**
  * Returns the configured max number of API requests that can be in flight at
- * once, or `null` to disable the cap.
+ * once, or `0` to disable the cap.
  *
  * Defaults to {@link DEFAULT_API_INFLIGHT_LIMIT} ({@link 1000}). Override via
- * `E2B_API_INFLIGHT_REQUESTS` env var; set to `0` (or any non-positive value)
- * to disable the cap entirely.
+ * `E2B_API_INFLIGHT_REQUESTS` env var; set to `0` to disable the cap entirely.
  */
-export function getApiInflightLimit(): number | null {
-  const raw = getEnvVar('E2B_API_INFLIGHT_REQUESTS')
-  if (!raw) return DEFAULT_API_INFLIGHT_LIMIT
-
-  const parsed = Number.parseInt(raw, 10)
-  if (!Number.isFinite(parsed) || parsed < 1) return null
-
-  return parsed
+export function getApiInflightLimit(): number {
+  return parseInflightLimitEnv(
+    'E2B_API_INFLIGHT_REQUESTS',
+    DEFAULT_API_INFLIGHT_LIMIT
+  )
 }
 
 function warnUndiciFallback() {

--- a/packages/js-sdk/src/api/inflight.ts
+++ b/packages/js-sdk/src/api/inflight.ts
@@ -2,38 +2,94 @@
  * Simple FIFO semaphore used to cap the number of in-flight requests sent
  * through a fetch dispatcher. Once `max` requests are outstanding, additional
  * acquires park until an in-flight release.
+ *
+ * `acquire(signal?)` can be cancelled while queued: if `signal` aborts before
+ * a slot is granted, the call rejects with the abort reason and the waiter
+ * is skipped when the next slot is released. This keeps `requestTimeoutMs`
+ * and user-driven cancellation effective even when many requests are queued
+ * behind the limiter.
  */
 class Semaphore {
   private active = 0
-  private readonly queue: Array<() => void> = []
+  private readonly queue: Array<QueuedWaiter> = []
 
   constructor(private readonly max: number) {}
 
-  async acquire(): Promise<() => void> {
+  async acquire(signal?: AbortSignal): Promise<() => void> {
+    if (signal?.aborted) {
+      throw abortReason(signal)
+    }
+
     if (this.active < this.max) {
       this.active++
       return () => this.release()
     }
 
-    return new Promise<() => void>((resolve) => {
-      this.queue.push(() => {
-        this.active++
-        resolve(() => this.release())
-      })
+    return new Promise<() => void>((resolve, reject) => {
+      const waiter: QueuedWaiter = {
+        aborted: false,
+        resolve: () => {
+          if (signal) signal.removeEventListener('abort', onAbort)
+          resolve(() => this.release())
+        },
+      }
+
+      const onAbort = () => {
+        if (waiter.aborted) return
+        waiter.aborted = true
+        // Leave the entry in the queue; `release()` will skip aborted
+        // waiters so we don't pay an O(n) splice on every cancellation.
+        reject(abortReason(signal))
+      }
+
+      this.queue.push(waiter)
+      if (signal) signal.addEventListener('abort', onAbort, { once: true })
     })
   }
 
   private release() {
+    // Hand the slot off to the next non-aborted waiter without bouncing
+    // `active` below `max`. If every queued waiter has been cancelled, the
+    // slot is returned to the pool.
+    while (this.queue.length > 0) {
+      const next = this.queue.shift()!
+      if (next.aborted) continue
+      next.resolve()
+      return
+    }
     this.active--
-    const next = this.queue.shift()
-    if (next) next()
   }
+}
+
+type QueuedWaiter = {
+  aborted: boolean
+  resolve: () => void
+}
+
+function abortReason(signal: AbortSignal | undefined): unknown {
+  const reason = signal?.reason
+  if (reason !== undefined) return reason
+  return new DOMException('Aborted', 'AbortError')
+}
+
+function extractSignal(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): AbortSignal | undefined {
+  if (init?.signal) return init.signal
+  if (input instanceof Request) return input.signal
+  return undefined
 }
 
 /**
  * Wrap `fetcher` so at most `max` requests are in-flight at any time.
  * Subsequent requests are FIFO-queued inside the SDK process and dispatched
  * as earlier requests settle.
+ *
+ * Honors the caller's abort signal while queued: if `init.signal` (or the
+ * `Request`'s signal) aborts before a slot is acquired, the wrapped fetch
+ * rejects immediately with the abort reason instead of blocking behind
+ * earlier requests.
  *
  * Useful for capping bursts (e.g., 20k concurrent `Sandbox.create` calls)
  * so they don't queue inside undici/h2/load balancer.
@@ -49,7 +105,8 @@ export function limitConcurrency(
   const sem = new Semaphore(max)
 
   return (async (input, init) => {
-    const release = await sem.acquire()
+    const signal = extractSignal(input, init)
+    const release = await sem.acquire(signal)
     try {
       return await fetcher(input, init)
     } finally {

--- a/packages/js-sdk/src/api/inflight.ts
+++ b/packages/js-sdk/src/api/inflight.ts
@@ -1,11 +1,6 @@
 /**
  * Simple FIFO semaphore used to cap the number of in-flight requests sent
- * through a fetch dispatcher. Once `max` requests are outstanding, additional
- * acquires park until an in-flight release.
- *
- * `acquire(signal?)` rejects if `signal` is or becomes aborted, so queued
- * requests can be cancelled by `requestTimeoutMs` or user code without
- * waiting for an earlier in-flight request to finish.
+ * through a fetch dispatcher.
  */
 class Semaphore {
   private active = 0
@@ -51,14 +46,6 @@ function abortReason(signal: AbortSignal | undefined): unknown {
  * Wrap `fetcher` so at most `max` requests are in-flight at any time.
  * Subsequent requests are FIFO-queued inside the SDK process and dispatched
  * as earlier requests settle.
- *
- * Honors the caller's abort signal while queued: if `init.signal` (or the
- * `Request`'s signal) aborts before a slot is acquired, the wrapped fetch
- * rejects immediately with the abort reason instead of blocking behind
- * earlier requests.
- *
- * Useful for capping bursts (e.g., 20k concurrent `Sandbox.create` calls)
- * so they don't queue inside undici/h2/load balancer.
  */
 export function limitConcurrency(
   fetcher: typeof fetch,

--- a/packages/js-sdk/src/api/inflight.ts
+++ b/packages/js-sdk/src/api/inflight.ts
@@ -46,6 +46,14 @@ function abortReason(signal: AbortSignal | undefined): unknown {
  * Wrap `fetcher` so at most `max` requests are in-flight at any time.
  * Subsequent requests are FIFO-queued inside the SDK process and dispatched
  * as earlier requests settle.
+ *
+ * NOTE: the slot is released as soon as `fetcher` resolves with the response
+ * headers, not when the response body is fully consumed. This means the
+ * effective concurrency can be higher than `max` while bodies are
+ * still streaming.
+ *
+ * TODO: release on body end (consume/cancel/error) so the
+ * SDK-level cap aligns with the dispatcher's connection accounting
  */
 export function limitConcurrency(
   fetcher: typeof fetch,

--- a/packages/js-sdk/src/api/inflight.ts
+++ b/packages/js-sdk/src/api/inflight.ts
@@ -3,82 +3,48 @@
  * through a fetch dispatcher. Once `max` requests are outstanding, additional
  * acquires park until an in-flight release.
  *
- * `acquire(signal?)` can be cancelled while queued: if `signal` aborts before
- * a slot is granted, the call rejects with the abort reason and the waiter
- * is skipped when the next slot is released. This keeps `requestTimeoutMs`
- * and user-driven cancellation effective even when many requests are queued
- * behind the limiter.
+ * `acquire(signal?)` rejects if `signal` is or becomes aborted, so queued
+ * requests can be cancelled by `requestTimeoutMs` or user code without
+ * waiting for an earlier in-flight request to finish.
  */
 class Semaphore {
   private active = 0
-  private readonly queue: Array<QueuedWaiter> = []
+  private readonly queue: Array<() => void> = []
 
   constructor(private readonly max: number) {}
 
   async acquire(signal?: AbortSignal): Promise<() => void> {
-    if (signal?.aborted) {
-      throw abortReason(signal)
-    }
-
+    if (signal?.aborted) throw abortReason(signal)
     if (this.active < this.max) {
       this.active++
       return () => this.release()
     }
 
     return new Promise<() => void>((resolve, reject) => {
-      const waiter: QueuedWaiter = {
-        aborted: false,
-        resolve: () => {
-          if (signal) signal.removeEventListener('abort', onAbort)
-          resolve(() => this.release())
-        },
+      const onAcquire = () => {
+        signal?.removeEventListener('abort', onAbort)
+        this.active++
+        resolve(() => this.release())
       }
-
       const onAbort = () => {
-        if (waiter.aborted) return
-        waiter.aborted = true
-        // Leave the entry in the queue; `release()` will skip aborted
-        // waiters so we don't pay an O(n) splice on every cancellation.
+        const i = this.queue.indexOf(onAcquire)
+        if (i >= 0) this.queue.splice(i, 1)
         reject(abortReason(signal))
       }
-
-      this.queue.push(waiter)
-      if (signal) signal.addEventListener('abort', onAbort, { once: true })
+      this.queue.push(onAcquire)
+      signal?.addEventListener('abort', onAbort, { once: true })
     })
   }
 
   private release() {
-    // Hand the slot off to the next non-aborted waiter without bouncing
-    // `active` below `max`. If every queued waiter has been cancelled, the
-    // slot is returned to the pool.
-    while (this.queue.length > 0) {
-      const next = this.queue.shift()!
-      if (next.aborted) continue
-      next.resolve()
-      return
-    }
     this.active--
+    const next = this.queue.shift()
+    if (next) next()
   }
 }
 
-type QueuedWaiter = {
-  aborted: boolean
-  resolve: () => void
-}
-
 function abortReason(signal: AbortSignal | undefined): unknown {
-  const reason = signal?.reason
-  if (reason !== undefined) return reason
-  return new DOMException('Aborted', 'AbortError')
-}
-
-function extractSignal(
-  input: RequestInfo | URL,
-  init?: RequestInit
-): AbortSignal | undefined {
-  if (init?.signal) return init.signal
-  if (input instanceof Request) return input.signal
-  return undefined
+  return signal?.reason ?? new DOMException('Aborted', 'AbortError')
 }
 
 /**
@@ -105,7 +71,8 @@ export function limitConcurrency(
   const sem = new Semaphore(max)
 
   return (async (input, init) => {
-    const signal = extractSignal(input, init)
+    const signal =
+      init?.signal ?? (input instanceof Request ? input.signal : undefined)
     const release = await sem.acquire(signal)
     try {
       return await fetcher(input, init)

--- a/packages/js-sdk/src/api/inflight.ts
+++ b/packages/js-sdk/src/api/inflight.ts
@@ -1,0 +1,59 @@
+/**
+ * Simple FIFO semaphore used to cap the number of in-flight requests sent
+ * through a fetch dispatcher. Once `max` requests are outstanding, additional
+ * acquires park until an in-flight release.
+ */
+class Semaphore {
+  private active = 0
+  private readonly queue: Array<() => void> = []
+
+  constructor(private readonly max: number) {}
+
+  async acquire(): Promise<() => void> {
+    if (this.active < this.max) {
+      this.active++
+      return () => this.release()
+    }
+
+    return new Promise<() => void>((resolve) => {
+      this.queue.push(() => {
+        this.active++
+        resolve(() => this.release())
+      })
+    })
+  }
+
+  private release() {
+    this.active--
+    const next = this.queue.shift()
+    if (next) next()
+  }
+}
+
+/**
+ * Wrap `fetcher` so at most `max` requests are in-flight at any time.
+ * Subsequent requests are FIFO-queued inside the SDK process and dispatched
+ * as earlier requests settle.
+ *
+ * Useful for capping bursts (e.g., 20k concurrent `Sandbox.create` calls)
+ * so they don't queue inside undici/h2/load balancer.
+ */
+export function limitConcurrency(
+  fetcher: typeof fetch,
+  max: number
+): typeof fetch {
+  if (!Number.isFinite(max) || max <= 0) {
+    return fetcher
+  }
+
+  const sem = new Semaphore(max)
+
+  return (async (input, init) => {
+    const release = await sem.acquire()
+    try {
+      return await fetcher(input, init)
+    } finally {
+      release()
+    }
+  }) as typeof fetch
+}

--- a/packages/js-sdk/src/api/metadata.ts
+++ b/packages/js-sdk/src/api/metadata.ts
@@ -64,15 +64,22 @@ export function parsePositiveIntEnv(
 }
 
 /**
- * Parse an inflight-limit env var. Returns `0` to disable the cap when the
- * caller explicitly sets a non-positive integer (documented opt-out). Throws on
- * non-integer values so misconfiguration is surfaced loudly. A return value of
- * `0` is recognized by {@link limitConcurrency} as "no cap".
+ * Parse an inflight-limit env var. Returns `0` to disable the cap (documented
+ * opt-out) or a positive integer to cap concurrency. Throws on non-integer or
+ * negative values so misconfiguration is surfaced loudly rather than silently
+ * removing the cap. A return value of `0` is recognized by
+ * {@link limitConcurrency} as "no cap".
  */
 export function parseInflightLimitEnv(
   name: string,
   defaultValue: number
 ): number {
   const parsed = parseIntEnv(name, defaultValue)
-  return parsed < 1 ? 0 : parsed
+  if (parsed < 0) {
+    throw new Error(
+      `Invalid ${name}=${parsed}: expected a non-negative integer ` +
+        '(use 0 to disable the cap).'
+    )
+  }
+  return parsed
 }

--- a/packages/js-sdk/src/api/metadata.ts
+++ b/packages/js-sdk/src/api/metadata.ts
@@ -27,3 +27,52 @@ export function getEnvVar(name: string) {
 
   return process.env[name]
 }
+
+/**
+ * Parse an env var as a base-10 integer, falling back to `defaultValue` when
+ * the env var is unset. Throws on non-integer input rather than silently
+ * falling back so misconfiguration is surfaced loudly.
+ */
+export function parseIntEnv(name: string, defaultValue: number): number {
+  const raw = getEnvVar(name)
+  if (!raw) return defaultValue
+
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) {
+    throw new Error(
+      `Invalid ${name}=${JSON.stringify(raw)}: expected an integer.`
+    )
+  }
+
+  return parsed
+}
+
+/**
+ * Parse an env var that must be a positive integer (>= 1). Throws on
+ * non-positive or non-integer input.
+ */
+export function parsePositiveIntEnv(
+  name: string,
+  defaultValue: number
+): number {
+  const parsed = parseIntEnv(name, defaultValue)
+  if (parsed < 1) {
+    throw new Error(`Invalid ${name}=${parsed}: expected a positive integer.`)
+  }
+
+  return parsed
+}
+
+/**
+ * Parse an inflight-limit env var. Returns `0` to disable the cap when the
+ * caller explicitly sets a non-positive integer (documented opt-out). Throws on
+ * non-integer values so misconfiguration is surfaced loudly. A return value of
+ * `0` is recognized by {@link limitConcurrency} as "no cap".
+ */
+export function parseInflightLimitEnv(
+  name: string,
+  defaultValue: number
+): number {
+  const parsed = parseIntEnv(name, defaultValue)
+  return parsed < 1 ? 0 : parsed
+}

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -1,5 +1,6 @@
 import { runtime } from '../utils'
 import { getEnvVar } from '../api/metadata'
+import { limitConcurrency } from '../api/inflight'
 import {
   loadUndici,
   toUndiciRequestInput,
@@ -9,14 +10,16 @@ import {
 
 type EnvdFetchOptions = {
   connectionLimit?: number
+  inflightLimit?: number
   loadUndici?: () => Promise<UndiciModule | undefined>
 }
 
 let envdFetch: typeof fetch | undefined
 let envdRpcFetch: typeof fetch | undefined
 let hasWarnedUndiciFallback = false
-const DEFAULT_ENVD_CONNECTION_LIMIT = 10
 const DEFAULT_ENVD_RPC_CONNECTION_LIMIT = 200
+const DEFAULT_ENVD_INFLIGHT_LIMIT = 2000
+const DEFAULT_ENVD_RPC_INFLIGHT_LIMIT = 2000
 
 export function createEnvdFetchForRuntime(
   currentRuntime = runtime,
@@ -44,7 +47,7 @@ async function buildEnvdFetcher(
   if (!undici) {
     warnUndiciFallback()
 
-    return fetch
+    return applyInflightLimit(fetch, options.inflightLimit)
   }
 
   const { Agent, fetch: undiciFetch } = undici
@@ -59,7 +62,7 @@ async function buildEnvdFetcher(
     init?: UndiciRequestInit
   ) => Promise<Response>
 
-  return ((input, init) => {
+  const wrapped: typeof fetch = ((input, init) => {
     const request = toUndiciRequestInput(input, init)
 
     return fetchWithDispatcher(request.input, {
@@ -67,6 +70,16 @@ async function buildEnvdFetcher(
       dispatcher,
     })
   }) as typeof fetch
+
+  return applyInflightLimit(wrapped, options.inflightLimit)
+}
+
+function applyInflightLimit(
+  fetcher: typeof fetch,
+  limit: number | undefined
+): typeof fetch {
+  if (limit == null) return fetcher
+  return limitConcurrency(fetcher, limit)
 }
 
 function warnUndiciFallback() {
@@ -87,7 +100,9 @@ export function createEnvdFetch(): typeof fetch {
 
   // Keep one origin connection for short envd REST calls. If ALPN falls back
   // to h1, this favors connection pressure over per-sandbox throughput.
-  envdFetch = createEnvdFetchForRuntime(runtime)
+  envdFetch = createEnvdFetchForRuntime(runtime, {
+    inflightLimit: getEnvdInflightLimit() ?? undefined,
+  })
 
   return envdFetch
 }
@@ -99,6 +114,7 @@ export function createEnvdRpcFetch(): typeof fetch {
 
   envdRpcFetch = createEnvdFetchForRuntime(runtime, {
     connectionLimit: getEnvdRpcConnectionLimit(),
+    inflightLimit: getEnvdRpcInflightLimit() ?? undefined,
   })
 
   return envdRpcFetch
@@ -114,6 +130,44 @@ export function getEnvdRpcConnectionLimit() {
   if (!Number.isFinite(parsed) || parsed < 1) {
     return DEFAULT_ENVD_RPC_CONNECTION_LIMIT
   }
+
+  return parsed
+}
+
+/**
+ * Returns the configured max number of envd REST requests (e.g.
+ * `files.read`/`files.write`) that can be in flight at once across all
+ * sandboxes in this SDK process, or `null` to disable the cap.
+ *
+ * Defaults to {@link DEFAULT_ENVD_INFLIGHT_LIMIT} ({@link 2000}). Override
+ * via `E2B_ENVD_INFLIGHT_REQUESTS` env var; set to `0` (or any non-positive
+ * value) to disable the cap entirely.
+ */
+export function getEnvdInflightLimit(): number | null {
+  const raw = getEnvVar('E2B_ENVD_INFLIGHT_REQUESTS')
+  if (!raw) return DEFAULT_ENVD_INFLIGHT_LIMIT
+
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 1) return null
+
+  return parsed
+}
+
+/**
+ * Returns the configured max number of envd RPC requests that
+ * can be in flight at once across all sandboxes in this SDK process,
+ * or `null` to disable the cap.
+ *
+ * Defaults to {@link DEFAULT_ENVD_RPC_INFLIGHT_LIMIT} ({@link 2000}). Override
+ * via `E2B_ENVD_RPC_INFLIGHT_REQUESTS` env var; set to `0` (or any
+ * non-positive value) to disable the cap entirely.
+ */
+export function getEnvdRpcInflightLimit(): number | null {
+  const raw = getEnvVar('E2B_ENVD_RPC_INFLIGHT_REQUESTS')
+  if (!raw) return DEFAULT_ENVD_RPC_INFLIGHT_LIMIT
+
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 1) return null
 
   return parsed
 }

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -17,6 +17,7 @@ type EnvdFetchOptions = {
 let envdFetch: typeof fetch | undefined
 let envdRpcFetch: typeof fetch | undefined
 let hasWarnedUndiciFallback = false
+const DEFAULT_ENVD_CONNECTION_LIMIT = 10
 const DEFAULT_ENVD_RPC_CONNECTION_LIMIT = 200
 const DEFAULT_ENVD_INFLIGHT_LIMIT = 2000
 const DEFAULT_ENVD_RPC_INFLIGHT_LIMIT = 2000

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -1,5 +1,5 @@
 import { runtime } from '../utils'
-import { getEnvVar } from '../api/metadata'
+import { parseInflightLimitEnv, parsePositiveIntEnv } from '../api/metadata'
 import { limitConcurrency } from '../api/inflight'
 import {
   loadUndici,
@@ -44,11 +44,12 @@ async function buildEnvdFetcher(
   options: EnvdFetchOptions
 ): Promise<typeof fetch> {
   const undici = await (options.loadUndici ?? loadUndici)()
+  const inflightLimit = options.inflightLimit ?? 0
 
   if (!undici) {
     warnUndiciFallback()
 
-    return applyInflightLimit(fetch, options.inflightLimit)
+    return limitConcurrency(fetch, inflightLimit)
   }
 
   const { Agent, fetch: undiciFetch } = undici
@@ -72,15 +73,7 @@ async function buildEnvdFetcher(
     })
   }) as typeof fetch
 
-  return applyInflightLimit(wrapped, options.inflightLimit)
-}
-
-function applyInflightLimit(
-  fetcher: typeof fetch,
-  limit: number | undefined
-): typeof fetch {
-  if (limit == null) return fetcher
-  return limitConcurrency(fetcher, limit)
+  return limitConcurrency(wrapped, inflightLimit)
 }
 
 function warnUndiciFallback() {
@@ -102,7 +95,7 @@ export function createEnvdFetch(): typeof fetch {
   // Keep one origin connection for short envd REST calls. If ALPN falls back
   // to h1, this favors connection pressure over per-sandbox throughput.
   envdFetch = createEnvdFetchForRuntime(runtime, {
-    inflightLimit: getEnvdInflightLimit() ?? undefined,
+    inflightLimit: getEnvdInflightLimit(),
   })
 
   return envdFetch
@@ -115,60 +108,47 @@ export function createEnvdRpcFetch(): typeof fetch {
 
   envdRpcFetch = createEnvdFetchForRuntime(runtime, {
     connectionLimit: getEnvdRpcConnectionLimit(),
-    inflightLimit: getEnvdRpcInflightLimit() ?? undefined,
+    inflightLimit: getEnvdRpcInflightLimit(),
   })
 
   return envdRpcFetch
 }
 
-export function getEnvdRpcConnectionLimit() {
-  const raw = getEnvVar('E2B_ENVD_RPC_CONNECTIONS')
-  if (!raw) {
-    return DEFAULT_ENVD_RPC_CONNECTION_LIMIT
-  }
-
-  const parsed = Number.parseInt(raw, 10)
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    return DEFAULT_ENVD_RPC_CONNECTION_LIMIT
-  }
-
-  return parsed
+export function getEnvdRpcConnectionLimit(): number {
+  return parsePositiveIntEnv(
+    'E2B_ENVD_RPC_CONNECTIONS',
+    DEFAULT_ENVD_RPC_CONNECTION_LIMIT
+  )
 }
 
 /**
  * Returns the configured max number of envd REST requests (e.g.
  * `files.read`/`files.write`) that can be in flight at once across all
- * sandboxes in this SDK process, or `null` to disable the cap.
+ * sandboxes in this SDK process, or `0` to disable the cap.
  *
  * Defaults to {@link DEFAULT_ENVD_INFLIGHT_LIMIT} ({@link 2000}). Override
- * via `E2B_ENVD_INFLIGHT_REQUESTS` env var; set to `0` (or any non-positive
- * value) to disable the cap entirely.
+ * via `E2B_ENVD_INFLIGHT_REQUESTS` env var; set to `0` to disable the cap
+ * entirely.
  */
-export function getEnvdInflightLimit(): number | null {
-  const raw = getEnvVar('E2B_ENVD_INFLIGHT_REQUESTS')
-  if (!raw) return DEFAULT_ENVD_INFLIGHT_LIMIT
-
-  const parsed = Number.parseInt(raw, 10)
-  if (!Number.isFinite(parsed) || parsed < 1) return null
-
-  return parsed
+export function getEnvdInflightLimit(): number {
+  return parseInflightLimitEnv(
+    'E2B_ENVD_INFLIGHT_REQUESTS',
+    DEFAULT_ENVD_INFLIGHT_LIMIT
+  )
 }
 
 /**
  * Returns the configured max number of envd RPC requests that
  * can be in flight at once across all sandboxes in this SDK process,
- * or `null` to disable the cap.
+ * or `0` to disable the cap.
  *
  * Defaults to {@link DEFAULT_ENVD_RPC_INFLIGHT_LIMIT} ({@link 2000}). Override
- * via `E2B_ENVD_RPC_INFLIGHT_REQUESTS` env var; set to `0` (or any
- * non-positive value) to disable the cap entirely.
+ * via `E2B_ENVD_RPC_INFLIGHT_REQUESTS` env var; set to `0` to disable the cap
+ * entirely.
  */
-export function getEnvdRpcInflightLimit(): number | null {
-  const raw = getEnvVar('E2B_ENVD_RPC_INFLIGHT_REQUESTS')
-  if (!raw) return DEFAULT_ENVD_RPC_INFLIGHT_LIMIT
-
-  const parsed = Number.parseInt(raw, 10)
-  if (!Number.isFinite(parsed) || parsed < 1) return null
-
-  return parsed
+export function getEnvdRpcInflightLimit(): number {
+  return parseInflightLimitEnv(
+    'E2B_ENVD_RPC_INFLIGHT_REQUESTS',
+    DEFAULT_ENVD_RPC_INFLIGHT_LIMIT
+  )
 }

--- a/packages/js-sdk/tests/api/http2.test.ts
+++ b/packages/js-sdk/tests/api/http2.test.ts
@@ -5,6 +5,8 @@ afterEach(() => {
   vi.resetModules()
   vi.doUnmock('undici')
   vi.doUnmock('../../src/utils')
+  delete process.env.E2B_API_CONNECTIONS
+  delete process.env.E2B_API_INFLIGHT_REQUESTS
 })
 
 test('uses undici with a bounded HTTP/2 dispatcher for API requests', async () => {
@@ -34,4 +36,28 @@ test('uses undici with a bounded HTTP/2 dispatcher for API requests', async () =
   expect(loadUndici).toHaveBeenCalledOnce()
   expect(agents).toEqual([{ allowH2: true, connections: 100 }])
   expect(requests[0].init?.dispatcher).toBeInstanceOf(Agent)
+})
+
+test('getApiConnectionLimit throws on a malformed env value', async () => {
+  process.env.E2B_API_CONNECTIONS = 'not-a-number'
+
+  const { getApiConnectionLimit } = await import('../../src/api/http2')
+
+  expect(() => getApiConnectionLimit()).toThrow(/E2B_API_CONNECTIONS/)
+})
+
+test('getApiInflightLimit throws on a malformed env value', async () => {
+  process.env.E2B_API_INFLIGHT_REQUESTS = 'not-a-number'
+
+  const { getApiInflightLimit } = await import('../../src/api/http2')
+
+  expect(() => getApiInflightLimit()).toThrow(/E2B_API_INFLIGHT_REQUESTS/)
+})
+
+test('getApiInflightLimit returns 0 for non-positive values (disable)', async () => {
+  process.env.E2B_API_INFLIGHT_REQUESTS = '0'
+
+  const { getApiInflightLimit } = await import('../../src/api/http2')
+
+  expect(getApiInflightLimit()).toBe(0)
 })

--- a/packages/js-sdk/tests/api/http2.test.ts
+++ b/packages/js-sdk/tests/api/http2.test.ts
@@ -54,10 +54,18 @@ test('getApiInflightLimit throws on a malformed env value', async () => {
   expect(() => getApiInflightLimit()).toThrow(/E2B_API_INFLIGHT_REQUESTS/)
 })
 
-test('getApiInflightLimit returns 0 for non-positive values (disable)', async () => {
+test('getApiInflightLimit returns 0 when explicitly disabled', async () => {
   process.env.E2B_API_INFLIGHT_REQUESTS = '0'
 
   const { getApiInflightLimit } = await import('../../src/api/http2')
 
   expect(getApiInflightLimit()).toBe(0)
+})
+
+test('getApiInflightLimit throws on negative env value', async () => {
+  process.env.E2B_API_INFLIGHT_REQUESTS = '-5'
+
+  const { getApiInflightLimit } = await import('../../src/api/http2')
+
+  expect(() => getApiInflightLimit()).toThrow(/E2B_API_INFLIGHT_REQUESTS=-5/)
 })

--- a/packages/js-sdk/tests/api/inflight.test.ts
+++ b/packages/js-sdk/tests/api/inflight.test.ts
@@ -1,0 +1,75 @@
+import { expect, test, vi } from 'vitest'
+
+import { limitConcurrency } from '../../src/api/inflight'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+test('limitConcurrency queues requests over the cap and releases on response', async () => {
+  const gate = deferred<Response>()
+  let secondStarted = false
+  const inner = vi.fn(async (input: RequestInfo | URL) => {
+    if (String(input).endsWith('/first')) return gate.promise
+    secondStarted = true
+    return new Response('second')
+  }) as unknown as typeof fetch
+
+  const limited = limitConcurrency(inner, 1)
+  const first = limited('https://example.com/first')
+  const second = limited('https://example.com/second')
+
+  await Promise.resolve()
+  await Promise.resolve()
+  expect(secondStarted).toBe(false)
+
+  gate.resolve(new Response('first'))
+  expect(await (await first).text()).toBe('first')
+  expect(await (await second).text()).toBe('second')
+  expect(secondStarted).toBe(true)
+})
+
+test('limitConcurrency releases when the underlying fetch rejects', async () => {
+  let calls = 0
+  const inner = vi.fn(async () => {
+    calls++
+    if (calls === 1) throw new Error('boom')
+    return new Response('ok')
+  }) as unknown as typeof fetch
+
+  const limited = limitConcurrency(inner, 1)
+  await expect(limited('https://example.com/a')).rejects.toThrow('boom')
+
+  // Slot should be free for the next request.
+  const res = await limited('https://example.com/b')
+  expect(await res.text()).toBe('ok')
+})
+
+test('limitConcurrency aborts queued requests when their signal fires', async () => {
+  const gate = deferred<Response>()
+  const inner = vi.fn(async () => gate.promise) as unknown as typeof fetch
+  const limited = limitConcurrency(inner, 1)
+
+  // Occupy the only slot.
+  const first = limited('https://example.com/first')
+
+  const controller = new AbortController()
+  const queued = limited('https://example.com/queued', {
+    signal: controller.signal,
+  })
+
+  // Abort the queued request before the slot frees.
+  controller.abort()
+  await expect(queued).rejects.toMatchObject({ name: 'AbortError' })
+
+  // Release the first request to make sure cleanup did not break the slot.
+  gate.resolve(new Response('done'))
+  const resp = await first
+  expect(await resp.text()).toBe('done')
+})

--- a/packages/js-sdk/tests/connectionConfig.test.ts
+++ b/packages/js-sdk/tests/connectionConfig.test.ts
@@ -56,6 +56,22 @@ test('api_url has correct priority', () => {
   assert.equal(config.apiUrl, 'http://localhost:8080')
 })
 
+test('sandbox_url defaults to stable sandbox host in production', () => {
+  delete process.env.E2B_SANDBOX_URL
+  delete process.env.E2B_DOMAIN
+  delete process.env.E2B_DEBUG
+
+  const config = new ConnectionConfig()
+
+  assert.equal(
+    config.getSandboxUrl('sbx-test', {
+      sandboxDomain: 'e2b.app',
+      envdPort: 49983,
+    }),
+    'https://sandbox.e2b.app'
+  )
+})
+
 test('sandbox_direct_url keeps per-sandbox host in production', () => {
   delete process.env.E2B_SANDBOX_URL
   delete process.env.E2B_DOMAIN
@@ -69,6 +85,21 @@ test('sandbox_direct_url keeps per-sandbox host in production', () => {
       envdPort: 49983,
     }),
     'https://49983-sbx-test.e2b.app'
+  )
+})
+
+test('sandbox_url keeps per-sandbox host outside production', () => {
+  delete process.env.E2B_SANDBOX_URL
+  delete process.env.E2B_DEBUG
+
+  const config = new ConnectionConfig({ domain: 'e2b.dev' })
+
+  assert.equal(
+    config.getSandboxUrl('sbx-test', {
+      sandboxDomain: 'sandbox.e2b.dev',
+      envdPort: 49983,
+    }),
+    'https://49983-sbx-test.sandbox.e2b.dev'
   )
 })
 

--- a/packages/js-sdk/tests/connectionConfig.test.ts
+++ b/packages/js-sdk/tests/connectionConfig.test.ts
@@ -56,22 +56,6 @@ test('api_url has correct priority', () => {
   assert.equal(config.apiUrl, 'http://localhost:8080')
 })
 
-test('sandbox_url defaults to stable sandbox host in production', () => {
-  delete process.env.E2B_SANDBOX_URL
-  delete process.env.E2B_DOMAIN
-  delete process.env.E2B_DEBUG
-
-  const config = new ConnectionConfig()
-
-  assert.equal(
-    config.getSandboxUrl('sbx-test', {
-      sandboxDomain: 'e2b.app',
-      envdPort: 49983,
-    }),
-    'https://sandbox.e2b.app'
-  )
-})
-
 test('sandbox_direct_url keeps per-sandbox host in production', () => {
   delete process.env.E2B_SANDBOX_URL
   delete process.env.E2B_DOMAIN
@@ -85,21 +69,6 @@ test('sandbox_direct_url keeps per-sandbox host in production', () => {
       envdPort: 49983,
     }),
     'https://49983-sbx-test.e2b.app'
-  )
-})
-
-test('sandbox_url keeps per-sandbox host outside production', () => {
-  delete process.env.E2B_SANDBOX_URL
-  delete process.env.E2B_DEBUG
-
-  const config = new ConnectionConfig({ domain: 'e2b.dev' })
-
-  assert.equal(
-    config.getSandboxUrl('sbx-test', {
-      sandboxDomain: 'sandbox.e2b.dev',
-      envdPort: 49983,
-    }),
-    'https://49983-sbx-test.sandbox.e2b.dev'
   )
 })
 

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -6,6 +6,8 @@ afterEach(() => {
   vi.doUnmock('undici')
   vi.doUnmock('../../src/utils')
   delete process.env.E2B_ENVD_RPC_CONNECTIONS
+  delete process.env.E2B_ENVD_INFLIGHT_REQUESTS
+  delete process.env.E2B_ENVD_RPC_INFLIGHT_REQUESTS
 })
 
 test('uses undici with HTTP/2 enabled in Node', async () => {
@@ -95,6 +97,44 @@ test('reads RPC stream dispatcher connection limit from env', async () => {
   const { getEnvdRpcConnectionLimit } = await import('../../src/envd/http2')
 
   expect(getEnvdRpcConnectionLimit()).toBe(200)
+})
+
+test('getEnvdRpcConnectionLimit throws on malformed env value', async () => {
+  process.env.E2B_ENVD_RPC_CONNECTIONS = 'bogus'
+
+  const { getEnvdRpcConnectionLimit } = await import('../../src/envd/http2')
+
+  expect(() => getEnvdRpcConnectionLimit()).toThrow(/E2B_ENVD_RPC_CONNECTIONS/)
+})
+
+test('getEnvdInflightLimit throws on malformed env value', async () => {
+  process.env.E2B_ENVD_INFLIGHT_REQUESTS = 'bogus'
+
+  const { getEnvdInflightLimit } = await import('../../src/envd/http2')
+
+  expect(() => getEnvdInflightLimit()).toThrow(/E2B_ENVD_INFLIGHT_REQUESTS/)
+})
+
+test('getEnvdRpcInflightLimit throws on malformed env value', async () => {
+  process.env.E2B_ENVD_RPC_INFLIGHT_REQUESTS = 'bogus'
+
+  const { getEnvdRpcInflightLimit } = await import('../../src/envd/http2')
+
+  expect(() => getEnvdRpcInflightLimit()).toThrow(
+    /E2B_ENVD_RPC_INFLIGHT_REQUESTS/
+  )
+})
+
+test('inflight limit env vars return 0 for non-positive values (disable)', async () => {
+  process.env.E2B_ENVD_INFLIGHT_REQUESTS = '0'
+  process.env.E2B_ENVD_RPC_INFLIGHT_REQUESTS = '-1'
+
+  const { getEnvdInflightLimit, getEnvdRpcInflightLimit } = await import(
+    '../../src/envd/http2'
+  )
+
+  expect(getEnvdInflightLimit()).toBe(0)
+  expect(getEnvdRpcInflightLimit()).toBe(0)
 })
 
 test('defers loading undici until the first Node request', async () => {

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -125,16 +125,33 @@ test('getEnvdRpcInflightLimit throws on malformed env value', async () => {
   )
 })
 
-test('inflight limit env vars return 0 for non-positive values (disable)', async () => {
+test('inflight limit env vars return 0 when explicitly disabled', async () => {
   process.env.E2B_ENVD_INFLIGHT_REQUESTS = '0'
-  process.env.E2B_ENVD_RPC_INFLIGHT_REQUESTS = '-1'
+  process.env.E2B_ENVD_RPC_INFLIGHT_REQUESTS = '0'
 
-  const { getEnvdInflightLimit, getEnvdRpcInflightLimit } = await import(
-    '../../src/envd/http2'
-  )
+  const { getEnvdInflightLimit, getEnvdRpcInflightLimit } =
+    await import('../../src/envd/http2')
 
   expect(getEnvdInflightLimit()).toBe(0)
   expect(getEnvdRpcInflightLimit()).toBe(0)
+})
+
+test('getEnvdInflightLimit throws on negative env value', async () => {
+  process.env.E2B_ENVD_INFLIGHT_REQUESTS = '-1'
+
+  const { getEnvdInflightLimit } = await import('../../src/envd/http2')
+
+  expect(() => getEnvdInflightLimit()).toThrow(/E2B_ENVD_INFLIGHT_REQUESTS=-1/)
+})
+
+test('getEnvdRpcInflightLimit throws on negative env value', async () => {
+  process.env.E2B_ENVD_RPC_INFLIGHT_REQUESTS = '-5'
+
+  const { getEnvdRpcInflightLimit } = await import('../../src/envd/http2')
+
+  expect(() => getEnvdRpcInflightLimit()).toThrow(
+    /E2B_ENVD_RPC_INFLIGHT_REQUESTS=-5/
+  )
 })
 
 test('defers loading undici until the first Node request', async () => {

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -129,8 +129,9 @@ test('inflight limit env vars return 0 when explicitly disabled', async () => {
   process.env.E2B_ENVD_INFLIGHT_REQUESTS = '0'
   process.env.E2B_ENVD_RPC_INFLIGHT_REQUESTS = '0'
 
-  const { getEnvdInflightLimit, getEnvdRpcInflightLimit } =
-    await import('../../src/envd/http2')
+  const { getEnvdInflightLimit, getEnvdRpcInflightLimit } = await import(
+    '../../src/envd/http2'
+  )
 
   expect(getEnvdInflightLimit()).toBe(0)
   expect(getEnvdRpcInflightLimit()).toBe(0)


### PR DESCRIPTION
Set limit for max concurrent inflight connection, with burst traffic it could happen that the number of connection overwhelms the underlaying infrastructure or at least saturate it to the point each request is too slow to succeed and blocking the rest