### PR TITLE
chore: remove unused dead code across SDK packages

### DIFF
--- a/.changeset/dead-code-cleanup.md
+++ b/.changeset/dead-code-cleanup.md
@@ -1,0 +1,7 @@
+---
+'@e2b/python-sdk': patch
+'@e2b/cli': patch
+'e2b': patch
+---
+
+Remove unused internal code: `wait` helper (js-sdk), `asSandboxTemplate`/`asHeadline`/`selectOption`/`basicDockerfile` (cli), and `format_execution_timeout_error` (python-sdk). No public API changes.

--- a/packages/cli/src/docker/constants.ts
+++ b/packages/cli/src/docker/constants.ts
@@ -1,8 +1,2 @@
 export const defaultDockerfileName = 'e2b.Dockerfile'
 export const fallbackDockerfileName = 'Dockerfile'
-
-export const basicDockerfile = `# You can use most Debian-based base images
-FROM ubuntu:22.04
-
-# Install dependencies and customize sandbox
-`

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -16,11 +16,6 @@ export const configOption = new commander.Option(
   )} in root directory. We recommend using the new build system (https://e2b.dev/docs/template/defining-template) that does not use config files.`
 )
 
-export const selectOption = new commander.Option(
-  '-s, --select',
-  'select multiple sandbox templates from interactive list'
-)
-
 export const selectMultipleOption = new commander.Option(
   '-s, --select',
   'select sandbox template from interactive list'

--- a/packages/cli/src/utils/format.ts
+++ b/packages/cli/src/utils/format.ts
@@ -72,10 +72,6 @@ export function asTimestamp(content: string) {
   return chalk.default.blue(content)
 }
 
-export function asSandboxTemplate(pathInTemplate?: string) {
-  return chalk.default.green(pathInTemplate)
-}
-
 export function asLocal(pathInLocal?: string) {
   return chalk.default.blue(pathInLocal)
 }
@@ -87,10 +83,6 @@ export function asLocalRelative(absolutePathInLocal?: string) {
 
 export function asBuildLogs(content: string) {
   return chalk.default.blueBright(content)
-}
-
-export function asHeadline(content: string) {
-  return chalk.default.underline(asPrimary(asBold(content)))
 }
 
 export function withUnderline(content: string) {

--- a/packages/js-sdk/src/utils.ts
+++ b/packages/js-sdk/src/utils.ts
@@ -103,10 +103,6 @@ export function stripAnsi(text: string): string {
   return text.replace(ansiRegex(), '')
 }
 
-export async function wait(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 /**
  * Convert data to a Blob, avoiding unnecessary conversions when possible.
  */

--- a/packages/python-sdk/e2b/exceptions.py
+++ b/packages/python-sdk/e2b/exceptions.py
@@ -10,12 +10,6 @@ def format_request_timeout_error() -> Exception:
     )
 
 
-def format_execution_timeout_error() -> Exception:
-    return TimeoutException(
-        "Execution timed out — the 'timeout' option can be used to increase this timeout",
-    )
-
-
 class SandboxException(Exception):
     """
     Base class for all sandbox errors.


### PR DESCRIPTION
Removes internal symbols with zero references, found via knip (js-sdk/cli) and vulture (python-sdk) and verified with repo-wide greps: `wait` (js-sdk), `asSandboxTemplate`/`asHeadline`/`selectOption`/`basicDockerfile` (cli), and `format_execution_timeout_error` (python-sdk). No public API changes — only dead, unexported-from-index or unreferenced code is dropped. `format`, `lint`, and `typecheck` pass for all touched packages, and a patch changeset is included for the three published packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)