### PR TITLE
fix(python-sdk): anchor file-metadata validation regexes with \A/\Z

### DIFF
--- a/.changeset/tidy-knees-attach.md
+++ b/.changeset/tidy-knees-attach.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Anchor file-metadata validation regexes with `\A`/`\Z` instead of `^`/`$`. In Python, `$` also matches just before a trailing newline, so metadata keys or values ending in `\n` passed client-side validation (unlike the JS SDK) and then failed later with an opaque low-level HTTP "illegal header value" error. They are now rejected upfront with `InvalidArgumentException`.

--- a/packages/js-sdk/tests/sandbox/files/metadata.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/metadata.test.ts
@@ -181,6 +181,14 @@ sandboxTest('rejects invalid metadata', async ({ sandbox }) => {
     sandbox.files.write(filename, 'x', { metadata: { good: 'bad\nvalue' } })
   ).rejects.toThrow(InvalidArgumentError)
 
+  // Trailing newline in value or key.
+  await expect(
+    sandbox.files.write(filename, 'x', { metadata: { good: 'value\n' } })
+  ).rejects.toThrow(InvalidArgumentError)
+  await expect(
+    sandbox.files.write(filename, 'x', { metadata: { 'key\n': 'value' } })
+  ).rejects.toThrow(InvalidArgumentError)
+
   // The file must not have been created by a rejected write.
   assert.isFalse(await sandbox.files.exists(filename))
 })

--- a/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
@@ -170,8 +170,8 @@ METADATA_HEADER_PREFIX = "X-Metadata-"
 # Metadata keys travel as `X-Metadata-<key>` HTTP header names, so they must be
 # valid header tokens (RFC 7230); values travel as header values, restricted to
 # printable US-ASCII.
-_METADATA_KEY_REGEX = re.compile(r"^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$")
-_METADATA_VALUE_REGEX = re.compile(r"^[\x20-\x7e]*$")
+_METADATA_KEY_REGEX = re.compile(r"\A[A-Za-z0-9!#$%&'*+\-.^_`|~]+\Z")
+_METADATA_VALUE_REGEX = re.compile(r"\A[\x20-\x7e]*\Z")
 
 
 def validate_metadata(metadata: Optional[Dict[str, str]]) -> None:

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_metadata.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_metadata.py
@@ -162,5 +162,11 @@ async def test_write_rejects_invalid_metadata(async_sandbox: AsyncSandbox):
     with pytest.raises(InvalidArgumentException):
         await async_sandbox.files.write(filename, "x", metadata={"good": "bad\nvalue"})
 
+    # Trailing newline (Python's `$` would accept it; `\Z` must not).
+    with pytest.raises(InvalidArgumentException):
+        await async_sandbox.files.write(filename, "x", metadata={"good": "value\n"})
+    with pytest.raises(InvalidArgumentException):
+        await async_sandbox.files.write(filename, "x", metadata={"key\n": "value"})
+
     # The file must not have been created by a rejected write.
     assert not await async_sandbox.files.exists(filename)

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_metadata.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_metadata.py
@@ -153,5 +153,11 @@ def test_write_rejects_invalid_metadata(sandbox):
     with pytest.raises(InvalidArgumentException):
         sandbox.files.write(filename, "x", metadata={"good": "bad\nvalue"})
 
+    # Trailing newline (Python's `$` would accept it; `\Z` must not).
+    with pytest.raises(InvalidArgumentException):
+        sandbox.files.write(filename, "x", metadata={"good": "value\n"})
+    with pytest.raises(InvalidArgumentException):
+        sandbox.files.write(filename, "x", metadata={"key\n": "value"})
+
     # The file must not have been created by a rejected write.
     assert not sandbox.files.exists(filename)


### PR DESCRIPTION
## Summary

Python's `$` regex anchor also matches just before a trailing newline, so file-metadata keys/values ending in `\n` passed client-side validation (unlike the JS SDK, where `$` matches only the true end of string) and then failed deep in the HTTP stack with an opaque "illegal header value" error. This re-anchors both validation regexes with `\A`/`\Z` so such inputs are rejected upfront with `InvalidArgumentException`, matching JS behavior and the existing convention used for the API-key pattern.

Also adds trailing-newline rejection test cases to the sync/async Python suites and, for parity of coverage, to the JS SDK suite (JS already rejected them — no behavior change there).

## Usage example

```python
sandbox.files.write("file.txt", "x", metadata={"author": "mish\n"})
# before: passed validation, then httpcore raised 'Illegal header value'
# after:  raises InvalidArgumentException with a clear message
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)