### PR TITLE
Deduplicate sync thread-local client setup

### DIFF
--- a/.changeset/quiet-threads-wait.md
+++ b/.changeset/quiet-threads-wait.md
@@ -2,4 +2,4 @@
 "@e2b/python-sdk": patch
 ---
 
-Deduplicate sync sandbox client initialization so envd HTTP and RPC clients are created from the calling thread's transport.
+Create Python SDK sync HTTP clients from the calling thread, including sandbox envd clients and API clients used by template uploads.

--- a/.changeset/quiet-threads-wait.md
+++ b/.changeset/quiet-threads-wait.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Deduplicate sync sandbox client initialization so envd HTTP and RPC clients are created from the calling thread's transport.

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -1,11 +1,14 @@
+import asyncio
 import json
 import logging
 import os
 import re
+import threading
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Optional, Protocol, Union
+from typing import Callable, Dict, Optional, Protocol, Union
 
+import httpx
 from httpx import AsyncBaseTransport, BaseTransport, Limits, Timeout
 
 from e2b.api.client.client import AuthenticatedClient
@@ -102,9 +105,21 @@ class ApiClient(AuthenticatedClient):
         require_api_key: bool = True,
         require_access_token: bool = False,
         transport: Optional[Union[BaseTransport, AsyncBaseTransport]] = None,
+        transport_factory: Optional[Callable[[], BaseTransport]] = None,
+        async_transport_factory: Optional[Callable[[], AsyncBaseTransport]] = None,
         *args,
         **kwargs,
     ):
+        if transport is not None and (
+            transport_factory is not None or async_transport_factory is not None
+        ):
+            raise ValueError("Use either transport or transport_factory, not both")
+
+        self._transport_factory = transport_factory
+        self._async_transport_factory = async_transport_factory
+        self._thread_local = threading.local()
+        self._async_clients: Dict[int, httpx.AsyncClient] = {}
+
         if require_api_key and require_access_token:
             raise AuthenticationException(
                 "Only one of api_key or access_token can be required, not both",
@@ -157,9 +172,14 @@ class ApiClient(AuthenticatedClient):
                 "request": [self._log_request],
                 "response": [self._log_response],
             },
-            "transport": transport,
         }
-        if transport is None:
+        if transport is not None:
+            httpx_args["transport"] = transport
+        if (
+            transport is None
+            and transport_factory is None
+            and async_transport_factory is None
+        ):
             httpx_args["proxy"] = config.proxy
 
         # config.request_timeout is None when the timeout is explicitly
@@ -176,6 +196,53 @@ class ApiClient(AuthenticatedClient):
             *args,
             **kwargs,
         )
+
+    def _headers_with_auth(self) -> dict:
+        return {
+            **self._headers,
+            self.auth_header_name: (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            ),
+        }
+
+    def get_httpx_client(self) -> httpx.Client:
+        if self._client is not None or self._transport_factory is None:
+            return super().get_httpx_client()
+
+        client = getattr(self._thread_local, "client", None)
+        if client is None:
+            client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers_with_auth(),
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                event_hooks=self._httpx_args.get("event_hooks"),
+                transport=self._transport_factory(),
+            )
+            self._thread_local.client = client
+        return client
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        if self._async_client is not None or self._async_transport_factory is None:
+            return super().get_async_httpx_client()
+
+        loop_id = id(asyncio.get_running_loop())
+        client = self._async_clients.get(loop_id)
+        if client is None:
+            client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers_with_auth(),
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                event_hooks=self._httpx_args.get("event_hooks"),
+                transport=self._async_transport_factory(),
+            )
+            self._async_clients[loop_id] = client
+        return client
 
     def _log_request(self, request):
         logger.info(f"Request {request.method} {request.url}")

--- a/packages/python-sdk/e2b/api/client_async/__init__.py
+++ b/packages/python-sdk/e2b/api/client_async/__init__.py
@@ -17,7 +17,7 @@ TransportKey = Tuple[int, bool, Optional[ProxyTypes]]
 def get_api_client(config: ConnectionConfig, **kwargs) -> AsyncApiClient:
     return AsyncApiClient(
         config,
-        transport=get_transport(config),
+        async_transport_factory=lambda: get_transport(config),
         **kwargs,
     )
 

