### PR TITLE
refactor(cli): remove ensureAccessToken from template create

### DIFF
--- a/.changeset/remove-ensureaccesstoken-template-create.md
+++ b/.changeset/remove-ensureaccesstoken-template-create.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Remove `ensureAccessToken` call from `e2b template create`: the command now relies solely on the API key for authentication.

--- a/packages/cli/src/commands/template/create.ts
+++ b/packages/cli/src/commands/template/create.ts
@@ -1,7 +1,7 @@
 import * as boxen from 'boxen'
 import * as commander from 'commander'
 import { defaultBuildLogger, Template, TemplateClass } from 'e2b'
-import { connectionConfig, ensureAccessToken, ensureAPIKey } from 'src/api'
+import { connectionConfig, ensureAPIKey } from 'src/api'
 import {
   defaultDockerfileName,
   fallbackDockerfileName,
@@ -68,8 +68,6 @@ export const createCommand = new commander.Command('create')
       }
     ) => {
       try {
-        // Ensure we have access token
-        ensureAccessToken()
         process.stdout.write('\n')
 
         // Validate template name


### PR DESCRIPTION
## Summary

Removes the `ensureAccessToken()` call (and its now-unused import) from `e2b template create`. The command authenticates solely via the API key (`ensureAPIKey()`), so the access-token check was redundant.

## Changes

- Drop `ensureAccessToken` import and call in `packages/cli/src/commands/template/create.ts`.
- Add a patch changeset for `@e2b/cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)