### PR TITLE
Fix/python envd stable transport

### DIFF
--- a/.changeset/sharp-sandboxes-sip.md
+++ b/.changeset/sharp-sandboxes-sip.md
@@ -2,4 +2,4 @@
 "@e2b/python-sdk": patch
 ---
 
-Use the stable sandbox host for envd requests on supported E2B domains and give envd traffic a separate HTTP transport cache from API traffic. Async envd requests continue to use HTTP/2; sync envd requests use HTTP/1.1 to avoid shared HTTP/2 contention under threaded sync workloads.
+Use the stable sandbox host for envd requests on supported E2B domains and give envd traffic a separate HTTP transport cache from API traffic. Sync envd transports are cached per thread to avoid sharing a single HTTP/2 connection across threaded sync workloads.

--- a/.changeset/sharp-sandboxes-sip.md
+++ b/.changeset/sharp-sandboxes-sip.md
@@ -2,4 +2,4 @@
 "@e2b/python-sdk": patch
 ---
 
-Use the stable sandbox host for envd requests on supported E2B domains and give envd traffic a separate HTTP transport cache from API traffic.
+Use the stable sandbox host for envd requests on supported E2B domains and give envd traffic a separate HTTP transport cache from API traffic. Async envd requests continue to use HTTP/2; sync envd requests use HTTP/1.1 to avoid shared HTTP/2 contention under threaded sync workloads.

--- a/.changeset/sharp-sandboxes-sip.md
+++ b/.changeset/sharp-sandboxes-sip.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Use the stable sandbox host for envd requests on supported E2B domains and give envd traffic a separate HTTP transport cache from API traffic.

--- a/packages/python-sdk/e2b/api/client_async/__init__.py
+++ b/packages/python-sdk/e2b/api/client_async/__init__.py
@@ -52,3 +52,25 @@ def get_transport(
 
     AsyncTransportWithLogger._instances[loop_id] = transport
     return transport
+
+
+class AsyncEnvdTransportWithLogger(AsyncTransportWithLogger):
+    _instances: Dict[Tuple[int, bool], "AsyncEnvdTransportWithLogger"] = {}
+
+
+def get_envd_transport(
+    config: ConnectionConfig, http2: bool = True
+) -> AsyncEnvdTransportWithLogger:
+    loop_id = (id(asyncio.get_running_loop()), http2)
+
+    if loop_id in AsyncEnvdTransportWithLogger._instances:
+        return AsyncEnvdTransportWithLogger._instances[loop_id]
+
+    transport = AsyncEnvdTransportWithLogger(
+        limits=limits,
+        proxy=config.proxy,
+        http2=http2,
+    )
+
+    AsyncEnvdTransportWithLogger._instances[loop_id] = transport
+    return transport

--- a/packages/python-sdk/e2b/api/client_sync/__init__.py
+++ b/packages/python-sdk/e2b/api/client_sync/__init__.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 import httpx
 import logging
+import threading
 
 from e2b.api import ApiClient, limits
 from e2b.connection_config import ConnectionConfig
@@ -50,13 +51,16 @@ def get_transport(config: ConnectionConfig, http2: bool = True) -> TransportWith
 
 
 class EnvdTransportWithLogger(TransportWithLogger):
-    _instances: Dict[bool, "EnvdTransportWithLogger"] = {}
+    _thread_local = threading.local()
 
 
 def get_envd_transport(
     config: ConnectionConfig, http2: bool = True
 ) -> EnvdTransportWithLogger:
-    cached = EnvdTransportWithLogger._instances.get(http2)
+    instances: Dict[bool, EnvdTransportWithLogger] = getattr(
+        EnvdTransportWithLogger._thread_local, "instances", {}
+    )
+    cached = instances.get(http2)
     if cached is not None:
         return cached
 
@@ -65,5 +69,6 @@ def get_envd_transport(
         proxy=config.proxy,
         http2=http2,
     )
-    EnvdTransportWithLogger._instances[http2] = transport
+    instances[http2] = transport
+    EnvdTransportWithLogger._thread_local.instances = instances
     return transport

--- a/packages/python-sdk/e2b/api/client_sync/__init__.py
+++ b/packages/python-sdk/e2b/api/client_sync/__init__.py
@@ -47,3 +47,23 @@ def get_transport(config: ConnectionConfig, http2: bool = True) -> TransportWith
     )
     TransportWithLogger._instances[http2] = transport
     return transport
