### PR TITLE
chore: add issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: E2B Docs
+    url: https://e2b.dev/docs
+    about: Read the E2B documentation.
+  - name: E2B Discord
+    url: https://discord.gg/dSBY3ms2Qr
+    about: Ask questions and get help from the E2B community.


### PR DESCRIPTION
Adds `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues, forcing users to pick an existing template. Also adds contact links to the E2B Docs and the E2B Discord (reusing the invite already referenced in `CONTRIBUTING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)