--- a/packages/python-sdk/e2b/api/client_sync/__init__.py
+++ b/packages/python-sdk/e2b/api/client_sync/__init__.py
@@ -17,7 +17,7 @@ TransportKey = Tuple[bool, Optional[ProxyTypes]]
 def get_api_client(config: ConnectionConfig, **kwargs) -> ApiClient:
     return ApiClient(
         config,
-        transport=get_transport(config),
+        transport_factory=lambda: get_transport(config),
         **kwargs,
     )
 

--- a/packages/python-sdk/e2b/sandbox_sync/commands/command.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/command.py
@@ -2,7 +2,6 @@ import threading
 from typing import Callable, Dict, List, Literal, Optional, Union, overload
 
 import e2b_connect
-import httpcore
 from packaging.version import Version
 from e2b.api.client_sync import get_envd_transport
 from e2b.connection_config import (
@@ -29,23 +28,20 @@ class Commands:
         self,
         envd_api_url: str,
         connection_config: ConnectionConfig,
-        pool: httpcore.ConnectionPool,
         envd_version: Version,
     ) -> None:
         self._envd_api_url = envd_api_url
         self._connection_config = connection_config
         self._envd_version = envd_version
         self._thread_local = threading.local()
-        self._thread_local.rpc = self._create_rpc(pool)
 
-    def _create_rpc(
-        self, pool: httpcore.ConnectionPool
-    ) -> process_connect.ProcessClient:
+    def _create_rpc(self) -> process_connect.ProcessClient:
+        transport = get_envd_transport(self._connection_config)
         return process_connect.ProcessClient(
             self._envd_api_url,
             # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
             # compressor=e2b_connect.GzipCompressor,
-            pool=pool,
+            pool=transport.pool,
             json=True,
             headers=self._connection_config.sandbox_headers,
         )
@@ -54,8 +50,7 @@ class Commands:
     def _rpc(self) -> process_connect.ProcessClient:
         rpc = getattr(self._thread_local, "rpc", None)
         if rpc is None:
-            transport = get_envd_transport(self._connection_config)
-            rpc = self._create_rpc(transport.pool)
+            rpc = self._create_rpc()
             self._thread_local.rpc = rpc
         return rpc
 

--- a/packages/python-sdk/e2b/sandbox_sync/commands/pty.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/pty.py
@@ -1,5 +1,4 @@
 import e2b_connect
-import httpcore
 import threading
 
 from typing import Dict, Optional
@@ -28,23 +27,20 @@ class Pty:
         self,
         envd_api_url: str,
         connection_config: ConnectionConfig,
-        pool: httpcore.ConnectionPool,
         envd_version: Version,
     ) -> None:
         self._envd_api_url = envd_api_url
         self._connection_config = connection_config
         self._envd_version = envd_version
         self._thread_local = threading.local()
-        self._thread_local.rpc = self._create_rpc(pool)
 
-    def _create_rpc(
-        self, pool: httpcore.ConnectionPool
-    ) -> process_connect.ProcessClient:
+    def _create_rpc(self) -> process_connect.ProcessClient:
+        transport = get_envd_transport(self._connection_config)
         return process_connect.ProcessClient(
             self._envd_api_url,
             # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
             # compressor=e2b_connect.GzipCompressor,
-            pool=pool,
+            pool=transport.pool,
             json=True,
             headers=self._connection_config.sandbox_headers,
         )
@@ -53,8 +49,7 @@ class Pty:
     def _rpc(self) -> process_connect.ProcessClient:
         rpc = getattr(self._thread_local, "rpc", None)
         if rpc is None:
-            transport = get_envd_transport(self._connection_config)
-            rpc = self._create_rpc(transport.pool)
+            rpc = self._create_rpc()
             self._thread_local.rpc = rpc
         return rpc
 

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -1,7 +1,6 @@
 import threading
 from typing import IO, Dict, Iterator, List, Literal, Optional, Union, overload
 
