### PR TITLE
Add sandbox create timeout option

### DIFF
--- a/.changeset/cli-create-timeout.md
+++ b/.changeset/cli-create-timeout.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Add `--timeout` support to `e2b sandbox create`.

--- a/packages/cli/src/commands/sandbox/create.ts
+++ b/packages/cli/src/commands/sandbox/create.ts
@@ -11,6 +11,8 @@ import fs from 'fs'
 import { configOption, pathOption } from '../../options'
 import { printDashboardSandboxInspectUrl } from 'src/utils/urls'
 
+const MIN_TIMEOUT_MS = 30_000
+
 export function createCommand(
   name: string,
   alias: string,
@@ -25,6 +27,7 @@ export function createCommand(
     .addOption(pathOption)
     .addOption(configOption)
     .option('-d, --detach', 'create sandbox without connecting terminal to it')
+    .option('--timeout <seconds>', 'sandbox timeout in seconds', parseTimeout)
     .alias(alias)
     .action(
       async (
@@ -34,6 +37,7 @@ export function createCommand(
           path?: string
           config?: string
           detach?: boolean
+          timeout?: number
         }
       ) => {
         if (deprecated) {
@@ -72,11 +76,19 @@ export function createCommand(
             templateID = 'base'
           }
 
-          const sandbox = await e2b.Sandbox.create(templateID, { apiKey })
+          const sandboxOpts = {
+            apiKey,
+            ...(opts.timeout !== undefined ? { timeoutMs: opts.timeout } : {}),
+          }
+          const sandbox = await e2b.Sandbox.create(templateID, sandboxOpts)
           printDashboardSandboxInspectUrl(sandbox.sandboxId)
 
           if (!opts.detach) {
-            await connectSandbox({ sandbox, template: { templateID } })
+            await connectSandbox({
+              sandbox,
+              template: { templateID },
+              timeoutMs: opts.timeout,
+            })
           } else {
             console.log(
               `Sandbox created with ID ${sandbox.sandboxId} using template ${templateID}`
@@ -91,17 +103,36 @@ export function createCommand(
     )
 }
 
+function parseTimeout(timeoutRaw: string): number {
+  const timeoutSeconds = Number(timeoutRaw)
+  const timeoutMs = Math.floor(timeoutSeconds * 1000)
+  if (
+    !Number.isFinite(timeoutSeconds) ||
+    timeoutSeconds <= 0 ||
+    timeoutMs < MIN_TIMEOUT_MS
+  ) {
+    throw new commander.InvalidArgumentError(
+      '--timeout must be at least 30 seconds'
+    )
+  }
+
+  return timeoutMs
+}
+
 export async function connectSandbox({
   sandbox,
   template,
+  timeoutMs,
 }: {
   sandbox: e2b.Sandbox
   template: Pick<e2b.components['schemas']['Template'], 'templateID'>
+  timeoutMs?: number
 }) {
   // keep-alive loop — track the in-flight promise so we can await it on shutdown
   let pendingKeepAlive: Promise<void> = Promise.resolve()
+  const keepAliveTimeoutMs = timeoutMs ?? 30_000
   const intervalId = setInterval(() => {
-    pendingKeepAlive = sandbox.setTimeout(30_000)
+    pendingKeepAlive = sandbox.setTimeout(keepAliveTimeoutMs)
   }, 5_000)
 
   console.log(
@@ -114,7 +145,7 @@ export async function connectSandbox({
   } finally {
     clearInterval(intervalId)
     await pendingKeepAlive.catch(() => {})
-    await sandbox.setTimeout(1_000)
+    await sandbox.setTimeout(timeoutMs ?? 1_000)
     console.log(
       `Closing terminal connection to template ${asFormattedSandboxTemplate(
         template

--- a/packages/cli/tests/commands/sandbox/create_timeout.test.ts
+++ b/packages/cli/tests/commands/sandbox/create_timeout.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const create = vi.fn()
+  const ensureAPIKey = vi.fn(() => 'test-api-key')
+  const spawnConnectedTerminal = vi.fn()
+
+  return {
+    create,
+    ensureAPIKey,
+    spawnConnectedTerminal,
+  }
+})
+
+vi.mock('e2b', () => ({
+  Sandbox: {
+    create: mocks.create,
+  },
+}))
+
+vi.mock('../../../src/api', () => ({
+  ensureAPIKey: mocks.ensureAPIKey,
+}))
+
+vi.mock('src/utils/urls', () => ({
+  printDashboardSandboxInspectUrl: vi.fn(),
+}))
+
+vi.mock('src/terminal', () => ({
+  spawnConnectedTerminal: mocks.spawnConnectedTerminal,
+}))
+
+describe('sandbox create timeout option', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    mocks.create.mockResolvedValue({
+      sandboxId: 'sandbox-id',
+      setTimeout: vi.fn().mockResolvedValue(undefined),
+    })
+    mocks.spawnConnectedTerminal.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('passes timeout seconds to Sandbox.create as milliseconds', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never)
+
+    const { createCommand } = await import(
+      '../../../src/commands/sandbox/create'
+    )
+    await createCommand('create', 'cr', false).parseAsync(
+      ['base', '--detach', '--timeout', '120'],
+      { from: 'user' }
+    )
+
+    expect(mocks.create).toHaveBeenCalledWith('base', {
+      apiKey: 'test-api-key',
+      timeoutMs: 120_000,
+    })
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  })
+
+  test('preserves explicit timeout after attached terminal closes', async () => {
+    vi.useFakeTimers()
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never)
+    const sandbox = {
+      sandboxId: 'sandbox-id',
+      setTimeout: vi.fn().mockResolvedValue(undefined),
+    }
+    mocks.create.mockResolvedValue(sandbox)
+
+    const { createCommand } = await import(
+      '../../../src/commands/sandbox/create'
+    )
+    await createCommand('create', 'cr', false).parseAsync(
+      ['base', '--timeout', '120'],
+      { from: 'user' }
+    )
+
+    expect(mocks.spawnConnectedTerminal).toHaveBeenCalledWith(sandbox)
+    expect(sandbox.setTimeout).toHaveBeenCalledWith(120_000)
+    expect(sandbox.setTimeout).not.toHaveBeenCalledWith(1_000)
+    expect(exitSpy).toHaveBeenCalledWith(0)
+    vi.useRealTimers()
+  })
+
+  test('rejects zero timeout before creating sandbox', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never)
+
+    const { createCommand } = await import(
+      '../../../src/commands/sandbox/create'
+    )
+    await expect(
+      createCommand('create', 'cr', false).parseAsync(
+        ['base', '--detach', '--timeout', '0'],
+        { from: 'user' }
+      )
+    ).rejects.toThrow('--timeout must be at least 30 seconds')
+
+    expect(mocks.create).not.toHaveBeenCalled()
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  test('rejects timeout values shorter than the keep-alive interval', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never)
+
+    const { createCommand } = await import(
+      '../../../src/commands/sandbox/create'
+    )
+    await expect(
+      createCommand('create', 'cr', false).parseAsync(
+        ['base', '--detach', '--timeout', '29.999'],
+        { from: 'user' }
+      )
+    ).rejects.toThrow('--timeout must be at least 30 seconds')
+
+    expect(mocks.create).not.toHaveBeenCalled()
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `--timeout <seconds>` to `e2b sandbox create` and forwards it to `Sandbox.create` as `timeoutMs`.

For attached sandbox sessions, the explicit timeout is also used by the keep-alive loop and preserved when the terminal closes, instead of being overwritten by the default short cleanup timeout.

## Usage

```bash
e2b sandbox create base --timeout 120
```

```bash
e2b sandbox create base --detach --timeout 120
```

Timeout values must be at least 30 seconds so attached sessions cannot expire before the keep-alive loop refreshes them.

## Tests

- `pnpm --filter @e2b/cli test -- commands/sandbox/create_timeout.test.ts`
- `pnpm --filter @e2b/cli test -- commands/sandbox`
- `pnpm --filter @e2b/cli typecheck`
- `pnpm --filter @e2b/cli lint`
