### PR TITLE
fix(sdk): consistent rate limit error for envd 429 responses

### DIFF
--- a/.changeset/rate-limit-error-consistency.md
+++ b/.changeset/rate-limit-error-consistency.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Return a dedicated rate limit error for HTTP 429 responses from the envd API. Previously these were surfaced as a generic sandbox error, unlike the main API client which already raised `RateLimitError` (JS) / `RateLimitException` (Python). Rate limit errors are now consistent across all SDK request paths.

--- a/.changeset/rate-limit-error-consistency.md
+++ b/.changeset/rate-limit-error-consistency.md
@@ -1,5 +1,6 @@
 ---
 "e2b": patch
+"@e2b/python-sdk": patch
 ---
 
 Return a dedicated rate limit error for HTTP 429 responses from the envd API. Previously these were surfaced as a generic sandbox error, unlike the main API client which already raised `RateLimitError` (JS) / `RateLimitException` (Python). Rate limit errors are now consistent across all SDK request paths.

--- a/packages/js-sdk/src/envd/api.ts
+++ b/packages/js-sdk/src/envd/api.ts
@@ -11,6 +11,7 @@ import {
   SandboxNotFoundError,
   formatSandboxTimeoutError,
   AuthenticationError,
+  RateLimitError,
 } from '../errors'
 import { StartResponse, ConnectResponse } from './process/process_pb'
 import { Code, ConnectError } from '@connectrpc/connect'
@@ -23,7 +24,7 @@ const DEFAULT_ERROR_MAP: Record<number, (message: string) => Error> = {
   401: (message) => new AuthenticationError(message),
   404: (message) => new NotFoundError(message),
   429: (message) =>
-    new SandboxError(`${message}: The requests are being rate limited.`),
+    new RateLimitError(`${message}: The requests are being rate limited.`),
   502: formatSandboxTimeoutError,
   507: (message) => new NotEnoughSpaceError(message),
 }

--- a/packages/js-sdk/src/envd/rpc.ts
+++ b/packages/js-sdk/src/envd/rpc.ts
@@ -8,6 +8,7 @@ import {
   formatSandboxTimeoutError,
   InvalidArgumentError,
   NotFoundError,
+  RateLimitError,
   SandboxError,
   TimeoutError,
 } from '../errors'
@@ -17,6 +18,10 @@ const DEFAULT_ERROR_MAP: Partial<Record<Code, (message: string) => Error>> = {
   [Code.InvalidArgument]: (message) => new InvalidArgumentError(message),
   [Code.Unauthenticated]: (message) => new AuthenticationError(message),
   [Code.NotFound]: (message) => new NotFoundError(message),
+  [Code.ResourceExhausted]: (message) =>
+    new RateLimitError(
+      `${message}: Rate limit exceeded, please try again later.`
+    ),
   [Code.Unavailable]: formatSandboxTimeoutError,
   [Code.Canceled]: (message) =>
     new TimeoutError(

--- a/packages/js-sdk/tests/envd/handleEnvdApiError.test.ts
+++ b/packages/js-sdk/tests/envd/handleEnvdApiError.test.ts
@@ -1,0 +1,80 @@
+import { assert, test, describe } from 'vitest'
+import { handleEnvdApiError } from '../../src/envd/api'
+import {
+  AuthenticationError,
+  InvalidArgumentError,
+  NotEnoughSpaceError,
+  NotFoundError,
+  RateLimitError,
+  SandboxError,
+  TimeoutError,
+} from '../../src/errors'
+
+function createMockResponse(
+  status: number,
+  error: { message?: string } | string
+): {
+  error: { message?: string } | string
+  response: Response
+} {
+  return {
+    error,
+    response: {
+      status,
+      text: async () => (typeof error === 'string' ? error : ''),
+    } as Response,
+  }
+}
+
+describe('handleEnvdApiError', () => {
+  test('returns undefined for a successful response', async () => {
+    const err = await handleEnvdApiError({
+      response: { status: 200 } as Response,
+    })
+    assert.isUndefined(err)
+  })
+
+  test('returns InvalidArgumentError for 400', async () => {
+    const res = createMockResponse(400, { message: 'Bad request' })
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, InvalidArgumentError)
+  })
+
+  test('returns AuthenticationError for 401', async () => {
+    const res = createMockResponse(401, { message: 'Invalid token' })
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, AuthenticationError)
+  })
+
+  test('returns NotFoundError for 404', async () => {
+    const res = createMockResponse(404, { message: 'Not found' })
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, NotFoundError)
+  })
+
+  test('returns RateLimitError for 429', async () => {
+    const res = createMockResponse(429, { message: 'Too many requests' })
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, RateLimitError)
+    assert.include(err?.message, 'rate limited')
+  })
+
+  test('returns TimeoutError for 502', async () => {
+    const res = createMockResponse(502, { message: 'Bad gateway' })
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, TimeoutError)
+  })
+
+  test('returns NotEnoughSpaceError for 507', async () => {
+    const res = createMockResponse(507, { message: 'No space left' })
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, NotEnoughSpaceError)
+  })
+
+  test('falls back to SandboxError for unmapped status', async () => {
+    const res = createMockResponse(500, { message: 'Internal error' })
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, SandboxError)
+    assert.include(err?.message, '500')
+  })
+})