-import httpcore
 import httpx
 from packaging.version import Version
 
@@ -73,15 +72,11 @@ class Filesystem:
         envd_api_url: str,
         envd_version: Version,
         connection_config: ConnectionConfig,
-        pool: httpcore.ConnectionPool,
-        envd_api: httpx.Client,
     ) -> None:
         self._envd_api_url = envd_api_url
         self._envd_version = envd_version
         self._connection_config = connection_config
         self._thread_local = threading.local()
-        self._thread_local.envd_api = envd_api
-        self._thread_local.rpc = self._create_rpc(pool)
 
     def _create_envd_api(self) -> httpx.Client:
         transport = get_envd_transport(self._connection_config)
@@ -91,14 +86,13 @@ class Filesystem:
             headers=self._connection_config.sandbox_headers,
         )
 
-    def _create_rpc(
-        self, pool: httpcore.ConnectionPool
-    ) -> filesystem_connect.FilesystemClient:
+    def _create_rpc(self) -> filesystem_connect.FilesystemClient:
+        transport = get_envd_transport(self._connection_config)
         return filesystem_connect.FilesystemClient(
             self._envd_api_url,
             # TODO: Fix and enable compression again — the headers compression is not solved for streaming.
             # compressor=e2b_connect.GzipCompressor,
-            pool=pool,
+            pool=transport.pool,
             json=True,
             headers=self._connection_config.sandbox_headers,
         )
@@ -115,8 +109,7 @@ class Filesystem:
     def _rpc(self) -> filesystem_connect.FilesystemClient:
         rpc = getattr(self._thread_local, "rpc", None)
         if rpc is None:
-            transport = get_envd_transport(self._connection_config)
-            rpc = self._create_rpc(transport.pool)
+            rpc = self._create_rpc()
             self._thread_local.rpc = rpc
         return rpc
 

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import logging
 import shlex
-import threading
 import uuid
 from typing import Dict, List, Optional, Union, overload
 
@@ -11,7 +10,6 @@ from packaging.version import Version
 from typing_extensions import Self, Unpack
 
 from e2b.api.client.types import Unset
-from e2b.api.client_sync import get_envd_transport as get_transport
 from e2b.connection_config import ApiParams, ConnectionConfig
 from e2b.envd.api import ENVD_API_HEALTH_ROUTE, handle_envd_api_exception
 from e2b.envd.versions import ENVD_DEBUG_FALLBACK
@@ -102,45 +100,26 @@ class Sandbox(SandboxApi):
         """
         super().__init__(**opts)
 
-        transport = get_transport(self.connection_config)
-        self._envd_api_thread_local = threading.local()
-
-        self._envd_api_thread_local.envd_api = self._create_envd_api(transport)
         self._filesystem = Filesystem(
             self.envd_api_url,
             self._envd_version,
             self.connection_config,
-            transport.pool,
-            self._envd_api,
         )
         self._commands = Commands(
             self.envd_api_url,
             self.connection_config,
-            transport.pool,
             self._envd_version,
         )
         self._pty = Pty(
             self.envd_api_url,
             self.connection_config,
-            transport.pool,
             self._envd_version,
         )
         self._git = Git(self._commands)
 
-    def _create_envd_api(self, transport) -> httpx.Client:
-        return httpx.Client(
-            base_url=self.envd_api_url,
-            transport=transport,
-            headers=self.connection_config.sandbox_headers,
-        )
-
     @property
     def _envd_api(self) -> httpx.Client:
-        envd_api = getattr(self._envd_api_thread_local, "envd_api", None)
-        if envd_api is None:
-            envd_api = self._create_envd_api(get_transport(self.connection_config))
-            self._envd_api_thread_local.envd_api = envd_api
-        return envd_api
+        return self._filesystem._envd_api
 
     def is_running(self, request_timeout: Optional[float] = None) -> bool:
         """

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
@@ -16,14 +16,6 @@ BASE_HEADERS = {"X-Test": "base"}
 
 
 def create_sandbox(monkeypatch, api_key: str) -> Sandbox:
