### PR TITLE
fix(js-sdk): return boolean from Sandbox.kill() instance method

### DIFF
--- a/.changeset/itchy-camels-report.md
+++ b/.changeset/itchy-camels-report.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Return `boolean` from the `Sandbox.kill()` instance method (`true` if the sandbox was killed, `false` if it was not found), matching the static `Sandbox.kill()` and the Python SDK.

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -507,14 +507,18 @@ export class Sandbox extends SandboxApi {
    * Kill the sandbox.
    *
    * @param opts connection options.
+   *
+   * @returns `true` if the sandbox was killed, `false` if the sandbox was not found.
    */
-  async kill(opts?: Pick<SandboxOpts, 'requestTimeoutMs' | 'signal'>) {
+  async kill(
+    opts?: Pick<SandboxOpts, 'requestTimeoutMs' | 'signal'>
+  ): Promise<boolean> {
     if (this.connectionConfig.debug) {
       // Skip killing the sandbox in debug mode
-      return
+      return true
     }
 
-    await SandboxApi.kill(this.sandboxId, this.resolveApiOpts(opts))
+    return await SandboxApi.kill(this.sandboxId, this.resolveApiOpts(opts))
   }
 
   /**

--- a/packages/js-sdk/tests/sandbox/kill.test.ts
+++ b/packages/js-sdk/tests/sandbox/kill.test.ts
@@ -4,7 +4,8 @@ import { Sandbox } from '../../src'
 import { sandboxTest, isDebug } from '../setup.js'
 
 sandboxTest.skipIf(isDebug)('kill', async ({ sandbox, sandboxTestId }) => {
-  await sandbox.kill()
+  const killed = await sandbox.kill()
+  expect(killed).toBe(true)
 
   const paginator = Sandbox.list({
     query: { state: ['running'], metadata: { sandboxTestId } },


### PR DESCRIPTION
## Description

The `Sandbox.kill()` instance method discarded the boolean result of the static `SandboxApi.kill()`, returning `Promise<void>` — inconsistent with the static method and with both Python SDKs (sync and async), which return `bool` from both variants. It now returns `Promise<boolean>` (`true` if the sandbox was killed, `false` if it was not found), including `true` in debug mode to match the other implementations. Non-breaking: `void` → `boolean` is additive for existing callers. The kill test now asserts the return value.

## Usage

```ts
const sandbox = await Sandbox.create()
const killed = await sandbox.kill()
console.log(killed) // true if killed, false if the sandbox was not found
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)