### PR TITLE
Remove deprecated Sandbox.betaPause / beta_pause

### DIFF
--- a/.changeset/remove-beta-pause.md
+++ b/.changeset/remove-beta-pause.md
@@ -1,0 +1,20 @@
+---
+'e2b': minor
+'@e2b/python-sdk': minor
+---
+
+Remove `Sandbox.betaPause` (JS) and `Sandbox.beta_pause` (Python). These were deprecated aliases of `pause`. Migrate by calling `pause` instead:
+
+```ts
+// before
+await sandbox.betaPause()
+// after
+await sandbox.pause()
+```
+
+```python
+# before
+sandbox.beta_pause()
+# after
+sandbox.pause()
+```

--- a/packages/cli/src/commands/sandbox/pause.ts
+++ b/packages/cli/src/commands/sandbox/pause.ts
@@ -7,7 +7,7 @@ import { NotFoundError } from 'e2b'
 
 async function pauseSandbox(sandboxID: string, apiKey: string) {
   try {
-    const paused = await e2b.Sandbox.betaPause(sandboxID, { apiKey })
+    const paused = await e2b.Sandbox.pause(sandboxID, { apiKey })
     if (paused) {
       console.log(`Sandbox ${asBold(sandboxID)} has been paused`)
     } else {

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -383,7 +383,7 @@ export class Sandbox extends SandboxApi {
    * @example
    * ```ts
    * const sandbox = await Sandbox.create()
-   * await sandbox.betaPause()
+   * await sandbox.pause()
    *
    * // Connect to the same sandbox.
    * const sameSandbox = await sandbox.connect()
@@ -532,13 +532,6 @@ export class Sandbox extends SandboxApi {
    */
   async pause(opts?: ConnectionOpts): Promise<boolean> {
     return await SandboxApi.pause(this.sandboxId, this.resolveApiOpts(opts))
-  }
-
-  /**
-   * @deprecated Use {@link Sandbox.pause} instead.
-   */
-  async betaPause(opts?: ConnectionOpts): Promise<boolean> {
-    return await SandboxApi.betaPause(this.sandboxId, this.resolveApiOpts(opts))
   }
 
   /**

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -923,16 +923,6 @@ export class SandboxApi {
   }
 
   /**
-   * @deprecated Use {@link SandboxApi.pause} instead.
-   */
-  static async betaPause(
-    sandboxId: string,
-    opts?: SandboxApiOpts
-  ): Promise<boolean> {
-    return this.pause(sandboxId, opts)
-  }
-
-  /**
    * Create a snapshot from a sandbox.
    *
    * The sandbox will be paused while the snapshot is being created.

--- a/packages/js-sdk/tests/api/list.test.ts
+++ b/packages/js-sdk/tests/api/list.test.ts
@@ -65,7 +65,7 @@ sandboxTest.skipIf(isDebug)(
   async ({ sandboxTestId }) => {
     // Create and pause a sandbox
     const extraSbx = await Sandbox.create({ metadata: { sandboxTestId } })
-    await extraSbx.betaPause()
+    await extraSbx.pause()
 
     try {
       const paginator = Sandbox.list({
@@ -125,11 +125,11 @@ sandboxTest.skipIf(isDebug)(
 sandboxTest.skipIf(isDebug)(
   'paginate paused sandboxes',
   async ({ sandbox, sandboxTestId }) => {
-    await sandbox.betaPause()
+    await sandbox.pause()
 
     // Create extra paused sandbox
     const extraSbx = await Sandbox.create({ metadata: { sandboxTestId } })
-    await extraSbx.betaPause()
+    await extraSbx.pause()
 
     try {
       // Test pagination with limit
@@ -168,7 +168,7 @@ sandboxTest.skipIf(isDebug)(
     const extraSbx = await Sandbox.create({ metadata: { sandboxTestId } })
 
     // Pause the extra sandbox
-    await extraSbx.betaPause()
+    await extraSbx.pause()
 
     try {
       // Test pagination with limit
@@ -282,7 +282,7 @@ sandboxTest.skipIf(isDebug)(
   async ({ sandboxTestId }) => {
     // Create and pause a sandbox
     const extraSbx = await Sandbox.create({ metadata: { sandboxTestId } })
-    await Sandbox.betaPause(extraSbx.sandboxId)
+    await Sandbox.pause(extraSbx.sandboxId)
 
     try {
       const paginator = Sandbox.list({
@@ -342,11 +342,11 @@ sandboxTest.skipIf(isDebug)(
 sandboxTest.skipIf(isDebug)(
   'paginate paused sandboxes',
   async ({ sandbox, sandboxTestId }) => {
-    await Sandbox.betaPause(sandbox.sandboxId)
+    await Sandbox.pause(sandbox.sandboxId)
 
     // Create extra paused sandbox
     const extraSbx = await Sandbox.create({ metadata: { sandboxTestId } })
-    await Sandbox.betaPause(extraSbx.sandboxId)
+    await Sandbox.pause(extraSbx.sandboxId)
 
     try {
       // Test pagination with limit
@@ -385,7 +385,7 @@ sandboxTest.skipIf(isDebug)(
     const extraSbx = await Sandbox.create({ metadata: { sandboxTestId } })
 
     // Pause the extra sandbox
-    await Sandbox.betaPause(sandbox.sandboxId)
+    await Sandbox.pause(sandbox.sandboxId)
 
     try {
       // Test pagination with limit

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -644,29 +644,6 @@ class AsyncSandbox(SandboxApi):
         )
 
     @overload
-    async def beta_pause(
-        self,
-        **opts: Unpack[ApiParams],
-    ) -> bool: ...
-
-    @overload
-    @staticmethod
-    async def beta_pause(
-        sandbox_id: str,
-        **opts: Unpack[ApiParams],
-    ) -> bool: ...
-
-    @class_method_variant("_cls_pause")
-    async def beta_pause(
-        self,
-        **opts: Unpack[ApiParams],
-    ) -> bool:
-        """
-        :deprecated: Use `pause()` instead.
-        """
-        return await self.pause(**opts)
-
-    @overload
     async def create_snapshot(
         self,
         name: Optional[str] = None,

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -646,29 +646,6 @@ class Sandbox(SandboxApi):
         )
 
     @overload
-    def beta_pause(
-        self,
-        **opts: Unpack[ApiParams],
-    ) -> bool: ...
-
-    @overload
-    @staticmethod
-    def beta_pause(
-        sandbox_id: str,
-        **opts: Unpack[ApiParams],
-    ) -> bool: ...
-
-    @class_method_variant("_cls_pause")
-    def beta_pause(
-        self,
-        **opts: Unpack[ApiParams],
-    ) -> bool:
-        """
-        :deprecated: Use `pause()` instead.
-        """
-        return self.pause(**opts)
-
-    @overload
     def create_snapshot(
         self,
         name: Optional[str] = None,

--- a/packages/python-sdk/tests/async/api_async/test_sbx_list.py
+++ b/packages/python-sdk/tests/async/api_async/test_sbx_list.py
@@ -47,7 +47,7 @@ async def test_list_running_sandboxes(
 
 @pytest.mark.skip_debug()
 async def test_list_paused_sandboxes(async_sandbox: AsyncSandbox, sandbox_test_id: str):
-    await async_sandbox.beta_pause()
+    await async_sandbox.pause()
 
     paginator = AsyncSandbox.list(
         query=SandboxQuery(
@@ -101,13 +101,13 @@ async def test_paginate_running_sandboxes(sandbox_test_id: str, async_sandbox_fa
 async def test_paginate_paused_sandboxes(
     async_sandbox: AsyncSandbox, sandbox_test_id: str, async_sandbox_factory
 ):
-    await async_sandbox.beta_pause()
+    await async_sandbox.pause()
 
     # create another paused sandbox
     extra_sbx = await async_sandbox_factory(
         metadata={"sandbox_test_id": sandbox_test_id}
     )
-    await extra_sbx.beta_pause()
+    await extra_sbx.pause()
 
     # Test pagination with limit
     paginator = AsyncSandbox.list(
@@ -145,7 +145,7 @@ async def test_paginate_running_and_paused_sandboxes(
     extra_sbx = await async_sandbox_factory(
         metadata={"sandbox_test_id": sandbox_test_id}
     )
-    await extra_sbx.beta_pause()
+    await extra_sbx.pause()
 
     # Test pagination with limit
     paginator = AsyncSandbox.list(

--- a/packages/python-sdk/tests/sync/api_sync/test_sbx_list.py
+++ b/packages/python-sdk/tests/sync/api_sync/test_sbx_list.py
@@ -45,7 +45,7 @@ def test_list_running_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
 
 @pytest.mark.skip_debug()
 def test_list_paused_sandboxes(sandbox: Sandbox, sandbox_test_id: str):
-    sandbox.beta_pause()
+    sandbox.pause()
 
     paginator = Sandbox.list(
         query=SandboxQuery(
@@ -102,11 +102,11 @@ def test_paginate_running_sandboxes(
 def test_paginate_paused_sandboxes(
     sandbox: Sandbox, sandbox_factory, sandbox_test_id: str
 ):
-    sandbox.beta_pause()
+    sandbox.pause()
 
     # create another paused sandbox
     extra_sbx = sandbox_factory(metadata={"sandbox_test_id": sandbox_test_id})
-    extra_sbx.beta_pause()
+    extra_sbx.pause()
 
     # Test pagination with limit
     paginator = Sandbox.list(
@@ -143,7 +143,7 @@ def test_paginate_running_and_paused_sandboxes(
 ):
     # Create extra paused sandbox
     extra_sbx = sandbox_factory(metadata={"sandbox_test_id": sandbox_test_id})
-    extra_sbx.beta_pause()
+    extra_sbx.pause()
 
     # Test pagination with limit
     paginator = Sandbox.list(


### PR DESCRIPTION
Removes the deprecated `Sandbox.betaPause` (JS) and `Sandbox.beta_pause` (Python sync + async) methods, which were just aliases of `pause`. The CLI `pause` command, SDK tests, and doc examples now call `pause` directly, and a `minor` changeset is included for `e2b` and `@e2b/python-sdk`. There was no `betaResume` method — resume is handled via `Sandbox.connect`, which is unchanged.

## Migration

```ts
// before
await sandbox.betaPause()
// after
await sandbox.pause()
```

```python
# before
sandbox.beta_pause()
# after
sandbox.pause()
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)