### PR TITLE
Add sandbox create lifecycle flags

### DIFF
--- a/.changeset/cli-create-lifecycle-flags.md
+++ b/.changeset/cli-create-lifecycle-flags.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Add `--ontimeout` and `--autoresume` support to `e2b sandbox create`.

--- a/packages/cli/src/commands/sandbox/create.ts
+++ b/packages/cli/src/commands/sandbox/create.ts
@@ -13,6 +13,11 @@ import { printDashboardSandboxInspectUrl } from 'src/utils/urls'
 
 const MIN_TIMEOUT_MS = 30_000
 
+type SandboxLifecycle = {
+  onTimeout: 'pause' | 'kill'
+  autoResume?: boolean
+}
+
 export function createCommand(
   name: string,
   alias: string,
@@ -27,6 +32,15 @@ export function createCommand(
     .addOption(pathOption)
     .addOption(configOption)
     .option('-d, --detach', 'create sandbox without connecting terminal to it')
+    .option(
+      '--ontimeout <action>',
+      'action when sandbox timeout is reached: pause or kill',
+      parseOnTimeout
+    )
+    .option(
+      '--autoresume',
+      'enable sandbox auto-resume, requires --ontimeout pause'
+    )
     .option('--timeout <seconds>', 'sandbox timeout in seconds', parseTimeout)
     .alias(alias)
     .action(
@@ -37,6 +51,8 @@ export function createCommand(
           path?: string
           config?: string
           detach?: boolean
+          ontimeout?: SandboxLifecycle['onTimeout']
+          autoresume?: boolean
           timeout?: number
         }
       ) => {
@@ -76,8 +92,10 @@ export function createCommand(
             templateID = 'base'
           }
 
+          const lifecycle = buildLifecycle(opts.ontimeout, opts.autoresume)
           const sandboxOpts = {
             apiKey,
+            ...(lifecycle ? { lifecycle } : {}),
             ...(opts.timeout !== undefined ? { timeoutMs: opts.timeout } : {}),
           }
           const sandbox = await e2b.Sandbox.create(templateID, sandboxOpts)
@@ -117,6 +135,45 @@ function parseTimeout(timeoutRaw: string): number {
   }
 
   return timeoutMs
+}
+
+function parseOnTimeout(onTimeout: string): SandboxLifecycle['onTimeout'] {
+  if (onTimeout !== 'pause' && onTimeout !== 'kill') {
+    throw new commander.InvalidArgumentError(
+      '--ontimeout must be "pause" or "kill"'
+    )
+  }
+
+  return onTimeout
+}
+
+function buildLifecycle(
+  onTimeout: SandboxLifecycle['onTimeout'] | undefined,
+  autoResume: boolean | undefined
+): SandboxLifecycle | undefined {
+  if (!onTimeout && !autoResume) {
+    return undefined
+  }
+
+  if (autoResume && !onTimeout) {
+    throw new commander.InvalidArgumentError(
+      '--ontimeout is required when using --autoresume'
+    )
+  }
+
+  if (autoResume && onTimeout !== 'pause') {
+    throw new commander.InvalidArgumentError(
+      '--autoresume requires --ontimeout pause'
+    )
+  }
+
+  if (!onTimeout) {
+    throw new commander.InvalidArgumentError(
+      '--ontimeout is required when using --autoresume'
+    )
+  }
+
+  return { onTimeout, ...(autoResume ? { autoResume: true } : {}) }
 }
 
 export async function connectSandbox({

--- a/packages/cli/tests/commands/sandbox/create_lifecycle.test.ts
+++ b/packages/cli/tests/commands/sandbox/create_lifecycle.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const create = vi.fn()
+  const ensureAPIKey = vi.fn(() => 'test-api-key')
+  const spawnConnectedTerminal = vi.fn()
+
+  return {
+    create,
+    ensureAPIKey,
+    spawnConnectedTerminal,
+  }
+})
+
+vi.mock('e2b', () => ({
+  Sandbox: {
+    create: mocks.create,
+  },
+}))
+
+vi.mock('../../../src/api', () => ({
+  ensureAPIKey: mocks.ensureAPIKey,
+}))
+
+vi.mock('src/utils/urls', () => ({
+  printDashboardSandboxInspectUrl: vi.fn(),
+}))
+
+vi.mock('src/terminal', () => ({
+  spawnConnectedTerminal: mocks.spawnConnectedTerminal,
+}))
+
+describe('sandbox create lifecycle options', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    mocks.create.mockResolvedValue({
+      sandboxId: 'sandbox-id',
+      setTimeout: vi.fn().mockResolvedValue(undefined),
+    })
+    mocks.spawnConnectedTerminal.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('passes ontimeout and autoresume to Sandbox.create', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never)
+
+    const { createCommand } = await import(
+      '../../../src/commands/sandbox/create'
+    )
+    await createCommand('create', 'cr', false).parseAsync(
+      ['base', '--detach', '--ontimeout', 'pause', '--autoresume'],
+      { from: 'user' }
+    )
+
+    expect(mocks.create).toHaveBeenCalledWith('base', {
+      apiKey: 'test-api-key',
+      lifecycle: {
+        onTimeout: 'pause',
+        autoResume: true,
+      },
+    })
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  })
+
+  test('passes ontimeout without autoresume to Sandbox.create', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never)
+
+    const { createCommand } = await import(
+      '../../../src/commands/sandbox/create'
+    )
+    await createCommand('create', 'cr', false).parseAsync(
+      ['base', '--detach', '--ontimeout', 'kill'],
+      { from: 'user' }
+    )
+
+    expect(mocks.create).toHaveBeenCalledWith('base', {
+      apiKey: 'test-api-key',
+      lifecycle: {
+        onTimeout: 'kill',
+      },
+    })
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  })
+
+  test('rejects autoresume without pause on timeout', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never)
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { createCommand } = await import(
+      '../../../src/commands/sandbox/create'
+    )
+    await createCommand('create', 'cr', false).parseAsync(
+      ['base', '--detach', '--ontimeout', 'kill', '--autoresume'],
+      { from: 'user' }
+    )
+
+    expect(mocks.create).not.toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: '--autoresume requires --ontimeout pause',
+      })
+    )
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  test('rejects autoresume without ontimeout', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never)
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { createCommand } = await import(
+      '../../../src/commands/sandbox/create'
+    )
+    await createCommand('create', 'cr', false).parseAsync(
+      ['base', '--detach', '--autoresume'],
+      { from: 'user' }
+    )
+
+    expect(mocks.create).not.toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: '--ontimeout is required when using --autoresume',
+      })
+    )
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  test('rejects invalid ontimeout option', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never)
+
+    const { createCommand } = await import(
+      '../../../src/commands/sandbox/create'
+    )
+    await expect(
+      createCommand('create', 'cr', false).parseAsync(
+        ['base', '--detach', '--ontimeout', 'hibernate'],
+        { from: 'user' }
+      )
+    ).rejects.toThrow('--ontimeout must be "pause" or "kill"')
+
+    expect(mocks.create).not.toHaveBeenCalled()
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+})


### PR DESCRIPTION
## Summary

Adds flattened lifecycle flags to `e2b sandbox create`:

- `--ontimeout <pause|kill>`
- `--autoresume`

This replaces the JSON-shaped lifecycle flag approach with CLI-native options.

## Usage

```bash
e2b sandbox create base --ontimeout pause --autoresume
```

```bash
e2b sandbox create base --detach --ontimeout kill
```

`--autoresume` requires `--ontimeout pause`.

## Stack

This PR is stacked on #1415 (`cli-create-timeout`) so the timeout and lifecycle changes can be reviewed separately.

## Tests

- `pnpm --filter @e2b/cli test -- commands/sandbox/create_lifecycle.test.ts`
- `pnpm --filter @e2b/cli test -- commands/sandbox/create_timeout.test.ts commands/sandbox/create_lifecycle.test.ts`
- `pnpm --filter @e2b/cli test -- commands/sandbox`
- `pnpm --filter @e2b/cli typecheck`
- `pnpm --filter @e2b/cli lint`
