### PR TITLE
fix(parse_git_status): fix false-positive detached HEAD when upstream name contains 'detached'

### DIFF
--- a/packages/python-sdk/e2b/sandbox/_git/parse.py
+++ b/packages/python-sdk/e2b/sandbox/_git/parse.py
@@ -125,9 +125,7 @@ def parse_git_status(output: str) -> GitStatus:
         ahead_part = None if ahead_start == -1 else branch_info[ahead_start + 2 : -1]
         normalized_branch = _normalize_branch_name(branch_part)
         raw_branch = branch_part
-        is_detached = raw_branch.startswith("HEAD (detached at ") or (
-            "detached" in raw_branch
-        )
+        is_detached = raw_branch.startswith("HEAD (detached at ")
 
         if is_detached or normalized_branch.startswith("HEAD"):
             detached = True

--- a/packages/python-sdk/tests/bugs/test_parse_git_status_detached.py
+++ b/packages/python-sdk/tests/bugs/test_parse_git_status_detached.py
@@ -1,0 +1,11 @@
+from e2b.sandbox._git.parse import parse_git_status
+
+
+def test_upstream_with_detached_in_name_is_not_detached_head():
+    # Branch 'main' tracking 'origin/detached-work': NOT a detached HEAD.
+    # Previously "detached" in raw_branch caused a false positive.
+    output = "## main...origin/detached-work\n"
+    status = parse_git_status(output)
+    assert not status.detached
+    assert status.current_branch == "main"
+    assert status.upstream == "origin/detached-work"


### PR DESCRIPTION
## What's broken

`parse_git_status` in `packages/python-sdk/e2b/sandbox/_git/parse.py` returns `detached=True` and leaves `current_branch` and `upstream` empty for a repository that is not in detached HEAD mode. This happens whenever the upstream tracking branch name contains the word `detached` — for example, a branch `main` tracking `origin/detached-work`. The porcelain line `## main...origin/detached-work` causes `raw_branch` to equal `"main...origin/detached-work"`, and the condition `"detached" in raw_branch` on line 129 fires, sending execution into the detached-HEAD code path and returning completely wrong state.

## Why it happens

The `"detached" in raw_branch` sub-check is a substring match against the full `branch...upstream` string, not just the branch name, so it matches any upstream whose name contains the word `detached`.

## Fix

Remove the `"detached" in raw_branch` sub-check from line 128–130. The `raw_branch.startswith("HEAD (detached at ")` check already covers real detached HEAD, and the subsequent `normalized_branch.startswith("HEAD")` check on line 130 catches `HEAD (no branch)` and similar HEAD variants.

## Test

Added `tests/bugs/test_parse_git_status_detached.py` which feeds `## main...origin/detached-work` into `parse_git_status` and asserts `detached=False`, `current_branch="main"`, and `upstream="origin/detached-work"`.

Fixes #1373