### PR TITLE
fix: debug-mode Sandbox.connect() and Unset token handling in Python connect()

### DIFF
--- a/.changeset/wise-otters-connect.md
+++ b/.changeset/wise-otters-connect.md
@@ -1,0 +1,6 @@
+---
+"e2b": patch
+"@e2b/python-sdk": patch
+---
+
+Skip the control plane request in `Sandbox.connect()` when running in debug mode, matching the behavior of `Sandbox.create()`. In the Python SDK, `Sandbox.connect()` now also normalizes missing envd and traffic access tokens to `None` instead of leaking the `Unset` sentinel, which previously broke `download_url()`/`upload_url()` for non-secure sandboxes.

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -357,8 +357,16 @@ export class Sandbox extends SandboxApi {
     sandboxId: string,
     opts?: SandboxConnectOpts
   ): Promise<InstanceType<S>> {
-    const sandbox = await SandboxApi.connectSandbox(sandboxId, opts)
     const config = new ConnectionConfig(opts)
+    if (config.debug) {
+      return new this({
+        sandboxId,
+        envdVersion: ENVD_DEBUG_FALLBACK,
+        ...config,
+      }) as InstanceType<S>
+    }
+
+    const sandbox = await SandboxApi.connectSandbox(sandboxId, opts)
 
     return new this({
       sandboxId,
@@ -390,6 +398,11 @@ export class Sandbox extends SandboxApi {
    * ```
    */
   async connect(opts?: SandboxConnectOpts): Promise<this> {
+    if (this.connectionConfig.debug) {
+      // Skip connecting to the sandbox in debug mode
+      return this
+    }
+
     await SandboxApi.connectSandbox(this.sandboxId, this.resolveApiOpts(opts))
 
     return this

--- a/packages/js-sdk/tests/sandbox/connect.test.ts
+++ b/packages/js-sdk/tests/sandbox/connect.test.ts
@@ -1,7 +1,29 @@
-import { assert, test, expect } from 'vitest'
+import { assert, test, expect, vi } from 'vitest'
 
 import { Sandbox } from '../../src'
 import { isDebug, sandboxTest, template } from '../setup.js'
+
+test('connect in debug mode does not call the API', async () => {
+  const fetchSpy = vi.fn(() => {
+    throw new Error('unexpected request in debug mode')
+  })
+  vi.stubGlobal('fetch', fetchSpy)
+
+  try {
+    const sbx = await Sandbox.connect('debug-sandbox-id', {
+      debug: true,
+      apiKey: 'test-api-key',
+    })
+    assert.equal(sbx.sandboxId, 'debug-sandbox-id')
+
+    const sameSbx = await sbx.connect()
+    assert.strictEqual(sameSbx, sbx)
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  } finally {
+    vi.unstubAllGlobals()
+  }
+})
 
 test.skipIf(isDebug)('connect', async () => {
   const sbx = await Sandbox.create(template, { timeoutMs: 10_000 })

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -851,7 +851,7 @@ class AsyncSandbox(SandboxApi):
         timeout: Optional[int] = None,
         **opts: Unpack[ApiParams],
     ) -> Self:
-        debug = opts.get("debug")
+        debug = ConnectionConfig(**opts).debug
         if debug:
             sandbox_domain = None
             envd_version = ENVD_DEBUG_FALLBACK
@@ -908,7 +908,7 @@ class AsyncSandbox(SandboxApi):
     ) -> Self:
         extra_sandbox_headers = {}
 
-        debug = opts.get("debug")
+        debug = ConnectionConfig(**opts).debug
         if debug:
             sandbox_id = "debug_sandbox_id"
             sandbox_domain = None

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -9,7 +9,6 @@ import httpx
 from packaging.version import Version
 from typing_extensions import Self, Unpack
 
-from e2b.api.client.types import Unset
 from e2b.api.client_async import get_envd_transport as get_transport
 from e2b.connection_config import ApiParams, ConnectionConfig
 from e2b.envd.api import ENVD_API_HEALTH_ROUTE, ahandle_envd_api_exception
@@ -326,6 +325,10 @@ class AsyncSandbox(SandboxApi):
         same_sandbox = await sandbox.connect()
         ```
         """
+        if self.connection_config.debug:
+            # Skip connecting to the sandbox in debug mode
+            return self
+
         await SandboxApi._cls_connect(
             sandbox_id=self.sandbox_id,
             timeout=timeout,
@@ -848,18 +851,30 @@ class AsyncSandbox(SandboxApi):
         timeout: Optional[int] = None,
         **opts: Unpack[ApiParams],
     ) -> Self:
-        sandbox = await SandboxApi._cls_connect(
-            sandbox_id=sandbox_id,
-            timeout=timeout,
-            **opts,
-        )
+        debug = opts.get("debug")
+        if debug:
+            sandbox_domain = None
+            envd_version = ENVD_DEBUG_FALLBACK
+            envd_access_token = None
+            traffic_access_token = None
+        else:
+            sandbox = await SandboxApi._cls_connect(
+                sandbox_id=sandbox_id,
+                timeout=timeout,
+                **opts,
+            )
+
+            sandbox_id = sandbox.sandbox_id
+            sandbox_domain = sandbox.sandbox_domain
+            envd_version = Version(sandbox.envd_version)
+            envd_access_token = sandbox.envd_access_token
+            traffic_access_token = sandbox.traffic_access_token
 
         sandbox_headers = {
-            "E2b-Sandbox-Id": sandbox.sandbox_id,
+            "E2b-Sandbox-Id": sandbox_id,
             "E2b-Sandbox-Port": str(ConnectionConfig.envd_port),
         }
-        envd_access_token = sandbox.envd_access_token
-        if envd_access_token is not None and not isinstance(envd_access_token, Unset):
+        if envd_access_token is not None:
             sandbox_headers["X-Access-Token"] = envd_access_token
 
         connection_config = ConnectionConfig(
@@ -868,11 +883,11 @@ class AsyncSandbox(SandboxApi):
         )
 
         return cls(
-            sandbox_id=sandbox.sandbox_id,
-            sandbox_domain=sandbox.domain,
-            envd_version=Version(sandbox.envd_version),
+            sandbox_id=sandbox_id,
+            sandbox_domain=sandbox_domain,
+            envd_version=envd_version,
             envd_access_token=envd_access_token,
-            traffic_access_token=sandbox.traffic_access_token,
+            traffic_access_token=traffic_access_token,
             connection_config=connection_config,
         )
 
@@ -921,9 +936,7 @@ class AsyncSandbox(SandboxApi):
             envd_access_token = response.envd_access_token
             traffic_access_token = response.traffic_access_token
 
-            if envd_access_token is not None and not isinstance(
-                envd_access_token, Unset
-            ):
+            if envd_access_token is not None:
                 extra_sandbox_headers["X-Access-Token"] = envd_access_token
 
         extra_sandbox_headers["E2b-Sandbox-Id"] = sandbox_id

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -23,7 +23,6 @@ from e2b.api.client.models import (
     NewSandbox,
     PostSandboxesSandboxIDSnapshotsBody,
     PostSandboxesSandboxIDTimeoutBody,
-    Sandbox,
     SandboxAutoResumeConfig,
     SandboxNetworkConfig,
     SandboxVolumeMount as SandboxVolumeMountAPI,
@@ -416,7 +415,7 @@ class SandboxApi(SandboxBase):
         sandbox_id: str,
         timeout: Optional[int] = None,
         **opts: Unpack[ApiParams],
-    ) -> Sandbox:
+    ) -> SandboxCreateResponse:
         timeout = timeout or SandboxBase.default_sandbox_timeout
 
         # Sandbox is not running, resume it
@@ -442,4 +441,22 @@ class SandboxApi(SandboxBase):
         if res.parsed is None:
             raise Exception("Body of the request is None")
 
-        return res.parsed
+        domain = res.parsed.domain if isinstance(res.parsed.domain, str) else None
+        envd_token = (
+            res.parsed.envd_access_token
+            if isinstance(res.parsed.envd_access_token, str)
+            else None
+        )
+        traffic_token = (
+            res.parsed.traffic_access_token
+            if isinstance(res.parsed.traffic_access_token, str)
+            else None
+        )
+
+        return SandboxCreateResponse(
+            sandbox_id=res.parsed.sandbox_id,
+            sandbox_domain=domain,
+            envd_version=res.parsed.envd_version,
+            envd_access_token=envd_token,
+            traffic_access_token=traffic_token,
+        )

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -9,7 +9,6 @@ import httpx
 from packaging.version import Version
 from typing_extensions import Self, Unpack
 
-from e2b.api.client.types import Unset
 from e2b.connection_config import ApiParams, ConnectionConfig
 from e2b.envd.api import ENVD_API_HEALTH_ROUTE, handle_envd_api_exception
 from e2b.envd.versions import ENVD_DEBUG_FALLBACK
@@ -317,6 +316,10 @@ class Sandbox(SandboxApi):
         same_sandbox = sandbox.connect()
         ```
         """
+        if self.connection_config.debug:
+            # Skip connecting to the sandbox in debug mode
+            return self
+
         SandboxApi._cls_connect(
             sandbox_id=self.sandbox_id,
             timeout=timeout,
@@ -840,18 +843,30 @@ class Sandbox(SandboxApi):
         timeout: Optional[int] = None,
         **opts: Unpack[ApiParams],
     ) -> Self:
-        sandbox = SandboxApi._cls_connect(
-            sandbox_id=sandbox_id,
-            timeout=timeout,
-            **opts,
-        )
+        debug = opts.get("debug")
+        if debug:
+            sandbox_domain = None
+            envd_version = ENVD_DEBUG_FALLBACK
+            envd_access_token = None
+            traffic_access_token = None
+        else:
+            sandbox = SandboxApi._cls_connect(
+                sandbox_id=sandbox_id,
+                timeout=timeout,
+                **opts,
+            )
+
+            sandbox_id = sandbox.sandbox_id
+            sandbox_domain = sandbox.sandbox_domain
+            envd_version = Version(sandbox.envd_version)
+            envd_access_token = sandbox.envd_access_token
+            traffic_access_token = sandbox.traffic_access_token
 
         sandbox_headers = {
-            "E2b-Sandbox-Id": sandbox.sandbox_id,
+            "E2b-Sandbox-Id": sandbox_id,
             "E2b-Sandbox-Port": str(ConnectionConfig.envd_port),
         }
-        envd_access_token = sandbox.envd_access_token
-        if envd_access_token is not None and not isinstance(envd_access_token, Unset):
+        if envd_access_token is not None:
             sandbox_headers["X-Access-Token"] = envd_access_token
 
         connection_config = ConnectionConfig(
@@ -860,11 +875,11 @@ class Sandbox(SandboxApi):
         )
 
         return cls(
-            sandbox_id=sandbox.sandbox_id,
-            sandbox_domain=sandbox.domain,
-            envd_version=Version(sandbox.envd_version),
+            sandbox_id=sandbox_id,
+            sandbox_domain=sandbox_domain,
+            envd_version=envd_version,
             envd_access_token=envd_access_token,
-            traffic_access_token=sandbox.traffic_access_token,
+            traffic_access_token=traffic_access_token,
             connection_config=connection_config,
         )
 
@@ -913,9 +928,7 @@ class Sandbox(SandboxApi):
             envd_access_token = response.envd_access_token
             traffic_access_token = response.traffic_access_token
 
-            if envd_access_token is not None and not isinstance(
-                envd_access_token, Unset
-            ):
+            if envd_access_token is not None:
                 extra_sandbox_headers["X-Access-Token"] = envd_access_token
 
         extra_sandbox_headers["E2b-Sandbox-Id"] = sandbox_id

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -843,7 +843,7 @@ class Sandbox(SandboxApi):
         timeout: Optional[int] = None,
         **opts: Unpack[ApiParams],
     ) -> Self:
-        debug = opts.get("debug")
+        debug = ConnectionConfig(**opts).debug
         if debug:
             sandbox_domain = None
             envd_version = ENVD_DEBUG_FALLBACK
@@ -900,7 +900,7 @@ class Sandbox(SandboxApi):
     ) -> Self:
         extra_sandbox_headers = {}
 
-        debug = opts.get("debug")
+        debug = ConnectionConfig(**opts).debug
         if debug:
             sandbox_id = "debug_sandbox_id"
             sandbox_domain = None

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -23,7 +23,6 @@ from e2b.api.client.models import (
     NewSandbox,
     PostSandboxesSandboxIDSnapshotsBody,
     PostSandboxesSandboxIDTimeoutBody,
-    Sandbox,
     SandboxAutoResumeConfig,
     SandboxNetworkConfig,
     SandboxVolumeMount as SandboxVolumeMountAPI,
@@ -320,7 +319,7 @@ class SandboxApi(SandboxBase):
         sandbox_id: str,
         timeout: Optional[int] = None,
         **opts: Unpack[ApiParams],
-    ) -> Sandbox:
+    ) -> SandboxCreateResponse:
         timeout = timeout or SandboxBase.default_sandbox_timeout
 
         config = ConnectionConfig(**opts)
@@ -344,7 +343,25 @@ class SandboxApi(SandboxBase):
         if res.parsed is None:
             raise Exception("Body of the request is None")
 
-        return res.parsed
+        domain = res.parsed.domain if isinstance(res.parsed.domain, str) else None
+        envd_token = (
+            res.parsed.envd_access_token
+            if isinstance(res.parsed.envd_access_token, str)
+            else None
+        )
+        traffic_token = (
+            res.parsed.traffic_access_token
+            if isinstance(res.parsed.traffic_access_token, str)
+            else None
+        )
+
+        return SandboxCreateResponse(
+            sandbox_id=res.parsed.sandbox_id,
+            sandbox_domain=domain,
+            envd_version=res.parsed.envd_version,
+            envd_access_token=envd_token,
+            traffic_access_token=traffic_token,
+        )
 
     @classmethod
     def _cls_create_snapshot(

--- a/packages/python-sdk/tests/async/sandbox_async/test_config_propagation.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_config_propagation.py
@@ -5,6 +5,7 @@ import pytest
 from packaging.version import Version
 
 from e2b import AsyncSandbox
+from e2b.api import SandboxCreateResponse
 from e2b.connection_config import ConnectionConfig
 import e2b.sandbox_async.main as sandbox_async_main
 
@@ -93,9 +94,9 @@ async def test_pause_applies_overrides(monkeypatch, test_api_key):
 @pytest.mark.skip_debug()
 async def test_connect_sets_stable_host_routing_headers(monkeypatch, test_api_key):
     mock_connect = AsyncMock(
-        return_value=SimpleNamespace(
+        return_value=SandboxCreateResponse(
             sandbox_id="sbx-test",
-            domain="e2b.app",
+            sandbox_domain="e2b.app",
             envd_version="0.4.0",
             envd_access_token="tok",
             traffic_access_token="traffic",

--- a/packages/python-sdk/tests/async/sandbox_async/test_connect.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_connect.py
@@ -99,6 +99,17 @@ async def test_connect_in_debug_mode_does_not_call_api(monkeypatch, test_api_key
     assert sbx.traffic_access_token is None
 
 
+async def test_connect_in_env_debug_mode_does_not_call_api(monkeypatch, test_api_key):
+    monkeypatch.setenv("E2B_DEBUG", "true")
+    mock_connect = AsyncMock()
+    monkeypatch.setattr(sandbox_async_main.SandboxApi, "_cls_connect", mock_connect)
+
+    sbx = await AsyncSandbox.connect("sbx-debug", api_key=test_api_key)
+
+    mock_connect.assert_not_called()
+    assert sbx.sandbox_id == "sbx-debug"
+
+
 async def test_instance_connect_in_debug_mode_does_not_call_api(
     monkeypatch, test_api_key
 ):

--- a/packages/python-sdk/tests/async/sandbox_async/test_connect.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_connect.py
@@ -1,7 +1,13 @@
 import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
 
 from e2b import AsyncSandbox
+from e2b.api.client.api.sandboxes import post_sandboxes_sandbox_id_connect
+from e2b.api.client.models import Sandbox as SandboxModel
+import e2b.sandbox_async.main as sandbox_async_main
 
 
 @pytest.mark.skip_debug()
@@ -79,3 +85,50 @@ async def test_connect_extends_timeout_on_running_sandbox(async_sandbox):
     assert info_after.end_at > info_before.end_at, (
         f"Timeout was not extended: before={info_before.end_at}, after={info_after.end_at}"
     )
+
+
+async def test_connect_in_debug_mode_does_not_call_api(monkeypatch, test_api_key):
+    mock_connect = AsyncMock()
+    monkeypatch.setattr(sandbox_async_main.SandboxApi, "_cls_connect", mock_connect)
+
+    sbx = await AsyncSandbox.connect("sbx-debug", debug=True, api_key=test_api_key)
+
+    mock_connect.assert_not_called()
+    assert sbx.sandbox_id == "sbx-debug"
+    assert sbx._envd_access_token is None
+    assert sbx.traffic_access_token is None
+
+
+async def test_instance_connect_in_debug_mode_does_not_call_api(
+    monkeypatch, test_api_key
+):
+    mock_connect = AsyncMock()
+    monkeypatch.setattr(sandbox_async_main.SandboxApi, "_cls_connect", mock_connect)
+
+    sbx = await AsyncSandbox.connect("sbx-debug", debug=True, api_key=test_api_key)
+
+    assert await sbx.connect() is sbx
+    mock_connect.assert_not_called()
+
+
+async def test_connect_normalizes_unset_tokens(monkeypatch, test_api_key):
+    # Tokens and domain are absent in the API response for non-secure sandboxes
+    model = SandboxModel(
+        client_id="client-id",
+        envd_version="0.2.4",
+        sandbox_id="sbx-test",
+        template_id="template-id",
+    )
+    mock_request = AsyncMock(
+        return_value=SimpleNamespace(status_code=200, parsed=model)
+    )
+    monkeypatch.setattr(
+        post_sandboxes_sandbox_id_connect, "asyncio_detailed", mock_request
+    )
+
+    sbx = await AsyncSandbox.connect("sbx-test", debug=False, api_key=test_api_key)
+
+    mock_request.assert_called_once()
+    assert sbx._envd_access_token is None
+    assert sbx.traffic_access_token is None
+    assert "signature" not in sbx.download_url("test.txt")

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
@@ -5,6 +5,7 @@ import pytest
 from packaging.version import Version
 
 from e2b import Sandbox
+from e2b.api import SandboxCreateResponse
 from e2b.connection_config import ConnectionConfig
 import e2b.sandbox_sync.main as sandbox_sync_main
 
@@ -81,9 +82,9 @@ def test_pause_applies_overrides(monkeypatch, test_api_key):
 @pytest.mark.skip_debug()
 def test_connect_sets_stable_host_routing_headers(monkeypatch, test_api_key):
     mock_connect = Mock(
-        return_value=SimpleNamespace(
+        return_value=SandboxCreateResponse(
             sandbox_id="sbx-test",
-            domain="e2b.app",
+            sandbox_domain="e2b.app",
             envd_version="0.4.0",
             envd_access_token="tok",
             traffic_access_token="traffic",

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_connect.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_connect.py
@@ -1,7 +1,13 @@
 import uuid
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 
 from e2b import Sandbox
+from e2b.api.client.api.sandboxes import post_sandboxes_sandbox_id_connect
+from e2b.api.client.models import Sandbox as SandboxModel
+import e2b.sandbox_sync.main as sandbox_sync_main
 
 
 @pytest.mark.skip_debug()
@@ -74,3 +80,46 @@ def test_connect_extends_timeout_on_running_sandbox(sandbox):
     assert info_after.end_at > info_before.end_at, (
         f"Timeout was not extended: before={info_before.end_at}, after={info_after.end_at}"
     )
+
+
+def test_connect_in_debug_mode_does_not_call_api(monkeypatch, test_api_key):
+    mock_connect = Mock()
+    monkeypatch.setattr(sandbox_sync_main.SandboxApi, "_cls_connect", mock_connect)
+
+    sbx = Sandbox.connect("sbx-debug", debug=True, api_key=test_api_key)
+
+    mock_connect.assert_not_called()
+    assert sbx.sandbox_id == "sbx-debug"
+    assert sbx._envd_access_token is None
+    assert sbx.traffic_access_token is None
+
+
+def test_instance_connect_in_debug_mode_does_not_call_api(monkeypatch, test_api_key):
+    mock_connect = Mock()
+    monkeypatch.setattr(sandbox_sync_main.SandboxApi, "_cls_connect", mock_connect)
+
+    sbx = Sandbox.connect("sbx-debug", debug=True, api_key=test_api_key)
+
+    assert sbx.connect() is sbx
+    mock_connect.assert_not_called()
+
+
+def test_connect_normalizes_unset_tokens(monkeypatch, test_api_key):
+    # Tokens and domain are absent in the API response for non-secure sandboxes
+    model = SandboxModel(
+        client_id="client-id",
+        envd_version="0.2.4",
+        sandbox_id="sbx-test",
+        template_id="template-id",
+    )
+    mock_request = Mock(return_value=SimpleNamespace(status_code=200, parsed=model))
+    monkeypatch.setattr(
+        post_sandboxes_sandbox_id_connect, "sync_detailed", mock_request
+    )
+
+    sbx = Sandbox.connect("sbx-test", debug=False, api_key=test_api_key)
+
+    mock_request.assert_called_once()
+    assert sbx._envd_access_token is None
+    assert sbx.traffic_access_token is None
+    assert "signature" not in sbx.download_url("test.txt")

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_connect.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_connect.py
@@ -94,6 +94,17 @@ def test_connect_in_debug_mode_does_not_call_api(monkeypatch, test_api_key):
     assert sbx.traffic_access_token is None
 
 
+def test_connect_in_env_debug_mode_does_not_call_api(monkeypatch, test_api_key):
+    monkeypatch.setenv("E2B_DEBUG", "true")
+    mock_connect = Mock()
+    monkeypatch.setattr(sandbox_sync_main.SandboxApi, "_cls_connect", mock_connect)
+
+    sbx = Sandbox.connect("sbx-debug", api_key=test_api_key)
+
+    mock_connect.assert_not_called()
+    assert sbx.sandbox_id == "sbx-debug"
+
+
 def test_instance_connect_in_debug_mode_does_not_call_api(monkeypatch, test_api_key):
     mock_connect = Mock()
     monkeypatch.setattr(sandbox_sync_main.SandboxApi, "_cls_connect", mock_connect)


### PR DESCRIPTION
## Description

`Sandbox.connect()` now short-circuits in debug mode instead of calling the control plane, matching `Sandbox.create()` — fixed in the JS SDK and both sync/async Python SDKs (static and instance variants). The Python SDK's `connect()` also previously passed the generated client's `Unset` sentinel through as the envd/traffic access tokens when they were absent (non-secure sandboxes), which made `download_url()`/`upload_url()` emit broken signed URLs; `_cls_connect` now normalizes the response into `SandboxCreateResponse` with proper `None` values, the same pattern `_create_sandbox` already uses. Dead `Unset` checks and the now-unused generated `Sandbox` model import were cleaned up, and unit tests cover both behaviors in all three implementations. Debug mode is resolved through `ConnectionConfig`, so the `E2B_DEBUG` env var triggers the short-circuit in both `connect()` and `create()`, not just an explicit `debug=True`.

## Usage

```ts
// JS: works fully offline with E2B_DEBUG / debug: true (no control plane call)
const sbx = await Sandbox.connect(sandboxId, { debug: true })
```

```python
# Python: non-secure sandboxes get unsigned URLs again instead of broken signatures
sbx = Sandbox.connect(sandbox_id)
print(sbx.download_url("file.txt"))  # no garbage signature when envd token is absent

# Debug mode skips the control plane, like Sandbox.create()
sbx = Sandbox.connect(sandbox_id, debug=True)
```

## Testing

New unit tests in `tests/sandbox/connect.test.ts`, `tests/sync/sandbox_sync/test_connect.py`, and `tests/async/sandbox_async/test_connect.py`; existing connect integration suites pass against the live API (8/8 sync Python, 8/8 async Python, 6/6 JS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
