### PR TITLE
fix(python-sdk): drop envd headers from control-plane connect request

### DIFF
--- a/.changeset/python-connect-no-envd-headers.md
+++ b/.changeset/python-connect-no-envd-headers.md
@@ -1,0 +1,7 @@
+---
+"@e2b/python-sdk": patch
+---
+
+fix(python-sdk): stop sending `E2b-Sandbox-Id`/`E2b-Sandbox-Port` headers on the control-plane `connect` request
+
+`Sandbox.connect` was attaching the envd data-plane headers (`E2b-Sandbox-Id`, `E2b-Sandbox-Port`) to the `POST /sandboxes/{id}/connect` API call. These headers belong only on data-plane (filesystem/commands/pty) requests, matching the JS SDK behavior.

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -419,13 +419,7 @@ class SandboxApi(SandboxBase):
         # Sandbox is not running, resume it
         config = ConnectionConfig(**opts)
 
-        api_client = get_api_client(
-            config,
-            headers={
-                "E2b-Sandbox-Id": sandbox_id,
-                "E2b-Sandbox-Port": str(config.envd_port),
-            },
-        )
+        api_client = get_api_client(config)
         res = await post_sandboxes_sandbox_id_connect.asyncio_detailed(
             sandbox_id,
             client=api_client,

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -323,13 +323,7 @@ class SandboxApi(SandboxBase):
 
         config = ConnectionConfig(**opts)
 
-        api_client = get_api_client(
-            config,
-            headers={
-                "E2b-Sandbox-Id": sandbox_id,
-                "E2b-Sandbox-Port": str(config.envd_port),
-            },
-        )
+        api_client = get_api_client(config)
         res = post_sandboxes_sandbox_id_connect.sync_detailed(
             sandbox_id,
             client=api_client,


### PR DESCRIPTION
`Sandbox.connect` was attaching the data-plane envd headers (`E2b-Sandbox-Id`, `E2b-Sandbox-Port`) to the control-plane `POST /sandboxes/{id}/connect` call in both the sync and async SDKs. These headers belong only on data-plane (filesystem/commands/pty) requests, so this aligns the Python SDK with the JS SDK, which never sends them on the connect call.

## Usage

No API change — `Sandbox.connect(sandbox_id)` (and the async equivalent) behaves the same, just without the spurious headers on the control-plane request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)