### PR TITLE
fix(sdks): handle signed URL expiration edge cases in upload/download URLs

### DIFF
--- a/.changeset/brown-jokes-design.md
+++ b/.changeset/brown-jokes-design.md
@@ -1,0 +1,9 @@
+---
+'@e2b/python-sdk': patch
+'e2b': patch
+---
+
+Fix signed URL expiration edge cases in `uploadUrl`/`downloadUrl` (`upload_url`/`download_url`):
+
+- Python now raises `InvalidArgumentException` when `use_signature_expiration` is passed for an unsecured sandbox, matching the JS SDK behavior (which now throws `InvalidArgumentError` instead of a plain `Error`).
+- A signature expiration of `0` now produces an immediately expiring URL instead of silently creating a never-expiring one.

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -28,7 +28,7 @@ import {
 } from './sandboxApi'
 import { getSignature } from './signature'
 import { compareVersions } from 'compare-versions'
-import { TemplateError } from '../errors'
+import { InvalidArgumentError, TemplateError } from '../errors'
 import { ENVD_DEBUG_FALLBACK, ENVD_DEFAULT_USER } from '../envd/versions'
 import { shellQuote } from '../utils'
 
@@ -633,7 +633,7 @@ export class Sandbox extends SandboxApi {
     const useSignature = !!this.envdAccessToken
 
     if (!useSignature && opts.useSignatureExpiration != undefined) {
-      throw new Error(
+      throw new InvalidArgumentError(
         'Signature expiration can be used only when sandbox is created as secured.'
       )
     }
@@ -685,7 +685,7 @@ export class Sandbox extends SandboxApi {
     const useSignature = !!this.envdAccessToken
 
     if (!useSignature && opts.useSignatureExpiration != undefined) {
-      throw new Error(
+      throw new InvalidArgumentError(
         'Signature expiration can be used only when sandbox is created as secured.'
       )
     }

--- a/packages/js-sdk/src/sandbox/signature.ts
+++ b/packages/js-sdk/src/sandbox/signature.ts
@@ -34,9 +34,10 @@ export async function getSignature({
   }
 
   // expiration is unix timestamp
-  const signatureExpiration = expirationInSeconds
-    ? Math.floor(Date.now() / 1000) + expirationInSeconds
-    : null
+  const signatureExpiration =
+    expirationInSeconds != null
+      ? Math.floor(Date.now() / 1000) + expirationInSeconds
+      : null
   let signatureRaw: string
 
   // if user is undefined, set it to empty string to handle default user

--- a/packages/js-sdk/tests/sandbox/urls.test.ts
+++ b/packages/js-sdk/tests/sandbox/urls.test.ts
@@ -1,0 +1,90 @@
+import { assert, describe, test } from 'vitest'
+
+import { getSignature, InvalidArgumentError, Sandbox } from '../../src'
+import { TEST_API_KEY } from '../setup'
+
+function createSandbox(envdAccessToken?: string) {
+  return new Sandbox({
+    sandboxId: 'sandbox-id',
+    sandboxDomain: 'e2b.app',
+    envdVersion: '0.4.0',
+    envdAccessToken,
+    apiKey: TEST_API_KEY,
+    domain: 'e2b.app',
+    debug: false,
+  })
+}
+
+describe('sandbox file URLs', () => {
+  test('file URLs use direct sandbox host when envd API uses stable host', async () => {
+    const sandbox = createSandbox()
+
+    assert.equal(sandbox['envdApiUrl'], 'https://sandbox.e2b.app')
+    assert.equal(sandbox['envdDirectUrl'], 'https://49983-sandbox-id.e2b.app')
+    assert.equal(
+      await sandbox.downloadUrl('/tmp/a.txt'),
+      'https://49983-sandbox-id.e2b.app/files?path=%2Ftmp%2Fa.txt'
+    )
+    assert.equal(
+      await sandbox.uploadUrl('/tmp/a.txt'),
+      'https://49983-sandbox-id.e2b.app/files?path=%2Ftmp%2Fa.txt'
+    )
+  })
+
+  test('throws when signature expiration is used on unsecured sandbox', async () => {
+    const sandbox = createSandbox()
+
+    await Promise.all(
+      [
+        sandbox.downloadUrl('/tmp/a.txt', { useSignatureExpiration: 120 }),
+        sandbox.uploadUrl('/tmp/a.txt', { useSignatureExpiration: 120 }),
+      ].map((promise) =>
+        promise.then(
+          () => assert.fail('expected InvalidArgumentError'),
+          (err) => {
+            assert.instanceOf(err, InvalidArgumentError)
+            assert.equal(
+              err.message,
+              'Signature expiration can be used only when sandbox is created as secured.'
+            )
+          }
+        )
+      )
+    )
+  })
+
+  test('zero signature expiration expires immediately', async () => {
+    const before = Math.floor(Date.now() / 1000)
+
+    const signature = await getSignature({
+      path: '/tmp/a.txt',
+      operation: 'read',
+      user: 'user',
+      envdAccessToken: 'access-token',
+      expirationInSeconds: 0,
+    })
+
+    const after = Math.floor(Date.now() / 1000)
+
+    assert.isNotNull(signature.expiration)
+    assert.isAtLeast(signature.expiration!, before)
+    assert.isAtMost(signature.expiration!, after)
+  })
+
+  test('zero signature expiration is included in URL', async () => {
+    const sandbox = createSandbox('access-token')
+
+    for (const url of [
+      await sandbox.downloadUrl('/tmp/a.txt', { useSignatureExpiration: 0 }),
+      await sandbox.uploadUrl('/tmp/a.txt', { useSignatureExpiration: 0 }),
+    ]) {
+      const expiration = new URL(url).searchParams.get('signature_expiration')
+      assert.isNotNull(expiration)
+      assert.approximately(
+        parseInt(expiration!),
+        Math.floor(Date.now() / 1000),
+        5
+      )
+    }
+  })
+})

--- a/packages/python-sdk/e2b/sandbox/main.py
+++ b/packages/python-sdk/e2b/sandbox/main.py
@@ -6,6 +6,7 @@ from packaging.version import Version
 from e2b.connection_config import ConnectionConfig, default_username
 from e2b.envd.api import ENVD_API_FILES_ROUTE
 from e2b.envd.versions import ENVD_DEFAULT_USER
+from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.signature import get_signature
 
 
@@ -138,11 +139,16 @@ class SandboxBase:
         :return: URL for downloading file
         """
 
+        use_signature = self._envd_access_token is not None
+        if not use_signature and use_signature_expiration is not None:
+            raise InvalidArgumentException(
+                "Signature expiration can be used only when sandbox is created as secured."
+            )
+
         username = user
         if username is None and self._envd_version < ENVD_DEFAULT_USER:
             username = default_username
 
-        use_signature = self._envd_access_token is not None
         if use_signature:
             signature = get_signature(
                 path,
@@ -175,11 +181,16 @@ class SandboxBase:
         :return: URL for uploading file
         """
 
+        use_signature = self._envd_access_token is not None
+        if not use_signature and use_signature_expiration is not None:
+            raise InvalidArgumentException(
+                "Signature expiration can be used only when sandbox is created as secured."
+            )
+
         username = user
         if username is None and self._envd_version < ENVD_DEFAULT_USER:
             username = default_username
 
-        use_signature = self._envd_access_token is not None
         if use_signature:
             signature = get_signature(
                 path,

--- a/packages/python-sdk/e2b/sandbox/signature.py
+++ b/packages/python-sdk/e2b/sandbox/signature.py
@@ -26,7 +26,9 @@ def get_signature(
         raise ValueError("Access token is not set and signature cannot be generated!")
 
     expiration = (
-        int(time.time()) + expiration_in_seconds if expiration_in_seconds else None
+        int(time.time()) + expiration_in_seconds
+        if expiration_in_seconds is not None
+        else None
     )
 
     # if user is None, set it to empty string to handle default user

--- a/packages/python-sdk/tests/test_sandbox_urls.py
+++ b/packages/python-sdk/tests/test_sandbox_urls.py
@@ -1,18 +1,28 @@
+import time
+import urllib.parse
+
+import pytest
 from packaging.version import Version
 
 from e2b.connection_config import ConnectionConfig
+from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.main import SandboxBase
+from e2b.sandbox.signature import get_signature
 
 
-def test_file_urls_use_direct_sandbox_host_when_envd_api_uses_stable_host():
-    sandbox = SandboxBase(
+def create_sandbox(envd_access_token=None):
+    return SandboxBase(
         sandbox_id="sandbox-id",
         sandbox_domain="e2b.app",
         envd_version=Version("0.4.0"),
-        envd_access_token=None,
+        envd_access_token=envd_access_token,
         traffic_access_token=None,
         connection_config=ConnectionConfig(domain="e2b.app"),
     )
+
+
+def test_file_urls_use_direct_sandbox_host_when_envd_api_uses_stable_host():
+    sandbox = create_sandbox()
 
     assert sandbox.envd_api_url == "https://sandbox.e2b.app"
     assert sandbox.envd_direct_url == "https://49983-sandbox-id.e2b.app"
@@ -24,3 +34,39 @@ def test_file_urls_use_direct_sandbox_host_when_envd_api_uses_stable_host():
         sandbox.upload_url("/tmp/a.txt")
         == "https://49983-sandbox-id.e2b.app/files?path=%2Ftmp%2Fa.txt"
     )
+
+
+def test_file_urls_raise_when_signature_expiration_used_on_unsecured_sandbox():
+    sandbox = create_sandbox(envd_access_token=None)
+
+    with pytest.raises(
+        InvalidArgumentException,
+        match="Signature expiration can be used only when sandbox is created as secured.",
+    ):
+        sandbox.download_url("/tmp/a.txt", use_signature_expiration=120)
+
+    with pytest.raises(
+        InvalidArgumentException,
+        match="Signature expiration can be used only when sandbox is created as secured.",
+    ):
+        sandbox.upload_url("/tmp/a.txt", use_signature_expiration=120)
+
+
+def test_zero_signature_expiration_expires_immediately():
+    before = int(time.time())
+    signature = get_signature("/tmp/a.txt", "read", "user", "access-token", 0)
+    after = int(time.time())
+
+    assert signature["expiration"] is not None
+    assert before <= signature["expiration"] <= after
+
+
+def test_zero_signature_expiration_is_included_in_url():
+    sandbox = create_sandbox(envd_access_token="access-token")
+
+    for url in (
+        sandbox.download_url("/tmp/a.txt", use_signature_expiration=0),
+        sandbox.upload_url("/tmp/a.txt", use_signature_expiration=0),
+    ):
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+        assert "signature_expiration" in query


### PR DESCRIPTION
## Summary

- Python `upload_url`/`download_url` now raise `InvalidArgumentException` when `use_signature_expiration` is passed for an unsecured sandbox, matching the JS SDK (which now throws `InvalidArgumentError` instead of a plain `Error`).
- A signature expiration of `0` was treated as falsy and silently produced a never-expiring signed URL; it now produces an immediately expiring URL in both SDKs.
- Adds unit tests mirrored across both SDKs (`tests/sandbox/urls.test.ts` ↔ `tests/test_sandbox_urls.py`) plus a changeset.

## Usage

```python
sbx = Sandbox()  # not secure=True
sbx.download_url("a.txt", use_signature_expiration=120)  # now raises InvalidArgumentException instead of silently ignoring the expiration
```

```ts
const sbx = await Sandbox.create({ secure: true })
await sbx.downloadUrl('a.txt', { useSignatureExpiration: 0 })  // URL now expires immediately instead of never
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)