### PR TITLE
chore(sdk): sync OpenAPI spec from infra, regenerate clients

### DIFF
--- a/.changeset/sandbox-metrics-mem-cache.md
+++ b/.changeset/sandbox-metrics-mem-cache.md
@@ -1,0 +1,6 @@
+---
+'e2b': minor
+'@e2b/python-sdk': minor
+---
+
+Add `memCache` / `mem_cache` to `SandboxMetrics` — cached memory (page cache) in bytes, now returned by the metrics API.

--- a/.changeset/sandbox-metrics-mem-cache.md
+++ b/.changeset/sandbox-metrics-mem-cache.md
@@ -1,6 +1,0 @@
----
-'e2b': minor
-'@e2b/python-sdk': minor
----
-
-Add `memCache` / `mem_cache` to `SandboxMetrics` — cached memory (page cache) in bytes, now returned by the metrics API.

--- a/.changeset/sync-openapi-spec.md
+++ b/.changeset/sync-openapi-spec.md
@@ -1,6 +1,6 @@
 ---
-'e2b': patch
-'@e2b/python-sdk': patch
+'e2b': minor
+'@e2b/python-sdk': minor
 ---
 
-Sync OpenAPI spec from e2b-dev/infra: adds `standby` value to `NodeStatus`, marks `TeamUser.email` as nullable and deprecated, and adds a `403` response to template creation.
+Sync OpenAPI spec from `e2b-dev/infra`. Notable changes: `SandboxMetrics` gains `memCache` / `mem_cache` (cached memory in bytes), `NodeStatus` gains `standby`, `TeamUser.email` is now nullable and deprecated, and `POST /v3/templates` can now return `403`.

--- a/.changeset/sync-openapi-spec.md
+++ b/.changeset/sync-openapi-spec.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/python-sdk': patch
+---
+
+Sync OpenAPI spec from e2b-dev/infra: adds `standby` value to `NodeStatus`, marks `TeamUser.email` as nullable and deprecated, and adds a `403` response to template creation.

--- a/packages/js-sdk/src/api/schema.gen.ts
+++ b/packages/js-sdk/src/api/schema.gen.ts
@@ -295,7 +295,7 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
-        /** @description Update the network configuration for a running sandbox. Replaces the current egress rules with the provided configuration. Omitting a field clears it. */
+        /** @description Update the network configuration for a running sandbox. Replaces the current egress rules with the provided configuration. Omitting field clears it. */
         put: {
             parameters: {
                 query?: never;
@@ -1585,6 +1585,7 @@ export interface paths {
                 };
                 400: components["responses"]["400"];
                 401: components["responses"]["401"];
+                403: components["responses"]["403"];
                 500: components["responses"]["500"];
             };
         };
@@ -2136,10 +2137,13 @@ export interface components {
             memoryUsedBytes: number;
         };
         /**
-         * @description Status of the node
+         * @description Status of the node.
+         *     - draining: the node is bound to be shut down. It will not accept new sandboxes and will stop once all existing sandboxes are done.
+         *     - standby: the node is not actively used, but it can return to ready and continue serving traffic.
+         *
          * @enum {string}
          */