--- a/packages/js-sdk/tests/envd/handleRpcError.test.ts
+++ b/packages/js-sdk/tests/envd/handleRpcError.test.ts
@@ -1,0 +1,52 @@
+import { assert, test, describe } from 'vitest'
+import { Code, ConnectError } from '@connectrpc/connect'
+import { handleRpcError } from '../../src/envd/rpc'
+import {
+  AuthenticationError,
+  InvalidArgumentError,
+  NotFoundError,
+  RateLimitError,
+  SandboxError,
+  TimeoutError,
+} from '../../src/errors'
+
+describe('handleRpcError', () => {
+  test('returns InvalidArgumentError for InvalidArgument', () => {
+    const err = handleRpcError(new ConnectError('bad', Code.InvalidArgument))
+    assert.instanceOf(err, InvalidArgumentError)
+  })
+
+  test('returns AuthenticationError for Unauthenticated', () => {
+    const err = handleRpcError(new ConnectError('nope', Code.Unauthenticated))
+    assert.instanceOf(err, AuthenticationError)
+  })
+
+  test('returns NotFoundError for NotFound', () => {
+    const err = handleRpcError(new ConnectError('missing', Code.NotFound))
+    assert.instanceOf(err, NotFoundError)
+  })
+
+  test('returns RateLimitError for ResourceExhausted', () => {
+    const err = handleRpcError(
+      new ConnectError('too many', Code.ResourceExhausted)
+    )
+    assert.instanceOf(err, RateLimitError)
+    assert.include(err.message, 'Rate limit')
+  })
+
+  test('returns TimeoutError for Unavailable', () => {
+    const err = handleRpcError(new ConnectError('gone', Code.Unavailable))
+    assert.instanceOf(err, TimeoutError)
+  })
+
+  test('falls back to SandboxError for unmapped code', () => {
+    const err = handleRpcError(new ConnectError('boom', Code.Internal))
+    assert.instanceOf(err, SandboxError)
+  })
+
+  test('returns the original error when not a ConnectError', () => {
+    const original = new Error('not connect')
+    const err = handleRpcError(original)
+    assert.strictEqual(err, original)
+  })
+})

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -105,13 +105,6 @@ class ConnectionConfig:
             request_timeout,
         )
 
