### PR TITLE
fix(python-sdk): remove dead code in ConnectionConfig.__init__

### DIFF
--- a/.changeset/remove-dead-request-timeout-code.md
+++ b/.changeset/remove-dead-request-timeout-code.md
@@ -1,0 +1,5 @@
+---
+'@e2b/python-sdk': patch
+---
+
+Remove dead code in `ConnectionConfig.__init__` that duplicated the logic of `_get_request_timeout` and immediately overwrote its result. Behavior is unchanged.

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -104,13 +104,6 @@ class ConnectionConfig:
             request_timeout,
         )
 
-        if request_timeout == 0:
-            self.request_timeout = None
-        elif request_timeout is not None:
-            self.request_timeout = request_timeout
-        else:
-            self.request_timeout = REQUEST_TIMEOUT
-
         self.api_url = (
             api_url
             or ConnectionConfig._api_url()

--- a/packages/python-sdk/tests/test_connection_config.py
+++ b/packages/python-sdk/tests/test_connection_config.py
@@ -25,3 +25,37 @@ def test_api_url_has_correct_priority(monkeypatch):
 
     config = ConnectionConfig(api_url="http://localhost:8080")
     assert config.api_url == "http://localhost:8080"
+
+
+def test_request_timeout_defaults_to_60():
+    config = ConnectionConfig()
+    assert config.request_timeout == 60.0
+
+
+def test_request_timeout_explicit_value():
+    config = ConnectionConfig(request_timeout=30.0)
+    assert config.request_timeout == 30.0
+
+
+def test_request_timeout_zero_means_no_limit():
+    """Passing 0 should disable the timeout (set to None)."""
+    config = ConnectionConfig(request_timeout=0)
+    assert config.request_timeout is None
+
+
+def test_get_request_timeout_inherits_from_config():
+    """get_request_timeout with no argument returns the configured default."""
+    config = ConnectionConfig(request_timeout=45.0)
+    assert config.get_request_timeout() == 45.0
+
+
+def test_get_request_timeout_overrides_with_arg():
+    """get_request_timeout with an explicit arg overrides the configured default."""
+    config = ConnectionConfig(request_timeout=45.0)
+    assert config.get_request_timeout(10.0) == 10.0
+
+
+def test_get_request_timeout_zero_arg_means_no_limit():
+    """Passing 0 to get_request_timeout disables the timeout regardless of config."""
+    config = ConnectionConfig(request_timeout=45.0)
+    assert config.get_request_timeout(0) is None


### PR DESCRIPTION
## Problem

In `ConnectionConfig.__init__`, `_get_request_timeout` is called and its
result assigned to `self.request_timeout`, but that assignment is
immediately overwritten by an inline `if/elif/else` block that duplicates
the same logic:

```python
# lines 102-105 — result is never used
self.request_timeout = ConnectionConfig._get_request_timeout(
    REQUEST_TIMEOUT,
    request_timeout,
)

# lines 107-112 — always overwrites the above
if request_timeout == 0:
    self.request_timeout = None
elif request_timeout is not None:
    self.request_timeout = request_timeout
else:
    self.request_timeout = REQUEST_TIMEOUT
```

`_get_request_timeout` already implements all three cases identically, so
lines 107–112 are unreachable dead code. This creates a misleading
impression that the static method is *checked* before the inline fallback,
and silently breaks if someone later changes `_get_request_timeout`
without noticing the duplicate.

## Fix

Remove the inline `if/elif/else` block and rely solely on
`_get_request_timeout`, which is already the method used by
`get_request_timeout` for per-call overrides.

## Tests

Added six unit tests to `tests/test_connection_config.py` covering:
- default timeout (60 s)
- explicit timeout value
- `0` → `None` (no limit)
- `get_request_timeout()` with no argument inherits configured default
- `get_request_timeout(override)` returns the override
- `get_request_timeout(0)` returns `None` regardless of config