### PR TITLE
fix(js-sdk): pass getMetrics start/end as query params

### DIFF
--- a/.changeset/brave-pandas-listen.md
+++ b/.changeset/brave-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Fix `Sandbox.getMetrics()` sending `start` and `end` as path parameters instead of query parameters, which caused the requested time range to be silently ignored

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -798,6 +798,8 @@ export class SandboxApi {
       params: {
         path: {
           sandboxID: sandboxId,
+        },
+        query: {
           start,
           end,
         },

--- a/packages/js-sdk/tests/sandbox/metrics.test.ts
+++ b/packages/js-sdk/tests/sandbox/metrics.test.ts
@@ -7,6 +7,31 @@ sandboxTest.skipIf(isDebug)(
   'sbx metrics',
   { timeout: 60_000 },
   async ({ sandbox }) => {
+    // Wait for the sandbox to have some metrics
+    let metrics: SandboxMetrics[] = []
+    for (let i = 0; i < 60; i++) {
+      metrics = await sandbox.getMetrics()
+      if (metrics.length > 0) {
+        break
+      }
+      await wait(500)
+    }
+
+    expect(metrics.length).toBeGreaterThan(0)
+    const metric = metrics[0]
+    expect(metric.diskTotal).toBeDefined()
+    expect(metric.diskUsed).toBeDefined()
+    expect(metric.memTotal).toBeDefined()
+    expect(metric.memUsed).toBeDefined()
+    expect(metric.cpuUsedPct).toBeDefined()
+    expect(metric.cpuCount).toBeDefined()
+  }
+)
+
+sandboxTest.skipIf(isDebug)(
+  'sbx metrics time range',
+  { timeout: 60_000 },
+  async ({ sandbox }) => {
     const start = new Date()
 
     // Wait for the sandbox to have some metrics within the test's time window
@@ -22,13 +47,6 @@ sandboxTest.skipIf(isDebug)(
     }
 
     expect(metrics.length).toBeGreaterThan(0)
-    const metric = metrics[0]
-    expect(metric.diskTotal).toBeDefined()
-    expect(metric.diskUsed).toBeDefined()
-    expect(metric.memTotal).toBeDefined()
-    expect(metric.memUsed).toBeDefined()
-    expect(metric.cpuUsedPct).toBeDefined()
-    expect(metric.cpuCount).toBeDefined()
 
     // All returned metrics must fall within the requested time range
     // (10s slack — metric timestamps are aligned to collection buckets,

--- a/packages/js-sdk/tests/sandbox/metrics.test.ts
+++ b/packages/js-sdk/tests/sandbox/metrics.test.ts
@@ -7,10 +7,14 @@ sandboxTest.skipIf(isDebug)(
   'sbx metrics',
   { timeout: 60_000 },
   async ({ sandbox }) => {
-    const now = new Date()
-    let metrics: SandboxMetrics[]
+    const start = new Date()
+
+    // Wait for the sandbox to have some metrics within the test's time window
+    let metrics: SandboxMetrics[] = []
+    let end = new Date()
     for (let i = 0; i < 60; i++) {
-      metrics = await sandbox.getMetrics()
+      end = new Date()
+      metrics = await sandbox.getMetrics({ start, end })
       if (metrics.length > 0) {
         break
       }
@@ -26,7 +30,22 @@ sandboxTest.skipIf(isDebug)(
     expect(metric.cpuUsedPct).toBeDefined()
     expect(metric.cpuCount).toBeDefined()
 
-    metrics = await sandbox.getMetrics({ start: now, end: new Date() })
-    expect(metrics.length).toBeGreaterThan(0)
+    // All returned metrics must fall within the requested time range
+    // (10s slack — metric timestamps are aligned to collection buckets,
+    // currently 5s, and the query params are second-precision)
+    const slackMs = 10_000
+    for (const m of metrics) {
+      expect(m.timestamp.getTime()).toBeGreaterThanOrEqual(
+        start.getTime() - slackMs
+      )
+      expect(m.timestamp.getTime()).toBeLessThanOrEqual(end.getTime() + slackMs)
+    }
+
+    // A time range from before the sandbox existed must return no metrics
+    const noMetrics = await sandbox.getMetrics({
+      start: new Date(start.getTime() - 60 * 60 * 1000),
+      end: new Date(start.getTime() - 30 * 60 * 1000),
+    })
+    expect(noMetrics).toHaveLength(0)
   }
 )

--- a/packages/python-sdk/tests/async/sandbox_async/test_metrics.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_metrics.py
@@ -7,13 +7,15 @@ import pytest
 @pytest.mark.skip_debug()
 @pytest.mark.timeout(60)
 async def test_sbx_metrics(async_sandbox_factory):
-    start_time = datetime.datetime.now()
+    start_time = datetime.datetime.now(datetime.timezone.utc)
     sbx = await async_sandbox_factory(timeout=60)
 
-    # Wait for the sandbox to have some metrics
+    # Wait for the sandbox to have some metrics within the test's time window
     metrics = []
+    end_time = start_time
     for _ in range(60):
-        metrics = await sbx.get_metrics()
+        end_time = datetime.datetime.now(datetime.timezone.utc)
+        metrics = await sbx.get_metrics(start=start_time, end=end_time)
         if len(metrics) > 0:
             break
         await asyncio.sleep(0.5)
@@ -28,5 +30,17 @@ async def test_sbx_metrics(async_sandbox_factory):
     assert metric.disk_used is not None
     assert metric.disk_total is not None
 
-    metrics = await sbx.get_metrics(start=start_time, end=datetime.datetime.now())
-    assert len(metrics) > 0
+    # All returned metrics must fall within the requested time range
+    # (10s slack - metric timestamps are aligned to collection buckets,
+    # currently 5s, and the query params are second-precision)
+    slack = 10
+    for metric in metrics:
+        assert metric.timestamp.timestamp() >= start_time.timestamp() - slack
+        assert metric.timestamp.timestamp() <= end_time.timestamp() + slack
+
+    # A time range from before the sandbox existed must return no metrics
+    metrics = await sbx.get_metrics(
+        start=start_time - datetime.timedelta(hours=1),
+        end=start_time - datetime.timedelta(minutes=30),
+    )
+    assert len(metrics) == 0

--- a/packages/python-sdk/tests/async/sandbox_async/test_metrics.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_metrics.py
@@ -7,6 +7,30 @@ import pytest
 @pytest.mark.skip_debug()
 @pytest.mark.timeout(60)
 async def test_sbx_metrics(async_sandbox_factory):
+    sbx = await async_sandbox_factory(timeout=60)
+
+    # Wait for the sandbox to have some metrics
+    metrics = []
+    for _ in range(60):
+        metrics = await sbx.get_metrics()
+        if len(metrics) > 0:
+            break
+        await asyncio.sleep(0.5)
+
+    assert len(metrics) > 0
+
+    metric = metrics[0]
+    assert metric.cpu_count is not None
+    assert metric.cpu_used_pct is not None
+    assert metric.mem_used is not None
+    assert metric.mem_total is not None
+    assert metric.disk_used is not None
+    assert metric.disk_total is not None
+
+
+@pytest.mark.skip_debug()
+@pytest.mark.timeout(60)
+async def test_sbx_metrics_time_range(async_sandbox_factory):
     start_time = datetime.datetime.now(datetime.timezone.utc)
     sbx = await async_sandbox_factory(timeout=60)
 
@@ -21,14 +45,6 @@ async def test_sbx_metrics(async_sandbox_factory):
         await asyncio.sleep(0.5)
 
     assert len(metrics) > 0
-
-    metric = metrics[0]
-    assert metric.cpu_count is not None
-    assert metric.cpu_used_pct is not None
-    assert metric.mem_used is not None
-    assert metric.mem_total is not None
-    assert metric.disk_used is not None
-    assert metric.disk_total is not None
 
     # All returned metrics must fall within the requested time range
     # (10s slack - metric timestamps are aligned to collection buckets,

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_metrics.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_metrics.py
@@ -7,12 +7,15 @@ import pytest
 @pytest.mark.skip_debug()
 @pytest.mark.timeout(60)
 def test_sbx_metrics(sandbox_factory) -> None:
-    start_time = datetime.datetime.now()
+    start_time = datetime.datetime.now(datetime.timezone.utc)
     sbx = sandbox_factory(timeout=60)
-    # Wait for the sandbox to have some metrics
+
+    # Wait for the sandbox to have some metrics within the test's time window
     metrics = []
+    end_time = start_time
     for _ in range(60):
-        metrics = sbx.get_metrics()
+        end_time = datetime.datetime.now(datetime.timezone.utc)
+        metrics = sbx.get_metrics(start=start_time, end=end_time)
         if len(metrics) > 0:
             break
         time.sleep(0.5)
@@ -27,5 +30,17 @@ def test_sbx_metrics(sandbox_factory) -> None:
     assert metric.disk_used is not None
     assert metric.disk_total is not None
 
-    metrics = sbx.get_metrics(start=start_time, end=datetime.datetime.now())
-    assert len(metrics) > 0
+    # All returned metrics must fall within the requested time range
+    # (10s slack - metric timestamps are aligned to collection buckets,
+    # currently 5s, and the query params are second-precision)
+    slack = 10
+    for metric in metrics:
+        assert metric.timestamp.timestamp() >= start_time.timestamp() - slack
+        assert metric.timestamp.timestamp() <= end_time.timestamp() + slack
+
+    # A time range from before the sandbox existed must return no metrics
+    metrics = sbx.get_metrics(
+        start=start_time - datetime.timedelta(hours=1),
+        end=start_time - datetime.timedelta(minutes=30),
+    )
+    assert len(metrics) == 0

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_metrics.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_metrics.py
@@ -7,6 +7,30 @@ import pytest
 @pytest.mark.skip_debug()
 @pytest.mark.timeout(60)
 def test_sbx_metrics(sandbox_factory) -> None:
+    sbx = sandbox_factory(timeout=60)
+
+    # Wait for the sandbox to have some metrics
+    metrics = []
+    for _ in range(60):
+        metrics = sbx.get_metrics()
+        if len(metrics) > 0:
+            break
+        time.sleep(0.5)
+
+    assert len(metrics) > 0
+
+    metric = metrics[0]
+    assert metric.cpu_count is not None
+    assert metric.cpu_used_pct is not None
+    assert metric.mem_used is not None
+    assert metric.mem_total is not None
+    assert metric.disk_used is not None
+    assert metric.disk_total is not None
+
+
+@pytest.mark.skip_debug()
+@pytest.mark.timeout(60)
+def test_sbx_metrics_time_range(sandbox_factory) -> None:
     start_time = datetime.datetime.now(datetime.timezone.utc)
     sbx = sandbox_factory(timeout=60)
 
@@ -21,14 +45,6 @@ def test_sbx_metrics(sandbox_factory) -> None:
         time.sleep(0.5)
 
     assert len(metrics) > 0
-
-    metric = metrics[0]
-    assert metric.cpu_count is not None
-    assert metric.cpu_used_pct is not None
-    assert metric.mem_used is not None
-    assert metric.mem_total is not None
-    assert metric.disk_used is not None
-    assert metric.disk_total is not None
 
     # All returned metrics must fall within the requested time range
     # (10s slack - metric timestamps are aligned to collection buckets,


### PR DESCRIPTION
## Description

`Sandbox.getMetrics()` in the JS SDK passed the `start` and `end` options as path parameters instead of query parameters, so openapi-fetch never serialized them and the requested time range was silently ignored. They are now sent under `query`, matching the OpenAPI spec; the Python SDKs already passed them correctly. The metrics tests across JS and Python (sync/async) now assert that returned metrics fall within the requested window (with slack for 5s metric-bucket alignment) and that a window from before the sandbox existed returns no metrics, which would have caught this regression.

## Usage

```ts
const start = new Date(Date.now() - 60_000)
const metrics = await sandbox.getMetrics({ start, end: new Date() })
// metrics are now actually limited to the requested time range
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)