-        if request_timeout == 0:
-            self.request_timeout = None
-        elif request_timeout is not None:
-            self.request_timeout = request_timeout
-        else:
-            self.request_timeout = REQUEST_TIMEOUT
-
         self.api_url = (
             api_url
             or ConnectionConfig._api_url()

--- a/packages/python-sdk/e2b/envd/api.py
+++ b/packages/python-sdk/e2b/envd/api.py
@@ -9,6 +9,7 @@ from e2b.exceptions import (
     AuthenticationException,
     InvalidArgumentException,
     NotEnoughSpaceException,
+    RateLimitException,
     format_sandbox_timeout_exception,
 )
 
@@ -20,7 +21,7 @@ _DEFAULT_API_ERROR_MAP: dict[int, Callable[[str], Exception]] = {
     400: InvalidArgumentException,
     401: AuthenticationException,
     404: NotFoundException,
-    429: lambda message: SandboxException(
+    429: lambda message: RateLimitException(
         f"{message}: The requests are being rate limited."
     ),
     502: format_sandbox_timeout_exception,

--- a/packages/python-sdk/tests/test_envd_api_exception.py
+++ b/packages/python-sdk/tests/test_envd_api_exception.py
@@ -1,0 +1,47 @@
+from e2b.envd.api import format_envd_api_exception
+from e2b.exceptions import (
+    AuthenticationException,
+    InvalidArgumentException,
+    NotEnoughSpaceException,
+    NotFoundException,
+    RateLimitException,
+    SandboxException,
+    TimeoutException,
+)
+
+
+def test_maps_400_to_invalid_argument():
+    err = format_envd_api_exception(400, "Bad request")
+    assert isinstance(err, InvalidArgumentException)
+
+
+def test_maps_401_to_authentication():
+    err = format_envd_api_exception(401, "Invalid token")
+    assert isinstance(err, AuthenticationException)
+
+
+def test_maps_404_to_not_found():
+    err = format_envd_api_exception(404, "Not found")
+    assert isinstance(err, NotFoundException)
+
+
+def test_maps_429_to_rate_limit():
+    err = format_envd_api_exception(429, "Too many requests")
+    assert isinstance(err, RateLimitException)
+    assert "rate limited" in str(err)
+
+
+def test_maps_502_to_timeout():
+    err = format_envd_api_exception(502, "Bad gateway")
+    assert isinstance(err, TimeoutException)
+
+
+def test_maps_507_to_not_enough_space():
+    err = format_envd_api_exception(507, "No space left")
+    assert isinstance(err, NotEnoughSpaceException)
+
+
+def test_falls_back_to_sandbox_exception():
+    err = format_envd_api_exception(500, "Internal error")
+    assert isinstance(err, SandboxException)
+    assert "500" in str(err)

--- a/packages/python-sdk/tests/test_envd_rpc_exception.py
+++ b/packages/python-sdk/tests/test_envd_rpc_exception.py
@@ -1,0 +1,47 @@
+from e2b_connect.client import Code, ConnectException
+from e2b.envd.rpc import handle_rpc_exception
+from e2b.exceptions import (
+    AuthenticationException,
+    InvalidArgumentException,
+    NotFoundException,
+    RateLimitException,
+    SandboxException,
+    TimeoutException,
+)
+
+
+def test_maps_invalid_argument():
+    err = handle_rpc_exception(ConnectException(Code.invalid_argument, "bad"))
+    assert isinstance(err, InvalidArgumentException)
+
+
+def test_maps_unauthenticated():
+    err = handle_rpc_exception(ConnectException(Code.unauthenticated, "nope"))
+    assert isinstance(err, AuthenticationException)
+
+
+def test_maps_not_found():
+    err = handle_rpc_exception(ConnectException(Code.not_found, "missing"))
+    assert isinstance(err, NotFoundException)
+
+
+def test_maps_resource_exhausted_to_rate_limit():
+    err = handle_rpc_exception(ConnectException(Code.resource_exhausted, "too many"))
+    assert isinstance(err, RateLimitException)
+    assert "Rate limit" in str(err)
+
+
+def test_maps_unavailable_to_timeout():
+    err = handle_rpc_exception(ConnectException(Code.unavailable, "gone"))
+    assert isinstance(err, TimeoutException)
+
+
+def test_falls_back_to_sandbox_exception():
+    err = handle_rpc_exception(ConnectException(Code.internal, "boom"))
+    assert isinstance(err, SandboxException)
+
+
+def test_returns_original_when_not_connect_exception():
+    original = ValueError("not connect")
+    err = handle_rpc_exception(original)
+    assert err is original


### PR DESCRIPTION
## Summary

The main API client already raised `RateLimitError` (JS) / `RateLimitException` (Python) for HTTP 429, but the lower-level **envd** HTTP and RPC layers fell through to a generic sandbox error, so the same rate-limit condition surfaced as a different type depending on which request path hit it. This maps envd 429 (and the equivalent gRPC `ResourceExhausted` code) to the dedicated rate-limit error consistently across the JS SDK and the Python sync/async SDKs. The JS RPC layer was also missing the `ResourceExhausted` mapping entirely, which is now added for parity with Python.

Also includes a small Python-SDK cleanup: `ConnectionConfig` set `request_timeout` via `_get_request_timeout` and then immediately overwrote it with an inline copy of the same logic — the duplicate block is removed (no behavior change).

## Changes
- `js-sdk/src/envd/api.ts`, `python-sdk/e2b/envd/api.py` — envd HTTP 429 → `RateLimitError`/`RateLimitException`
- `js-sdk/src/envd/rpc.ts` — added gRPC `Code.ResourceExhausted` → `RateLimitError`
- `python-sdk/e2b/connection_config.py` — removed redundant `request_timeout` reassignment
- Added unit tests for both the envd HTTP and RPC error mappers in JS and Python
- Changeset (`e2b`: patch)

## Usage example
```ts
import { Sandbox, RateLimitError } from 'e2b'

try {
  await sandbox.files.write('/tmp/file.txt', 'data')
} catch (err) {
  if (err instanceof RateLimitError) {
    // now reliably caught regardless of which request path was rate limited
  }
}
```

```python
from e2b import RateLimitException

try:
    sandbox.files.write("/tmp/file.txt", "data")
except RateLimitException:
    ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)