### PR TITLE
test(sdk): add pty.kill coverage for JS and Python sync/async

### DIFF
--- a/packages/js-sdk/tests/sandbox/pty/kill.test.ts
+++ b/packages/js-sdk/tests/sandbox/pty/kill.test.ts
@@ -1,0 +1,25 @@
+import { sandboxTest } from '../../setup'
+import { assert, expect } from 'vitest'
+import { ProcessExitError } from '../../../src/index.js'
+
+sandboxTest('kill PTY', async ({ sandbox }) => {
+  const terminal = await sandbox.pty.create({
+    cols: 80,
+    rows: 24,
+    onData: () => {},
+  })
+
+  const result = await sandbox.pty.kill(terminal.pid)
+  assert.isTrue(result)
+
+  // The PTY process should no longer be running.
+  await expect(
+    sandbox.commands.run(`kill -0 ${terminal.pid}`)
+  ).rejects.toThrowError(ProcessExitError)
+})
+
+sandboxTest('kill non-existing PTY', async ({ sandbox }) => {
+  const nonExistingPid = 999999
+
+  await expect(sandbox.pty.kill(nonExistingPid)).resolves.toBe(false)
+})

--- a/packages/python-sdk/tests/async/sandbox_async/pty/test_pty_kill.py
+++ b/packages/python-sdk/tests/async/sandbox_async/pty/test_pty_kill.py
@@ -5,7 +5,7 @@ from e2b.sandbox.commands.command_handle import PtySize
 
 
 async def test_kill_pty(async_sandbox: AsyncSandbox):
-    terminal = await async_sandbox.pty.create(PtySize(80, 24))
+    terminal = await async_sandbox.pty.create(PtySize(80, 24), on_data=lambda _: None)
 
     assert await async_sandbox.pty.kill(terminal.pid)
 

--- a/packages/python-sdk/tests/async/sandbox_async/pty/test_pty_kill.py
+++ b/packages/python-sdk/tests/async/sandbox_async/pty/test_pty_kill.py
@@ -1,0 +1,20 @@
+import pytest
+
+from e2b import AsyncSandbox, CommandExitException
+from e2b.sandbox.commands.command_handle import PtySize
+
+
+async def test_kill_pty(async_sandbox: AsyncSandbox):
+    terminal = await async_sandbox.pty.create(PtySize(80, 24))
+
+    assert await async_sandbox.pty.kill(terminal.pid)
+
+    # The PTY process should no longer be running.
+    with pytest.raises(CommandExitException):
+        await async_sandbox.commands.run(f"kill -0 {terminal.pid}")
+
+
+async def test_kill_non_existing_pty(async_sandbox: AsyncSandbox):
+    non_existing_pid = 999999
+
+    assert not await async_sandbox.pty.kill(non_existing_pid)

--- a/packages/python-sdk/tests/sync/sandbox_sync/pty/test_pty_kill.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/pty/test_pty_kill.py
@@ -1,0 +1,20 @@
+import pytest
+
+from e2b import Sandbox, CommandExitException
+from e2b.sandbox.commands.command_handle import PtySize
+
+
+def test_kill_pty(sandbox: Sandbox):
+    terminal = sandbox.pty.create(PtySize(80, 24))
+
+    assert sandbox.pty.kill(terminal.pid)
+
+    # The PTY process should no longer be running.
+    with pytest.raises(CommandExitException):
+        sandbox.commands.run(f"kill -0 {terminal.pid}")
+
+
+def test_kill_non_existing_pty(sandbox: Sandbox):
+    non_existing_pid = 999999
+
+    assert not sandbox.pty.kill(non_existing_pid)


### PR DESCRIPTION
Adds the previously-missing test coverage for `pty.kill()`, which was untested across all three SDK implementations despite the rest of the PTY API (create/connect/sendInput/resize) being well covered.

Each suite gets two tests covering both return paths of `kill()`:
- **Kill a live PTY** — asserts `kill()` returns `true`, then confirms the process is gone via `kill -0 <pid>` (throws `ProcessExitError`/`CommandExitException`).
- **Kill a non-existent PID** — asserts `kill()` returns `false`, matching the documented not-found behavior.

The tests mirror the style of the existing `commands.kill` tests and were verified to lint cleanly and be discovered by vitest/pytest (full runs require a live sandbox).

## Files
- `packages/js-sdk/tests/sandbox/pty/kill.test.ts`
- `packages/python-sdk/tests/sync/sandbox_sync/pty/test_pty_kill.py`
- `packages/python-sdk/tests/async/sandbox_async/pty/test_pty_kill.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)