### PR TITLE
feat: add skipApiKeyValidation flag to bypass API key format check

### DIFF
--- a/.changeset/three-pants-tap.md
+++ b/.changeset/three-pants-tap.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': patch
+'e2b': patch
+---
+
+Add skipApiKeyValidation / skip_api_key_validation option to bypass API key format check for self-hosted endpoints

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -83,7 +83,7 @@ class ApiClient {
       )
     }
 
-    if (config.apiKey) {
+    if (config.apiKey && !config.skipApiKeyValidation) {
       validateApiKey(config.apiKey)
     }
 

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -22,6 +22,17 @@ export interface ConnectionOpts {
    */
   apiKey?: string
   /**
+   * When true, skips client-side API key **format** validation.
+   * The key is still required — only the `e2b_<hex>` pattern check is bypassed.
+   *
+   * Use this when connecting to a self-hosted or E2B-compatible endpoint
+   * that issues credentials in a different format (e.g. `sk-...`, JWTs,
+   * opaque tokens). Has no effect on E2B Cloud where the default format applies.
+   *
+   * @default E2B_SKIP_API_KEY_VALIDATION // environment variable or `false`
+   */
+  skipApiKeyValidation?: boolean
+  /**
    * E2B access token to use for authentication.
    *
    * @default E2B_ACCESS_TOKEN // environment variable
@@ -198,6 +209,7 @@ export class ConnectionConfig {
   readonly requestTimeoutMs: number
 
   readonly apiKey?: string
+  readonly skipApiKeyValidation: boolean
   readonly accessToken?: string
 
   readonly headers?: Record<string, string>
@@ -206,6 +218,8 @@ export class ConnectionConfig {
 
   constructor(opts?: ConnectionOpts) {
     this.apiKey = opts?.apiKey || ConnectionConfig.apiKey
+    this.skipApiKeyValidation =
+      opts?.skipApiKeyValidation ?? ConnectionConfig.skipApiKeyValidation
     this.debug = opts?.debug ?? ConnectionConfig.debug
     this.domain = opts?.domain || ConnectionConfig.domain
     this.accessToken = opts?.accessToken || ConnectionConfig.accessToken
@@ -241,6 +255,13 @@ export class ConnectionConfig {
 
   private static get apiKey() {
     return getEnvVar('E2B_API_KEY')
+  }
+
+  private static get skipApiKeyValidation() {
+    return (
+      (getEnvVar('E2B_SKIP_API_KEY_VALIDATION') || 'false').toLowerCase() ===
+      'true'
+    )
   }
 
   private static get accessToken() {

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -232,6 +232,7 @@ export interface SandboxApiOpts
     Pick<
       ConnectionOpts,
       | 'apiKey'
+      | 'skipApiKeyValidation'
       | 'headers'
       | 'apiHeaders'
       | 'debug'

--- a/packages/js-sdk/tests/api/validateApiKey.test.ts
+++ b/packages/js-sdk/tests/api/validateApiKey.test.ts
@@ -1,6 +1,26 @@
 import { assert, test, describe } from 'vitest'
-import { validateApiKey } from '../../src/api'
+import { ApiClient, validateApiKey } from '../../src/api'
+import { ConnectionConfig } from '../../src/connectionConfig'
 import { AuthenticationError } from '../../src/errors'
+
+describe('ApiClient key validation', () => {
+  test('skips validation when skipApiKeyValidation is true', () => {
+    const config = new ConnectionConfig({
+      apiKey: 'sk-' + '0'.repeat(40),
+      skipApiKeyValidation: true,
+    })
+    assert.doesNotThrow(() => new ApiClient(config))
+  })
+
+  test('rejects non-standard key by default', () => {
+    const config = new ConnectionConfig({ apiKey: 'sk-' + '0'.repeat(40) })
+    assert.throws(
+      () => new ApiClient(config),
+      AuthenticationError,
+      /Invalid API key format/
+    )
+  })
+})
 
 describe('validateApiKey', () => {
   const validKey = 'e2b_' + '0123456789abcdef'.repeat(2) + '01234567'

--- a/packages/js-sdk/tests/connectionConfig.test.ts
+++ b/packages/js-sdk/tests/connectionConfig.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
     E2B_DOMAIN: process.env.E2B_DOMAIN,
     E2B_SANDBOX_URL: process.env.E2B_SANDBOX_URL,
     E2B_DEBUG: process.env.E2B_DEBUG,
+    E2B_SKIP_API_KEY_VALIDATION: process.env.E2B_SKIP_API_KEY_VALIDATION,
   }
 })
 
@@ -144,6 +145,36 @@ test('sandbox_url stays localhost in debug mode', () => {
     }),
     'http://localhost:49983'
   )
+})
+
+test('skipApiKeyValidation defaults to false', () => {
+  delete process.env.E2B_SKIP_API_KEY_VALIDATION
+  const config = new ConnectionConfig()
+  assert.equal(config.skipApiKeyValidation, false)
+})
+
+test('skipApiKeyValidation reads from env var', () => {
+  process.env.E2B_SKIP_API_KEY_VALIDATION = 'true'
+  const config = new ConnectionConfig()
+  assert.equal(config.skipApiKeyValidation, true)
+})
+
+test('skipApiKeyValidation env var is case-insensitive', () => {
+  process.env.E2B_SKIP_API_KEY_VALIDATION = 'TRUE'
+  const config = new ConnectionConfig()
+  assert.equal(config.skipApiKeyValidation, true)
+})
+
+test('skipApiKeyValidation env var false keeps validation enabled', () => {
+  process.env.E2B_SKIP_API_KEY_VALIDATION = 'false'
+  const config = new ConnectionConfig()
+  assert.equal(config.skipApiKeyValidation, false)
+})
+
+test('skipApiKeyValidation in args takes priority over env var', () => {
+  process.env.E2B_SKIP_API_KEY_VALIDATION = 'true'
+  const config = new ConnectionConfig({ skipApiKeyValidation: false })
+  assert.equal(config.skipApiKeyValidation, false)
 })
 
 test('debug false in args overrides E2B_DEBUG env var', () => {

--- a/packages/js-sdk/tests/sandbox/configPropagation.test.ts
+++ b/packages/js-sdk/tests/sandbox/configPropagation.test.ts
@@ -12,6 +12,7 @@ const baseConfig = {
   requestTimeoutMs: 1111,
   debug: false,
   apiHeaders: { 'X-Test': 'base' },
+  skipApiKeyValidation: true,
 }
 
 function createSandbox() {
@@ -51,6 +52,7 @@ describe('Sandbox API config propagation', () => {
     assert.equal(opts?.requestTimeoutMs, baseConfig.requestTimeoutMs)
     assert.equal(opts?.debug, baseConfig.debug)
     assert.equal(opts?.headers?.['X-Test'], baseConfig.apiHeaders['X-Test'])
+    assert.equal(opts?.skipApiKeyValidation, baseConfig.skipApiKeyValidation)
   })
 
   test('accepts apiHeaders in static Sandbox API options', () => {

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -149,7 +149,7 @@ class ApiClient(AuthenticatedClient):
                 )
             token = config.api_key
 
-        if config.api_key is not None:
+        if config.api_key is not None and not config.skip_api_key_validation:
             validate_api_key(config.api_key)
 
         if require_access_token:

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -33,6 +33,15 @@ class ApiParams(TypedDict, total=False):
     api_key: Optional[str]
     """E2B API Key to use for authentication, defaults to `E2B_API_KEY` environment variable."""
 
+    skip_api_key_validation: Optional[bool]
+    """When True, skips client-side API key **format** validation.
+    The key is still required — only the ``e2b_<hex>`` pattern check is bypassed.
+
+    Use this when connecting to a self-hosted or E2B-compatible endpoint
+    that issues credentials in a different format (e.g. ``sk-...``, JWTs,
+    opaque tokens). Has no effect on E2B Cloud where the default format applies.
+    Defaults to ``E2B_SKIP_API_KEY_VALIDATION`` environment variable or ``False``."""
+
     domain: Optional[str]
     """E2B domain to use for authentication, defaults to `E2B_DOMAIN` environment variable."""
 
@@ -69,6 +78,10 @@ class ConnectionConfig:
         return os.getenv("E2B_API_KEY")
 
     @staticmethod
+    def _skip_api_key_validation():
+        return os.getenv("E2B_SKIP_API_KEY_VALIDATION", "false").lower() == "true"
+
+    @staticmethod
     def _api_url():
         return os.getenv("E2B_API_URL")
 
@@ -85,6 +98,7 @@ class ConnectionConfig:
         domain: Optional[str] = None,
         debug: Optional[bool] = None,
         api_key: Optional[str] = None,
+        skip_api_key_validation: Optional[bool] = None,
         api_url: Optional[str] = None,
         sandbox_url: Optional[str] = None,
         access_token: Optional[str] = None,
@@ -97,6 +111,11 @@ class ConnectionConfig:
         self.domain = domain or ConnectionConfig._domain()
         self.debug = debug if debug is not None else ConnectionConfig._debug()
         self.api_key = api_key or ConnectionConfig._api_key()
+        self.skip_api_key_validation = (
+            skip_api_key_validation
+            if skip_api_key_validation is not None
+            else ConnectionConfig._skip_api_key_validation()
+        )
         self.access_token = access_token or ConnectionConfig._access_token()
         self.headers = {**(headers or {}), **(api_headers or {})}
         self.headers["User-Agent"] = f"e2b-python-sdk/{package_version}"
@@ -191,6 +210,7 @@ class ConnectionConfig:
         api_headers = opts.get("api_headers")
         request_timeout = opts.get("request_timeout")
         api_key = opts.get("api_key")
+        skip_api_key_validation = opts.get("skip_api_key_validation")
         api_url = opts.get("api_url")
         domain = opts.get("domain")
         debug = opts.get("debug")
@@ -206,6 +226,9 @@ class ConnectionConfig:
         return dict(
             ApiParams(
                 api_key=api_key if api_key is not None else self.api_key,
+                skip_api_key_validation=skip_api_key_validation
+                if skip_api_key_validation is not None
+                else self.skip_api_key_validation,
                 api_url=api_url if api_url is not None else self.api_url,
                 domain=domain if domain is not None else self.domain,
                 debug=debug if debug is not None else self.debug,

--- a/packages/python-sdk/tests/async/sandbox_async/test_config_propagation.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_config_propagation.py
@@ -91,6 +91,43 @@ async def test_pause_applies_overrides(monkeypatch, test_api_key):
 
 
 @pytest.mark.skip_debug()
+async def test_pause_propagates_skip_api_key_validation(monkeypatch, test_api_key):
+    mock_pause = AsyncMock(return_value="sbx-test")
+    monkeypatch.setattr(sandbox_async_main.SandboxApi, "_cls_pause", mock_pause)
+
+    dummy_transport = SimpleNamespace(pool=object())
+    monkeypatch.setattr(
+        sandbox_async_main, "get_transport", lambda *_args, **_kwargs: dummy_transport
+    )
+    monkeypatch.setattr(
+        sandbox_async_main.httpx, "AsyncClient", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        sandbox_async_main, "Filesystem", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        sandbox_async_main, "Commands", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(sandbox_async_main, "Pty", lambda *args, **kwargs: object())
+    monkeypatch.setattr(sandbox_async_main, "Git", lambda *args, **kwargs: object())
+
+    sandbox = AsyncSandbox(
+        sandbox_id="sbx-test",
+        sandbox_domain="sandbox.e2b.dev",
+        envd_version=Version("0.2.4"),
+        envd_access_token="tok",
+        traffic_access_token="tok",
+        connection_config=ConnectionConfig(
+            api_key=test_api_key,
+            skip_api_key_validation=True,
+        ),
+    )
+    await sandbox.pause()
+
+    assert mock_pause.call_args.kwargs["skip_api_key_validation"] is True
+
+
+@pytest.mark.skip_debug()
 async def test_connect_sets_stable_host_routing_headers(monkeypatch, test_api_key):
     mock_connect = AsyncMock(
         return_value=SimpleNamespace(

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_config_propagation.py
@@ -79,6 +79,33 @@ def test_pause_applies_overrides(monkeypatch, test_api_key):
 
 
 @pytest.mark.skip_debug()
+def test_pause_propagates_skip_api_key_validation(monkeypatch, test_api_key):
+    mock_pause = Mock(return_value="sbx-test")
+    monkeypatch.setattr(sandbox_sync_main.SandboxApi, "_cls_pause", mock_pause)
+    monkeypatch.setattr(
+        sandbox_sync_main, "Filesystem", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(sandbox_sync_main, "Commands", lambda *args, **kwargs: object())
+    monkeypatch.setattr(sandbox_sync_main, "Pty", lambda *args, **kwargs: object())
+    monkeypatch.setattr(sandbox_sync_main, "Git", lambda *args, **kwargs: object())
+
+    sandbox = Sandbox(
+        sandbox_id="sbx-test",
+        sandbox_domain="sandbox.e2b.dev",
+        envd_version=Version("0.2.4"),
+        envd_access_token="tok",
+        traffic_access_token="tok",
+        connection_config=ConnectionConfig(
+            api_key=test_api_key,
+            skip_api_key_validation=True,
+        ),
+    )
+    sandbox.pause()
+
+    assert mock_pause.call_args.kwargs["skip_api_key_validation"] is True
+
+
+@pytest.mark.skip_debug()
 def test_connect_sets_stable_host_routing_headers(monkeypatch, test_api_key):
     mock_connect = Mock(
         return_value=SimpleNamespace(

--- a/packages/python-sdk/tests/test_connection_config.py
+++ b/packages/python-sdk/tests/test_connection_config.py
@@ -127,3 +127,39 @@ def test_get_api_params_includes_sandbox_url():
     # Per-call override takes priority.
     overridden = config.get_api_params(sandbox_url="https://sandbox.override.com")
     assert overridden["sandbox_url"] == "https://sandbox.override.com"
+
+
+def test_skip_api_key_validation_defaults_to_false(monkeypatch):
+    monkeypatch.delenv("E2B_SKIP_API_KEY_VALIDATION", raising=False)
+    config = ConnectionConfig()
+    assert config.skip_api_key_validation is False
+
+
+def test_skip_api_key_validation_from_env_var(monkeypatch):
+    monkeypatch.setenv("E2B_SKIP_API_KEY_VALIDATION", "true")
+    config = ConnectionConfig()
+    assert config.skip_api_key_validation is True
+
+
+def test_skip_api_key_validation_env_var_is_case_insensitive(monkeypatch):
+    monkeypatch.setenv("E2B_SKIP_API_KEY_VALIDATION", "TRUE")
+    config = ConnectionConfig()
+    assert config.skip_api_key_validation is True
+
+
+def test_skip_api_key_validation_env_var_false_keeps_validation_enabled(monkeypatch):
+    monkeypatch.setenv("E2B_SKIP_API_KEY_VALIDATION", "false")
+    config = ConnectionConfig()
+    assert config.skip_api_key_validation is False
+
+
+def test_skip_api_key_validation_arg_has_priority_over_env_var(monkeypatch):
+    monkeypatch.setenv("E2B_SKIP_API_KEY_VALIDATION", "true")
+    config = ConnectionConfig(skip_api_key_validation=False)
+    assert config.skip_api_key_validation is False
+
+
+def test_get_api_params_propagates_skip_api_key_validation():
+    config = ConnectionConfig(skip_api_key_validation=True)
+    params = config.get_api_params()
+    assert params["skip_api_key_validation"] is True

--- a/packages/python-sdk/tests/test_validate_api_key.py
+++ b/packages/python-sdk/tests/test_validate_api_key.py
@@ -1,6 +1,7 @@
 import pytest
 
-from e2b.api import validate_api_key
+from e2b.api import ApiClient, validate_api_key
+from e2b.connection_config import ConnectionConfig
 from e2b.exceptions import AuthenticationException
 
 
@@ -36,3 +37,14 @@ def test_error_message_includes_example_token(test_api_key):
     with pytest.raises(AuthenticationException) as exc_info:
         validate_api_key("nope")
     assert test_api_key in str(exc_info.value)
+
+
+def test_api_client_accepts_non_standard_key_when_skip_enabled():
+    config = ConnectionConfig(api_key="sk-" + "0" * 40, skip_api_key_validation=True)
+    ApiClient(config)
+
+
+def test_api_client_rejects_non_standard_key_by_default():
+    config = ConnectionConfig(api_key="sk-" + "0" * 40)
+    with pytest.raises(AuthenticationException, match=r"Invalid API key format"):
+        ApiClient(config)


### PR DESCRIPTION
## Problem

Since #1356, both SDKs validate API keys against the `e2b_<hex>` pattern client-side before any request is made. This breaks self-hosted or E2B-compatible backends that issue credentials in different formats (e.g. `sk-...`, JWTs, opaque tokens).

Fixes #1398

## Solution

Add a `skipApiKeyValidation` / `skip_api_key_validation` boolean that bypasses the format check when set. The presence check is still enforced — a key is still required, only the `e2b_<hex>` pattern check is skipped.

**JS SDK**

```ts
const sandbox = await Sandbox.create({
  apiKey: 'sk-my-custom-token',
  skipApiKeyValidation: true,
})
```

**Python SDK**

```python
sandbox = Sandbox(
    api_key="sk-my-custom-token",
    skip_api_key_validation=True,
)
```

**Environment variable**

```bash
E2B_SKIP_API_KEY_VALIDATION=true
```

## Difference from PR #1360

PR #1360 adds `apiKeyPrefix` which still validates a hex body after the prefix, fails for JWTs and tokens with non-hex characters. This PR skips the entire format check, covering all non-standard credential formats.

## Changes

- New `skipApiKeyValidation` (JS) / `skip_api_key_validation` (Python) boolean, defaults to `false`
- `E2B_SKIP_API_KEY_VALIDATION` env var support
- `SandboxApiOpts` updated so per-call overrides are type-safe
- `get_api_params` propagates the flag through child `ConnectionConfig` objects
- Tests: default value, env var, case-insensitivity, arg priority, propagation through `sandbox.pause()`, `ApiClient` accept/reject behavior