### PR TITLE
fix(sdk): WriteInfo.type enum, tz-aware times, gzip on default upload path

### DIFF
--- a/.changeset/tidy-files-gzip-fix.md
+++ b/.changeset/tidy-files-gzip-fix.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Make the `gzip: true` upload option imply the `application/octet-stream` upload path so it is no longer silently ignored on the default `multipart/form-data` path. On envd versions older than 0.5.7 the upload still falls back to uncompressed `multipart/form-data`.

--- a/.changeset/tidy-files-write-fixes.md
+++ b/.changeset/tidy-files-write-fixes.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Fix `write()` / `write_files()` returning `WriteInfo.type` as a raw string instead of the `FileType` enum. Make `EntryInfo.modified_time` timezone-aware (UTC) and normalize naive volume `atime`/`mtime`/`ctime` timestamps to UTC. Make the `gzip=True` upload option imply the `application/octet-stream` upload path so it is no longer silently ignored on the default `multipart/form-data` path.

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -245,7 +245,11 @@ export interface FilesystemRequestOpts
  */
 export interface FilesystemWriteOpts extends FilesystemRequestOpts {
   /**
-   * When true, the upload will be gzip-compressed.
+   * When true, the upload will be gzip-compressed. Implies the
+   * `application/octet-stream` upload.
+   *
+   * Requires envd 0.5.7 or later — when not supported by the sandbox's envd
+   * version, the upload falls back to uncompressed `multipart/form-data`.
    */
   gzip?: boolean
   /**
@@ -519,10 +523,15 @@ export class Filesystem {
       user = defaultUsername
     }
 
+    const useGzip = writeOpts?.gzip === true
+
     const supportsOctetStream =
       compareVersions(this.envdApi.version, ENVD_OCTET_STREAM_UPLOAD) >= 0
+    // Gzip compression only works with the octet-stream upload (the
+    // Content-Encoding header applies to the whole request body), so
+    // requesting gzip implies it when envd supports it.
     const useOctetStream =
-      (writeOpts?.useOctetStream ?? false) && supportsOctetStream
+      ((writeOpts?.useOctetStream ?? false) || useGzip) && supportsOctetStream
 
     const metadata = writeOpts?.metadata
     validateMetadata(metadata)
@@ -538,8 +547,6 @@ export class Filesystem {
     const extraHeaders = metadataHeaders(metadata)
 
     const results: WriteInfo[] = []
-
-    const useGzip = writeOpts?.gzip === true
 
     if (useOctetStream) {
       const headers: Record<string, string> = {

--- a/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
@@ -1,7 +1,7 @@
 import gzip
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from io import IOBase, TextIOBase
 from typing import IO, Dict, Optional, Union, TypedDict
@@ -30,6 +30,15 @@ def map_file_type(ft: filesystem_pb2.FileType):
         return FileType.FILE
     elif ft == filesystem_pb2.FileType.FILE_TYPE_DIRECTORY:
         return FileType.DIR
+
+
+def map_file_type_str(value: Optional[str]) -> Optional[FileType]:
+    """Map a `/files` API type string to `FileType`, `None` when unknown."""
+    if value == FileType.FILE.value:
+        return FileType.FILE
+    elif value == FileType.DIR.value:
+        return FileType.DIR
+    return None
 
 
 @dataclass
@@ -63,7 +72,7 @@ class WriteInfo:
         """Build a `WriteInfo` from a `/files` upload response entry."""
         return cls(
             name=payload["name"],
-            type=payload.get("type"),
+            type=map_file_type_str(payload.get("type")),
             path=payload["path"],
             metadata=map_metadata(payload.get("metadata")),
         )
@@ -116,7 +125,7 @@ def map_entry_info(entry: filesystem_pb2.EntryInfo) -> EntryInfo:
         permissions=entry.permissions,
         owner=entry.owner,
         group=entry.group,
-        modified_time=entry.modified_time.ToDatetime(),
+        modified_time=entry.modified_time.ToDatetime(tzinfo=timezone.utc),
         # Optional, we can't directly access symlink_target otherwise it will be "" instead of None
         symlink_target=(
             entry.symlink_target if entry.HasField("symlink_target") else None

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
@@ -215,7 +215,7 @@ class Filesystem:
         :param data: Data to write to the file, can be a `str`, `bytes`, or `IO`.
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request in **seconds**
-        :param gzip: Use gzip compression for the request
+        :param gzip: Use gzip compression for the upload. Implies the `application/octet-stream` upload. Requires envd 0.5.7 or later — when not supported, the upload falls back to uncompressed `multipart/form-data`.
         :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later — when not supported, the upload falls back to `multipart/form-data`.
         :param metadata: User-defined metadata to persist on the uploaded file as extended attributes. Keys are lowercased by the sandbox; invalid keys or values raise an `InvalidArgumentException`. Requires envd 0.6.2 or later.
 
@@ -255,7 +255,7 @@ class Filesystem:
         :param files: list of files to write as `WriteEntry` objects, each containing `path` and `data`
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request
-        :param gzip: Use gzip compression for the request
+        :param gzip: Use gzip compression for the upload. Implies the `application/octet-stream` upload. Requires envd 0.5.7 or later — when not supported, the upload falls back to uncompressed `multipart/form-data`.
         :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later — when not supported, the upload falls back to `multipart/form-data`.
         :param metadata: User-defined metadata to persist on each uploaded file as extended attributes; the same map is applied to every file. Keys are lowercased by the sandbox; invalid keys or values raise an `InvalidArgumentException`. Requires envd 0.6.2 or later.
         :return: Information about the written files
@@ -273,7 +273,10 @@ class Filesystem:
             raise TemplateException("File metadata requires envd 0.6.2 or later.")
 
         supports_octet_stream = self._envd_version >= ENVD_OCTET_STREAM_UPLOAD
-        use_octet_stream = use_octet_stream and supports_octet_stream
+        # Gzip compression only works with the octet-stream upload (the
+        # Content-Encoding header applies to the whole request body), so
+        # requesting gzip implies it when envd supports it.
+        use_octet_stream = (use_octet_stream or gzip) and supports_octet_stream
 
         # Metadata is sent as request-scoped X-Metadata-* headers, so the same
         # metadata is applied to every file in a multi-file upload.

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -237,7 +237,7 @@ class Filesystem:
         :param data: Data to write to the file, can be a `str`, `bytes`, or `IO`.
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request in **seconds**
-        :param gzip: Use gzip compression for the request
+        :param gzip: Use gzip compression for the upload. Implies the `application/octet-stream` upload. Requires envd 0.5.7 or later — when not supported, the upload falls back to uncompressed `multipart/form-data`.
         :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later — when not supported, the upload falls back to `multipart/form-data`.
         :param metadata: User-defined metadata to persist on the uploaded file as extended attributes. Keys are lowercased by the sandbox; invalid keys or values raise an `InvalidArgumentException`. Requires envd 0.6.2 or later.
 
@@ -277,7 +277,7 @@ class Filesystem:
         :param files: list of files to write as `WriteEntry` objects, each containing `path` and `data`
         :param user: Run the operation as this user
         :param request_timeout: Timeout for the request
-        :param gzip: Use gzip compression for the request
+        :param gzip: Use gzip compression for the upload. Implies the `application/octet-stream` upload. Requires envd 0.5.7 or later — when not supported, the upload falls back to uncompressed `multipart/form-data`.
         :param use_octet_stream: Upload using `application/octet-stream` instead of `multipart/form-data`. Defaults to `False`. Requires envd 0.5.7 or later — when not supported, the upload falls back to `multipart/form-data`.
         :param metadata: User-defined metadata to persist on each uploaded file as extended attributes; the same map is applied to every file. Keys are lowercased by the sandbox; invalid keys or values raise an `InvalidArgumentException`. Requires envd 0.6.2 or later.
         :return: Information about the written files
@@ -295,7 +295,10 @@ class Filesystem:
             raise TemplateException("File metadata requires envd 0.6.2 or later.")
 
         supports_octet_stream = self._envd_version >= ENVD_OCTET_STREAM_UPLOAD
-        use_octet_stream = use_octet_stream and supports_octet_stream
+        # Gzip compression only works with the octet-stream upload (the
+        # Content-Encoding header applies to the whole request body), so
+        # requesting gzip implies it when envd supports it.
+        use_octet_stream = (use_octet_stream or gzip) and supports_octet_stream
 
         # Metadata is sent as request-scoped X-Metadata-* headers, so the same
         # metadata is applied to every file in a multi-file upload.

--- a/packages/python-sdk/e2b/volume/utils.py
+++ b/packages/python-sdk/e2b/volume/utils.py
@@ -1,8 +1,16 @@
+import datetime
 from typing import Optional
 
 from e2b.volume.client.models import VolumeEntryStat as VolumeEntryStatApi
 from e2b.volume.client.types import UNSET
 from e2b.volume.types import VolumeEntryStat
+
+
+def _ensure_utc(dt: datetime.datetime) -> datetime.datetime:
+    """Mark a timezone-naive datetime as UTC (API timestamps are UTC)."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=datetime.timezone.utc)
+    return dt
 
 
 def convert_volume_entry_stat(api_stat: VolumeEntryStatApi) -> VolumeEntryStat:
@@ -19,9 +27,9 @@ def convert_volume_entry_stat(api_stat: VolumeEntryStatApi) -> VolumeEntryStat:
         mode=api_stat.mode,
         uid=api_stat.uid,
         gid=api_stat.gid,
-        atime=api_stat.atime,
-        mtime=api_stat.mtime,
-        ctime=api_stat.ctime,
+        atime=_ensure_utc(api_stat.atime),
+        mtime=_ensure_utc(api_stat.mtime),
+        ctime=_ensure_utc(api_stat.ctime),
         target=target,
     )
 

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_info.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_info.py
@@ -20,6 +20,7 @@ async def test_get_info_of_file(async_sandbox: AsyncSandbox):
     assert info.owner == "user"
     assert info.group == "user"
     assert info.modified_time is not None
+    assert info.modified_time.tzinfo is not None
 
 
 @pytest.mark.asyncio
@@ -47,6 +48,7 @@ async def test_get_info_of_directory(async_sandbox: AsyncSandbox):
     assert info.owner == "user"
     assert info.group == "user"
     assert info.modified_time is not None
+    assert info.modified_time.tzinfo is not None
 
 
 @pytest.mark.asyncio

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_write.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_write.py
@@ -2,7 +2,7 @@ import io
 import uuid
 
 from e2b import AsyncSandbox
-from e2b.sandbox.filesystem.filesystem import WriteEntry
+from e2b.sandbox.filesystem.filesystem import FileType, WriteEntry
 from e2b.sandbox_async.filesystem.filesystem import WriteInfo
 
 
@@ -12,6 +12,7 @@ async def test_write_text_file(async_sandbox: AsyncSandbox, debug):
 
     info = await async_sandbox.files.write(filename, content)
     assert info.path == f"/home/user/{filename}"
+    assert info.type == FileType.FILE
 
     exists = await async_sandbox.files.exists(filename)
     assert exists
@@ -80,6 +81,7 @@ async def test_write_multiple_files(async_sandbox: AsyncSandbox, debug):
     for i, info in enumerate(infos):
         assert isinstance(info, WriteInfo)
         assert info.path == f"/home/user/test_write_{i}.txt"
+        assert info.type == FileType.FILE
         exists = await async_sandbox.files.exists(path)
         assert exists
 

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_info.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_info.py
@@ -19,6 +19,7 @@ def test_get_info_of_file(sandbox: Sandbox):
     assert info.owner == "user"
     assert info.group == "user"
     assert info.modified_time is not None
+    assert info.modified_time.tzinfo is not None
 
 
 def test_get_info_of_nonexistent_file(sandbox: Sandbox):
@@ -44,6 +45,7 @@ def test_get_info_of_directory(sandbox: Sandbox):
     assert info.owner == "user"
     assert info.group == "user"
     assert info.modified_time is not None
+    assert info.modified_time.tzinfo is not None
 
 
 def test_get_info_of_nonexistent_directory(sandbox: Sandbox):

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_write.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_write.py
@@ -1,7 +1,7 @@
 import io
 import uuid
 
-from e2b.sandbox.filesystem.filesystem import WriteInfo, WriteEntry
+from e2b.sandbox.filesystem.filesystem import FileType, WriteInfo, WriteEntry
 
 
 def test_write_text_file(sandbox, debug):
@@ -10,6 +10,7 @@ def test_write_text_file(sandbox, debug):
 
     info = sandbox.files.write(filename, content)
     assert info.path == f"/home/user/{filename}"
+    assert info.type == FileType.FILE
 
     exists = sandbox.files.exists(filename)
     assert exists
@@ -81,6 +82,7 @@ def test_write_multiple_files(sandbox, debug):
     for i, info in enumerate(infos):
         assert isinstance(info, WriteInfo)
         assert info.path == f"/home/user/test_write_{i}.txt"
+        assert info.type == FileType.FILE
         exists = sandbox.files.exists(path)
         assert exists
 

--- a/packages/python-sdk/tests/test_filesystem_models.py
+++ b/packages/python-sdk/tests/test_filesystem_models.py
@@ -1,0 +1,89 @@
+import datetime
+
+from e2b.envd.filesystem import filesystem_pb2
+from e2b.sandbox.filesystem.filesystem import (
+    FileType,
+    WriteInfo,
+    map_entry_info,
+    map_file_type_str,
+)
+from e2b.volume.client.models import VolumeEntryStat as VolumeEntryStatApi
+from e2b.volume.client.models import VolumeEntryStatType
+from e2b.volume.utils import convert_volume_entry_stat
+
+
+def test_write_info_from_dict_converts_type_to_enum():
+    info = WriteInfo.from_dict(
+        {"name": "a.txt", "type": "file", "path": "/home/user/a.txt"}
+    )
+    assert info.type is FileType.FILE
+
+    info = WriteInfo.from_dict({"name": "dir", "type": "dir", "path": "/home/user/dir"})
+    assert info.type is FileType.DIR
+
+
+def test_write_info_from_dict_handles_missing_or_unknown_type():
+    info = WriteInfo.from_dict({"name": "a.txt", "path": "/home/user/a.txt"})
+    assert info.type is None
+
+    info = WriteInfo.from_dict(
+        {"name": "a.txt", "type": "symlink", "path": "/home/user/a.txt"}
+    )
+    assert info.type is None
+
+
+def test_map_file_type_str():
+    assert map_file_type_str("file") is FileType.FILE
+    assert map_file_type_str("dir") is FileType.DIR
+    assert map_file_type_str("unknown") is None
+    assert map_file_type_str(None) is None
+
+
+def test_map_entry_info_modified_time_is_timezone_aware():
+    entry = filesystem_pb2.EntryInfo(
+        name="a.txt",
+        type=filesystem_pb2.FileType.FILE_TYPE_FILE,
+        path="/home/user/a.txt",
+        size=4,
+        mode=0o644,
+        permissions="-rw-r--r--",
+        owner="user",
+        group="user",
+    )
+    entry.modified_time.FromDatetime(
+        datetime.datetime(2026, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)
+    )
+
+    info = map_entry_info(entry)
+
+    assert info.modified_time.tzinfo == datetime.timezone.utc
+    assert info.modified_time == datetime.datetime(
+        2026, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc
+    )
+
+
+def test_convert_volume_entry_stat_normalizes_naive_times_to_utc():
+    naive = datetime.datetime(2026, 1, 2, 3, 4, 5)
+    aware = datetime.datetime(2026, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)
+
+    api_stat = VolumeEntryStatApi(
+        name="a.txt",
+        type_=VolumeEntryStatType.FILE,
+        path="/a.txt",
+        size=4,
+        mode=0o644,
+        uid=1000,
+        gid=1000,
+        atime=naive,
+        mtime=naive,
+        ctime=aware,
+    )
+
+    stat = convert_volume_entry_stat(api_stat)
+
+    assert stat.atime == aware
+    assert stat.mtime == aware
+    assert stat.ctime == aware
+    assert stat.atime.tzinfo == datetime.timezone.utc
+    assert stat.mtime.tzinfo == datetime.timezone.utc
+    assert stat.ctime.tzinfo == datetime.timezone.utc


### PR DESCRIPTION
## Summary

- Python `write()` / `write_files()` now return `WriteInfo.type` as the `FileType` enum instead of the raw API string (sync and async; the JS string union was already correct, and the volumes client already converts to `VolumeEntryStatType`).
- `EntryInfo.modified_time` is now timezone-aware UTC (protobuf `ToDatetime()` returns naive datetimes by default), and naive volume `atime`/`mtime`/`ctime` timestamps are normalized to UTC.
- `gzip=true` uploads now imply the `application/octet-stream` path in both JS and Python instead of being silently ignored on the default `multipart/form-data` path; on envd < 0.5.7 the upload falls back to uncompressed multipart, matching the existing `use_octet_stream` fallback.
- Adds sandbox-free unit tests for the model conversions, strengthens write/info integration test assertions, and includes changesets for `@e2b/python-sdk` and `e2b`.

## Usage examples

```python
info = sandbox.files.write("hello.txt", "hi")
info.type == FileType.FILE          # was the raw string "file"

entry = sandbox.files.get_info("hello.txt")
entry.modified_time.tzinfo          # datetime.timezone.utc (was None)

sandbox.files.write("big.bin", data, gzip=True)  # now actually gzip-compressed
```

## Test plan

- [x] `pytest tests/test_filesystem_models.py` (new unit tests, 5 passed)
- [x] Python sync + async integration tests for `write`, `info`, `content_encoding` (16 each, passed against live sandboxes)
- [x] JS `write.test.ts` + `contentEncoding.test.ts` (14 passed)
- [x] `pnpm run format`, `pnpm run lint`, `pnpm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)