+
+
+class EnvdTransportWithLogger(TransportWithLogger):
+    _instances: Dict[bool, "EnvdTransportWithLogger"] = {}
+
+
+def get_envd_transport(
+    config: ConnectionConfig, http2: bool = True
+) -> EnvdTransportWithLogger:
+    cached = EnvdTransportWithLogger._instances.get(http2)
+    if cached is not None:
+        return cached
+
+    transport = EnvdTransportWithLogger(
+        limits=limits,
+        proxy=config.proxy,
+        http2=http2,
+    )
+    EnvdTransportWithLogger._instances[http2] = transport
+    return transport

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -150,6 +150,15 @@ class ConnectionConfig:
 
         return f"https://{self.get_host(sandbox_id, sandbox_domain, self.envd_port)}"
 
+    def get_sandbox_direct_url(self, sandbox_id: str, sandbox_domain: str) -> str:
+        if self._sandbox_url:
+            return self._sandbox_url  # type: ignore[return-value]
+
+        if self.debug:
+            return f"http://{self.get_host(sandbox_id, sandbox_domain, self.envd_port)}"
+
+        return f"https://{self.get_host(sandbox_id, sandbox_domain, self.envd_port)}"
+
     def get_host(self, sandbox_id: str, sandbox_domain: str, port: int) -> str:
         """
         Get the host address to connect to the sandbox.

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -6,6 +6,7 @@ from httpx._types import ProxyTypes
 from typing_extensions import Unpack
 
 from e2b.api.metadata import package_version
+from e2b.sandbox_domains import is_supported_sandbox_domain
 
 REQUEST_TIMEOUT: float = 60.0  # 60 seconds
 
@@ -140,7 +141,14 @@ class ConnectionConfig:
         if self._sandbox_url:
             return self._sandbox_url  # type: ignore[return-value]
 
-        return f"{'http' if self.debug else 'https'}://{self.get_host(sandbox_id, sandbox_domain, self.envd_port)}"
+        if self.debug:
+            return f"http://{self.get_host(sandbox_id, sandbox_domain, self.envd_port)}"
+
+        sandbox_domain = sandbox_domain or self.domain
+        if is_supported_sandbox_domain(sandbox_domain):
+            return f"https://sandbox.{sandbox_domain}"
+
+        return f"https://{self.get_host(sandbox_id, sandbox_domain, self.envd_port)}"
 
     def get_host(self, sandbox_id: str, sandbox_domain: str, port: int) -> str:
         """

--- a/packages/python-sdk/e2b/sandbox/main.py
+++ b/packages/python-sdk/e2b/sandbox/main.py
@@ -45,6 +45,9 @@ class SandboxBase:
         self.__envd_api_url = self.connection_config.get_sandbox_url(
             self.sandbox_id, self.sandbox_domain
         )
+        self.__envd_direct_url = self.connection_config.get_sandbox_direct_url(
+            self.sandbox_id, self.sandbox_domain
+        )
         self.__mcp_token: Optional[str] = None
 
     @property
@@ -81,6 +84,10 @@ class SandboxBase:
         return self.__envd_api_url
 
     @property
+    def envd_direct_url(self) -> str:
+        return self.__envd_direct_url
+
+    @property
     def sandbox_id(self) -> str:
         """
         Unique identifier of the sandbox.
@@ -94,7 +101,7 @@ class SandboxBase:
         signature: Optional[str] = None,
         signature_expiration: Optional[int] = None,
     ) -> str:
-        url = urllib.parse.urljoin(self.envd_api_url, ENVD_API_FILES_ROUTE)
+        url = urllib.parse.urljoin(self.envd_direct_url, ENVD_API_FILES_ROUTE)
         query = {"path": path} if path else {}
 
         if user:

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -10,7 +10,7 @@ from packaging.version import Version
 from typing_extensions import Self, Unpack
 
 from e2b.api.client.types import Unset
-from e2b.api.client_async import get_transport
+from e2b.api.client_async import get_envd_transport as get_transport
 from e2b.connection_config import ApiParams, ConnectionConfig
 from e2b.envd.api import ENVD_API_HEALTH_ROUTE, ahandle_envd_api_exception
 from e2b.envd.versions import ENVD_DEBUG_FALLBACK

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -844,7 +844,10 @@ class AsyncSandbox(SandboxApi):
             **opts,
         )
 
-        sandbox_headers = {}
+        sandbox_headers = {
+            "E2b-Sandbox-Id": sandbox.sandbox_id,
+            "E2b-Sandbox-Port": str(ConnectionConfig.envd_port),
+        }
         envd_access_token = sandbox.envd_access_token
         if envd_access_token is not None and not isinstance(envd_access_token, Unset):
             sandbox_headers["X-Access-Token"] = envd_access_token

--- a/packages/python-sdk/e2b/sandbox_domains.py
+++ b/packages/python-sdk/e2b/sandbox_domains.py
@@ -1,0 +1,5 @@
+SUPPORTED_SANDBOX_DOMAINS = ("e2b.app", "e2b.dev", "e2b.pro", "e2b-staging.dev")
+
+
+def is_supported_sandbox_domain(sandbox_domain: str) -> bool:
+    return sandbox_domain in SUPPORTED_SANDBOX_DOMAINS

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -101,7 +101,7 @@ class Sandbox(SandboxApi):
         """
         super().__init__(**opts)
 
