### PR TITLE
fix(js-sdk): raise errors for non-2xx API and envd responses with empty bodies

### DIFF
--- a/.changeset/shiny-pugs-check.md
+++ b/.changeset/shiny-pugs-check.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Raise an error for non-2xx API and envd responses with empty bodies (e.g. `Content-Length: 0`) instead of treating them as successful.

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -31,9 +31,9 @@ export function handleApiError(
   ) => Error = SandboxError,
   stackTrace?: string
 ): Error | undefined {
-  // openapi-fetch returns empty string for error when response body is empty,
-  // so we check !== undefined instead of truthiness
-  if (response.error === undefined) {
+  // openapi-fetch leaves `error` undefined for non-2xx responses with
+  // Content-Length: 0, so check the status instead
+  if (response.response.ok) {
     return
   }
 
@@ -57,7 +57,8 @@ export function handleApiError(
     return new RateLimitError(message)
   }
 
-  const message = response.error?.message ?? response.error
+  const message =
+    response.error?.message || response.error || response.response.statusText
   return new errorClass(`${response.response.status}: ${message}`, stackTrace)
 }
 

--- a/packages/js-sdk/src/envd/api.ts
+++ b/packages/js-sdk/src/envd/api.ts
@@ -43,14 +43,27 @@ export async function handleEnvdApiError(
   },
   errorMap?: Record<number, (message: string) => Error>
 ) {
-  if (!res.error) {
+  // openapi-fetch leaves `error` empty for non-2xx responses without content
+  // (undefined for Content-Length: 0, '' for an empty body without the
+  // header), so check the status instead
+  if (res.response.ok) {
     return
   }
 
-  const message: string =
-    typeof res.error == 'string'
-      ? res.error
-      : res.error?.message || (await res.response.text())
+  let message =
+    (typeof res.error === 'string' ? res.error : res.error?.message) ?? ''
+
+  // openapi-fetch consumes the body when parsing the error, except for
+  // responses without content
+  if (!message && !res.response.bodyUsed) {
+    try {
+      message = await res.response.text()
+    } catch {
+      // ignore unreadable bodies
+    }
+  }
+
+  message = message || res.response.statusText
 
   // Check if a custom error mapping is provided for this error code
   if (errorMap && res.response.status in errorMap) {

--- a/packages/js-sdk/tests/api/handleApiError.test.ts
+++ b/packages/js-sdk/tests/api/handleApiError.test.ts
@@ -23,6 +23,31 @@ function createMockResponse(
 }
 
 describe('handleApiError', () => {
+  describe('without content', () => {
+    // openapi-fetch leaves `error` undefined for non-2xx responses with
+    // Content-Length: 0
+    test('catches 404 with undefined error', () => {
+      const res = createMockResponse(404, undefined)
+      const err = handleApiError(res as any)
+      assert.instanceOf(err, SandboxError)
+      assert.include(err?.message, '404')
+    })
+
+    test('catches 500 with undefined error', () => {
+      const res = createMockResponse(500, undefined)
+      const err = handleApiError(res as any)
+      assert.instanceOf(err, SandboxError)
+      assert.include(err?.message, '500')
+    })
+
+    test('returns AuthenticationError for 401 with undefined error', () => {
+      const res = createMockResponse(401, undefined)
+      const err = handleApiError(res as any)
+      assert.instanceOf(err, AuthenticationError)
+      assert.include(err?.message, 'Unauthorized')
+    })
+  })
+
   describe('with empty error body', () => {
     test('catches 404 with empty string error', () => {
       const res = createMockResponse(404, '')

--- a/packages/js-sdk/tests/envd/handleEnvdApiError.test.ts
+++ b/packages/js-sdk/tests/envd/handleEnvdApiError.test.ts
@@ -12,26 +12,50 @@ import {
 
 function createMockResponse(
   status: number,
-  error: { message?: string } | string
+  error?: { message?: string } | string
 ): {
-  error: { message?: string } | string
+  error?: { message?: string } | string
   response: Response
 } {
   return {
     error,
     response: {
       status,
+      ok: status >= 200 && status < 300,
+      statusText: '',
+      // openapi-fetch consumes the body whenever it produces an error value
+      bodyUsed: error !== undefined,
       text: async () => (typeof error === 'string' ? error : ''),
-    } as Response,
+    } as unknown as Response,
   }
 }
 
 describe('handleEnvdApiError', () => {
   test('returns undefined for a successful response', async () => {
-    const err = await handleEnvdApiError({
-      response: { status: 200 } as Response,
-    })
+    const err = await handleEnvdApiError(createMockResponse(200))
     assert.isUndefined(err)
+  })
+
+  test('returns an error for non-2xx response without content', async () => {
+    // openapi-fetch leaves `error` undefined for responses with
+    // Content-Length: 0
+    const res = createMockResponse(500)
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, SandboxError)
+    assert.include(err?.message, '500')
+  })
+
+  test('returns an error for non-2xx response with empty string error', async () => {
+    const res = createMockResponse(500, '')
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, SandboxError)
+    assert.include(err?.message, '500')
+  })
+
+  test('returns a mapped error for non-2xx response without content', async () => {
+    const res = createMockResponse(404)
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, NotFoundError)
   })
 
   test('returns InvalidArgumentError for 400', async () => {

--- a/packages/js-sdk/tests/volume/volume.test.ts
+++ b/packages/js-sdk/tests/volume/volume.test.ts
@@ -3,7 +3,7 @@ import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { randomUUID } from 'node:crypto'
 
-import { Volume, NotFoundError } from '../../src'
+import { Volume, NotFoundError, VolumeError } from '../../src'
 import { VolumeConnectionConfig } from '../../src/volume/client'
 import { apiUrl } from '../setup'
 
@@ -123,6 +123,21 @@ describe('Volume CRUD', () => {
     await expect(Volume.getInfo('non-existent-id')).rejects.toThrow(
       NotFoundError
     )
+  })
+
+  it('should throw VolumeError for a non-2xx response without content', async () => {
+    server.use(
+      http.post(
+        apiUrl('/volumes'),
+        () =>
+          new HttpResponse(null, {
+            status: 500,
+            headers: { 'Content-Length': '0' },
+          })
+      )
+    )
+
+    await expect(Volume.create('error-volume')).rejects.toThrow(VolumeError)
   })
 
   it('should keep the proxy on the instance so content calls reuse it', async () => {


### PR DESCRIPTION
## Description

`handleApiError` and `handleEnvdApiError` used the presence of an error body as the failure signal, but openapi-fetch returns `error: undefined` for non-2xx responses with `Content-Length: 0` (and `error: ''` for empty bodies without that header), so such failures were silently treated as success — e.g. `sandbox.isRunning()` returned `true` for a failing `/health` endpoint. Both handlers now gate on `response.ok` and fall back to the status text when no error message is available. Volumes go through the same shared handler, so they inherit the fix. Regression tests cover both handlers and the volume path, including a 500-with-empty-body case that fails against the old code.

## Example

```ts
// Before: a 500 response with Content-Length: 0 was treated as success
await Volume.create('my-volume') // resolved with 'Response data is missing'

// After: the failure surfaces as the proper SDK error
await Volume.create('my-volume') // throws VolumeError('500: Internal Server Error')
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)