### PR TITLE
chore(spec): add prettier yaml formatting check to lint workflow

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,12 @@ importers:
 
   packages/python-sdk: {}
 
+  spec:
+    devDependencies:
+      prettier:
+        specifier: ^3.3.3
+        version: 3.6.2
+
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - packages/*
+  - spec

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -346,7 +346,7 @@ components:
         - enabled
       properties:
         enabled:
-          $ref: "#/components/schemas/SandboxAutoResumeEnabled"
+          $ref: '#/components/schemas/SandboxAutoResumeEnabled'
 
     SandboxOnTimeout:
       type: string
@@ -366,7 +366,7 @@ components:
           type: boolean
           description: Whether the sandbox can auto-resume.
         onTimeout:
-          $ref: "#/components/schemas/SandboxOnTimeout"
+          $ref: '#/components/schemas/SandboxOnTimeout'
 
     SandboxLog:
       description: Log entry with timestamp and line

--- a/spec/package.json
+++ b/spec/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@e2b/spec",
+  "private": true,
+  "scripts": {
+    "lint": "prettier --check openapi.yml envd/envd.yaml",
+    "format": "prettier --write openapi.yml envd/envd.yaml"
+  },
+  "devDependencies": {
+    "prettier": "^3.3.3"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `spec/` to the pnpm workspace with a `package.json` that runs `prettier --check`/`--write` on `openapi.yml` and `envd/envd.yaml`.
- The existing Lint workflow's recursive `pnpm run lint`/`pnpm run format` now enforces YAML formatting automatically — no workflow changes needed.
- Reformat `spec/openapi.yml` (two `$ref` quote-style changes) so the new check passes.

## Test plan
- [ ] CI Lint workflow passes
- [ ] `pnpm --filter @e2b/spec run lint` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)