-    dummy_transport = SimpleNamespace(pool=object())
-
-    monkeypatch.setattr(
-        sandbox_sync_main, "get_transport", lambda *_args, **_kwargs: dummy_transport
-    )
-    monkeypatch.setattr(
-        sandbox_sync_main.httpx, "Client", lambda *args, **kwargs: object()
-    )
     monkeypatch.setattr(
         sandbox_sync_main, "Filesystem", lambda *args, **kwargs: object()
     )

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_thread_local_clients.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_thread_local_clients.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 import threading
 from types import SimpleNamespace
@@ -54,6 +55,110 @@ def test_sync_sandbox_envd_api_is_bound_per_calling_thread(monkeypatch, test_api
     assert sandbox._envd_api is main_api
     assert sandbox._envd_api is sandbox.files._envd_api
     assert not hasattr(sandbox, "_transport")
+
+
+def test_sync_sandbox_clients_are_created_once_per_calling_thread(
+    monkeypatch, test_api_key
+):
+    config = ConnectionConfig(api_key=test_api_key)
+    created = []
+    transports = {}
+    lock = threading.Lock()
+
+    def get_transport(*_args, **_kwargs):
+        thread_id = threading.get_ident()
+        with lock:
+            transport = transports.get(thread_id)
+            if transport is None:
+                transport = fake_transport()
+                transports[thread_id] = transport
+            return transport
+
+    def record(kind):
+        with lock:
+            created.append((kind, threading.get_ident()))
+
+    class FakeHttpClient:
+        def __init__(self, *args, **kwargs):
+            self.transport = kwargs["transport"]
+            record("http")
+
+    class FakeFilesystemClient:
+        def __init__(self, *args, **kwargs):
+            self.pool = kwargs["pool"]
+            record("filesystem_rpc")
+
+    class FakeProcessClient:
+        def __init__(self, *args, **kwargs):
+            self.pool = kwargs["pool"]
+            record("process_rpc")
+
+    monkeypatch.setattr(filesystem_sync, "get_envd_transport", get_transport)
+    monkeypatch.setattr(command_sync, "get_envd_transport", get_transport)
+    monkeypatch.setattr(pty_sync, "get_envd_transport", get_transport)
+    monkeypatch.setattr(filesystem_sync.httpx, "Client", FakeHttpClient)
+    monkeypatch.setattr(
+        filesystem_sync.filesystem_connect, "FilesystemClient", FakeFilesystemClient
+    )
+    monkeypatch.setattr(
+        command_sync.process_connect, "ProcessClient", FakeProcessClient
+    )
+    monkeypatch.setattr(pty_sync.process_connect, "ProcessClient", FakeProcessClient)
+
+    main_thread_id = threading.get_ident()
+    sandbox = sandbox_sync_main.Sandbox(
+        sandbox_id="sbx-test",
+        sandbox_domain="e2b.app",
+        envd_version=ENVD_VERSION,
+        envd_access_token="tok",
+        traffic_access_token="tok",
+        connection_config=config,
+    )
+
+    assert Counter(kind for kind, thread in created if thread == main_thread_id) == {}
+
+    worker_count = 10
+    barrier = threading.Barrier(worker_count + 1)
+
+    def worker():
+        barrier.wait()
+        envd_api = sandbox._envd_api
+        files_envd_api = sandbox.files._envd_api
+        files_rpc = sandbox.files._rpc
+        commands_rpc = sandbox.commands._rpc
+        pty_rpc = sandbox.pty._rpc
+
+        return {
+            "thread": threading.get_ident(),
+            "same_envd_api": envd_api is files_envd_api,
+            "stable": (
+                envd_api is sandbox._envd_api
+                and files_envd_api is sandbox.files._envd_api
+                and files_rpc is sandbox.files._rpc
+                and commands_rpc is sandbox.commands._rpc
+                and pty_rpc is sandbox.pty._rpc
+            ),
+        }
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = [executor.submit(worker) for _ in range(worker_count)]
+        barrier.wait()
+        results = [future.result() for future in futures]
+
+    worker_threads = {result["thread"] for result in results}
+    worker_created = [
+        (kind, thread) for kind, thread in created if thread in worker_threads
+    ]
+
+    assert Counter(result["same_envd_api"] for result in results) == {
+        True: worker_count
+    }
+    assert Counter(result["stable"] for result in results) == {True: worker_count}
+    assert Counter(kind for kind, _thread in worker_created) == {
+        "http": worker_count,
+        "filesystem_rpc": worker_count,
+        "process_rpc": worker_count * 2,
+    }
 
 
 def test_sync_filesystem_envd_clients_are_bound_per_calling_thread(

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_thread_local_clients.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_thread_local_clients.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
+import threading
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, sentinel
 
 import httpx
 from packaging.version import Version
@@ -32,18 +33,10 @@ def fake_transport():
 def test_sync_sandbox_envd_api_is_bound_per_calling_thread(monkeypatch, test_api_key):
     config = ConnectionConfig(api_key=test_api_key)
     main_api = Mock(spec=httpx.Client)
-    worker_api = Mock(spec=httpx.Client)
+    filesystem = SimpleNamespace(_envd_api=main_api)
 
     monkeypatch.setattr(
-        sandbox_sync_main, "get_transport", lambda *_args, **_kwargs: fake_transport()
-    )
-    monkeypatch.setattr(
-        sandbox_sync_main.httpx,
-        "Client",
-        lambda *args, **kwargs: worker_api,
-    )
-    monkeypatch.setattr(
-        sandbox_sync_main, "Filesystem", lambda *args, **kwargs: object()
+        sandbox_sync_main, "Filesystem", lambda *args, **kwargs: filesystem
     )
     monkeypatch.setattr(sandbox_sync_main, "Commands", lambda *args, **kwargs: object())
     monkeypatch.setattr(sandbox_sync_main, "Pty", lambda *args, **kwargs: object())
@@ -58,13 +51,8 @@ def test_sync_sandbox_envd_api_is_bound_per_calling_thread(monkeypatch, test_api
         connection_config=config,
     )
 
-    # Replace the construction-thread client so the assertion does not depend
-    # on how Sandbox.__init__ got its initial transport.
-    sandbox._envd_api_thread_local.envd_api = main_api
-
     assert sandbox._envd_api is main_api
-    assert run_in_worker_thread(lambda: sandbox._envd_api) is worker_api
-    assert sandbox._envd_api is main_api
+    assert sandbox._envd_api is sandbox.files._envd_api
     assert not hasattr(sandbox, "_transport")
 
 
@@ -72,43 +60,50 @@ def test_sync_filesystem_envd_clients_are_bound_per_calling_thread(
     monkeypatch, test_api_key
 ):
     config = ConnectionConfig(api_key=test_api_key)
-    main_api = Mock(spec=httpx.Client)
-    main_rpc = object()
+    main_thread_id = threading.get_ident()
+    main_transport = fake_transport()
     worker_transport = fake_transport()
+    main_api = Mock(spec=httpx.Client)
+    worker_api = Mock(spec=httpx.Client)
+    main_rpc = sentinel.main_filesystem_rpc
+    worker_rpc = sentinel.worker_filesystem_rpc
 
     monkeypatch.setattr(
         filesystem_sync,
         "get_envd_transport",
-        lambda *_args, **_kwargs: worker_transport,
+        lambda *_args, **_kwargs: main_transport
+        if threading.get_ident() == main_thread_id
+        else worker_transport,
     )
     monkeypatch.setattr(
         filesystem_sync.httpx,
         "Client",
-        lambda *args, **kwargs: SimpleNamespace(transport=kwargs["transport"]),
+        lambda *args, **kwargs: main_api
+        if kwargs["transport"] is main_transport
+        else worker_api,
     )
     monkeypatch.setattr(
         filesystem_sync.filesystem_connect,
         "FilesystemClient",
-        lambda *args, **kwargs: SimpleNamespace(pool=kwargs["pool"]),
+        lambda *args, **kwargs: main_rpc
+        if kwargs["pool"] is main_transport.pool
+        else worker_rpc,
     )
 
     fs = Filesystem(
         ENVD_API_URL,
         ENVD_VERSION,
         config,
-        fake_transport().pool,
-        main_api,
     )
-    fs._thread_local.rpc = main_rpc
 
     assert fs._envd_api is main_api
     assert fs._rpc is main_rpc
 
-    worker_api, worker_rpc = run_in_worker_thread(lambda: (fs._envd_api, fs._rpc))
-    assert worker_api is not main_api
-    assert worker_api.transport is worker_transport
-    assert worker_rpc is not main_rpc
-    assert worker_rpc.pool is worker_transport.pool
+    worker_api_result, worker_rpc_result = run_in_worker_thread(
+        lambda: (fs._envd_api, fs._rpc)
+    )
+    assert worker_api_result is worker_api
+    assert worker_rpc_result is worker_rpc
     assert fs._envd_api is main_api
     assert fs._rpc is main_rpc
 
@@ -117,53 +112,63 @@ def test_sync_command_rpc_clients_are_bound_per_calling_thread(
     monkeypatch, test_api_key
 ):
     config = ConnectionConfig(api_key=test_api_key)
-    main_rpc = object()
+    main_thread_id = threading.get_ident()
+    main_transport = fake_transport()
     worker_transport = fake_transport()
+    main_rpc = sentinel.main_command_rpc
+    worker_rpc = sentinel.worker_command_rpc
 
     monkeypatch.setattr(
         command_sync,
         "get_envd_transport",
-        lambda *_args, **_kwargs: worker_transport,
+        lambda *_args, **_kwargs: main_transport
+        if threading.get_ident() == main_thread_id
+        else worker_transport,
     )
     monkeypatch.setattr(
         command_sync.process_connect,
         "ProcessClient",
-        lambda *args, **kwargs: SimpleNamespace(pool=kwargs["pool"]),
+        lambda *args, **kwargs: main_rpc
+        if kwargs["pool"] is main_transport.pool
+        else worker_rpc,
     )
 
-    commands = Commands(ENVD_API_URL, config, fake_transport().pool, ENVD_VERSION)
-    commands._thread_local.rpc = main_rpc
+    commands = Commands(ENVD_API_URL, config, ENVD_VERSION)
 
     assert commands._rpc is main_rpc
-    worker_rpc = run_in_worker_thread(lambda: commands._rpc)
-    assert worker_rpc is not main_rpc
-    assert worker_rpc.pool is worker_transport.pool
+    worker_rpc_result = run_in_worker_thread(lambda: commands._rpc)
+    assert worker_rpc_result is worker_rpc
     assert commands._rpc is main_rpc
 
 
 def test_sync_pty_rpc_clients_are_bound_per_calling_thread(monkeypatch, test_api_key):
     config = ConnectionConfig(api_key=test_api_key)
-    main_rpc = object()
+    main_thread_id = threading.get_ident()
+    main_transport = fake_transport()
     worker_transport = fake_transport()
+    main_rpc = sentinel.main_pty_rpc
+    worker_rpc = sentinel.worker_pty_rpc
 
     monkeypatch.setattr(
         pty_sync,
         "get_envd_transport",
-        lambda *_args, **_kwargs: worker_transport,
+        lambda *_args, **_kwargs: main_transport
+        if threading.get_ident() == main_thread_id
+        else worker_transport,
     )
     monkeypatch.setattr(
         pty_sync.process_connect,
         "ProcessClient",
-        lambda *args, **kwargs: SimpleNamespace(pool=kwargs["pool"]),
+        lambda *args, **kwargs: main_rpc
+        if kwargs["pool"] is main_transport.pool
+        else worker_rpc,
     )
 
-    pty = Pty(ENVD_API_URL, config, fake_transport().pool, ENVD_VERSION)
-    pty._thread_local.rpc = main_rpc
+    pty = Pty(ENVD_API_URL, config, ENVD_VERSION)
 
     assert pty._rpc is main_rpc
-    worker_rpc = run_in_worker_thread(lambda: pty._rpc)
-    assert worker_rpc is not main_rpc
-    assert worker_rpc.pool is worker_transport.pool
+    worker_rpc_result = run_in_worker_thread(lambda: pty._rpc)
+    assert worker_rpc_result is worker_rpc
     assert pty._rpc is main_rpc
 
 

--- a/packages/python-sdk/tests/test_api_client_transport.py
+++ b/packages/python-sdk/tests/test_api_client_transport.py
@@ -158,6 +158,44 @@ def test_sync_api_transport_cache_reuses_within_thread_and_isolates_across_threa
         reset_sync_api_transports()
 
 
+def test_sync_api_client_cache_reuses_within_thread_and_isolates_across_threads(
+    test_api_key,
+):
+    reset_sync_api_transports()
+    config = ConnectionConfig(api_key=test_api_key)
+    api_client = get_sync_api_client(config)
+
+    def get_worker_client_ids():
+        httpx_client = api_client.get_httpx_client()
+        try:
+            return (
+                id(httpx_client),
+                id(api_client.get_httpx_client()),
+                id(httpx_client._transport),
+                id(get_sync_transport(config)),
+            )
+        finally:
+            httpx_client.close()
+
+    try:
+        main_client = api_client.get_httpx_client()
+        (
+            worker_client_id,
+            worker_cached_client_id,
+            worker_transport_id,
+            worker_cached_transport_id,
+        ) = run_in_worker_thread(get_worker_client_ids)
+
+        assert api_client.get_httpx_client() is main_client
+        assert worker_client_id == worker_cached_client_id
+        assert worker_transport_id == worker_cached_transport_id
+        assert worker_client_id != id(main_client)
+        assert worker_transport_id != id(main_client._transport)
+    finally:
+        main_client.close()
+        reset_sync_api_transports()
+
+
 def test_sync_envd_transport_cache_is_thread_local(test_api_key):
     reset_sync_envd_transports()
     config = ConnectionConfig(api_key=test_api_key)
@@ -252,6 +290,48 @@ async def test_async_api_client_applies_request_timeout(test_api_key):
         assert httpx_client.timeout == httpx.Timeout(1.5)
     finally:
         await httpx_client.aclose()
+        AsyncTransportWithLogger._instances.clear()
+
+
+@pytest.mark.asyncio
+async def test_async_api_client_cache_reuses_within_loop_and_isolates_across_loops(
+    test_api_key,
+):
+    AsyncTransportWithLogger._instances.clear()
+    config = ConnectionConfig(api_key=test_api_key)
+    api_client = get_async_api_client(config)
+
+    async def get_client_ids():
+        httpx_client = api_client.get_async_httpx_client()
+        try:
+            return (
+                id(httpx_client),
+                id(api_client.get_async_httpx_client()),
+                id(httpx_client._transport),
+                id(get_async_transport(config)),
+            )
+        finally:
+            await httpx_client.aclose()
+
+    try:
+        main_client = api_client.get_async_httpx_client()
+        (
+            worker_client_id,
+            worker_cached_client_id,
+            worker_transport_id,
+            worker_cached_transport_id,
+        ) = await asyncio.get_running_loop().run_in_executor(
+            None,
+            lambda: asyncio.run(get_client_ids()),
+        )
+
+        assert api_client.get_async_httpx_client() is main_client
+        assert worker_client_id == worker_cached_client_id
+        assert worker_transport_id == worker_cached_transport_id
+        assert worker_client_id != id(main_client)
+        assert worker_transport_id != id(main_client._transport)
+    finally:
+        await main_client.aclose()
         AsyncTransportWithLogger._instances.clear()
 
 


### PR DESCRIPTION
## Summary
- remove eager sync envd/RPC client construction from sandbox helpers
- make sync sandbox filesystem, commands, pty, and API clients initialize from the calling thread's transport
- deduplicate `Sandbox` and `Filesystem` envd HTTP client caching so each thread gets one envd client
- cover `Template.build` file uploads by making generated API clients thread-local too