-        self._transport = get_transport(self.connection_config)
+        self._transport = get_transport(self.connection_config, http2=False)
 
         self._envd_api = httpx.Client(
             base_url=self.envd_api_url,

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -101,7 +101,7 @@ class Sandbox(SandboxApi):
         """
         super().__init__(**opts)
 
-        self._transport = get_transport(self.connection_config, http2=False)
+        self._transport = get_transport(self.connection_config)
 
         self._envd_api = httpx.Client(
             base_url=self.envd_api_url,

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -840,7 +840,10 @@ class Sandbox(SandboxApi):
             **opts,
         )
 
-        sandbox_headers = {}
+        sandbox_headers = {
+            "E2b-Sandbox-Id": sandbox.sandbox_id,
+            "E2b-Sandbox-Port": str(ConnectionConfig.envd_port),
+        }
         envd_access_token = sandbox.envd_access_token
         if envd_access_token is not None and not isinstance(envd_access_token, Unset):
             sandbox_headers["X-Access-Token"] = envd_access_token

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -10,7 +10,7 @@ from packaging.version import Version
 from typing_extensions import Self, Unpack
 
 from e2b.api.client.types import Unset
-from e2b.api.client_sync import get_transport
+from e2b.api.client_sync import get_envd_transport as get_transport
 from e2b.connection_config import ApiParams, ConnectionConfig
 from e2b.envd.api import ENVD_API_HEALTH_ROUTE, handle_envd_api_exception
 from e2b.envd.versions import ENVD_DEBUG_FALLBACK

--- a/packages/python-sdk/tests/async/sandbox_async/test_config_propagation.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_config_propagation.py
@@ -88,3 +88,26 @@ async def test_pause_applies_overrides(monkeypatch, test_api_key):
     assert mock_pause.call_args.kwargs["debug"] == BASE_DEBUG
     assert mock_pause.call_args.kwargs["headers"]["X-Test"] == BASE_HEADERS["X-Test"]
     assert mock_pause.call_args.kwargs["headers"]["X-Extra"] == "1"
+
+
+@pytest.mark.skip_debug()
+async def test_connect_sets_stable_host_routing_headers(monkeypatch, test_api_key):
+    mock_connect = AsyncMock(
+        return_value=SimpleNamespace(
+            sandbox_id="sbx-test",
+            domain="e2b.app",
+            envd_version="0.4.0",
+            envd_access_token="tok",
+            traffic_access_token="traffic",
+        )
+    )
+    monkeypatch.setattr(sandbox_async_main.SandboxApi, "_cls_connect", mock_connect)
+
+    sandbox = await AsyncSandbox.connect("sbx-test", api_key=test_api_key)
+
+    assert sandbox.envd_api_url == "https://sandbox.e2b.app"
+    assert sandbox.connection_config.sandbox_headers["E2b-Sandbox-Id"] == "sbx-test"
+    assert sandbox.connection_config.sandbox_headers["E2b-Sandbox-Port"] == str(
+        ConnectionConfig.envd_port
+    )
+    assert sandbox.connection_config.sandbox_headers["X-Access-Token"] == "tok"

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
@@ -48,35 +48,6 @@ def create_sandbox(monkeypatch, api_key: str) -> Sandbox:
 
 
 @pytest.mark.skip_debug()
-def test_sandbox_uses_http1_envd_transport(monkeypatch, test_api_key):
-    dummy_transport = SimpleNamespace(pool=object())
-    mock_transport = Mock(return_value=dummy_transport)
-
-    monkeypatch.setattr(sandbox_sync_main, "get_transport", mock_transport)
-    monkeypatch.setattr(
-        sandbox_sync_main.httpx, "Client", lambda *args, **kwargs: object()
-    )
-    monkeypatch.setattr(
-        sandbox_sync_main, "Filesystem", lambda *args, **kwargs: object()
-    )
-    monkeypatch.setattr(sandbox_sync_main, "Commands", lambda *args, **kwargs: object())
-    monkeypatch.setattr(sandbox_sync_main, "Pty", lambda *args, **kwargs: object())
-    monkeypatch.setattr(sandbox_sync_main, "Git", lambda *args, **kwargs: object())
-
-    Sandbox(
-        sandbox_id="sbx-test",
-        sandbox_domain="sandbox.e2b.dev",
-        envd_version=Version("0.2.4"),
-        envd_access_token="tok",
-        traffic_access_token="tok",
-        connection_config=ConnectionConfig(api_key=test_api_key),
-    )
-
-    mock_transport.assert_called_once()
-    assert mock_transport.call_args.kwargs["http2"] is False
-
-
-@pytest.mark.skip_debug()
 def test_pause_passes_connection_config_without_overrides(monkeypatch, test_api_key):
     mock_pause = Mock(return_value="sbx-test")
     monkeypatch.setattr(sandbox_sync_main.SandboxApi, "_cls_pause", mock_pause)

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
@@ -48,6 +48,35 @@ def create_sandbox(monkeypatch, api_key: str) -> Sandbox:
 
 
 @pytest.mark.skip_debug()
+def test_sandbox_uses_http1_envd_transport(monkeypatch, test_api_key):
+    dummy_transport = SimpleNamespace(pool=object())
+    mock_transport = Mock(return_value=dummy_transport)
+
+    monkeypatch.setattr(sandbox_sync_main, "get_transport", mock_transport)
+    monkeypatch.setattr(
+        sandbox_sync_main.httpx, "Client", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        sandbox_sync_main, "Filesystem", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(sandbox_sync_main, "Commands", lambda *args, **kwargs: object())
+    monkeypatch.setattr(sandbox_sync_main, "Pty", lambda *args, **kwargs: object())
+    monkeypatch.setattr(sandbox_sync_main, "Git", lambda *args, **kwargs: object())
+
+    Sandbox(
+        sandbox_id="sbx-test",
+        sandbox_domain="sandbox.e2b.dev",
+        envd_version=Version("0.2.4"),
+        envd_access_token="tok",
+        traffic_access_token="tok",
+        connection_config=ConnectionConfig(api_key=test_api_key),
+    )
+
+    mock_transport.assert_called_once()
+    assert mock_transport.call_args.kwargs["http2"] is False
+
+
+@pytest.mark.skip_debug()
 def test_pause_passes_connection_config_without_overrides(monkeypatch, test_api_key):
     mock_pause = Mock(return_value="sbx-test")
     monkeypatch.setattr(sandbox_sync_main.SandboxApi, "_cls_pause", mock_pause)

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
@@ -84,3 +84,26 @@ def test_pause_applies_overrides(monkeypatch, test_api_key):
     assert mock_pause.call_args.kwargs["debug"] == BASE_DEBUG
     assert mock_pause.call_args.kwargs["headers"]["X-Test"] == BASE_HEADERS["X-Test"]
     assert mock_pause.call_args.kwargs["headers"]["X-Extra"] == "1"
+
+
+@pytest.mark.skip_debug()
+def test_connect_sets_stable_host_routing_headers(monkeypatch, test_api_key):
+    mock_connect = Mock(
+        return_value=SimpleNamespace(
+            sandbox_id="sbx-test",
+            domain="e2b.app",
+            envd_version="0.4.0",
+            envd_access_token="tok",
+            traffic_access_token="traffic",
+        )
+    )
+    monkeypatch.setattr(sandbox_sync_main.SandboxApi, "_cls_connect", mock_connect)
+
+    sandbox = Sandbox.connect("sbx-test", api_key=test_api_key)
+
+    assert sandbox.envd_api_url == "https://sandbox.e2b.app"
+    assert sandbox.connection_config.sandbox_headers["E2b-Sandbox-Id"] == "sbx-test"
+    assert sandbox.connection_config.sandbox_headers["E2b-Sandbox-Port"] == str(
+        ConnectionConfig.envd_port
+    )
+    assert sandbox.connection_config.sandbox_headers["X-Access-Token"] == "tok"

--- a/packages/python-sdk/tests/test_api_client_transport.py
+++ b/packages/python-sdk/tests/test_api_client_transport.py
@@ -2,11 +2,13 @@ import asyncio
 
 import pytest
 
-from e2b.api.client_async import AsyncTransportWithLogger
+from e2b.api.client_async import AsyncEnvdTransportWithLogger, AsyncTransportWithLogger
 from e2b.api.client_async import get_api_client as get_async_api_client
+from e2b.api.client_async import get_envd_transport as get_async_envd_transport
 from e2b.api.client_async import get_transport as get_async_transport
-from e2b.api.client_sync import TransportWithLogger
+from e2b.api.client_sync import EnvdTransportWithLogger, TransportWithLogger
 from e2b.api.client_sync import get_api_client as get_sync_api_client
+from e2b.api.client_sync import get_envd_transport as get_sync_envd_transport
 from e2b.api.client_sync import get_transport as get_sync_transport
 from e2b.connection_config import ConnectionConfig
 
@@ -47,6 +49,24 @@ def test_sync_get_transport_http2_opt_out_returns_distinct_instance(test_api_key
         assert get_sync_transport(config, http2=False) is http1_transport
     finally:
         TransportWithLogger._instances.clear()
+
+
+def test_sync_envd_transport_uses_separate_cache(test_api_key):
+    TransportWithLogger._instances.clear()
+    EnvdTransportWithLogger._instances.clear()
+    config = ConnectionConfig(api_key=test_api_key)
+
+    try:
+        api_transport = get_sync_transport(config)
+        envd_transport = get_sync_envd_transport(config)
+
+        assert api_transport is not envd_transport
+        assert get_sync_transport(config) is api_transport
+        assert get_sync_envd_transport(config) is envd_transport
+        assert envd_transport._pool._http2 is True
+    finally:
+        TransportWithLogger._instances.clear()
+        EnvdTransportWithLogger._instances.clear()
 
 
 @pytest.mark.asyncio
@@ -92,3 +112,22 @@ async def test_async_get_transport_http2_opt_out_returns_distinct_instance(
         assert get_async_transport(config, http2=False) is http1_transport
     finally:
         AsyncTransportWithLogger._instances.clear()
+
+
+@pytest.mark.asyncio
+async def test_async_envd_transport_uses_separate_cache(test_api_key):
+    AsyncTransportWithLogger._instances.clear()
+    AsyncEnvdTransportWithLogger._instances.clear()
+    config = ConnectionConfig(api_key=test_api_key)
+
+    try:
+        api_transport = get_async_transport(config)
+        envd_transport = get_async_envd_transport(config)
+
+        assert api_transport is not envd_transport
+        assert get_async_transport(config) is api_transport
+        assert get_async_envd_transport(config) is envd_transport
+        assert envd_transport._pool._http2 is True
+    finally:
+        AsyncTransportWithLogger._instances.clear()
+        AsyncEnvdTransportWithLogger._instances.clear()

--- a/packages/python-sdk/tests/test_api_client_transport.py
+++ b/packages/python-sdk/tests/test_api_client_transport.py
@@ -1,4 +1,5 @@
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -53,7 +54,7 @@ def test_sync_get_transport_http2_opt_out_returns_distinct_instance(test_api_key
 
 def test_sync_envd_transport_uses_separate_cache(test_api_key):
     TransportWithLogger._instances.clear()
-    EnvdTransportWithLogger._instances.clear()
+    EnvdTransportWithLogger._thread_local.instances = {}
     config = ConnectionConfig(api_key=test_api_key)
 
     try:
@@ -66,7 +67,27 @@ def test_sync_envd_transport_uses_separate_cache(test_api_key):
         assert envd_transport._pool._http2 is True
     finally:
         TransportWithLogger._instances.clear()
-        EnvdTransportWithLogger._instances.clear()
+        EnvdTransportWithLogger._thread_local.instances = {}
+
+
+def test_sync_envd_transport_cache_is_thread_local(test_api_key):
+    EnvdTransportWithLogger._thread_local.instances = {}
+    config = ConnectionConfig(api_key=test_api_key)
+
+    def get_thread_transport():
+        return get_sync_envd_transport(config)
+
+    try:
+        main_transport = get_sync_envd_transport(config)
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            thread_transport = executor.submit(get_thread_transport).result()
+
+        assert main_transport is get_sync_envd_transport(config)
+        assert thread_transport is not main_transport
+        assert main_transport._pool._http2 is True
+        assert thread_transport._pool._http2 is True
+    finally:
+        EnvdTransportWithLogger._thread_local.instances = {}
 
 
 @pytest.mark.asyncio

--- a/packages/python-sdk/tests/test_connection_config.py
+++ b/packages/python-sdk/tests/test_connection_config.py
@@ -31,27 +31,20 @@ def test_api_url_has_correct_priority(monkeypatch):
 def test_sandbox_url_uses_stable_host_for_supported_domain():
     config = ConnectionConfig(domain="e2b.app")
 
-    assert (
-        config.get_sandbox_url("sandbox-id", "e2b.app")
-        == "https://sandbox.e2b.app"
-    )
+    assert config.get_sandbox_url("sandbox-id", "e2b.app") == "https://sandbox.e2b.app"
 
 
 def test_sandbox_url_uses_stable_host_for_supported_non_prod_domain():
     config = ConnectionConfig(domain="e2b.dev")
 
-    assert (
-        config.get_sandbox_url("sandbox-id", "e2b.dev")
-        == "https://sandbox.e2b.dev"
-    )
+    assert config.get_sandbox_url("sandbox-id", "e2b.dev") == "https://sandbox.e2b.dev"
 
 
 def test_sandbox_url_uses_explicit_url_first():
     config = ConnectionConfig(sandbox_url="https://sandbox.example.com")
 
     assert (
-        config.get_sandbox_url("sandbox-id", "e2b.app")
-        == "https://sandbox.example.com"
+        config.get_sandbox_url("sandbox-id", "e2b.app") == "https://sandbox.example.com"
     )
 
 
@@ -82,7 +75,4 @@ def test_sandbox_url_debug_uses_localhost():
 def test_get_host_keeps_per_sandbox_host_for_supported_domain():
     config = ConnectionConfig(domain="e2b.app")
 
-    assert (
-        config.get_host("sandbox-id", "e2b.app", 8888)
-        == "8888-sandbox-id.e2b.app"
-    )
+    assert config.get_host("sandbox-id", "e2b.app", 8888) == "8888-sandbox-id.e2b.app"

--- a/packages/python-sdk/tests/test_connection_config.py
+++ b/packages/python-sdk/tests/test_connection_config.py
@@ -76,3 +76,21 @@ def test_get_host_keeps_per_sandbox_host_for_supported_domain():
     config = ConnectionConfig(domain="e2b.app")
 
     assert config.get_host("sandbox-id", "e2b.app", 8888) == "8888-sandbox-id.e2b.app"
+
+
+def test_sandbox_direct_url_keeps_per_sandbox_host_for_supported_domain():
+    config = ConnectionConfig(domain="e2b.app")
+
+    assert (
+        config.get_sandbox_direct_url("sandbox-id", "e2b.app")
+        == "https://49983-sandbox-id.e2b.app"
+    )
+
+
+def test_sandbox_direct_url_uses_explicit_url_first():
+    config = ConnectionConfig(sandbox_url="https://sandbox.example.com")
+
+    assert (
+        config.get_sandbox_direct_url("sandbox-id", "e2b.app")
+        == "https://sandbox.example.com"
+    )

--- a/packages/python-sdk/tests/test_connection_config.py
+++ b/packages/python-sdk/tests/test_connection_config.py
@@ -3,6 +3,7 @@ from e2b import ConnectionConfig
 
 def test_api_url_defaults_correctly(monkeypatch):
     monkeypatch.setenv("E2B_DOMAIN", "")
+    monkeypatch.delenv("E2B_API_URL", raising=False)
 
     config = ConnectionConfig()
     assert config.api_url == "https://api.e2b.app"
@@ -25,3 +26,63 @@ def test_api_url_has_correct_priority(monkeypatch):
 
     config = ConnectionConfig(api_url="http://localhost:8080")
     assert config.api_url == "http://localhost:8080"
+
+
+def test_sandbox_url_uses_stable_host_for_supported_domain():
+    config = ConnectionConfig(domain="e2b.app")
+
+    assert (
+        config.get_sandbox_url("sandbox-id", "e2b.app")
+        == "https://sandbox.e2b.app"
+    )
+
+
+def test_sandbox_url_uses_stable_host_for_supported_non_prod_domain():
+    config = ConnectionConfig(domain="e2b.dev")
+
+    assert (
+        config.get_sandbox_url("sandbox-id", "e2b.dev")
+        == "https://sandbox.e2b.dev"
+    )
+
+
+def test_sandbox_url_uses_explicit_url_first():
+    config = ConnectionConfig(sandbox_url="https://sandbox.example.com")
+
+    assert (
+        config.get_sandbox_url("sandbox-id", "e2b.app")
+        == "https://sandbox.example.com"
+    )
+
+
+def test_sandbox_url_falls_back_to_per_sandbox_host_for_custom_domain():
+    config = ConnectionConfig(domain="custom.example")
+
+    assert (
+        config.get_sandbox_url("sandbox-id", "custom.example")
+        == "https://49983-sandbox-id.custom.example"
+    )
+
+
+def test_sandbox_url_falls_back_to_per_sandbox_host_for_unsupported_subdomain():
+    config = ConnectionConfig(domain="e2b.dev")
+
+    assert (
+        config.get_sandbox_url("sandbox-id", "sandbox.e2b.dev")
+        == "https://49983-sandbox-id.sandbox.e2b.dev"
+    )
+
+
+def test_sandbox_url_debug_uses_localhost():
+    config = ConnectionConfig(debug=True)
+
+    assert config.get_sandbox_url("sandbox-id", "e2b.app") == "http://localhost:49983"
+
+
+def test_get_host_keeps_per_sandbox_host_for_supported_domain():
+    config = ConnectionConfig(domain="e2b.app")
+
+    assert (
+        config.get_host("sandbox-id", "e2b.app", 8888)
+        == "8888-sandbox-id.e2b.app"
+    )

--- a/packages/python-sdk/tests/test_sandbox_urls.py
+++ b/packages/python-sdk/tests/test_sandbox_urls.py
@@ -1,0 +1,26 @@
+from packaging.version import Version
+
+from e2b.connection_config import ConnectionConfig
+from e2b.sandbox.main import SandboxBase
+
+
+def test_file_urls_use_direct_sandbox_host_when_envd_api_uses_stable_host():
+    sandbox = SandboxBase(
+        sandbox_id="sandbox-id",
+        sandbox_domain="e2b.app",
+        envd_version=Version("0.4.0"),
+        envd_access_token=None,
+        traffic_access_token=None,
+        connection_config=ConnectionConfig(domain="e2b.app"),
+    )
+
+    assert sandbox.envd_api_url == "https://sandbox.e2b.app"
+    assert sandbox.envd_direct_url == "https://49983-sandbox-id.e2b.app"
+    assert (
+        sandbox.download_url("/tmp/a.txt")
+        == "https://49983-sandbox-id.e2b.app/files?path=%2Ftmp%2Fa.txt"
+    )
+    assert (
+        sandbox.upload_url("/tmp/a.txt")
+        == "https://49983-sandbox-id.e2b.app/files?path=%2Ftmp%2Fa.txt"
+    )


### PR DESCRIPTION
Updates the Python SDK for perf gains from the JS SDK. The python sdk uses the unified `sandboxes.` host to allow for h2 gains on multiplexing and splits the api/sandbox transport. Does not implement the second transport split JS SDK has between RPC and Rest yet.

Point in Time Burst Concurrency (create sandbox, do quick 250ms sleep)
| variant | n | c | ok/n | sess/s | peak sockets | create p50/p95 ms | command p50/p95 ms | kill p50/p95 ms | total p50/p95 ms | errors |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| prod-h1 | 50 | 50 | 50/50 | 75.9 | 20 | 198 / 222 | 128 / 136 | 121 / 131 | 449 / 475 | 0 |
| prod-h2 | 50 | 50 | 50/50 | 85.5 | 20 | 228 / 269 | 141 / 147 | 57 / 93 | 439 / 452 | 0 |
| stable-split-h2 | 50 | 50 | 50/50 | 99.7 | 0 | 222 / 282 | 162 / 180 | 61 / 93 | 455 / 481 | 0 |
| prod-h1 | 100 | 100 | 99/100 | 105.4 | 10 | 212 / 286 | 162 / 446 | 114 / 133 | 492 / 848 | 1 |
| prod-h2 | 100 | 100 | 99/100 | 71.8 | 15 | 312 / 422 | 185 / 824 | 61 / 304 | 560 / 1218 | 1 |
| stable-split-h2 | 100 | 100 | 100/100 | 136.0 | 2 | 269 / 309 | 81 / 103 | 62 / 185 | 433 / 578 | 0 |
| prod-h1 | 200 | 200 | 200/200 | 83.1 | 20 | 301 / 773 | 524 / 1613 | 977 / 1254 | 1950 / 2214 | 0 |
| prod-h2 | 200 | 200 | 192/200 | 77.1 | 15 | 480 / 590 | 436 / 1550 | 105 / 317 | 1002 / 2152 | 8 |
| stable-split-h2 | 200 | 200 | 200/200 | 95.5 | 2 | 780 / 1073 | 269 / 373 | 166 / 283 | 1276 / 1496 | 0 |
| prod-h1 | 500 | 500 | 499/500 | 69.9 | 429 | 906 / 1933 | 2260 / 4436 | 2314 / 4148 | 6615 / 6894 | 1 |
| prod-h2 | 500 | 500 | 481/500 | 65.9 | 36 | 929 / 1532 | 2968 / 5154 | 1445 / 4233 | 6964 / 7211 | 19 |
| stable-split-h2 | 500 | 500 | 500/500 | 200.8 | 2 | 1177 / 1723 | 304 / 415 | 676 / 922 | 2164 / 2400 | 0 |

Sustained Concurrency: (create, run command, healthcheck, upload file)
| variant | route | http | n | ok/created | envd origins | pool origins | versions | health p95 | upload p95 | command p95 | total p95 | errors |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| prod-direct-h1 | direct | h1 | 100 | 100/100 | 100 | 19 | HTTP/1.1, HTTP/2 | 1.418s | 2.562s | 0.118s | 3.292s | 0 |
| prod-direct-h1 | direct | h1 | 200 | 199/200 | 200 | 20 | HTTP/1.1, HTTP/2 | 3.973s | 3.869s | 1.106s | 5.439s | 1 |
| prod-direct-h1 | direct | h1 | 225 | 225/225 | 225 | 20 | HTTP/1.1, HTTP/2 | 16.267s | 16.875s | 0.265s | 17.520s | 0 |
| prod-direct-h1 | direct | h1 | 250 | 0/250 | 250 | 234 | HTTP/1.1, HTTP/2 | n/a | n/a | n/a | n/a | 250 |
| prod-direct-h2 | direct | h2 | 100 | 69/100 | 100 | 20 | HTTP/2 | 1.008s | 1.000s | 0.374s | 1.211s | 31 |
| prod-direct-h2 | direct | h2 | 200 | 60/200 | 200 | 20 | HTTP/2 | 2.178s | 2.091s | 1.725s | 3.015s | 140 |
| prod-direct-h2 | direct | h2 | 225 | 100/225 | 225 | 20 | HTTP/2 | 2.653s | 2.546s | 1.488s | 2.962s | 125 |
| prod-direct-h2 | direct | h2 | 250 | 49/250 | 250 | 20 | HTTP/2 | 3.033s | 2.936s | 2.450s | 3.682s | 201 |
| stable-split-h2 | stable | h2 | 100 | 100/100 | 1 | 1 | HTTP/2 | 0.731s | 1.229s | 0.139s | 1.490s | 0 |
| stable-split-h2 | stable | h2 | 200 | 200/200 | 1 | 1 | HTTP/2 | 1.550s | 2.989s | 0.369s | 3.553s | 0 |
| stable-split-h2 | stable | h2 | 225 | 225/225 | 1 | 1 | HTTP/2 | 1.559s | 2.941s | 0.338s | 3.437s | 0 |
| stable-split-h2 | stable | h2 | 250 | 250/250 | 1 | 1 | HTTP/2 | 1.382s | 2.525s | 0.279s | 2.984s | 0 |

