### PR TITLE
Use dedicated clients for Python template uploads

### DIFF
--- a/.changeset/tall-forks-breathe.md
+++ b/.changeset/tall-forks-breathe.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Use dedicated HTTP/1.1 clients for Python template file uploads to signed storage URLs.

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -119,6 +119,7 @@ class ApiClient(AuthenticatedClient):
         self._async_transport_factory = async_transport_factory
         self._thread_local = threading.local()
         self._async_clients: Dict[int, httpx.AsyncClient] = {}
+        self._proxy = config.proxy
 
         if require_api_key and require_access_token:
             raise AuthenticationException(

--- a/packages/python-sdk/e2b/template_async/build_api.py
+++ b/packages/python-sdk/e2b/template_async/build_api.py
@@ -111,8 +111,14 @@ async def upload_file(
             file_name, context_path, ignore_patterns, resolve_symlinks
         )
 
-        client = api_client.get_async_httpx_client()
-        response = await client.put(url, content=tar_buffer.getvalue())
+        async with httpx.AsyncClient(
+            timeout=api_client._timeout,
+            verify=api_client._verify_ssl,
+            follow_redirects=api_client._follow_redirects,
+            proxy=getattr(api_client, "_proxy", None),
+            http2=False,
+        ) as client:
+            response = await client.put(url, content=tar_buffer.getvalue())
         response.raise_for_status()
     except httpx.HTTPStatusError as e:
         raise FileUploadException(f"Failed to upload file: {e}").with_traceback(

--- a/packages/python-sdk/e2b/template_sync/build_api.py
+++ b/packages/python-sdk/e2b/template_sync/build_api.py
@@ -110,8 +110,14 @@ def upload_file(
         tar_buffer = tar_file_stream(
             file_name, context_path, ignore_patterns, resolve_symlinks
         )
-        client = api_client.get_httpx_client()
-        response = client.put(url, content=tar_buffer.getvalue())
+        with httpx.Client(
+            timeout=api_client._timeout,
+            verify=api_client._verify_ssl,
+            follow_redirects=api_client._follow_redirects,
+            proxy=getattr(api_client, "_proxy", None),
+            http2=False,
+        ) as client:
+            response = client.put(url, content=tar_buffer.getvalue())
         response.raise_for_status()
     except httpx.HTTPStatusError as e:
         raise FileUploadException(f"Failed to upload file: {e}").with_traceback(

--- a/packages/python-sdk/tests/async/template_async/test_upload_file.py
+++ b/packages/python-sdk/tests/async/template_async/test_upload_file.py
@@ -45,7 +45,12 @@ async def test_upload_file_sets_content_length_and_no_chunked_encoding(tmp_path)
     url = f"http://{host}:{port}/upload"
 
     try:
-        client = AuthenticatedClient(base_url="http://test", token="test")
+
+        class UploadClient(AuthenticatedClient):
+            def get_async_httpx_client(self):
+                raise AssertionError("signed uploads should not use the API client")
+
+        client = UploadClient(base_url="http://test", token="test")
         await upload_file(
             api_client=client,
             file_name="*.txt",
@@ -69,3 +74,4 @@ async def test_upload_file_sets_content_length_and_no_chunked_encoding(tmp_path)
     transfer_encoding = state["headers"].get("Transfer-Encoding")
     if transfer_encoding is not None:
         assert "chunked" not in transfer_encoding.lower()
+    assert "Authorization" not in state["headers"]

--- a/packages/python-sdk/tests/sync/template_sync/test_upload_file.py
+++ b/packages/python-sdk/tests/sync/template_sync/test_upload_file.py
@@ -41,7 +41,12 @@ def test_upload_file_sets_content_length_and_no_chunked_encoding(tmp_path):
     url = f"http://{host}:{port}/upload"
 
     try:
-        client = AuthenticatedClient(base_url="http://test", token="test")
+
+        class UploadClient(AuthenticatedClient):
+            def get_httpx_client(self):
+                raise AssertionError("signed uploads should not use the API client")
+
+        client = UploadClient(base_url="http://test", token="test")
         upload_file(
             api_client=client,
             file_name="*.txt",
@@ -65,3 +70,4 @@ def test_upload_file_sets_content_length_and_no_chunked_encoding(tmp_path):
     transfer_encoding = state["headers"].get("Transfer-Encoding")
     if transfer_encoding is not None:
         assert "chunked" not in transfer_encoding.lower()
+    assert "Authorization" not in state["headers"]


### PR DESCRIPTION
## Summary

- use short-lived HTTP/1.1 clients for Python sync and async template file uploads to signed storage URLs
- keep signed storage uploads out of the long-lived E2B API client HTTP/2 pool
- assert uploads do not use the API client and do not send API auth headers to storage URLs
