### PR TITLE
fix(js-sdk): preserve multi-source COPY in fromDockerfile

### DIFF
--- a/.changeset/fromdockerfile-multi-source-copy.md
+++ b/.changeset/fromdockerfile-multi-source-copy.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Preserve all sources from multi-source Dockerfile COPY instructions in fromDockerfile.

--- a/packages/js-sdk/src/template/dockerfileParser.ts
+++ b/packages/js-sdk/src/template/dockerfileParser.ts
@@ -184,8 +184,8 @@ function handleCopyInstruction(
 ): void {
   const argumentsData = instruction.getArguments()
   if (argumentsData && argumentsData.length >= 2) {
-    const src = argumentsData[0].getValue()
     const dest = argumentsData[argumentsData.length - 1].getValue()
+    const sources = argumentsData.slice(0, -1).map((arg) => arg.getValue())
 
     let user: string | undefined
     const flags = instruction.getFlags()
@@ -194,7 +194,9 @@ function handleCopyInstruction(
       user = chownFlag.getValue() ?? undefined
     }
 
-    templateBuilder.copy(src, dest, { user })
+    for (const src of sources) {
+      templateBuilder.copy(src, dest, { user })
+    }
   }
 }
 

--- a/packages/js-sdk/tests/template/methods/fromDockerfile.test.ts
+++ b/packages/js-sdk/tests/template/methods/fromDockerfile.test.ts
@@ -154,3 +154,24 @@ COPY --chown=anotheruser config.json /config/`
   assert.equal(copyInstruction2.args[1], '/config/')
   assert.equal(copyInstruction2.args[2], 'anotheruser') // user from --chown (without group)
 })
+
+buildTemplateTest('fromDockerfile with multi-source COPY', () => {
+  const dockerfile = `FROM node:24
+COPY package.json package-lock.json /app/`
+
+  const template = Template().fromDockerfile(dockerfile)
+
+  // First COPY instruction (after initial USER root and WORKDIR /)
+  // @ts-expect-error - instructions is not a property of TemplateBuilder
+  const copyInstruction1 = template.instructions[2]
+  assert.equal(copyInstruction1.type, InstructionType.COPY)
+  assert.equal(copyInstruction1.args[0], 'package.json')
+  assert.equal(copyInstruction1.args[1], '/app/')
+
+  // Second source from the same Dockerfile COPY instruction
+  // @ts-expect-error - instructions is not a property of TemplateBuilder
+  const copyInstruction2 = template.instructions[3]
+  assert.equal(copyInstruction2.type, InstructionType.COPY)
+  assert.equal(copyInstruction2.args[0], 'package-lock.json')
+  assert.equal(copyInstruction2.args[1], '/app/')
+})


### PR DESCRIPTION
## Summary
- Fixes `Template().fromDockerfile()` dropping all but the first source in multi-source Dockerfile `COPY` instructions.
- Emits one template `COPY` step per source while preserving the shared destination and COPY flags like `--chown`.
- Adds regression coverage for multi-source COPY and a patch changeset for the JS SDK.

Fixes #1349

## Test plan
- [x] `pnpm --filter e2b exec vitest run tests/template/methods/fromDockerfile.test.ts -t "multi-source COPY"`
- [x] `pnpm --filter e2b exec vitest run tests/template/methods/fromDockerfile.test.ts`
- [x] `pnpm --filter e2b run typecheck`
- [x] `pnpm --filter e2b run lint`
- [x] `pnpm --filter e2b run build`
- [x] `pnpm --filter e2b exec prettier --check src/template/dockerfileParser.ts tests/template/methods/fromDockerfile.test.ts`