### PR TITLE
Fix/python sync thread local envd

### DIFF
--- a/.changeset/sharp-threads-share.md
+++ b/.changeset/sharp-threads-share.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Keep sync sandbox envd clients thread-local when a sandbox object is used from worker threads.

--- a/packages/python-sdk/e2b/sandbox_sync/commands/command.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/command.py
@@ -36,13 +36,18 @@ class Commands:
         self._connection_config = connection_config
         self._envd_version = envd_version
         self._thread_local = threading.local()
-        self._thread_local.rpc = process_connect.ProcessClient(
-            envd_api_url,
+        self._thread_local.rpc = self._create_rpc(pool)
+
+    def _create_rpc(
+        self, pool: httpcore.ConnectionPool
+    ) -> process_connect.ProcessClient:
+        return process_connect.ProcessClient(
+            self._envd_api_url,
             # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
             # compressor=e2b_connect.GzipCompressor,
             pool=pool,
             json=True,
-            headers=connection_config.sandbox_headers,
+            headers=self._connection_config.sandbox_headers,
         )
 
     @property
@@ -50,14 +55,7 @@ class Commands:
         rpc = getattr(self._thread_local, "rpc", None)
         if rpc is None:
             transport = get_envd_transport(self._connection_config)
-            rpc = process_connect.ProcessClient(
-                self._envd_api_url,
-                # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
-                # compressor=e2b_connect.GzipCompressor,
-                pool=transport.pool,
-                json=True,
-                headers=self._connection_config.sandbox_headers,
-            )
+            rpc = self._create_rpc(transport.pool)
             self._thread_local.rpc = rpc
         return rpc
 

--- a/packages/python-sdk/e2b/sandbox_sync/commands/command.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/command.py
@@ -1,8 +1,10 @@
+import threading
 from typing import Callable, Dict, List, Literal, Optional, Union, overload
 
 import e2b_connect
 import httpcore
 from packaging.version import Version
+from e2b.api.client_sync import get_envd_transport
 from e2b.connection_config import (
     ConnectionConfig,
     Username,
@@ -30,9 +32,11 @@ class Commands:
         pool: httpcore.ConnectionPool,
         envd_version: Version,
     ) -> None:
+        self._envd_api_url = envd_api_url
         self._connection_config = connection_config
         self._envd_version = envd_version
-        self._rpc = process_connect.ProcessClient(
+        self._thread_local = threading.local()
+        self._thread_local.rpc = process_connect.ProcessClient(
             envd_api_url,
             # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
             # compressor=e2b_connect.GzipCompressor,
@@ -40,6 +44,22 @@ class Commands:
             json=True,
             headers=connection_config.sandbox_headers,
         )
+
+    @property
+    def _rpc(self) -> process_connect.ProcessClient:
+        rpc = getattr(self._thread_local, "rpc", None)
+        if rpc is None:
+            transport = get_envd_transport(self._connection_config)
+            rpc = process_connect.ProcessClient(
+                self._envd_api_url,
+                # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
+                # compressor=e2b_connect.GzipCompressor,
+                pool=transport.pool,
+                json=True,
+                headers=self._connection_config.sandbox_headers,
+            )
+            self._thread_local.rpc = rpc
+        return rpc
 
     def list(
         self,

--- a/packages/python-sdk/e2b/sandbox_sync/commands/pty.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/pty.py
@@ -35,13 +35,18 @@ class Pty:
         self._connection_config = connection_config
         self._envd_version = envd_version
         self._thread_local = threading.local()
-        self._thread_local.rpc = process_connect.ProcessClient(
-            envd_api_url,
+        self._thread_local.rpc = self._create_rpc(pool)
+
+    def _create_rpc(
+        self, pool: httpcore.ConnectionPool
+    ) -> process_connect.ProcessClient:
+        return process_connect.ProcessClient(
+            self._envd_api_url,
             # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
             # compressor=e2b_connect.GzipCompressor,
             pool=pool,
             json=True,
-            headers=connection_config.sandbox_headers,
+            headers=self._connection_config.sandbox_headers,
         )
 
     @property
@@ -49,14 +54,7 @@ class Pty:
         rpc = getattr(self._thread_local, "rpc", None)
         if rpc is None:
             transport = get_envd_transport(self._connection_config)
-            rpc = process_connect.ProcessClient(
-                self._envd_api_url,
-                # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
-                # compressor=e2b_connect.GzipCompressor,
-                pool=transport.pool,
-                json=True,
-                headers=self._connection_config.sandbox_headers,
-            )
+            rpc = self._create_rpc(transport.pool)
             self._thread_local.rpc = rpc
         return rpc
 

--- a/packages/python-sdk/e2b/sandbox_sync/commands/pty.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/pty.py
@@ -1,9 +1,11 @@
 import e2b_connect
 import httpcore
+import threading
 
 from typing import Dict, Optional
 
 from packaging.version import Version
+from e2b.api.client_sync import get_envd_transport
 from e2b.envd.process import process_connect, process_pb2
 from e2b.connection_config import (
     Username,
@@ -29,9 +31,11 @@ class Pty:
         pool: httpcore.ConnectionPool,
         envd_version: Version,
     ) -> None:
+        self._envd_api_url = envd_api_url
         self._connection_config = connection_config
         self._envd_version = envd_version
-        self._rpc = process_connect.ProcessClient(
+        self._thread_local = threading.local()
+        self._thread_local.rpc = process_connect.ProcessClient(
             envd_api_url,
             # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
             # compressor=e2b_connect.GzipCompressor,
@@ -39,6 +43,22 @@ class Pty:
             json=True,
             headers=connection_config.sandbox_headers,
         )
+
+    @property
+    def _rpc(self) -> process_connect.ProcessClient:
+        rpc = getattr(self._thread_local, "rpc", None)
+        if rpc is None:
+            transport = get_envd_transport(self._connection_config)
+            rpc = process_connect.ProcessClient(
+                self._envd_api_url,
+                # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
+                # compressor=e2b_connect.GzipCompressor,
+                pool=transport.pool,
+                json=True,
+                headers=self._connection_config.sandbox_headers,
+            )
+            self._thread_local.rpc = rpc
+        return rpc
 
     def kill(
         self,

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -610,4 +610,4 @@ class Filesystem:
         except Exception as e:
             raise _handle_filesystem_rpc_exception(e)
 
-        return WatchHandle(self._rpc, r.watcher_id)
+        return WatchHandle(lambda: self._rpc, r.watcher_id)

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -1,3 +1,4 @@
+import threading
 from typing import IO, Dict, Iterator, List, Literal, Optional, Union, overload
 
 import httpcore
@@ -5,6 +6,7 @@ import httpx
 from packaging.version import Version
 
 import e2b_connect
+from e2b.api.client_sync import get_envd_transport
 from e2b.connection_config import (
     KEEPALIVE_PING_HEADER,
     KEEPALIVE_PING_INTERVAL_SEC,
@@ -77,10 +79,10 @@ class Filesystem:
         self._envd_api_url = envd_api_url
         self._envd_version = envd_version
         self._connection_config = connection_config
-        self._pool = pool
-        self._envd_api = envd_api
+        self._thread_local = threading.local()
+        self._thread_local.envd_api = envd_api
 
-        self._rpc = filesystem_connect.FilesystemClient(
+        self._thread_local.rpc = filesystem_connect.FilesystemClient(
             envd_api_url,
             # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
             # compressor=e2b_connect.GzipCompressor,
@@ -88,6 +90,35 @@ class Filesystem:
             json=True,
             headers=connection_config.sandbox_headers,
         )
+
+    @property
+    def _envd_api(self) -> httpx.Client:
+        envd_api = getattr(self._thread_local, "envd_api", None)
+        if envd_api is None:
+            transport = get_envd_transport(self._connection_config)
+            envd_api = httpx.Client(
+                base_url=self._envd_api_url,
+                transport=transport,
+                headers=self._connection_config.sandbox_headers,
+            )
+            self._thread_local.envd_api = envd_api
+        return envd_api
+
+    @property
+    def _rpc(self) -> filesystem_connect.FilesystemClient:
+        rpc = getattr(self._thread_local, "rpc", None)
+        if rpc is None:
+            transport = get_envd_transport(self._connection_config)
+            rpc = filesystem_connect.FilesystemClient(
+                self._envd_api_url,
+                # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
+                # compressor=e2b_connect.GzipCompressor,
+                pool=transport.pool,
+                json=True,
+                headers=self._connection_config.sandbox_headers,
+            )
+            self._thread_local.rpc = rpc
+        return rpc
 
     @overload
     def read(

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -81,26 +81,33 @@ class Filesystem:
         self._connection_config = connection_config
         self._thread_local = threading.local()
         self._thread_local.envd_api = envd_api
+        self._thread_local.rpc = self._create_rpc(pool)
 
-        self._thread_local.rpc = filesystem_connect.FilesystemClient(
-            envd_api_url,
+    def _create_envd_api(self) -> httpx.Client:
+        transport = get_envd_transport(self._connection_config)
+        return httpx.Client(
+            base_url=self._envd_api_url,
+            transport=transport,
+            headers=self._connection_config.sandbox_headers,
+        )
+
+    def _create_rpc(
+        self, pool: httpcore.ConnectionPool
+    ) -> filesystem_connect.FilesystemClient:
+        return filesystem_connect.FilesystemClient(
+            self._envd_api_url,
             # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
             # compressor=e2b_connect.GzipCompressor,
             pool=pool,
             json=True,
-            headers=connection_config.sandbox_headers,
+            headers=self._connection_config.sandbox_headers,
         )
 
     @property
     def _envd_api(self) -> httpx.Client:
         envd_api = getattr(self._thread_local, "envd_api", None)
         if envd_api is None:
-            transport = get_envd_transport(self._connection_config)
-            envd_api = httpx.Client(
-                base_url=self._envd_api_url,
-                transport=transport,
-                headers=self._connection_config.sandbox_headers,
-            )
+            envd_api = self._create_envd_api()
             self._thread_local.envd_api = envd_api
         return envd_api
 
@@ -109,14 +116,7 @@ class Filesystem:
         rpc = getattr(self._thread_local, "rpc", None)
         if rpc is None:
             transport = get_envd_transport(self._connection_config)
-            rpc = filesystem_connect.FilesystemClient(
-                self._envd_api_url,
-                # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
-                # compressor=e2b_connect.GzipCompressor,
-                pool=transport.pool,
-                json=True,
-                headers=self._connection_config.sandbox_headers,
-            )
+            rpc = self._create_rpc(transport.pool)
             self._thread_local.rpc = rpc
         return rpc
 

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/watch_handle.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/watch_handle.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Callable, List
 
 from e2b import SandboxException
 from e2b.envd.filesystem import filesystem_connect
@@ -21,10 +21,10 @@ class WatchHandle:
 
     def __init__(
         self,
-        rpc: filesystem_connect.FilesystemClient,
+        get_rpc: Callable[[], filesystem_connect.FilesystemClient],
         watcher_id: str,
     ):
-        self._rpc = rpc
+        self._get_rpc = get_rpc
         self._watcher_id = watcher_id
         self._closed = False
 
@@ -34,7 +34,9 @@ class WatchHandle:
         After you stop the watcher you won't be able to get the events anymore.
         """
         try:
-            self._rpc.remove_watcher(RemoveWatcherRequest(watcher_id=self._watcher_id))
+            self._get_rpc().remove_watcher(
+                RemoveWatcherRequest(watcher_id=self._watcher_id)
+            )
         except Exception as e:
             raise handle_rpc_exception(e)
 
@@ -50,7 +52,7 @@ class WatchHandle:
             raise SandboxException("The watcher is already stopped")
 
         try:
-            r = self._rpc.get_watcher_events(
+            r = self._get_rpc().get_watcher_events(
                 GetWatcherEventsRequest(watcher_id=self._watcher_id)
             )
         except Exception as e:

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -102,31 +102,31 @@ class Sandbox(SandboxApi):
         """
         super().__init__(**opts)
 
-        self._transport = get_transport(self.connection_config)
+        transport = get_transport(self.connection_config)
         self._envd_api_thread_local = threading.local()
 
         self._envd_api_thread_local.envd_api = httpx.Client(
             base_url=self.envd_api_url,
-            transport=self._transport,
+            transport=transport,
             headers=self.connection_config.sandbox_headers,
         )
         self._filesystem = Filesystem(
             self.envd_api_url,
             self._envd_version,
             self.connection_config,
-            self._transport.pool,
+            transport.pool,
             self._envd_api,
         )
         self._commands = Commands(
             self.envd_api_url,
             self.connection_config,
-            self._transport.pool,
+            transport.pool,
             self._envd_version,
         )
         self._pty = Pty(
             self.envd_api_url,
             self.connection_config,
-            self._transport.pool,
+            transport.pool,
             self._envd_version,
         )
         self._git = Git(self._commands)

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -105,11 +105,7 @@ class Sandbox(SandboxApi):
         transport = get_transport(self.connection_config)
         self._envd_api_thread_local = threading.local()
 
-        self._envd_api_thread_local.envd_api = httpx.Client(
-            base_url=self.envd_api_url,
-            transport=transport,
-            headers=self.connection_config.sandbox_headers,
-        )
+        self._envd_api_thread_local.envd_api = self._create_envd_api(transport)
         self._filesystem = Filesystem(
             self.envd_api_url,
             self._envd_version,
@@ -131,15 +127,18 @@ class Sandbox(SandboxApi):
         )
         self._git = Git(self._commands)
 
+    def _create_envd_api(self, transport) -> httpx.Client:
+        return httpx.Client(
+            base_url=self.envd_api_url,
+            transport=transport,
+            headers=self.connection_config.sandbox_headers,
+        )
+
     @property
     def _envd_api(self) -> httpx.Client:
         envd_api = getattr(self._envd_api_thread_local, "envd_api", None)
         if envd_api is None:
-            envd_api = httpx.Client(
-                base_url=self.envd_api_url,
-                transport=get_transport(self.connection_config),
-                headers=self.connection_config.sandbox_headers,
-            )
+            envd_api = self._create_envd_api(get_transport(self.connection_config))
             self._envd_api_thread_local.envd_api = envd_api
         return envd_api
 

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import logging
 import shlex
+import threading
 import uuid
 from typing import Dict, List, Optional, Union, overload
 
@@ -102,8 +103,9 @@ class Sandbox(SandboxApi):
         super().__init__(**opts)
 
         self._transport = get_transport(self.connection_config)
+        self._envd_api_thread_local = threading.local()
 
-        self._envd_api = httpx.Client(
+        self._envd_api_thread_local.envd_api = httpx.Client(
             base_url=self.envd_api_url,
             transport=self._transport,
             headers=self.connection_config.sandbox_headers,
@@ -128,6 +130,18 @@ class Sandbox(SandboxApi):
             self._envd_version,
         )
         self._git = Git(self._commands)
+
+    @property
+    def _envd_api(self) -> httpx.Client:
+        envd_api = getattr(self._envd_api_thread_local, "envd_api", None)
+        if envd_api is None:
+            envd_api = httpx.Client(
+                base_url=self.envd_api_url,
+                transport=get_transport(self.connection_config),
+                headers=self.connection_config.sandbox_headers,
+            )
+            self._envd_api_thread_local.envd_api = envd_api
+        return envd_api
 
     def is_running(self, request_timeout: Optional[float] = None) -> bool:
         """

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_thread_local_clients.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_thread_local_clients.py
@@ -1,0 +1,162 @@
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+from packaging.version import Version
+
+from e2b.connection_config import ConnectionConfig
+from e2b.sandbox_sync.commands.command import Commands
+from e2b.sandbox_sync.commands.pty import Pty
+from e2b.sandbox_sync.filesystem import filesystem as filesystem_sync
+from e2b.sandbox_sync.filesystem.filesystem import Filesystem
+import e2b.sandbox_sync.commands.command as command_sync
+import e2b.sandbox_sync.commands.pty as pty_sync
+import e2b.sandbox_sync.main as sandbox_sync_main
+
+
+ENVD_API_URL = "https://sandbox.e2b.app"
+ENVD_VERSION = Version("0.6.2")
+
+
+def run_in_worker_thread(fn):
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(fn).result()
+
+
+def fake_transport():
+    return SimpleNamespace(pool=object())
+
+
+def test_sync_sandbox_envd_api_is_bound_per_calling_thread(monkeypatch, test_api_key):
+    config = ConnectionConfig(api_key=test_api_key)
+    main_transport = fake_transport()
+    worker_transport = fake_transport()
+
+    monkeypatch.setattr(
+        sandbox_sync_main, "get_transport", lambda *_args, **_kwargs: worker_transport
+    )
+    monkeypatch.setattr(
+        sandbox_sync_main.httpx,
+        "Client",
+        lambda *args, **kwargs: SimpleNamespace(transport=kwargs["transport"]),
+    )
+    monkeypatch.setattr(sandbox_sync_main, "Filesystem", lambda *args, **kwargs: object())
+    monkeypatch.setattr(sandbox_sync_main, "Commands", lambda *args, **kwargs: object())
+    monkeypatch.setattr(sandbox_sync_main, "Pty", lambda *args, **kwargs: object())
+    monkeypatch.setattr(sandbox_sync_main, "Git", lambda *args, **kwargs: object())
+
+    sandbox = sandbox_sync_main.Sandbox(
+        sandbox_id="sbx-test",
+        sandbox_domain="e2b.app",
+        envd_version=ENVD_VERSION,
+        envd_access_token="tok",
+        traffic_access_token="tok",
+        connection_config=config,
+    )
+
+    # Replace the construction-thread client so the assertion does not depend
+    # on how Sandbox.__init__ got its initial transport.
+    sandbox._envd_api_thread_local.envd_api = SimpleNamespace(transport=main_transport)
+
+    assert sandbox._envd_api.transport is main_transport
+    worker_api = run_in_worker_thread(lambda: sandbox._envd_api)
+    assert worker_api.transport is worker_transport
+    assert sandbox._envd_api.transport is main_transport
+
+
+def test_sync_filesystem_envd_clients_are_bound_per_calling_thread(
+    monkeypatch, test_api_key
+):
+    config = ConnectionConfig(api_key=test_api_key)
+    main_api = object()
+    main_rpc = object()
+    worker_transport = fake_transport()
+
+    monkeypatch.setattr(
+        filesystem_sync,
+        "get_envd_transport",
+        lambda *_args, **_kwargs: worker_transport,
+    )
+    monkeypatch.setattr(
+        filesystem_sync.httpx,
+        "Client",
+        lambda *args, **kwargs: SimpleNamespace(transport=kwargs["transport"]),
+    )
+    monkeypatch.setattr(
+        filesystem_sync.filesystem_connect,
+        "FilesystemClient",
+        lambda *args, **kwargs: SimpleNamespace(pool=kwargs["pool"]),
+    )
+
+    fs = Filesystem(
+        ENVD_API_URL,
+        ENVD_VERSION,
+        config,
+        fake_transport().pool,
+        main_api,
+    )
+    fs._thread_local.rpc = main_rpc
+
+    assert fs._envd_api is main_api
+    assert fs._rpc is main_rpc
+
+    worker_api, worker_rpc = run_in_worker_thread(lambda: (fs._envd_api, fs._rpc))
+    assert worker_api is not main_api
+    assert worker_api.transport is worker_transport
+    assert worker_rpc is not main_rpc
+    assert worker_rpc.pool is worker_transport.pool
+    assert fs._envd_api is main_api
+    assert fs._rpc is main_rpc
+
+
+def test_sync_command_rpc_clients_are_bound_per_calling_thread(
+    monkeypatch, test_api_key
+):
+    config = ConnectionConfig(api_key=test_api_key)
+    main_rpc = object()
+    worker_transport = fake_transport()
+
+    monkeypatch.setattr(
+        command_sync,
+        "get_envd_transport",
+        lambda *_args, **_kwargs: worker_transport,
+    )
+    monkeypatch.setattr(
+        command_sync.process_connect,
+        "ProcessClient",
+        lambda *args, **kwargs: SimpleNamespace(pool=kwargs["pool"]),
+    )
+
+    commands = Commands(ENVD_API_URL, config, fake_transport().pool, ENVD_VERSION)
+    commands._thread_local.rpc = main_rpc
+
+    assert commands._rpc is main_rpc
+    worker_rpc = run_in_worker_thread(lambda: commands._rpc)
+    assert worker_rpc is not main_rpc
+    assert worker_rpc.pool is worker_transport.pool
+    assert commands._rpc is main_rpc
+
+
+def test_sync_pty_rpc_clients_are_bound_per_calling_thread(monkeypatch, test_api_key):
+    config = ConnectionConfig(api_key=test_api_key)
+    main_rpc = object()
+    worker_transport = fake_transport()
+
+    monkeypatch.setattr(
+        pty_sync,
+        "get_envd_transport",
+        lambda *_args, **_kwargs: worker_transport,
+    )
+    monkeypatch.setattr(
+        pty_sync.process_connect,
+        "ProcessClient",
+        lambda *args, **kwargs: SimpleNamespace(pool=kwargs["pool"]),
+    )
+
+    pty = Pty(ENVD_API_URL, config, fake_transport().pool, ENVD_VERSION)
+    pty._thread_local.rpc = main_rpc
+
+    assert pty._rpc is main_rpc
+    worker_rpc = run_in_worker_thread(lambda: pty._rpc)
+    assert worker_rpc is not main_rpc
+    assert worker_rpc.pool is worker_transport.pool
+    assert pty._rpc is main_rpc

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_thread_local_clients.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_thread_local_clients.py
@@ -8,6 +8,7 @@ from e2b.sandbox_sync.commands.command import Commands
 from e2b.sandbox_sync.commands.pty import Pty
 from e2b.sandbox_sync.filesystem import filesystem as filesystem_sync
 from e2b.sandbox_sync.filesystem.filesystem import Filesystem
+from e2b.sandbox_sync.filesystem.watch_handle import WatchHandle
 import e2b.sandbox_sync.commands.command as command_sync
 import e2b.sandbox_sync.commands.pty as pty_sync
 import e2b.sandbox_sync.main as sandbox_sync_main
@@ -61,6 +62,7 @@ def test_sync_sandbox_envd_api_is_bound_per_calling_thread(monkeypatch, test_api
     worker_api = run_in_worker_thread(lambda: sandbox._envd_api)
     assert worker_api.transport is worker_transport
     assert sandbox._envd_api.transport is main_transport
+    assert not hasattr(sandbox, "_transport")
 
 
 def test_sync_filesystem_envd_clients_are_bound_per_calling_thread(
@@ -160,3 +162,24 @@ def test_sync_pty_rpc_clients_are_bound_per_calling_thread(monkeypatch, test_api
     assert worker_rpc is not main_rpc
     assert worker_rpc.pool is worker_transport.pool
     assert pty._rpc is main_rpc
+
+
+def test_sync_watch_handle_uses_calling_thread_rpc():
+    class FakeRpc:
+        def __init__(self, name):
+            self.name = name
+            self.calls = []
+
+        def remove_watcher(self, request):
+            self.calls.append(("remove", request.watcher_id))
+
+    main_rpc = FakeRpc("main")
+    worker_rpc = FakeRpc("worker")
+    handle = WatchHandle(lambda: main_rpc, "watcher-id")
+
+    handle.stop()
+    assert main_rpc.calls == [("remove", "watcher-id")]
+
+    handle = WatchHandle(lambda: worker_rpc, "watcher-id")
+    run_in_worker_thread(handle.stop)
+    assert worker_rpc.calls == [("remove", "watcher-id")]

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_thread_local_clients.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_thread_local_clients.py
@@ -40,7 +40,9 @@ def test_sync_sandbox_envd_api_is_bound_per_calling_thread(monkeypatch, test_api
         "Client",
         lambda *args, **kwargs: SimpleNamespace(transport=kwargs["transport"]),
     )
-    monkeypatch.setattr(sandbox_sync_main, "Filesystem", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        sandbox_sync_main, "Filesystem", lambda *args, **kwargs: object()
+    )
     monkeypatch.setattr(sandbox_sync_main, "Commands", lambda *args, **kwargs: object())
     monkeypatch.setattr(sandbox_sync_main, "Pty", lambda *args, **kwargs: object())
     monkeypatch.setattr(sandbox_sync_main, "Git", lambda *args, **kwargs: object())

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_thread_local_clients.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_thread_local_clients.py
@@ -1,6 +1,8 @@
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
+from unittest.mock import Mock
 
+import httpx
 from packaging.version import Version
 
 from e2b.connection_config import ConnectionConfig
@@ -29,16 +31,16 @@ def fake_transport():
 
 def test_sync_sandbox_envd_api_is_bound_per_calling_thread(monkeypatch, test_api_key):
     config = ConnectionConfig(api_key=test_api_key)
-    main_transport = fake_transport()
-    worker_transport = fake_transport()
+    main_api = Mock(spec=httpx.Client)
+    worker_api = Mock(spec=httpx.Client)
 
     monkeypatch.setattr(
-        sandbox_sync_main, "get_transport", lambda *_args, **_kwargs: worker_transport
+        sandbox_sync_main, "get_transport", lambda *_args, **_kwargs: fake_transport()
     )
     monkeypatch.setattr(
         sandbox_sync_main.httpx,
         "Client",
-        lambda *args, **kwargs: SimpleNamespace(transport=kwargs["transport"]),
+        lambda *args, **kwargs: worker_api,
     )
     monkeypatch.setattr(
         sandbox_sync_main, "Filesystem", lambda *args, **kwargs: object()
@@ -58,12 +60,11 @@ def test_sync_sandbox_envd_api_is_bound_per_calling_thread(monkeypatch, test_api
 
     # Replace the construction-thread client so the assertion does not depend
     # on how Sandbox.__init__ got its initial transport.
-    sandbox._envd_api_thread_local.envd_api = SimpleNamespace(transport=main_transport)
+    sandbox._envd_api_thread_local.envd_api = main_api
 
-    assert sandbox._envd_api.transport is main_transport
-    worker_api = run_in_worker_thread(lambda: sandbox._envd_api)
-    assert worker_api.transport is worker_transport
-    assert sandbox._envd_api.transport is main_transport
+    assert sandbox._envd_api is main_api
+    assert run_in_worker_thread(lambda: sandbox._envd_api) is worker_api
+    assert sandbox._envd_api is main_api
     assert not hasattr(sandbox, "_transport")
 
 
@@ -71,7 +72,7 @@ def test_sync_filesystem_envd_clients_are_bound_per_calling_thread(
     monkeypatch, test_api_key
 ):
     config = ConnectionConfig(api_key=test_api_key)
-    main_api = object()
+    main_api = Mock(spec=httpx.Client)
     main_rpc = object()
     worker_transport = fake_transport()
 


### PR DESCRIPTION
Make sync Python sandbox clients thread-local at call time.

The SDK already cached transports per thread, but sync `Sandbox` modules kept the envd HTTP/RPC clients created during `Sandbox.__init__`. If a sandbox was created in one thread and then used from worker threads, those workers could reuse the construction thread’s client/pool.

This updates sync sandbox filesystem, commands, PTY, health, and watch-handle paths so envd clients/RPC wrappers are resolved for the calling thread.