-        NodeStatus: "ready" | "draining" | "connecting" | "unhealthy";
+        NodeStatus: "ready" | "draining" | "connecting" | "unhealthy" | "standby";
         NodeStatusChange: {
             /**
              * Format: uuid
@@ -2302,6 +2306,11 @@ export interface components {
             diskUsed: number;
             /**
              * Format: int64
+             * @description Cached memory (page cache) in bytes
+             */
+            memCache: number;
+            /**
+             * Format: int64
              * @description Total memory in bytes
              */
             memTotal: number;
@@ -2334,7 +2343,8 @@ export interface components {
             denyOut?: string[];
             /** @description Specify host mask which will be used for all sandbox requests */
             maskRequestHost?: string;
-            /** @description Per-domain transform rules applied to matching egress HTTP/HTTPS requests. Keys are domains (e.g. "api.example.com", "example.com"). A domain listed here is not automatically allowed - use allowOut to permit the traffic. */
+            /** @description Per-domain transform rules applied to matching egress HTTP/HTTPS requests. Keys are domains (e.g. "api.example.com", "example.com"). A domain listed here is not automatically allowed - use allowOut to permit the traffic.
+             *      */
             rules?: {
                 [key: string]: components["schemas"]["SandboxNetworkRule"][];
             };
@@ -2345,7 +2355,8 @@ export interface components {
         };
         /** @description Transformations applied to matching egress requests before forwarding. */
         SandboxNetworkTransform: {
-            /** @description HTTP headers to inject or override in matching requests. An existing header with the same name is replaced. Values are plain strings; secret resolution happens client-side before sending to the API. */
+            /** @description HTTP headers to inject or override in matching requests. An existing header with the same name is replaced. Values are plain strings; secret resolution happens client-side before sending to the API.
+             *      */
             headers?: {
                 [key: string]: string;
             };
@@ -2441,8 +2452,12 @@ export interface components {
             timestampUnix: number;
         };
         TeamUser: {
-            /** @description Email of the user */
-            email: string;
+            /**
+             * @deprecated
+             * @description Email of the user
+             * @default null
+             */
+            email: string | null;
             /**
              * Format: uuid
              * @description Identifier of the user

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -531,6 +531,11 @@ export interface SandboxMetrics {
   memTotal: number
 
   /**
+   * Cached memory (page cache) in bytes.
+   */
+  memCache: number
+
+  /**
    * Used disk space in bytes.
    */
   diskUsed: number
@@ -724,6 +729,7 @@ export class SandboxApi {
         cpuCount: metric.cpuCount,
         memUsed: metric.memUsed,
         memTotal: metric.memTotal,
+        memCache: metric.memCache,
         diskUsed: metric.diskUsed,
         diskTotal: metric.diskTotal,
       })) ?? []

--- a/packages/python-sdk/e2b/api/client/api/sandboxes/put_sandboxes_sandbox_id_network.py
+++ b/packages/python-sdk/e2b/api/client/api/sandboxes/put_sandboxes_sandbox_id_network.py
@@ -76,7 +76,7 @@ def sync_detailed(
     body: SandboxNetworkUpdateConfig,
 ) -> Response[Union[Any, Error]]:
     """Update the network configuration for a running sandbox. Replaces the current egress rules with the
-    provided configuration. Omitting a field clears it.
+    provided configuration. Omitting field clears it.
 
     Args:
         sandbox_id (str):
@@ -111,7 +111,7 @@ def sync(
     body: SandboxNetworkUpdateConfig,
 ) -> Optional[Union[Any, Error]]:
     """Update the network configuration for a running sandbox. Replaces the current egress rules with the
-    provided configuration. Omitting a field clears it.
+    provided configuration. Omitting field clears it.
 
     Args:
         sandbox_id (str):
@@ -141,7 +141,7 @@ async def asyncio_detailed(
     body: SandboxNetworkUpdateConfig,
 ) -> Response[Union[Any, Error]]:
     """Update the network configuration for a running sandbox. Replaces the current egress rules with the
-    provided configuration. Omitting a field clears it.
+    provided configuration. Omitting field clears it.
 
     Args:
         sandbox_id (str):
@@ -174,7 +174,7 @@ async def asyncio(
     body: SandboxNetworkUpdateConfig,
 ) -> Optional[Union[Any, Error]]:
     """Update the network configuration for a running sandbox. Replaces the current egress rules with the
-    provided configuration. Omitting a field clears it.
+    provided configuration. Omitting field clears it.
 
     Args:
         sandbox_id (str):

--- a/packages/python-sdk/e2b/api/client/api/templates/post_v3_templates.py
+++ b/packages/python-sdk/e2b/api/client/api/templates/post_v3_templates.py
@@ -45,6 +45,10 @@ def _parse_response(
         response_401 = Error.from_dict(response.json())
 
         return response_401
+    if response.status_code == 403:
+        response_403 = Error.from_dict(response.json())
+
+        return response_403
     if response.status_code == 500:
         response_500 = Error.from_dict(response.json())
 

--- a/packages/python-sdk/e2b/api/client/models/node.py
+++ b/packages/python-sdk/e2b/api/client/models/node.py
@@ -28,7 +28,10 @@ class Node:
         sandbox_count (int): Number of sandboxes running on the node
         sandbox_starting_count (int): Number of starting Sandboxes
         service_instance_id (str): Service instance identifier of the node
-        status (NodeStatus): Status of the node
+        status (NodeStatus): Status of the node.
+            - draining: the node is bound to be shut down. It will not accept new sandboxes and will stop once all existing
+            sandboxes are done.
+            - standby: the node is not actively used, but it can return to ready and continue serving traffic.
         version (str): Version of the orchestrator
     """
 

--- a/packages/python-sdk/e2b/api/client/models/node_detail.py
+++ b/packages/python-sdk/e2b/api/client/models/node_detail.py
@@ -28,7 +28,10 @@ class NodeDetail:
         metrics (NodeMetrics): Node metrics
         sandbox_count (int): Number of sandboxes running on the node
         service_instance_id (str): Service instance identifier of the node
-        status (NodeStatus): Status of the node
+        status (NodeStatus): Status of the node.
+            - draining: the node is bound to be shut down. It will not accept new sandboxes and will stop once all existing
+            sandboxes are done.
+            - standby: the node is not actively used, but it can return to ready and continue serving traffic.
         version (str): Version of the orchestrator
     """
 

--- a/packages/python-sdk/e2b/api/client/models/node_status.py
+++ b/packages/python-sdk/e2b/api/client/models/node_status.py
@@ -5,6 +5,7 @@ class NodeStatus(str, Enum):
     CONNECTING = "connecting"
     DRAINING = "draining"
     READY = "ready"
+    STANDBY = "standby"
     UNHEALTHY = "unhealthy"
 
     def __str__(self) -> str:

--- a/packages/python-sdk/e2b/api/client/models/node_status_change.py
+++ b/packages/python-sdk/e2b/api/client/models/node_status_change.py
@@ -15,7 +15,10 @@ T = TypeVar("T", bound="NodeStatusChange")
 class NodeStatusChange:
     """
     Attributes:
-        status (NodeStatus): Status of the node
+        status (NodeStatus): Status of the node.
+            - draining: the node is bound to be shut down. It will not accept new sandboxes and will stop once all existing
+            sandboxes are done.
+            - standby: the node is not actively used, but it can return to ready and continue serving traffic.
         cluster_id (Union[Unset, UUID]): Identifier of the cluster
     """
 

--- a/packages/python-sdk/e2b/api/client/models/sandbox_metric.py
+++ b/packages/python-sdk/e2b/api/client/models/sandbox_metric.py
@@ -18,6 +18,7 @@ class SandboxMetric:
         cpu_used_pct (float): CPU usage percentage
         disk_total (int): Total disk space in bytes
         disk_used (int): Disk used in bytes
+        mem_cache (int): Cached memory (page cache) in bytes
         mem_total (int): Total memory in bytes
         mem_used (int): Memory used in bytes
         timestamp (datetime.datetime): Timestamp of the metric entry
@@ -28,6 +29,7 @@ class SandboxMetric:
     cpu_used_pct: float
     disk_total: int
     disk_used: int
+    mem_cache: int
     mem_total: int
     mem_used: int
     timestamp: datetime.datetime
@@ -42,6 +44,8 @@ class SandboxMetric:
         disk_total = self.disk_total
 
         disk_used = self.disk_used
+
+        mem_cache = self.mem_cache
 
         mem_total = self.mem_total
 
@@ -59,6 +63,7 @@ class SandboxMetric:
                 "cpuUsedPct": cpu_used_pct,
                 "diskTotal": disk_total,
                 "diskUsed": disk_used,
+                "memCache": mem_cache,
                 "memTotal": mem_total,
                 "memUsed": mem_used,
                 "timestamp": timestamp,
@@ -79,6 +84,8 @@ class SandboxMetric:
 
         disk_used = d.pop("diskUsed")
 
+        mem_cache = d.pop("memCache")
+
         mem_total = d.pop("memTotal")
 
         mem_used = d.pop("memUsed")
@@ -92,6 +99,7 @@ class SandboxMetric:
             cpu_used_pct=cpu_used_pct,
             disk_total=disk_total,
             disk_used=disk_used,
+            mem_cache=mem_cache,
             mem_total=mem_total,
             mem_used=mem_used,
             timestamp=timestamp,

--- a/packages/python-sdk/e2b/api/client/models/team_user.py
+++ b/packages/python-sdk/e2b/api/client/models/team_user.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, Union, cast
 from uuid import UUID
 
 from attrs import define as _attrs_define
@@ -12,15 +12,16 @@ T = TypeVar("T", bound="TeamUser")
 class TeamUser:
     """
     Attributes:
-        email (str): Email of the user
+        email (Union[None, str]): Email of the user
         id (UUID): Identifier of the user
     """
 
-    email: str
+    email: Union[None, str]
     id: UUID
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        email: Union[None, str]
         email = self.email
 
         id = str(self.id)
@@ -39,7 +40,13 @@ class TeamUser:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        email = d.pop("email")
+
+        def _parse_email(data: object) -> Union[None, str]:
+            if data is None:
+                return data
+            return cast(Union[None, str], data)
+
+        email = _parse_email(d.pop("email"))
 
         id = UUID(d.pop("id"))
 

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -541,6 +541,8 @@ class SandboxMetrics:
     """Total memory in bytes."""
     mem_used: int
     """Memory used in bytes."""
+    mem_cache: int
+    """Cached memory (page cache) in bytes."""
     timestamp: datetime
     """Timestamp of the metric entry."""
 

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -317,6 +317,7 @@ class SandboxApi(SandboxBase):
                 disk_used=metric.disk_used,
                 mem_total=metric.mem_total,
                 mem_used=metric.mem_used,
+                mem_cache=metric.mem_cache,
                 timestamp=metric.timestamp,
             )
             for metric in res.parsed

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -306,6 +306,7 @@ class SandboxApi(SandboxBase):
                 disk_used=metric.disk_used,
                 mem_total=metric.mem_total,
                 mem_used=metric.mem_used,
+                mem_cache=metric.mem_cache,
                 timestamp=metric.timestamp,
             )
             for metric in res.parsed

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -125,42 +125,42 @@ components:
         type: string
 
   responses:
-    "400":
+    '400':
       description: Bad request
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
-    "401":
+            $ref: '#/components/schemas/Error'
+    '401':
       description: Authentication error
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
-    "403":
+            $ref: '#/components/schemas/Error'
+    '403':
       description: Forbidden
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
-    "404":
+            $ref: '#/components/schemas/Error'
+    '404':
       description: Not found
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
-    "409":
+            $ref: '#/components/schemas/Error'
+    '409':
       description: Conflict
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
-    "500":
+            $ref: '#/components/schemas/Error'
+    '500':
       description: Server error
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: '#/components/schemas/Error'
 
   schemas:
     Team:
@@ -304,7 +304,7 @@ components:
           additionalProperties:
             type: array
             items:
-              $ref: "#/components/schemas/SandboxNetworkRule"
+              $ref: '#/components/schemas/SandboxNetworkRule'
 
     SandboxNetworkUpdateConfig:
       type: object
@@ -326,7 +326,7 @@ components:
           additionalProperties:
             type: array
             items:
-              $ref: "#/components/schemas/SandboxNetworkRule"
+              $ref: '#/components/schemas/SandboxNetworkRule'
         allow_internet_access:
           type: boolean
           description:
@@ -338,7 +338,7 @@ components:
       description: Transform rule applied to egress requests matching a domain pattern.
       properties:
         transform:
-          $ref: "#/components/schemas/SandboxNetworkTransform"
+          $ref: '#/components/schemas/SandboxNetworkTransform'
 
     SandboxNetworkTransform:
       type: object
@@ -365,7 +365,7 @@ components:
         - enabled
       properties:
         enabled:
-          $ref: "#/components/schemas/SandboxAutoResumeEnabled"
+          $ref: '#/components/schemas/SandboxAutoResumeEnabled'
 
     SandboxOnTimeout:
       type: string
@@ -385,7 +385,7 @@ components:
           type: boolean
           description: Whether the sandbox can auto-resume.
         onTimeout:
-          $ref: "#/components/schemas/SandboxOnTimeout"
+          $ref: '#/components/schemas/SandboxOnTimeout'
 
     SandboxLog:
       description: Log entry with timestamp and line
@@ -416,7 +416,7 @@ components:
           type: string
           description: Log message content
         level:
-          $ref: "#/components/schemas/LogLevel"
+          $ref: '#/components/schemas/LogLevel'
         fields:
           type: object
           additionalProperties:
@@ -431,12 +431,12 @@ components:
           description: Logs of the sandbox
           type: array
           items:
-            $ref: "#/components/schemas/SandboxLog"
+            $ref: '#/components/schemas/SandboxLog'
         logEntries:
           description: Structured logs of the sandbox
           type: array
           items:
-            $ref: "#/components/schemas/SandboxLogEntry"
+            $ref: '#/components/schemas/SandboxLogEntry'
 
     SandboxLogsV2Response:
       required:
@@ -447,7 +447,7 @@ components:
           description: Sandbox logs structured
           type: array
           items:
-            $ref: "#/components/schemas/SandboxLogEntry"
+            $ref: '#/components/schemas/SandboxLogEntry'
 
     SandboxMetric:
       description: Metric entry with timestamp and line
@@ -534,7 +534,7 @@ components:
           deprecated: true
           description: Identifier of the client
         envdVersion:
-          $ref: "#/components/schemas/EnvdVersion"
+          $ref: '#/components/schemas/EnvdVersion'
         envdAccessToken:
           type: string
           description: Access token used for envd communication
@@ -582,7 +582,7 @@ components:
           format: date-time
           description: Time when the sandbox will expire
         envdVersion:
-          $ref: "#/components/schemas/EnvdVersion"
+          $ref: '#/components/schemas/EnvdVersion'
         envdAccessToken:
           type: string
           description: Access token used for envd communication
@@ -595,23 +595,23 @@ components:
           nullable: true
           description: Base domain where the sandbox traffic is accessible
         cpuCount:
-          $ref: "#/components/schemas/CPUCount"
+          $ref: '#/components/schemas/CPUCount'
         memoryMB:
-          $ref: "#/components/schemas/MemoryMB"
+          $ref: '#/components/schemas/MemoryMB'
         diskSizeMB:
-          $ref: "#/components/schemas/DiskSizeMB"
+          $ref: '#/components/schemas/DiskSizeMB'
         metadata:
-          $ref: "#/components/schemas/SandboxMetadata"
+          $ref: '#/components/schemas/SandboxMetadata'
         state:
-          $ref: "#/components/schemas/SandboxState"
+          $ref: '#/components/schemas/SandboxState'
         network:
-          $ref: "#/components/schemas/SandboxNetworkConfig"
+          $ref: '#/components/schemas/SandboxNetworkConfig'
         lifecycle:
-          $ref: "#/components/schemas/SandboxLifecycle"
+          $ref: '#/components/schemas/SandboxLifecycle'
         volumeMounts:
           type: array
           items:
-            $ref: "#/components/schemas/SandboxVolumeMount"
+            $ref: '#/components/schemas/SandboxVolumeMount'
 
     ListedSandbox:
       required:
@@ -648,21 +648,21 @@ components:
           format: date-time
           description: Time when the sandbox will expire
         cpuCount:
-          $ref: "#/components/schemas/CPUCount"
+          $ref: '#/components/schemas/CPUCount'
         memoryMB:
-          $ref: "#/components/schemas/MemoryMB"
+          $ref: '#/components/schemas/MemoryMB'
         diskSizeMB:
-          $ref: "#/components/schemas/DiskSizeMB"
+          $ref: '#/components/schemas/DiskSizeMB'
         metadata:
-          $ref: "#/components/schemas/SandboxMetadata"
+          $ref: '#/components/schemas/SandboxMetadata'
         state:
-          $ref: "#/components/schemas/SandboxState"
+          $ref: '#/components/schemas/SandboxState'
         envdVersion:
-          $ref: "#/components/schemas/EnvdVersion"
+          $ref: '#/components/schemas/EnvdVersion'
         volumeMounts:
           type: array
           items:
-            $ref: "#/components/schemas/SandboxVolumeMount"
+            $ref: '#/components/schemas/SandboxVolumeMount'
 
     SandboxesWithMetrics:
       required:
@@ -670,7 +670,7 @@ components:
       properties:
         sandboxes:
           additionalProperties:
-            $ref: "#/components/schemas/SandboxMetric"
+            $ref: '#/components/schemas/SandboxMetric'
 
     NewSandbox:
       required:
@@ -690,7 +690,7 @@ components:
           default: false
           description: Automatically pauses the sandbox after the timeout
         autoResume:
-          $ref: "#/components/schemas/SandboxAutoResumeConfig"
+          $ref: '#/components/schemas/SandboxAutoResumeConfig'
         secure:
           type: boolean
           description: Secure all system communication with sandbox
@@ -700,17 +700,17 @@ components:
             Allow sandbox to access the internet. When set to false, it behaves the same as specifying denyOut
             to 0.0.0.0/0 in the network config.
         network:
-          $ref: "#/components/schemas/SandboxNetworkConfig"
+          $ref: '#/components/schemas/SandboxNetworkConfig'
         metadata:
-          $ref: "#/components/schemas/SandboxMetadata"
+          $ref: '#/components/schemas/SandboxMetadata'
         envVars:
-          $ref: "#/components/schemas/EnvVars"
+          $ref: '#/components/schemas/EnvVars'
         mcp:
-          $ref: "#/components/schemas/Mcp"
+          $ref: '#/components/schemas/Mcp'
         volumeMounts:
           type: array
           items:
-            $ref: "#/components/schemas/SandboxVolumeMount"
+            $ref: '#/components/schemas/SandboxVolumeMount'
 
     ResumedSandbox:
       properties:
@@ -840,11 +840,11 @@ components:
           type: string
           description: Identifier of the last successful build for given template
         cpuCount:
-          $ref: "#/components/schemas/CPUCount"
+          $ref: '#/components/schemas/CPUCount'
         memoryMB:
-          $ref: "#/components/schemas/MemoryMB"
+          $ref: '#/components/schemas/MemoryMB'
         diskSizeMB:
-          $ref: "#/components/schemas/DiskSizeMB"
+          $ref: '#/components/schemas/DiskSizeMB'
         public:
           type: boolean
           description: Whether the template is public or only accessible by the team
@@ -869,7 +869,7 @@ components:
           description: Time when the template was last updated
         createdBy:
           allOf:
-            - $ref: "#/components/schemas/TeamUser"
+            - $ref: '#/components/schemas/TeamUser'
           nullable: true
         lastSpawnedAt:
           type: string
@@ -885,9 +885,9 @@ components:
           format: int32
           description: Number of times the template was built
         envdVersion:
-          $ref: "#/components/schemas/EnvdVersion"
+          $ref: '#/components/schemas/EnvdVersion'
         buildStatus:
-          $ref: "#/components/schemas/TemplateBuildStatus"
+          $ref: '#/components/schemas/TemplateBuildStatus'
 
     TemplateRequestResponseV3:
       required:
@@ -948,11 +948,11 @@ components:
           type: string
           description: Identifier of the last successful build for given template
         cpuCount:
-          $ref: "#/components/schemas/CPUCount"
+          $ref: '#/components/schemas/CPUCount'
         memoryMB:
-          $ref: "#/components/schemas/MemoryMB"
+          $ref: '#/components/schemas/MemoryMB'
         diskSizeMB:
-          $ref: "#/components/schemas/DiskSizeMB"
+          $ref: '#/components/schemas/DiskSizeMB'
         public:
           type: boolean
           description: Whether the template is public or only accessible by the team
@@ -971,7 +971,7 @@ components:
           description: Time when the template was last updated
         createdBy:
           allOf:
-            - $ref: "#/components/schemas/TeamUser"
+            - $ref: '#/components/schemas/TeamUser'
           nullable: true
         lastSpawnedAt:
           type: string
@@ -987,7 +987,7 @@ components:
           format: int32
           description: Number of times the template was built
         envdVersion:
-          $ref: "#/components/schemas/EnvdVersion"
+          $ref: '#/components/schemas/EnvdVersion'
 
     TemplateBuild:
       required:
@@ -1003,7 +1003,7 @@ components:
           format: uuid
           description: Identifier of the build
         status:
-          $ref: "#/components/schemas/TemplateBuildStatus"
+          $ref: '#/components/schemas/TemplateBuildStatus'
         createdAt:
           type: string
           format: date-time
@@ -1017,13 +1017,13 @@ components:
           format: date-time
           description: Time when the build was finished
         cpuCount:
-          $ref: "#/components/schemas/CPUCount"
+          $ref: '#/components/schemas/CPUCount'
         memoryMB:
-          $ref: "#/components/schemas/MemoryMB"
+          $ref: '#/components/schemas/MemoryMB'
         diskSizeMB:
-          $ref: "#/components/schemas/DiskSizeMB"
+          $ref: '#/components/schemas/DiskSizeMB'
         envdVersion:
-          $ref: "#/components/schemas/EnvdVersion"
+          $ref: '#/components/schemas/EnvdVersion'
 
     TemplateWithBuilds:
       required:
@@ -1075,7 +1075,7 @@ components:
           type: array
           description: List of builds for the template
           items:
-            $ref: "#/components/schemas/TemplateBuild"
+            $ref: '#/components/schemas/TemplateBuild'
 
     TemplateAliasResponse:
       required:
@@ -1109,9 +1109,9 @@ components:
           description: Ready check command to execute in the template after the build
           type: string
         cpuCount:
-          $ref: "#/components/schemas/CPUCount"
+          $ref: '#/components/schemas/CPUCount'
         memoryMB:
-          $ref: "#/components/schemas/MemoryMB"
+          $ref: '#/components/schemas/MemoryMB'
 
     TemplateStep:
       description: Step in the template build process
@@ -1154,9 +1154,9 @@ components:
           type: string
           description: Identifier of the team
         cpuCount:
-          $ref: "#/components/schemas/CPUCount"
+          $ref: '#/components/schemas/CPUCount'
         memoryMB:
-          $ref: "#/components/schemas/MemoryMB"
+          $ref: '#/components/schemas/MemoryMB'
 
     TemplateBuildRequestV2:
       required:
@@ -1170,21 +1170,21 @@ components:
           type: string
           description: Identifier of the team
         cpuCount:
-          $ref: "#/components/schemas/CPUCount"
+          $ref: '#/components/schemas/CPUCount'
         memoryMB:
-          $ref: "#/components/schemas/MemoryMB"
+          $ref: '#/components/schemas/MemoryMB'
 
     FromImageRegistry:
       oneOf:
-        - $ref: "#/components/schemas/AWSRegistry"
-        - $ref: "#/components/schemas/GCPRegistry"
-        - $ref: "#/components/schemas/GeneralRegistry"
+        - $ref: '#/components/schemas/AWSRegistry'
+        - $ref: '#/components/schemas/GCPRegistry'
+        - $ref: '#/components/schemas/GeneralRegistry'
       discriminator:
         propertyName: type
         mapping:
-          aws: "#/components/schemas/AWSRegistry"
-          gcp: "#/components/schemas/GCPRegistry"
-          registry: "#/components/schemas/GeneralRegistry"
+          aws: '#/components/schemas/AWSRegistry'
+          gcp: '#/components/schemas/GCPRegistry'
+          registry: '#/components/schemas/GeneralRegistry'
 
     AWSRegistry:
       type: object
@@ -1250,7 +1250,7 @@ components:
           type: string
           description: Template to use as a base for the template build
         fromImageRegistry:
-          $ref: "#/components/schemas/FromImageRegistry"
+          $ref: '#/components/schemas/FromImageRegistry'
         force:
           default: false
           type: boolean
@@ -1260,7 +1260,7 @@ components:
           description: List of steps to execute in the template build
           type: array
           items:
-            $ref: "#/components/schemas/TemplateStep"
+            $ref: '#/components/schemas/TemplateStep'
         startCmd:
           description: Start command to execute in the template after the build
           type: string
@@ -1302,7 +1302,7 @@ components:
           type: string
           description: Log message content
         level:
-          $ref: "#/components/schemas/LogLevel"
+          $ref: '#/components/schemas/LogLevel'
         step:
           type: string
           description: Step in the build process related to the log entry
@@ -1322,7 +1322,7 @@ components:
           description: Log entries related to the status reason
           type: array
           items:
-            $ref: "#/components/schemas/BuildLogEntry"
+            $ref: '#/components/schemas/BuildLogEntry'
 
     TemplateBuildStatus:
       type: string
@@ -1352,7 +1352,7 @@ components:
           description: Build logs structured
           type: array
           items:
-            $ref: "#/components/schemas/BuildLogEntry"
+            $ref: '#/components/schemas/BuildLogEntry'
         templateID:
           type: string
           description: Identifier of the template
@@ -1360,9 +1360,9 @@ components:
           type: string
           description: Identifier of the build
         status:
-          $ref: "#/components/schemas/TemplateBuildStatus"
+          $ref: '#/components/schemas/TemplateBuildStatus'
         reason:
-          $ref: "#/components/schemas/BuildStatusReason"
+          $ref: '#/components/schemas/BuildStatusReason'
 
     TemplateBuildLogsResponse:
       required:
@@ -1373,7 +1373,7 @@ components:
           description: Build logs structured
           type: array
           items:
-            $ref: "#/components/schemas/BuildLogEntry"
+            $ref: '#/components/schemas/BuildLogEntry'
 
     LogsDirection:
       type: string
@@ -1423,7 +1423,7 @@ components:
           format: uuid
           description: Identifier of the cluster
         status:
-          $ref: "#/components/schemas/NodeStatus"
+          $ref: '#/components/schemas/NodeStatus'
 
     DiskMetrics:
       required:
@@ -1490,7 +1490,7 @@ components:
           type: array
           description: Detailed metrics for each disk/mount point
           items:
-            $ref: "#/components/schemas/DiskMetrics"
+            $ref: '#/components/schemas/DiskMetrics'
     MachineInfo:
       required:
         - cpuFamily
@@ -1542,15 +1542,15 @@ components:
           type: string
           description: Identifier of the cluster
         machineInfo:
-          $ref: "#/components/schemas/MachineInfo"
+          $ref: '#/components/schemas/MachineInfo'
         status:
-          $ref: "#/components/schemas/NodeStatus"
+          $ref: '#/components/schemas/NodeStatus'
         sandboxCount:
           type: integer
           format: uint32
           description: Number of sandboxes running on the node
         metrics:
-          $ref: "#/components/schemas/NodeMetrics"
+          $ref: '#/components/schemas/NodeMetrics'
         createSuccesses:
           type: integer
           format: uint64
@@ -1595,15 +1595,15 @@ components:
           type: string
           description: Service instance identifier of the node
         machineInfo:
-          $ref: "#/components/schemas/MachineInfo"
+          $ref: '#/components/schemas/MachineInfo'
         status:
-          $ref: "#/components/schemas/NodeStatus"
+          $ref: '#/components/schemas/NodeStatus'
         sandboxCount:
           type: integer
           format: uint32
           description: Number of sandboxes running on the node
         metrics:
-          $ref: "#/components/schemas/NodeMetrics"
+          $ref: '#/components/schemas/NodeMetrics'
         cachedBuilds:
           type: array
           description: List of cached builds id on the node
@@ -1637,7 +1637,7 @@ components:
           type: string
           description: The fully created access token
         mask:
-          $ref: "#/components/schemas/IdentifierMaskingDetails"
+          $ref: '#/components/schemas/IdentifierMaskingDetails'
         createdAt:
           type: string
           format: date-time
@@ -1666,14 +1666,14 @@ components:
           type: string
           description: Name of the API key
         mask:
-          $ref: "#/components/schemas/IdentifierMaskingDetails"
+          $ref: '#/components/schemas/IdentifierMaskingDetails'
         createdAt:
           type: string
           format: date-time
           description: Timestamp of API key creation
         createdBy:
           allOf:
-            - $ref: "#/components/schemas/TeamUser"
+            - $ref: '#/components/schemas/TeamUser'
           nullable: true
         lastUsed:
           type: string
@@ -1697,7 +1697,7 @@ components:
           type: string
           description: Raw value of the API key
         mask:
-          $ref: "#/components/schemas/IdentifierMaskingDetails"
+          $ref: '#/components/schemas/IdentifierMaskingDetails'
         name:
           type: string
           description: Name of the API key
@@ -1707,7 +1707,7 @@ components:
           description: Timestamp of API key creation
         createdBy:
           allOf:
-            - $ref: "#/components/schemas/TeamUser"
+            - $ref: '#/components/schemas/TeamUser'
           nullable: true
         lastUsed:
           type: string
@@ -1861,7 +1861,7 @@ components:
         name:
           type: string
           description: Name of the volume
-          pattern: "^[a-zA-Z0-9_-]+$"
+          pattern: '^[a-zA-Z0-9_-]+$'
       required:
         - name
 
@@ -1879,10 +1879,10 @@ paths:
     get:
       description: Health check
       responses:
-        "204":
+        '204':
           description: The service is healthy
-        "401":
-          $ref: "#/components/responses/401"
+        '401':
+          $ref: '#/components/responses/401'
 
   /teams:
     get:
@@ -1893,7 +1893,7 @@ paths:
         - Supabase1TokenAuth: []
         - AuthProviderBearerAuth: []
       responses:
-        "200":
+        '200':
           description: Successfully returned all teams
           content:
             application/json:
@@ -1901,11 +1901,11 @@ paths:
                 type: array
                 items:
                   allOf:
-                    - $ref: "#/components/schemas/Team"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                    - $ref: '#/components/schemas/Team'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /teams/{teamID}/metrics:
     get:
@@ -1918,7 +1918,7 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/teamID"
+        - $ref: '#/components/parameters/teamID'
         - in: query
           name: start
           schema:
@@ -1934,22 +1934,22 @@ paths:
             minimum: 0
             description: Unix timestamp for the end of the interval, in seconds, for which the metrics
       responses:
-        "200":
+        '200':
           description: Successfully returned the team metrics
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/TeamMetric"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "500":
-          $ref: "#/components/responses/500"
+                  $ref: '#/components/schemas/TeamMetric'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '500':
+          $ref: '#/components/responses/500'
 
   /teams/{teamID}/metrics/max:
     get:
@@ -1962,7 +1962,7 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/teamID"
+        - $ref: '#/components/parameters/teamID'
         - in: query
           name: start
           schema:
@@ -1985,20 +1985,20 @@ paths:
             enum: [concurrent_sandboxes, sandbox_start_rate]
           description: Metric to retrieve the maximum value for
       responses:
-        "200":
+        '200':
           description: Successfully returned the team metrics
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MaxTeamMetric"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/MaxTeamMetric'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '500':
+          $ref: '#/components/responses/500'
 
   /sandboxes:
     get:
@@ -2018,7 +2018,7 @@ paths:
           schema:
             type: string
       responses:
-        "200":
+        '200':
           description: Successfully returned all running sandboxes
           content:
             application/json:
@@ -2026,13 +2026,13 @@ paths:
                 type: array
                 items:
                   allOf:
-                    - $ref: "#/components/schemas/ListedSandbox"
-        "401":
-          $ref: "#/components/responses/401"
-        "400":
-          $ref: "#/components/responses/400"
-        "500":
-          $ref: "#/components/responses/500"
+                    - $ref: '#/components/schemas/ListedSandbox'
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
     post:
       description: Create a sandbox from the template
       tags: [sandboxes]
@@ -2047,20 +2047,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/NewSandbox"
+              $ref: '#/components/schemas/NewSandbox'
       responses:
-        "201":
+        '201':
           description: The sandbox was created successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Sandbox"
-        "401":
-          $ref: "#/components/responses/401"
-        "400":
-          $ref: "#/components/responses/400"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/Sandbox'
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
 
   /v2/sandboxes:
     get:
@@ -2086,13 +2086,13 @@ paths:
           schema:
             type: array
             items:
-              $ref: "#/components/schemas/SandboxState"
+              $ref: '#/components/schemas/SandboxState'
           style: form
           explode: false
-        - $ref: "#/components/parameters/paginationNextToken"
-        - $ref: "#/components/parameters/paginationLimit"
+        - $ref: '#/components/parameters/paginationNextToken'
+        - $ref: '#/components/parameters/paginationLimit'
       responses:
-        "200":
+        '200':
           description: Successfully returned all running sandboxes
           content:
             application/json:
@@ -2100,13 +2100,13 @@ paths:
                 type: array
                 items:
                   allOf:
-                    - $ref: "#/components/schemas/ListedSandbox"
-        "401":
-          $ref: "#/components/responses/401"
-        "400":
-          $ref: "#/components/responses/400"
-        "500":
-          $ref: "#/components/responses/500"
+                    - $ref: '#/components/schemas/ListedSandbox'
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
 
   /sandboxes/metrics:
     get:
@@ -2131,18 +2131,18 @@ paths:
             maxItems: 100
             uniqueItems: true
       responses:
-        "200":
+        '200':
           description: Successfully returned all running sandboxes with metrics
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SandboxesWithMetrics"
-        "401":
-          $ref: "#/components/responses/401"
-        "400":
-          $ref: "#/components/responses/400"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/SandboxesWithMetrics'
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
 
   /sandboxes/{sandboxID}/logs:
     get:
@@ -2156,7 +2156,7 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/sandboxID"
+        - $ref: '#/components/parameters/sandboxID'
         - in: query
           name: start
           schema:
@@ -2173,18 +2173,18 @@ paths:
             type: integer
           description: Maximum number of logs that should be returned
       responses:
-        "200":
+        '200':
           description: Successfully returned the sandbox logs
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SandboxLogs"
-        "404":
-          $ref: "#/components/responses/404"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/SandboxLogs'
+        '404':
+          $ref: '#/components/responses/404'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /v2/sandboxes/{sandboxID}/logs:
     get:
@@ -2197,7 +2197,7 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/sandboxID"
+        - $ref: '#/components/parameters/sandboxID'
         - in: query
           name: cursor
           schema:
@@ -2217,12 +2217,12 @@ paths:
         - in: query
           name: direction
           schema:
-            $ref: "#/components/schemas/LogsDirection"
+            $ref: '#/components/schemas/LogsDirection'
           description: Direction of the logs that should be returned
         - in: query
           name: level
           schema:
-            $ref: "#/components/schemas/LogLevel"
+            $ref: '#/components/schemas/LogLevel'
           description: Minimum log level to return. Logs below this level are excluded
         - in: query
           name: search
@@ -2231,18 +2231,18 @@ paths:
             maxLength: 256
           description: Case-sensitive substring match on log message content
       responses:
-        "200":
+        '200':
           description: Successfully returned the sandbox logs
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SandboxLogsV2Response"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/SandboxLogsV2Response'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /sandboxes/{sandboxID}:
     get:
@@ -2255,20 +2255,20 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/sandboxID"
+        - $ref: '#/components/parameters/sandboxID'
       responses:
-        "200":
+        '200':
           description: Successfully returned the sandbox
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SandboxDetail"
-        "404":
-          $ref: "#/components/responses/404"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/SandboxDetail'
+        '404':
+          $ref: '#/components/responses/404'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
     delete:
       description: Kill a sandbox
@@ -2280,16 +2280,16 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/sandboxID"
+        - $ref: '#/components/parameters/sandboxID'
       responses:
-        "204":
+        '204':
           description: The sandbox was killed successfully
-        "404":
-          $ref: "#/components/responses/404"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+        '404':
+          $ref: '#/components/responses/404'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /sandboxes/{sandboxID}/metrics:
     get:
@@ -2302,7 +2302,7 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/sandboxID"
+        - $ref: '#/components/parameters/sandboxID'
         - in: query
           name: start
           schema:
@@ -2319,22 +2319,22 @@ paths:
             description: Unix timestamp for the end of the interval, in seconds, for which the metrics
 
       responses:
-        "200":
+        '200':
           description: Successfully returned the sandbox metrics
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/SandboxMetric"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                  $ref: '#/components/schemas/SandboxMetric'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   # TODO: Pause and resume might be exposed as POST /sandboxes/{sandboxID}/snapshot and then POST /sandboxes with specified snapshotting setup
   /sandboxes/{sandboxID}/pause:
@@ -2348,18 +2348,18 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/sandboxID"
+        - $ref: '#/components/parameters/sandboxID'
       responses:
-        "204":
+        '204':
           description: The sandbox was paused successfully and can be resumed
-        "409":
-          $ref: "#/components/responses/409"
-        "404":
-          $ref: "#/components/responses/404"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+        '409':
+          $ref: '#/components/responses/409'
+        '404':
+          $ref: '#/components/responses/404'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /sandboxes/{sandboxID}/resume:
     post:
@@ -2373,28 +2373,28 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/sandboxID"
+        - $ref: '#/components/parameters/sandboxID'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ResumedSandbox"
+              $ref: '#/components/schemas/ResumedSandbox'
       responses:
-        "201":
+        '201':
           description: The sandbox was resumed successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Sandbox"
-        "409":
-          $ref: "#/components/responses/409"
-        "404":
-          $ref: "#/components/responses/404"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/Sandbox'
+        '409':
+          $ref: '#/components/responses/409'
+        '404':
+          $ref: '#/components/responses/404'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /sandboxes/{sandboxID}/connect:
     post:
@@ -2407,34 +2407,34 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/sandboxID"
+        - $ref: '#/components/parameters/sandboxID'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ConnectSandbox"
+              $ref: '#/components/schemas/ConnectSandbox'
       responses:
-        "200":
+        '200':
           description: The sandbox was already running
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Sandbox"
-        "201":
+                $ref: '#/components/schemas/Sandbox'
+        '201':
           description: The sandbox was resumed successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Sandbox"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/Sandbox'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /sandboxes/{sandboxID}/timeout:
     post:
@@ -2460,16 +2460,16 @@ paths:
                   format: int32
                   minimum: 0
       parameters:
-        - $ref: "#/components/parameters/sandboxID"
+        - $ref: '#/components/parameters/sandboxID'
       responses:
-        "204":
+        '204':
           description: Successfully set the sandbox timeout
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /sandboxes/{sandboxID}/network:
     put:
@@ -2486,20 +2486,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SandboxNetworkUpdateConfig"
+              $ref: '#/components/schemas/SandboxNetworkUpdateConfig'
       parameters:
-        - $ref: "#/components/parameters/sandboxID"
+        - $ref: '#/components/parameters/sandboxID'
       responses:
-        "204":
+        '204':
           description: Successfully updated the sandbox network configuration
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
-          $ref: "#/components/responses/409"
-        "500":
-          $ref: "#/components/responses/500"
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
+          $ref: '#/components/responses/409'
+        '500':
+          $ref: '#/components/responses/500'
 
   /sandboxes/{sandboxID}/refreshes:
     post:
@@ -2523,14 +2523,14 @@ paths:
                   maximum: 3600 # 1 hour
                   minimum: 0
       parameters:
-        - $ref: "#/components/parameters/sandboxID"
+        - $ref: '#/components/parameters/sandboxID'
       responses:
-        "204":
+        '204':
           description: Successfully refreshed the sandbox
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
 
   /sandboxes/{sandboxID}/snapshots:
     post:
@@ -2543,7 +2543,7 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/sandboxID"
+        - $ref: '#/components/parameters/sandboxID'
       requestBody:
         required: true
         content:
@@ -2555,20 +2555,20 @@ paths:
                   type: string
                   description: Optional name for the snapshot template. If a snapshot template with this name already exists, a new build will be assigned to the existing template instead of creating a new one.
       responses:
-        "201":
+        '201':
           description: Snapshot created successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SnapshotInfo"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/SnapshotInfo'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /snapshots:
     get:
@@ -2587,21 +2587,21 @@ paths:
           schema:
             type: string
             description: Filter snapshots by source sandbox ID
-        - $ref: "#/components/parameters/paginationLimit"
-        - $ref: "#/components/parameters/paginationNextToken"
+        - $ref: '#/components/parameters/paginationLimit'
+        - $ref: '#/components/parameters/paginationNextToken'
       responses:
-        "200":
+        '200':
           description: Successfully returned snapshots
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/SnapshotInfo"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                  $ref: '#/components/schemas/SnapshotInfo'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /v3/templates:
     post:
@@ -2618,23 +2618,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TemplateBuildRequestV3"
+              $ref: '#/components/schemas/TemplateBuildRequestV3'
 
       responses:
-        "202":
+        '202':
           description: The build was requested successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TemplateRequestResponseV3"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/TemplateRequestResponseV3'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '500':
+          $ref: '#/components/responses/500'
 
   /v2/templates:
     post:
@@ -2652,21 +2652,21 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TemplateBuildRequestV2"
+              $ref: '#/components/schemas/TemplateBuildRequestV2'
 
       responses:
-        "202":
+        '202':
           description: The build was requested successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TemplateLegacy"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/TemplateLegacy'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /templates/{templateID}/files/{hash}:
     get:
@@ -2680,7 +2680,7 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/templateID"
+        - $ref: '#/components/parameters/templateID'
         - in: path
           name: hash
           required: true
@@ -2689,20 +2689,20 @@ paths:
             description: Hash of the files
 
       responses:
-        "201":
+        '201':
           description: The upload link where to upload the tar file
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TemplateBuildFileUpload"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/TemplateBuildFileUpload'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /templates:
     get:
@@ -2723,7 +2723,7 @@ paths:
             type: string
             description: Identifier of the team
       responses:
-        "200":
+        '200':
           description: Successfully returned all templates
           content:
             application/json:
@@ -2731,11 +2731,11 @@ paths:
                 type: array
                 items:
                   allOf:
-                    - $ref: "#/components/schemas/Template"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                    - $ref: '#/components/schemas/Template'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
     post:
       description: Create a new template
       deprecated: true
@@ -2751,21 +2751,21 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TemplateBuildRequest"
+              $ref: '#/components/schemas/TemplateBuildRequest'
 
       responses:
-        "202":
+        '202':
           description: The build was accepted
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TemplateLegacy"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/TemplateLegacy'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /templates/{templateID}:
     get:
@@ -2778,20 +2778,20 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/templateID"
-        - $ref: "#/components/parameters/paginationNextToken"
-        - $ref: "#/components/parameters/paginationLimit"
+        - $ref: '#/components/parameters/templateID'
+        - $ref: '#/components/parameters/paginationNextToken'
+        - $ref: '#/components/parameters/paginationLimit'
       responses:
-        "200":
+        '200':
           description: Successfully returned the template with its builds
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TemplateWithBuilds"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/TemplateWithBuilds'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
     post:
       description: Rebuild an template
       deprecated: true
@@ -2803,25 +2803,25 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/templateID"
+        - $ref: '#/components/parameters/templateID'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TemplateBuildRequest"
+              $ref: '#/components/schemas/TemplateBuildRequest'
 
       responses:
-        "202":
+        '202':
           description: The build was accepted
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TemplateLegacy"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/TemplateLegacy'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
     delete:
       description: Delete a template
       tags: [templates]
@@ -2833,14 +2833,14 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/templateID"
+        - $ref: '#/components/parameters/templateID'
       responses:
-        "204":
+        '204':
           description: The template was deleted successfully
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
     patch:
       description: Update template
       deprecated: true
@@ -2853,22 +2853,22 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/templateID"
+        - $ref: '#/components/parameters/templateID'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TemplateUpdateRequest"
+              $ref: '#/components/schemas/TemplateUpdateRequest'
       responses:
-        "200":
+        '200':
           description: The template was updated successfully
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /templates/{templateID}/builds/{buildID}:
     post:
@@ -2882,15 +2882,15 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/templateID"
-        - $ref: "#/components/parameters/buildID"
+        - $ref: '#/components/parameters/templateID'
+        - $ref: '#/components/parameters/buildID'
       responses:
-        "202":
+        '202':
           description: The build has started
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /v2/templates/{templateID}/builds/{buildID}:
     post:
@@ -2903,21 +2903,21 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/templateID"
-        - $ref: "#/components/parameters/buildID"
+        - $ref: '#/components/parameters/templateID'
+        - $ref: '#/components/parameters/buildID'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TemplateBuildStartV2"
+              $ref: '#/components/schemas/TemplateBuildStartV2'
       responses:
-        "202":
+        '202':
           description: The build has started
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /v2/templates/{templateID}:
     patch:
@@ -2931,26 +2931,26 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/templateID"
+        - $ref: '#/components/parameters/templateID'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TemplateUpdateRequest"
+              $ref: '#/components/schemas/TemplateUpdateRequest'
       responses:
-        "200":
+        '200':
           description: The template was updated successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TemplateUpdateResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/TemplateUpdateResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /templates/{templateID}/builds/{buildID}/status:
     get:
@@ -2964,8 +2964,8 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/templateID"
-        - $ref: "#/components/parameters/buildID"
+        - $ref: '#/components/parameters/templateID'
+        - $ref: '#/components/parameters/buildID'
         - in: query
           name: logsOffset
           schema:
@@ -2986,20 +2986,20 @@ paths:
         - in: query
           name: level
           schema:
-            $ref: "#/components/schemas/LogLevel"
+            $ref: '#/components/schemas/LogLevel'
       responses:
-        "200":
+        '200':
           description: Successfully returned the template
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TemplateBuildInfo"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/TemplateBuildInfo'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /templates/{templateID}/builds/{buildID}/logs:
     get:
@@ -3013,8 +3013,8 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/templateID"
-        - $ref: "#/components/parameters/buildID"
+        - $ref: '#/components/parameters/templateID'
+        - $ref: '#/components/parameters/buildID'
         - in: query
           name: cursor
           schema:
@@ -3034,29 +3034,29 @@ paths:
         - in: query
           name: direction
           schema:
-            $ref: "#/components/schemas/LogsDirection"
+            $ref: '#/components/schemas/LogsDirection'
         - in: query
           name: level
           schema:
-            $ref: "#/components/schemas/LogLevel"
+            $ref: '#/components/schemas/LogLevel'
         - in: query
           name: source
           schema:
-            $ref: "#/components/schemas/LogsSource"
+            $ref: '#/components/schemas/LogsSource'
           description: Source of the logs that should be returned from
       responses:
-        "200":
+        '200':
           description: Successfully returned the template build logs
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TemplateBuildLogsResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/TemplateBuildLogsResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /templates/tags:
     post:
@@ -3073,22 +3073,22 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AssignTemplateTagsRequest"
+              $ref: '#/components/schemas/AssignTemplateTagsRequest'
       responses:
-        "201":
+        '201':
           description: Tag assigned successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AssignedTemplateTags"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/AssignedTemplateTags'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
     delete:
       description: Delete multiple tags from templates
       tags: [tags]
@@ -3103,18 +3103,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeleteTemplateTagsRequest"
+              $ref: '#/components/schemas/DeleteTemplateTagsRequest'
       responses:
-        "204":
+        '204':
           description: Tags deleted successfully
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /templates/{templateID}/tags:
     get:
@@ -3127,24 +3127,24 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/templateID"
+        - $ref: '#/components/parameters/templateID'
       responses:
-        "200":
+        '200':
           description: Successfully returned the template tags
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/TemplateTag"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                  $ref: '#/components/schemas/TemplateTag'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /templates/aliases/{alias}:
     get:
@@ -3164,20 +3164,20 @@ paths:
             type: string
             description: Template alias
       responses:
-        "200":
+        '200':
           description: Successfully queried template by alias
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TemplateAliasResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/TemplateAliasResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /nodes:
     get:
@@ -3194,7 +3194,7 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
+        '200':
           description: Successfully returned all nodes
           content:
             application/json:
@@ -3202,11 +3202,11 @@ paths:
                 type: array
                 items:
                   allOf:
-                    - $ref: "#/components/schemas/Node"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                    - $ref: '#/components/schemas/Node'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /nodes/{nodeID}:
     get:
@@ -3215,7 +3215,7 @@ paths:
       security:
         - AdminTokenAuth: []
       parameters:
-        - $ref: "#/components/parameters/nodeID"
+        - $ref: '#/components/parameters/nodeID'
         - in: query
           name: clusterID
           description: Identifier of the cluster
@@ -3224,39 +3224,39 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
+        '200':
           description: Successfully returned the node
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/NodeDetail"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/NodeDetail'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
     post:
       description: Change status of a node
       tags: [admin]
       security:
         - AdminTokenAuth: []
       parameters:
-        - $ref: "#/components/parameters/nodeID"
+        - $ref: '#/components/parameters/nodeID'
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/NodeStatusChange"
+              $ref: '#/components/schemas/NodeStatusChange'
       responses:
-        "204":
+        '204':
           description: The node status was changed successfully
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /admin/teams/{teamID}/sandboxes/kill:
     post:
@@ -3274,18 +3274,18 @@ paths:
             format: uuid
           description: Team ID
       responses:
-        "200":
+        '200':
           description: Successfully killed sandboxes
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AdminSandboxKillResult"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/AdminSandboxKillResult'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /admin/teams/{teamID}/builds/cancel:
     post:
@@ -3303,18 +3303,18 @@ paths:
             format: uuid
           description: Team ID
       responses:
-        "200":
+        '200':
           description: Successfully cancelled builds
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AdminBuildCancelResult"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/AdminBuildCancelResult'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /admin/teams/{teamID}/api-keys:
     post:
@@ -3336,24 +3336,24 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/NewTeamAPIKey"
+              $ref: '#/components/schemas/NewTeamAPIKey'
       responses:
-        "201":
+        '201':
           description: Team API key created successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreatedTeamAPIKey"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/CreatedTeamAPIKey'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /admin/teams/{teamID}/api-keys/{apiKeyID}:
     delete:
@@ -3370,18 +3370,18 @@ paths:
             type: string
             format: uuid
           description: Team ID
-        - $ref: "#/components/parameters/apiKeyID"
+        - $ref: '#/components/parameters/apiKeyID'
       responses:
-        "204":
+        '204':
           description: Team API key deleted successfully
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /access-tokens:
     post:
@@ -3395,18 +3395,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/NewAccessToken"
+              $ref: '#/components/schemas/NewAccessToken'
       responses:
-        "201":
+        '201':
           description: Access token created successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreatedAccessToken"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/CreatedAccessToken'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /access-tokens/{accessTokenID}:
     delete:
@@ -3416,16 +3416,16 @@ paths:
         - Supabase1TokenAuth: []
         - AuthProviderBearerAuth: []
       parameters:
-        - $ref: "#/components/parameters/accessTokenID"
+        - $ref: '#/components/parameters/accessTokenID'
       responses:
-        "204":
+        '204':
           description: Access token deleted successfully
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /api-keys:
     get:
@@ -3437,18 +3437,18 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       responses:
-        "200":
+        '200':
           description: Successfully returned all team API keys
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/TeamAPIKey"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                  $ref: '#/components/schemas/TeamAPIKey'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
     post:
       description: Create a new team API key
       tags: [api-keys]
@@ -3462,18 +3462,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/NewTeamAPIKey"
+              $ref: '#/components/schemas/NewTeamAPIKey'
       responses:
-        "201":
+        '201':
           description: Team API key created successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreatedTeamAPIKey"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/CreatedTeamAPIKey'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /api-keys/{apiKeyID}:
     patch:
@@ -3485,22 +3485,22 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/apiKeyID"
+        - $ref: '#/components/parameters/apiKeyID'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UpdateTeamAPIKey"
+              $ref: '#/components/schemas/UpdateTeamAPIKey'
       responses:
-        "200":
+        '200':
           description: Team API key updated successfully
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
     delete:
       description: Delete a team API key
       tags: [api-keys]
@@ -3510,16 +3510,16 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/apiKeyID"
+        - $ref: '#/components/parameters/apiKeyID'
       responses:
-        "204":
+        '204':
           description: Team API key deleted successfully
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
   /volumes:
     get:
@@ -3532,18 +3532,18 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       responses:
-        "200":
+        '200':
           description: Successfully listed all team volumes
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Volume"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                  $ref: '#/components/schemas/Volume'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
     post:
       description: Create a new team volume
@@ -3559,20 +3559,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/NewVolume"
+              $ref: '#/components/schemas/NewVolume'
       responses:
-        "201":
+        '201':
           description: Successfully created a new team volume
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VolumeAndToken"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/VolumeAndToken'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   /volumes/{volumeID}:
     get:
@@ -3585,20 +3585,20 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/volumeID"
+        - $ref: '#/components/parameters/volumeID'
       responses:
-        "200":
+        '200':
           description: Successfully retrieved a team volume
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VolumeAndToken"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/VolumeAndToken'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
 
     delete:
       description: Delete a team volume
@@ -3610,13 +3610,13 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/volumeID"
+        - $ref: '#/components/parameters/volumeID'
       responses:
-        "204":
+        '204':
           description: Successfully deleted a team volume
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -27,6 +27,16 @@ components:
       type: apiKey
       in: header
       name: X-Supabase-Team
+    # AuthProviderBearerAuth / AuthProviderTeamAuth: B before T in the name
+    # so Bearer is validated before Team (same reason as Supabase1/2 above).
+    AuthProviderBearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: access_token
+    AuthProviderTeamAuth:
+      type: apiKey
+      in: header
+      name: X-Team-ID
     AdminTokenAuth:
       type: apiKey
       in: header
@@ -115,42 +125,42 @@ components:
         type: string
 
   responses:
-    '400':
+    "400":
       description: Bad request
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
-    '401':
+            $ref: "#/components/schemas/Error"
+    "401":
       description: Authentication error
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
-    '403':
+            $ref: "#/components/schemas/Error"
+    "403":
       description: Forbidden
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
-    '404':
+            $ref: "#/components/schemas/Error"
+    "404":
       description: Not found
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
-    '409':
+            $ref: "#/components/schemas/Error"
+    "409":
       description: Conflict
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
-    '500':
+            $ref: "#/components/schemas/Error"
+    "500":
       description: Server error
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: "#/components/schemas/Error"
 
   schemas:
     Team:
@@ -184,6 +194,9 @@ components:
           description: Identifier of the user
         email:
           type: string
+          nullable: true
+          deprecated: true
+          default: null
           description: Email of the user
 
     TemplateUpdateRequest:
@@ -284,11 +297,14 @@ components:
           description: Specify host mask which will be used for all sandbox requests
         rules:
           type: object
-          description: Per-domain transform rules applied to matching egress HTTP/HTTPS requests. Keys are domains (e.g. "api.example.com", "example.com"). A domain listed here is not automatically allowed - use allowOut to permit the traffic.
+          description: >
+            Per-domain transform rules applied to matching egress HTTP/HTTPS requests.
+            Keys are domains (e.g. "api.example.com", "example.com").
+            A domain listed here is not automatically allowed - use allowOut to permit the traffic.
           additionalProperties:
             type: array
             items:
-              $ref: '#/components/schemas/SandboxNetworkRule'
+              $ref: "#/components/schemas/SandboxNetworkRule"
 
     SandboxNetworkUpdateConfig:
       type: object
@@ -310,7 +326,7 @@ components:
           additionalProperties:
             type: array
             items:
-              $ref: '#/components/schemas/SandboxNetworkRule'
+              $ref: "#/components/schemas/SandboxNetworkRule"
         allow_internet_access:
           type: boolean
           description:
@@ -322,7 +338,7 @@ components:
       description: Transform rule applied to egress requests matching a domain pattern.
       properties:
         transform:
-          $ref: '#/components/schemas/SandboxNetworkTransform'
+          $ref: "#/components/schemas/SandboxNetworkTransform"
 
     SandboxNetworkTransform:
       type: object
@@ -330,7 +346,10 @@ components:
       properties:
         headers:
           type: object
-          description: HTTP headers to inject or override in matching requests. An existing header with the same name is replaced. Values are plain strings; secret resolution happens client-side before sending to the API.
+          description: >
+            HTTP headers to inject or override in matching requests.
+            An existing header with the same name is replaced. Values are plain strings;
+            secret resolution happens client-side before sending to the API.
           additionalProperties:
             type: string
 
@@ -397,7 +416,7 @@ components:
           type: string
           description: Log message content
         level:
-          $ref: '#/components/schemas/LogLevel'
+          $ref: "#/components/schemas/LogLevel"
         fields:
           type: object
           additionalProperties:
@@ -412,12 +431,12 @@ components:
           description: Logs of the sandbox
           type: array
           items:
-            $ref: '#/components/schemas/SandboxLog'
+            $ref: "#/components/schemas/SandboxLog"
         logEntries:
           description: Structured logs of the sandbox
           type: array
           items:
-            $ref: '#/components/schemas/SandboxLogEntry'
+            $ref: "#/components/schemas/SandboxLogEntry"
 
     SandboxLogsV2Response:
       required:
@@ -428,7 +447,7 @@ components:
           description: Sandbox logs structured
           type: array
           items:
-            $ref: '#/components/schemas/SandboxLogEntry'
+            $ref: "#/components/schemas/SandboxLogEntry"
 
     SandboxMetric:
       description: Metric entry with timestamp and line
@@ -439,6 +458,7 @@ components:
         - cpuUsedPct
         - memUsed
         - memTotal
+        - memCache
         - diskUsed
         - diskTotal
       properties:
@@ -467,6 +487,10 @@ components:
           type: integer
           format: int64
           description: Total memory in bytes
+        memCache:
+          type: integer
+          format: int64
+          description: Cached memory (page cache) in bytes
         diskUsed:
           type: integer
           format: int64
@@ -510,7 +534,7 @@ components:
           deprecated: true
           description: Identifier of the client
         envdVersion:
-          $ref: '#/components/schemas/EnvdVersion'
+          $ref: "#/components/schemas/EnvdVersion"
         envdAccessToken:
           type: string
           description: Access token used for envd communication
@@ -558,7 +582,7 @@ components:
           format: date-time
           description: Time when the sandbox will expire
         envdVersion:
-          $ref: '#/components/schemas/EnvdVersion'
+          $ref: "#/components/schemas/EnvdVersion"
         envdAccessToken:
           type: string
           description: Access token used for envd communication
@@ -571,23 +595,23 @@ components:
           nullable: true
           description: Base domain where the sandbox traffic is accessible
         cpuCount:
-          $ref: '#/components/schemas/CPUCount'
+          $ref: "#/components/schemas/CPUCount"
         memoryMB:
-          $ref: '#/components/schemas/MemoryMB'
+          $ref: "#/components/schemas/MemoryMB"
         diskSizeMB:
-          $ref: '#/components/schemas/DiskSizeMB'
+          $ref: "#/components/schemas/DiskSizeMB"
         metadata:
-          $ref: '#/components/schemas/SandboxMetadata'
+          $ref: "#/components/schemas/SandboxMetadata"
         state:
-          $ref: '#/components/schemas/SandboxState'
+          $ref: "#/components/schemas/SandboxState"
         network:
-          $ref: '#/components/schemas/SandboxNetworkConfig'
+          $ref: "#/components/schemas/SandboxNetworkConfig"
         lifecycle:
-          $ref: '#/components/schemas/SandboxLifecycle'
+          $ref: "#/components/schemas/SandboxLifecycle"
         volumeMounts:
           type: array
           items:
-            $ref: '#/components/schemas/SandboxVolumeMount'
+            $ref: "#/components/schemas/SandboxVolumeMount"
 
     ListedSandbox:
       required:
@@ -624,21 +648,21 @@ components:
           format: date-time
           description: Time when the sandbox will expire
         cpuCount:
-          $ref: '#/components/schemas/CPUCount'
+          $ref: "#/components/schemas/CPUCount"
         memoryMB:
-          $ref: '#/components/schemas/MemoryMB'
+          $ref: "#/components/schemas/MemoryMB"
         diskSizeMB:
-          $ref: '#/components/schemas/DiskSizeMB'
+          $ref: "#/components/schemas/DiskSizeMB"
         metadata:
-          $ref: '#/components/schemas/SandboxMetadata'
+          $ref: "#/components/schemas/SandboxMetadata"
         state:
-          $ref: '#/components/schemas/SandboxState'
+          $ref: "#/components/schemas/SandboxState"
         envdVersion:
-          $ref: '#/components/schemas/EnvdVersion'
+          $ref: "#/components/schemas/EnvdVersion"
         volumeMounts:
           type: array
           items:
-            $ref: '#/components/schemas/SandboxVolumeMount'
+            $ref: "#/components/schemas/SandboxVolumeMount"
 
     SandboxesWithMetrics:
       required:
@@ -646,7 +670,7 @@ components:
       properties:
         sandboxes:
           additionalProperties:
-            $ref: '#/components/schemas/SandboxMetric'
+            $ref: "#/components/schemas/SandboxMetric"
 
     NewSandbox:
       required:
@@ -666,7 +690,7 @@ components:
           default: false
           description: Automatically pauses the sandbox after the timeout
         autoResume:
-          $ref: '#/components/schemas/SandboxAutoResumeConfig'
+          $ref: "#/components/schemas/SandboxAutoResumeConfig"
         secure:
           type: boolean
           description: Secure all system communication with sandbox
@@ -676,17 +700,17 @@ components:
             Allow sandbox to access the internet. When set to false, it behaves the same as specifying denyOut
             to 0.0.0.0/0 in the network config.
         network:
-          $ref: '#/components/schemas/SandboxNetworkConfig'
+          $ref: "#/components/schemas/SandboxNetworkConfig"
         metadata:
-          $ref: '#/components/schemas/SandboxMetadata'
+          $ref: "#/components/schemas/SandboxMetadata"
         envVars:
-          $ref: '#/components/schemas/EnvVars'
+          $ref: "#/components/schemas/EnvVars"
         mcp:
-          $ref: '#/components/schemas/Mcp'
+          $ref: "#/components/schemas/Mcp"
         volumeMounts:
           type: array
           items:
-            $ref: '#/components/schemas/SandboxVolumeMount'
+            $ref: "#/components/schemas/SandboxVolumeMount"
 
     ResumedSandbox:
       properties:
@@ -816,11 +840,11 @@ components:
           type: string
           description: Identifier of the last successful build for given template
         cpuCount:
-          $ref: '#/components/schemas/CPUCount'
+          $ref: "#/components/schemas/CPUCount"
         memoryMB:
-          $ref: '#/components/schemas/MemoryMB'
+          $ref: "#/components/schemas/MemoryMB"
         diskSizeMB:
-          $ref: '#/components/schemas/DiskSizeMB'
+          $ref: "#/components/schemas/DiskSizeMB"
         public:
           type: boolean
           description: Whether the template is public or only accessible by the team
@@ -845,7 +869,7 @@ components:
           description: Time when the template was last updated
         createdBy:
           allOf:
-            - $ref: '#/components/schemas/TeamUser'
+            - $ref: "#/components/schemas/TeamUser"
           nullable: true
         lastSpawnedAt:
           type: string
@@ -861,9 +885,9 @@ components:
           format: int32
           description: Number of times the template was built
         envdVersion:
-          $ref: '#/components/schemas/EnvdVersion'
+          $ref: "#/components/schemas/EnvdVersion"
         buildStatus:
-          $ref: '#/components/schemas/TemplateBuildStatus'
+          $ref: "#/components/schemas/TemplateBuildStatus"
 
     TemplateRequestResponseV3:
       required:
@@ -924,11 +948,11 @@ components:
           type: string
           description: Identifier of the last successful build for given template
         cpuCount:
-          $ref: '#/components/schemas/CPUCount'
+          $ref: "#/components/schemas/CPUCount"
         memoryMB:
-          $ref: '#/components/schemas/MemoryMB'
+          $ref: "#/components/schemas/MemoryMB"
         diskSizeMB:
-          $ref: '#/components/schemas/DiskSizeMB'
+          $ref: "#/components/schemas/DiskSizeMB"
         public:
           type: boolean
           description: Whether the template is public or only accessible by the team
@@ -947,7 +971,7 @@ components:
           description: Time when the template was last updated
         createdBy:
           allOf:
-            - $ref: '#/components/schemas/TeamUser'
+            - $ref: "#/components/schemas/TeamUser"
           nullable: true
         lastSpawnedAt:
           type: string
@@ -963,7 +987,7 @@ components:
           format: int32
           description: Number of times the template was built
         envdVersion:
-          $ref: '#/components/schemas/EnvdVersion'
+          $ref: "#/components/schemas/EnvdVersion"
 
     TemplateBuild:
       required:
@@ -979,7 +1003,7 @@ components:
           format: uuid
           description: Identifier of the build
         status:
-          $ref: '#/components/schemas/TemplateBuildStatus'
+          $ref: "#/components/schemas/TemplateBuildStatus"
         createdAt:
           type: string
           format: date-time
@@ -993,13 +1017,13 @@ components:
           format: date-time
           description: Time when the build was finished
         cpuCount:
-          $ref: '#/components/schemas/CPUCount'
+          $ref: "#/components/schemas/CPUCount"
         memoryMB:
-          $ref: '#/components/schemas/MemoryMB'
+          $ref: "#/components/schemas/MemoryMB"
         diskSizeMB:
-          $ref: '#/components/schemas/DiskSizeMB'
+          $ref: "#/components/schemas/DiskSizeMB"
         envdVersion:
-          $ref: '#/components/schemas/EnvdVersion'
+          $ref: "#/components/schemas/EnvdVersion"
 
     TemplateWithBuilds:
       required:
@@ -1051,7 +1075,7 @@ components:
           type: array
           description: List of builds for the template
           items:
-            $ref: '#/components/schemas/TemplateBuild'
+            $ref: "#/components/schemas/TemplateBuild"
 
     TemplateAliasResponse:
       required:
@@ -1085,9 +1109,9 @@ components:
           description: Ready check command to execute in the template after the build
           type: string
         cpuCount:
-          $ref: '#/components/schemas/CPUCount'
+          $ref: "#/components/schemas/CPUCount"
         memoryMB:
-          $ref: '#/components/schemas/MemoryMB'
+          $ref: "#/components/schemas/MemoryMB"
 
     TemplateStep:
       description: Step in the template build process
@@ -1130,9 +1154,9 @@ components:
           type: string
           description: Identifier of the team
         cpuCount:
-          $ref: '#/components/schemas/CPUCount'
+          $ref: "#/components/schemas/CPUCount"
         memoryMB:
-          $ref: '#/components/schemas/MemoryMB'
+          $ref: "#/components/schemas/MemoryMB"
 
     TemplateBuildRequestV2:
       required:
@@ -1146,21 +1170,21 @@ components:
           type: string
           description: Identifier of the team
         cpuCount:
-          $ref: '#/components/schemas/CPUCount'
+          $ref: "#/components/schemas/CPUCount"
         memoryMB:
-          $ref: '#/components/schemas/MemoryMB'
+          $ref: "#/components/schemas/MemoryMB"
 
     FromImageRegistry:
       oneOf:
-        - $ref: '#/components/schemas/AWSRegistry'
-        - $ref: '#/components/schemas/GCPRegistry'
-        - $ref: '#/components/schemas/GeneralRegistry'
+        - $ref: "#/components/schemas/AWSRegistry"
+        - $ref: "#/components/schemas/GCPRegistry"
+        - $ref: "#/components/schemas/GeneralRegistry"
       discriminator:
         propertyName: type
         mapping:
-          aws: '#/components/schemas/AWSRegistry'
-          gcp: '#/components/schemas/GCPRegistry'
-          registry: '#/components/schemas/GeneralRegistry'
+          aws: "#/components/schemas/AWSRegistry"
+          gcp: "#/components/schemas/GCPRegistry"
+          registry: "#/components/schemas/GeneralRegistry"
 
     AWSRegistry:
       type: object
@@ -1226,7 +1250,7 @@ components:
           type: string
           description: Template to use as a base for the template build
         fromImageRegistry:
-          $ref: '#/components/schemas/FromImageRegistry'
+          $ref: "#/components/schemas/FromImageRegistry"
         force:
           default: false
           type: boolean
@@ -1236,7 +1260,7 @@ components:
           description: List of steps to execute in the template build
           type: array
           items:
-            $ref: '#/components/schemas/TemplateStep'
+            $ref: "#/components/schemas/TemplateStep"
         startCmd:
           description: Start command to execute in the template after the build
           type: string
@@ -1278,7 +1302,7 @@ components:
           type: string
           description: Log message content
         level:
-          $ref: '#/components/schemas/LogLevel'
+          $ref: "#/components/schemas/LogLevel"
         step:
           type: string
           description: Step in the build process related to the log entry
@@ -1298,7 +1322,7 @@ components:
           description: Log entries related to the status reason
           type: array
           items:
-            $ref: '#/components/schemas/BuildLogEntry'
+            $ref: "#/components/schemas/BuildLogEntry"
 
     TemplateBuildStatus:
       type: string
@@ -1328,7 +1352,7 @@ components:
           description: Build logs structured
           type: array
           items:
-            $ref: '#/components/schemas/BuildLogEntry'
+            $ref: "#/components/schemas/BuildLogEntry"
         templateID:
           type: string
           description: Identifier of the template
@@ -1336,9 +1360,9 @@ components:
           type: string
           description: Identifier of the build
         status:
-          $ref: '#/components/schemas/TemplateBuildStatus'
+          $ref: "#/components/schemas/TemplateBuildStatus"
         reason:
-          $ref: '#/components/schemas/BuildStatusReason'
+          $ref: "#/components/schemas/BuildStatusReason"
 
     TemplateBuildLogsResponse:
       required:
@@ -1349,7 +1373,7 @@ components:
           description: Build logs structured
           type: array
           items:
-            $ref: '#/components/schemas/BuildLogEntry'
+            $ref: "#/components/schemas/BuildLogEntry"
 
     LogsDirection:
       type: string
@@ -1373,17 +1397,22 @@ components:
 
     NodeStatus:
       type: string
-      description: Status of the node
+      description: |
+        Status of the node.
+        - draining: the node is bound to be shut down. It will not accept new sandboxes and will stop once all existing sandboxes are done.
+        - standby: the node is not actively used, but it can return to ready and continue serving traffic.
       enum:
         - ready
         - draining
         - connecting
         - unhealthy
+        - standby
       x-enum-varnames:
         - NodeStatusReady
         - NodeStatusDraining
         - NodeStatusConnecting
         - NodeStatusUnhealthy
+        - NodeStatusStandby
 
     NodeStatusChange:
       required:
@@ -1394,7 +1423,7 @@ components:
           format: uuid
           description: Identifier of the cluster
         status:
-          $ref: '#/components/schemas/NodeStatus'
+          $ref: "#/components/schemas/NodeStatus"
 
     DiskMetrics:
       required:
@@ -1461,7 +1490,7 @@ components:
           type: array
           description: Detailed metrics for each disk/mount point
           items:
-            $ref: '#/components/schemas/DiskMetrics'
+            $ref: "#/components/schemas/DiskMetrics"
     MachineInfo:
       required:
         - cpuFamily
@@ -1513,15 +1542,15 @@ components:
           type: string
           description: Identifier of the cluster
         machineInfo:
-          $ref: '#/components/schemas/MachineInfo'
+          $ref: "#/components/schemas/MachineInfo"
         status:
-          $ref: '#/components/schemas/NodeStatus'
+          $ref: "#/components/schemas/NodeStatus"
         sandboxCount:
           type: integer
           format: uint32
           description: Number of sandboxes running on the node
         metrics:
-          $ref: '#/components/schemas/NodeMetrics'
+          $ref: "#/components/schemas/NodeMetrics"
         createSuccesses:
           type: integer
           format: uint64
@@ -1566,15 +1595,15 @@ components:
           type: string
           description: Service instance identifier of the node
         machineInfo:
-          $ref: '#/components/schemas/MachineInfo'
+          $ref: "#/components/schemas/MachineInfo"
         status:
-          $ref: '#/components/schemas/NodeStatus'
+          $ref: "#/components/schemas/NodeStatus"
         sandboxCount:
           type: integer
           format: uint32
           description: Number of sandboxes running on the node
         metrics:
-          $ref: '#/components/schemas/NodeMetrics'
+          $ref: "#/components/schemas/NodeMetrics"
         cachedBuilds:
           type: array
           description: List of cached builds id on the node
@@ -1608,7 +1637,7 @@ components:
           type: string
           description: The fully created access token
         mask:
-          $ref: '#/components/schemas/IdentifierMaskingDetails'
+          $ref: "#/components/schemas/IdentifierMaskingDetails"
         createdAt:
           type: string
           format: date-time
@@ -1637,14 +1666,14 @@ components:
           type: string
           description: Name of the API key
         mask:
-          $ref: '#/components/schemas/IdentifierMaskingDetails'
+          $ref: "#/components/schemas/IdentifierMaskingDetails"
         createdAt:
           type: string
           format: date-time
           description: Timestamp of API key creation
         createdBy:
           allOf:
-            - $ref: '#/components/schemas/TeamUser'
+            - $ref: "#/components/schemas/TeamUser"
           nullable: true
         lastUsed:
           type: string
@@ -1668,7 +1697,7 @@ components:
           type: string
           description: Raw value of the API key
         mask:
-          $ref: '#/components/schemas/IdentifierMaskingDetails'
+          $ref: "#/components/schemas/IdentifierMaskingDetails"
         name:
           type: string
           description: Name of the API key
@@ -1678,7 +1707,7 @@ components:
           description: Timestamp of API key creation
         createdBy:
           allOf:
-            - $ref: '#/components/schemas/TeamUser'
+            - $ref: "#/components/schemas/TeamUser"
           nullable: true
         lastUsed:
           type: string
@@ -1832,7 +1861,7 @@ components:
         name:
           type: string
           description: Name of the volume
-          pattern: '^[a-zA-Z0-9_-]+$'
+          pattern: "^[a-zA-Z0-9_-]+$"
       required:
         - name
 
@@ -1850,10 +1879,10 @@ paths:
     get:
       description: Health check
       responses:
-        '204':
+        "204":
           description: The service is healthy
-        '401':
-          $ref: '#/components/responses/401'
+        "401":
+          $ref: "#/components/responses/401"
 
   /teams:
     get:
@@ -1862,8 +1891,9 @@ paths:
       security:
         - AccessTokenAuth: []
         - Supabase1TokenAuth: []
+        - AuthProviderBearerAuth: []
       responses:
-        '200':
+        "200":
           description: Successfully returned all teams
           content:
             application/json:
@@ -1871,11 +1901,11 @@ paths:
                 type: array
                 items:
                   allOf:
-                    - $ref: '#/components/schemas/Team'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                    - $ref: "#/components/schemas/Team"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /teams/{teamID}/metrics:
     get:
@@ -1885,8 +1915,10 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/teamID'
+        - $ref: "#/components/parameters/teamID"
         - in: query
           name: start
           schema:
@@ -1902,22 +1934,22 @@ paths:
             minimum: 0
             description: Unix timestamp for the end of the interval, in seconds, for which the metrics
       responses:
-        '200':
+        "200":
           description: Successfully returned the team metrics
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/TeamMetric'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '500':
-          $ref: '#/components/responses/500'
+                  $ref: "#/components/schemas/TeamMetric"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
 
   /teams/{teamID}/metrics/max:
     get:
@@ -1927,8 +1959,10 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/teamID'
+        - $ref: "#/components/parameters/teamID"
         - in: query
           name: start
           schema:
@@ -1951,20 +1985,20 @@ paths:
             enum: [concurrent_sandboxes, sandbox_start_rate]
           description: Metric to retrieve the maximum value for
       responses:
-        '200':
+        "200":
           description: Successfully returned the team metrics
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MaxTeamMetric'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/MaxTeamMetric"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
 
   /sandboxes:
     get:
@@ -1974,6 +2008,8 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
         - name: metadata
           in: query
@@ -1982,7 +2018,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successfully returned all running sandboxes
           content:
             application/json:
@@ -1990,13 +2026,13 @@ paths:
                 type: array
                 items:
                   allOf:
-                    - $ref: '#/components/schemas/ListedSandbox'
-        '401':
-          $ref: '#/components/responses/401'
-        '400':
-          $ref: '#/components/responses/400'
-        '500':
-          $ref: '#/components/responses/500'
+                    - $ref: "#/components/schemas/ListedSandbox"
+        "401":
+          $ref: "#/components/responses/401"
+        "400":
+          $ref: "#/components/responses/400"
+        "500":
+          $ref: "#/components/responses/500"
     post:
       description: Create a sandbox from the template
       tags: [sandboxes]
@@ -2004,25 +2040,27 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewSandbox'
+              $ref: "#/components/schemas/NewSandbox"
       responses:
-        '201':
+        "201":
           description: The sandbox was created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Sandbox'
-        '401':
-          $ref: '#/components/responses/401'
-        '400':
-          $ref: '#/components/responses/400'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/Sandbox"
+        "401":
+          $ref: "#/components/responses/401"
+        "400":
+          $ref: "#/components/responses/400"
+        "500":
+          $ref: "#/components/responses/500"
 
   /v2/sandboxes:
     get:
@@ -2032,6 +2070,8 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
         - name: metadata
           in: query
@@ -2046,13 +2086,13 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/SandboxState'
+              $ref: "#/components/schemas/SandboxState"
           style: form
           explode: false
-        - $ref: '#/components/parameters/paginationNextToken'
-        - $ref: '#/components/parameters/paginationLimit'
+        - $ref: "#/components/parameters/paginationNextToken"
+        - $ref: "#/components/parameters/paginationLimit"
       responses:
-        '200':
+        "200":
           description: Successfully returned all running sandboxes
           content:
             application/json:
@@ -2060,13 +2100,13 @@ paths:
                 type: array
                 items:
                   allOf:
-                    - $ref: '#/components/schemas/ListedSandbox'
-        '401':
-          $ref: '#/components/responses/401'
-        '400':
-          $ref: '#/components/responses/400'
-        '500':
-          $ref: '#/components/responses/500'
+                    - $ref: "#/components/schemas/ListedSandbox"
+        "401":
+          $ref: "#/components/responses/401"
+        "400":
+          $ref: "#/components/responses/400"
+        "500":
+          $ref: "#/components/responses/500"
 
   /sandboxes/metrics:
     get:
@@ -2076,6 +2116,8 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
         - name: sandbox_ids
           in: query
@@ -2089,18 +2131,18 @@ paths:
             maxItems: 100
             uniqueItems: true
       responses:
-        '200':
+        "200":
           description: Successfully returned all running sandboxes with metrics
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SandboxesWithMetrics'
-        '401':
-          $ref: '#/components/responses/401'
-        '400':
-          $ref: '#/components/responses/400'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/SandboxesWithMetrics"
+        "401":
+          $ref: "#/components/responses/401"
+        "400":
+          $ref: "#/components/responses/400"
+        "500":
+          $ref: "#/components/responses/500"
 
   /sandboxes/{sandboxID}/logs:
     get:
@@ -2111,8 +2153,10 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/sandboxID'
+        - $ref: "#/components/parameters/sandboxID"
         - in: query
           name: start
           schema:
@@ -2129,18 +2173,18 @@ paths:
             type: integer
           description: Maximum number of logs that should be returned
       responses:
-        '200':
+        "200":
           description: Successfully returned the sandbox logs
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SandboxLogs'
-        '404':
-          $ref: '#/components/responses/404'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/SandboxLogs"
+        "404":
+          $ref: "#/components/responses/404"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /v2/sandboxes/{sandboxID}/logs:
     get:
@@ -2150,8 +2194,10 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/sandboxID'
+        - $ref: "#/components/parameters/sandboxID"
         - in: query
           name: cursor
           schema:
@@ -2171,12 +2217,12 @@ paths:
         - in: query
           name: direction
           schema:
-            $ref: '#/components/schemas/LogsDirection'
+            $ref: "#/components/schemas/LogsDirection"
           description: Direction of the logs that should be returned
         - in: query
           name: level
           schema:
-            $ref: '#/components/schemas/LogLevel'
+            $ref: "#/components/schemas/LogLevel"
           description: Minimum log level to return. Logs below this level are excluded
         - in: query
           name: search
@@ -2185,18 +2231,18 @@ paths:
             maxLength: 256
           description: Case-sensitive substring match on log message content
       responses:
-        '200':
+        "200":
           description: Successfully returned the sandbox logs
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SandboxLogsV2Response'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/SandboxLogsV2Response"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /sandboxes/{sandboxID}:
     get:
@@ -2206,21 +2252,23 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/sandboxID'
+        - $ref: "#/components/parameters/sandboxID"
       responses:
-        '200':
+        "200":
           description: Successfully returned the sandbox
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SandboxDetail'
-        '404':
-          $ref: '#/components/responses/404'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/SandboxDetail"
+        "404":
+          $ref: "#/components/responses/404"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
     delete:
       description: Kill a sandbox
@@ -2229,17 +2277,19 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/sandboxID'
+        - $ref: "#/components/parameters/sandboxID"
       responses:
-        '204':
+        "204":
           description: The sandbox was killed successfully
-        '404':
-          $ref: '#/components/responses/404'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+        "404":
+          $ref: "#/components/responses/404"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /sandboxes/{sandboxID}/metrics:
     get:
@@ -2249,8 +2299,10 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/sandboxID'
+        - $ref: "#/components/parameters/sandboxID"
         - in: query
           name: start
           schema:
@@ -2267,22 +2319,22 @@ paths:
             description: Unix timestamp for the end of the interval, in seconds, for which the metrics
 
       responses:
-        '200':
+        "200":
           description: Successfully returned the sandbox metrics
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SandboxMetric'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                  $ref: "#/components/schemas/SandboxMetric"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   # TODO: Pause and resume might be exposed as POST /sandboxes/{sandboxID}/snapshot and then POST /sandboxes with specified snapshotting setup
   /sandboxes/{sandboxID}/pause:
@@ -2293,19 +2345,21 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/sandboxID'
+        - $ref: "#/components/parameters/sandboxID"
       responses:
-        '204':
+        "204":
           description: The sandbox was paused successfully and can be resumed
-        '409':
-          $ref: '#/components/responses/409'
-        '404':
-          $ref: '#/components/responses/404'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+        "409":
+          $ref: "#/components/responses/409"
+        "404":
+          $ref: "#/components/responses/404"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /sandboxes/{sandboxID}/resume:
     post:
@@ -2316,29 +2370,31 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/sandboxID'
+        - $ref: "#/components/parameters/sandboxID"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ResumedSandbox'
+              $ref: "#/components/schemas/ResumedSandbox"
       responses:
-        '201':
+        "201":
           description: The sandbox was resumed successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Sandbox'
-        '409':
-          $ref: '#/components/responses/409'
-        '404':
-          $ref: '#/components/responses/404'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/Sandbox"
+        "409":
+          $ref: "#/components/responses/409"
+        "404":
+          $ref: "#/components/responses/404"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /sandboxes/{sandboxID}/connect:
     post:
@@ -2348,35 +2404,37 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/sandboxID'
+        - $ref: "#/components/parameters/sandboxID"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ConnectSandbox'
+              $ref: "#/components/schemas/ConnectSandbox"
       responses:
-        '200':
+        "200":
           description: The sandbox was already running
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Sandbox'
-        '201':
+                $ref: "#/components/schemas/Sandbox"
+        "201":
           description: The sandbox was resumed successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Sandbox'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/Sandbox"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /sandboxes/{sandboxID}/timeout:
     post:
@@ -2385,6 +2443,8 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       tags: [sandboxes]
       requestBody:
         content:
@@ -2400,44 +2460,46 @@ paths:
                   format: int32
                   minimum: 0
       parameters:
-        - $ref: '#/components/parameters/sandboxID'
+        - $ref: "#/components/parameters/sandboxID"
       responses:
-        '204':
+        "204":
           description: Successfully set the sandbox timeout
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /sandboxes/{sandboxID}/network:
     put:
-      description: Update the network configuration for a running sandbox. Replaces the current egress rules with the provided configuration. Omitting a field clears it.
+      description: Update the network configuration for a running sandbox. Replaces the current egress rules with the provided configuration. Omitting field clears it.
       security:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       tags: [sandboxes]
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SandboxNetworkUpdateConfig'
+              $ref: "#/components/schemas/SandboxNetworkUpdateConfig"
       parameters:
-        - $ref: '#/components/parameters/sandboxID'
+        - $ref: "#/components/parameters/sandboxID"
       responses:
-        '204':
+        "204":
           description: Successfully updated the sandbox network configuration
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
-          $ref: '#/components/responses/409'
-        '500':
-          $ref: '#/components/responses/500'
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
+          $ref: "#/components/responses/409"
+        "500":
+          $ref: "#/components/responses/500"
 
   /sandboxes/{sandboxID}/refreshes:
     post:
@@ -2446,6 +2508,8 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       tags: [sandboxes]
       requestBody:
         content:
@@ -2459,14 +2523,14 @@ paths:
                   maximum: 3600 # 1 hour
                   minimum: 0
       parameters:
-        - $ref: '#/components/parameters/sandboxID'
+        - $ref: "#/components/parameters/sandboxID"
       responses:
-        '204':
+        "204":
           description: Successfully refreshed the sandbox
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
 
   /sandboxes/{sandboxID}/snapshots:
     post:
@@ -2476,8 +2540,10 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/sandboxID'
+        - $ref: "#/components/parameters/sandboxID"
       requestBody:
         required: true
         content:
@@ -2489,20 +2555,20 @@ paths:
                   type: string
                   description: Optional name for the snapshot template. If a snapshot template with this name already exists, a new build will be assigned to the existing template instead of creating a new one.
       responses:
-        '201':
+        "201":
           description: Snapshot created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SnapshotInfo'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/SnapshotInfo"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /snapshots:
     get:
@@ -2512,6 +2578,8 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
         - name: sandboxID
           in: query
@@ -2519,21 +2587,21 @@ paths:
           schema:
             type: string
             description: Filter snapshots by source sandbox ID
-        - $ref: '#/components/parameters/paginationLimit'
-        - $ref: '#/components/parameters/paginationNextToken'
+        - $ref: "#/components/parameters/paginationLimit"
+        - $ref: "#/components/parameters/paginationNextToken"
       responses:
-        '200':
+        "200":
           description: Successfully returned snapshots
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SnapshotInfo'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                  $ref: "#/components/schemas/SnapshotInfo"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /v3/templates:
     post:
@@ -2543,26 +2611,30 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TemplateBuildRequestV3'
+              $ref: "#/components/schemas/TemplateBuildRequestV3"
 
       responses:
-        '202':
+        "202":
           description: The build was requested successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TemplateRequestResponseV3'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/TemplateRequestResponseV3"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
 
   /v2/templates:
     post:
@@ -2573,26 +2645,28 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TemplateBuildRequestV2'
+              $ref: "#/components/schemas/TemplateBuildRequestV2"
 
       responses:
-        '202':
+        "202":
           description: The build was requested successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TemplateLegacy'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/TemplateLegacy"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /templates/{templateID}/files/{hash}:
     get:
@@ -2603,8 +2677,10 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/templateID'
+        - $ref: "#/components/parameters/templateID"
         - in: path
           name: hash
           required: true
@@ -2613,20 +2689,20 @@ paths:
             description: Hash of the files
 
       responses:
-        '201':
+        "201":
           description: The upload link where to upload the tar file
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TemplateBuildFileUpload'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/TemplateBuildFileUpload"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /templates:
     get:
@@ -2637,6 +2713,8 @@ paths:
         - AccessTokenAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
         - in: query
           required: false
@@ -2645,7 +2723,7 @@ paths:
             type: string
             description: Identifier of the team
       responses:
-        '200':
+        "200":
           description: Successfully returned all templates
           content:
             application/json:
@@ -2653,11 +2731,11 @@ paths:
                 type: array
                 items:
                   allOf:
-                    - $ref: '#/components/schemas/Template'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                    - $ref: "#/components/schemas/Template"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
     post:
       description: Create a new template
       deprecated: true
@@ -2666,26 +2744,28 @@ paths:
         - AccessTokenAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TemplateBuildRequest'
+              $ref: "#/components/schemas/TemplateBuildRequest"
 
       responses:
-        '202':
+        "202":
           description: The build was accepted
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TemplateLegacy'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/TemplateLegacy"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /templates/{templateID}:
     get:
@@ -2695,21 +2775,23 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/templateID'
-        - $ref: '#/components/parameters/paginationNextToken'
-        - $ref: '#/components/parameters/paginationLimit'
+        - $ref: "#/components/parameters/templateID"
+        - $ref: "#/components/parameters/paginationNextToken"
+        - $ref: "#/components/parameters/paginationLimit"
       responses:
-        '200':
+        "200":
           description: Successfully returned the template with its builds
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TemplateWithBuilds'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/TemplateWithBuilds"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
     post:
       description: Rebuild an template
       deprecated: true
@@ -2718,26 +2800,28 @@ paths:
         - AccessTokenAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/templateID'
+        - $ref: "#/components/parameters/templateID"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TemplateBuildRequest'
+              $ref: "#/components/schemas/TemplateBuildRequest"
 
       responses:
-        '202':
+        "202":
           description: The build was accepted
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TemplateLegacy'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/TemplateLegacy"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
     delete:
       description: Delete a template
       tags: [templates]
@@ -2746,15 +2830,17 @@ paths:
         - AccessTokenAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/templateID'
+        - $ref: "#/components/parameters/templateID"
       responses:
-        '204':
+        "204":
           description: The template was deleted successfully
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
     patch:
       description: Update template
       deprecated: true
@@ -2764,23 +2850,25 @@ paths:
         - AccessTokenAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/templateID'
+        - $ref: "#/components/parameters/templateID"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TemplateUpdateRequest'
+              $ref: "#/components/schemas/TemplateUpdateRequest"
       responses:
-        '200':
+        "200":
           description: The template was updated successfully
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /templates/{templateID}/builds/{buildID}:
     post:
@@ -2791,16 +2879,18 @@ paths:
         - AccessTokenAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/templateID'
-        - $ref: '#/components/parameters/buildID'
+        - $ref: "#/components/parameters/templateID"
+        - $ref: "#/components/parameters/buildID"
       responses:
-        '202':
+        "202":
           description: The build has started
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /v2/templates/{templateID}/builds/{buildID}:
     post:
@@ -2810,22 +2900,24 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/templateID'
-        - $ref: '#/components/parameters/buildID'
+        - $ref: "#/components/parameters/templateID"
+        - $ref: "#/components/parameters/buildID"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TemplateBuildStartV2'
+              $ref: "#/components/schemas/TemplateBuildStartV2"
       responses:
-        '202':
+        "202":
           description: The build has started
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /v2/templates/{templateID}:
     patch:
@@ -2836,27 +2928,29 @@ paths:
         - AccessTokenAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/templateID'
+        - $ref: "#/components/parameters/templateID"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TemplateUpdateRequest'
+              $ref: "#/components/schemas/TemplateUpdateRequest"
       responses:
-        '200':
+        "200":
           description: The template was updated successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TemplateUpdateResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/TemplateUpdateResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /templates/{templateID}/builds/{buildID}/status:
     get:
@@ -2867,9 +2961,11 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/templateID'
-        - $ref: '#/components/parameters/buildID'
+        - $ref: "#/components/parameters/templateID"
+        - $ref: "#/components/parameters/buildID"
         - in: query
           name: logsOffset
           schema:
@@ -2890,20 +2986,20 @@ paths:
         - in: query
           name: level
           schema:
-            $ref: '#/components/schemas/LogLevel'
+            $ref: "#/components/schemas/LogLevel"
       responses:
-        '200':
+        "200":
           description: Successfully returned the template
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TemplateBuildInfo'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/TemplateBuildInfo"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /templates/{templateID}/builds/{buildID}/logs:
     get:
@@ -2914,9 +3010,11 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/templateID'
-        - $ref: '#/components/parameters/buildID'
+        - $ref: "#/components/parameters/templateID"
+        - $ref: "#/components/parameters/buildID"
         - in: query
           name: cursor
           schema:
@@ -2936,29 +3034,29 @@ paths:
         - in: query
           name: direction
           schema:
-            $ref: '#/components/schemas/LogsDirection'
+            $ref: "#/components/schemas/LogsDirection"
         - in: query
           name: level
           schema:
-            $ref: '#/components/schemas/LogLevel'
+            $ref: "#/components/schemas/LogLevel"
         - in: query
           name: source
           schema:
-            $ref: '#/components/schemas/LogsSource'
+            $ref: "#/components/schemas/LogsSource"
           description: Source of the logs that should be returned from
       responses:
-        '200':
+        "200":
           description: Successfully returned the template build logs
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TemplateBuildLogsResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/TemplateBuildLogsResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /templates/tags:
     post:
@@ -2968,27 +3066,29 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AssignTemplateTagsRequest'
+              $ref: "#/components/schemas/AssignTemplateTagsRequest"
       responses:
-        '201':
+        "201":
           description: Tag assigned successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AssignedTemplateTags'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/AssignedTemplateTags"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
     delete:
       description: Delete multiple tags from templates
       tags: [tags]
@@ -2996,23 +3096,25 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteTemplateTagsRequest'
+              $ref: "#/components/schemas/DeleteTemplateTagsRequest"
       responses:
-        '204':
+        "204":
           description: Tags deleted successfully
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /templates/{templateID}/tags:
     get:
@@ -3022,25 +3124,27 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/templateID'
+        - $ref: "#/components/parameters/templateID"
       responses:
-        '200':
+        "200":
           description: Successfully returned the template tags
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/TemplateTag'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                  $ref: "#/components/schemas/TemplateTag"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /templates/aliases/{alias}:
     get:
@@ -3050,6 +3154,8 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
         - name: alias
           in: path
@@ -3058,20 +3164,20 @@ paths:
             type: string
             description: Template alias
       responses:
-        '200':
+        "200":
           description: Successfully queried template by alias
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TemplateAliasResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/TemplateAliasResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /nodes:
     get:
@@ -3079,29 +3185,7 @@ paths:
       tags: [admin]
       security:
         - AdminTokenAuth: []
-      responses:
-        '200':
-          description: Successfully returned all nodes
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  allOf:
-                    - $ref: '#/components/schemas/Node'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
-
-  /nodes/{nodeID}:
-    get:
-      description: Get node info
-      tags: [admin]
-      security:
-        - AdminTokenAuth: []
       parameters:
-        - $ref: '#/components/parameters/nodeID'
         - in: query
           name: clusterID
           description: Identifier of the cluster
@@ -3110,39 +3194,69 @@ paths:
             type: string
             format: uuid
       responses:
-        '200':
+        "200":
+          description: Successfully returned all nodes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  allOf:
+                    - $ref: "#/components/schemas/Node"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /nodes/{nodeID}:
+    get:
+      description: Get node info
+      tags: [admin]
+      security:
+        - AdminTokenAuth: []
+      parameters:
+        - $ref: "#/components/parameters/nodeID"
+        - in: query
+          name: clusterID
+          description: Identifier of the cluster
+          required: false
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
           description: Successfully returned the node
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NodeDetail'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/NodeDetail"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
     post:
       description: Change status of a node
       tags: [admin]
       security:
         - AdminTokenAuth: []
       parameters:
-        - $ref: '#/components/parameters/nodeID'
+        - $ref: "#/components/parameters/nodeID"
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NodeStatusChange'
+              $ref: "#/components/schemas/NodeStatusChange"
       responses:
-        '204':
+        "204":
           description: The node status was changed successfully
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /admin/teams/{teamID}/sandboxes/kill:
     post:
@@ -3160,18 +3274,18 @@ paths:
             format: uuid
           description: Team ID
       responses:
-        '200':
+        "200":
           description: Successfully killed sandboxes
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AdminSandboxKillResult'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/AdminSandboxKillResult"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /admin/teams/{teamID}/builds/cancel:
     post:
@@ -3189,18 +3303,85 @@ paths:
             format: uuid
           description: Team ID
       responses:
-        '200':
+        "200":
           description: Successfully cancelled builds
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AdminBuildCancelResult'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/AdminBuildCancelResult"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /admin/teams/{teamID}/api-keys:
+    post:
+      summary: Create team API key as admin
+      description: Creates a team API key for internal service workflows.
+      tags: [admin]
+      security:
+        - AdminTokenAuth: []
+      parameters:
+        - name: teamID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Team ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewTeamAPIKey"
+      responses:
+        "201":
+          description: Team API key created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreatedTeamAPIKey"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /admin/teams/{teamID}/api-keys/{apiKeyID}:
+    delete:
+      summary: Delete team API key as admin
+      description: Deletes a team API key for internal service workflows.
+      tags: [admin]
+      security:
+        - AdminTokenAuth: []
+      parameters:
+        - name: teamID
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Team ID
+        - $ref: "#/components/parameters/apiKeyID"
+      responses:
+        "204":
+          description: Team API key deleted successfully
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /access-tokens:
     post:
@@ -3208,23 +3389,24 @@ paths:
       tags: [access-tokens]
       security:
         - Supabase1TokenAuth: []
+        - AuthProviderBearerAuth: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewAccessToken'
+              $ref: "#/components/schemas/NewAccessToken"
       responses:
-        '201':
+        "201":
           description: Access token created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreatedAccessToken'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/CreatedAccessToken"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /access-tokens/{accessTokenID}:
     delete:
@@ -3232,17 +3414,18 @@ paths:
       tags: [access-tokens]
       security:
         - Supabase1TokenAuth: []
+        - AuthProviderBearerAuth: []
       parameters:
-        - $ref: '#/components/parameters/accessTokenID'
+        - $ref: "#/components/parameters/accessTokenID"
       responses:
-        '204':
+        "204":
           description: Access token deleted successfully
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /api-keys:
     get:
@@ -3251,42 +3434,46 @@ paths:
       security:
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       responses:
-        '200':
+        "200":
           description: Successfully returned all team API keys
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/TeamAPIKey'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                  $ref: "#/components/schemas/TeamAPIKey"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
     post:
       description: Create a new team API key
       tags: [api-keys]
       security:
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewTeamAPIKey'
+              $ref: "#/components/schemas/NewTeamAPIKey"
       responses:
-        '201':
+        "201":
           description: Team API key created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreatedTeamAPIKey'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/CreatedTeamAPIKey"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /api-keys/{apiKeyID}:
     patch:
@@ -3295,40 +3482,44 @@ paths:
       security:
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/apiKeyID'
+        - $ref: "#/components/parameters/apiKeyID"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateTeamAPIKey'
+              $ref: "#/components/schemas/UpdateTeamAPIKey"
       responses:
-        '200':
+        "200":
           description: Team API key updated successfully
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
     delete:
       description: Delete a team API key
       tags: [api-keys]
       security:
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/apiKeyID'
+        - $ref: "#/components/parameters/apiKeyID"
       responses:
-        '204':
+        "204":
           description: Team API key deleted successfully
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
   /volumes:
     get:
@@ -3338,19 +3529,21 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       responses:
-        '200':
+        "200":
           description: Successfully listed all team volumes
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Volume'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                  $ref: "#/components/schemas/Volume"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
     post:
       description: Create a new team volume
@@ -3359,25 +3552,27 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewVolume'
+              $ref: "#/components/schemas/NewVolume"
       responses:
-        '201':
+        "201":
           description: Successfully created a new team volume
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VolumeAndToken'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/VolumeAndToken"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
 
   /volumes/{volumeID}:
     get:
@@ -3387,21 +3582,23 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/volumeID'
+        - $ref: "#/components/parameters/volumeID"
       responses:
-        '200':
+        "200":
           description: Successfully retrieved a team volume
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VolumeAndToken'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+                $ref: "#/components/schemas/VolumeAndToken"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
 
     delete:
       description: Delete a team volume
@@ -3410,14 +3607,16 @@ paths:
         - ApiKeyAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
       parameters:
-        - $ref: '#/components/parameters/volumeID'
+        - $ref: "#/components/parameters/volumeID"
       responses:
-        '204':
+        "204":
           description: Successfully deleted a team volume
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          $ref: '#/components/responses/404'
-        '500':
-          $ref: '#/components/responses/500'
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"


### PR DESCRIPTION
## Summary
- Sync `spec/openapi.yml` from [e2b-dev/infra@main](https://github.com/e2b-dev/infra/blob/main/spec/openapi.yml) and re-run `make codegen`.
- Schema changes surfaced in the generated clients: `SandboxMetric.memCache` (new required int64 — also exposed on the public `SandboxMetrics` wrapper in both SDKs), `NodeStatus` gains `standby`, `TeamUser.email` becomes nullable + deprecated, and `POST /v3/templates` gains a `403` response.
- Upstream-only spec changes (not generated because the client filters by tag): new `AuthProviderBearerAuth`/`AuthProviderTeamAuth` security schemes, new admin endpoints for team API keys, and a `clusterID` query param on `GET /nodes`.

## Test plan
- [x] \`pnpm run format\`, \`pnpm run lint\`, \`pnpm run typecheck\`
- [x] JS \`tests/sandbox/metrics.test.ts\` against the live API
- [x] Python sync + async \`test_metrics.py\` against the live API

🤖 Generated with [Claude Code](https://claude.com/claude-code)