### PR TITLE
fix(ci): gate SDK test steps on inputs.run so matrix checks always expand

### DIFF
--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -21,7 +21,8 @@ permissions:
 
 jobs:
   test:
-    if: ${{ inputs.run }}
+    # Gate each step (not the job) on `inputs.run` so the matrix always expands
+    # and the per-OS required checks are created even when skipped.
     defaults:
       run:
         working-directory: ./packages/cli
@@ -33,9 +34,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
+        if: ${{ inputs.run }}
         uses: actions/checkout@v4
 
       - name: Parse .tool-versions
+        if: ${{ inputs.run }}
         uses: wistia/parse-tool-versions@v2.1.1
         with:
           filename: '.tool-versions'
@@ -43,11 +46,13 @@ jobs:
           prefix: 'tool_version_'
 
       - name: Install pnpm
+        if: ${{ inputs.run }}
         uses: pnpm/action-setup@v4
         with:
           version: '${{ env.TOOL_VERSION_PNPM }}'
 
       - name: Setup Node
+        if: ${{ inputs.run }}
         uses: actions/setup-node@v3
         with:
           node-version: '${{ env.TOOL_VERSION_NODEJS }}'
@@ -56,21 +61,26 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Configure pnpm
+        if: ${{ inputs.run }}
         run: |
           pnpm config set auto-install-peers true
 
       - name: Install dependencies
+        if: ${{ inputs.run }}
         run: pnpm install --frozen-lockfile
 
       - name: Build the SDK (pre-requisite for the tests)
+        if: ${{ inputs.run }}
         run: pnpm build
         working-directory: ./packages/js-sdk
 
       - name: Build the CLI
+        if: ${{ inputs.run }}
         run: pnpm build
         working-directory: ./packages/cli
 
       - name: Run tests
+        if: ${{ inputs.run }}
         run: pnpm test
         working-directory: ./packages/cli
         env:

--- a/.github/workflows/js_sdk_tests.yml
+++ b/.github/workflows/js_sdk_tests.yml
@@ -21,7 +21,8 @@ permissions:
 
 jobs:
   test:
-    if: ${{ inputs.run }}
+    # Gate each step (not the job) on `inputs.run` so the matrix always expands
+    # and the per-OS required checks are created even when skipped.
     defaults:
       run:
         working-directory: ./packages/js-sdk
@@ -34,9 +35,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
+        if: ${{ inputs.run }}
         uses: actions/checkout@v4
 
       - name: Parse .tool-versions
+        if: ${{ inputs.run }}
         uses: wistia/parse-tool-versions@v2.1.1
         with:
           filename: '.tool-versions'
@@ -44,12 +47,14 @@ jobs:
           prefix: 'tool_version_'
 
       - name: Install pnpm
+        if: ${{ inputs.run }}
         uses: pnpm/action-setup@v4
         id: pnpm-install
         with:
           version: '${{ env.TOOL_VERSION_PNPM }}'
 
       - name: Setup Node
+        if: ${{ inputs.run }}
         uses: actions/setup-node@v3
         with:
           node-version: '${{ env.TOOL_VERSION_NODEJS }}'
@@ -58,16 +63,18 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Configure pnpm
+        if: ${{ inputs.run }}
         run: |
           pnpm config set auto-install-peers true
           pnpm config set exclude-links-from-lockfile true
 
       - name: Install dependencies
+        if: ${{ inputs.run }}
         run: |
           pnpm install --frozen-lockfile
 
       - name: Cache Playwright binaries (Linux)
-        if: matrix.os == 'ubuntu-22.04'
+        if: ${{ inputs.run && matrix.os == 'ubuntu-22.04' }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
@@ -76,7 +83,7 @@ jobs:
             playwright-${{ runner.os }}-${{ env.TOOL_VERSION_NODEJS }}-
 
       - name: Cache Playwright binaries (Windows)
-        if: matrix.os == 'windows-latest'
+        if: ${{ inputs.run && matrix.os == 'windows-latest' }}
         uses: actions/cache@v4
         with:
           path: ~/AppData/Local/ms-playwright
@@ -85,29 +92,35 @@ jobs:
             playwright-${{ runner.os }}-${{ env.TOOL_VERSION_NODEJS }}-
 
       - name: Test build
+        if: ${{ inputs.run }}
         run: pnpm build
 
       - name: Run Node tests
+        if: ${{ inputs.run }}
         run: pnpm test
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           E2B_DOMAIN: ${{ inputs.E2B_DOMAIN }}
 
       - name: Install Bun
+        if: ${{ inputs.run }}
         uses: oven-sh/setup-bun@v2
 
       - name: Run Bun tests
+        if: ${{ inputs.run }}
         run: pnpm test:bun
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           E2B_DOMAIN: ${{ inputs.E2B_DOMAIN }}
 
       - name: Install Deno
+        if: ${{ inputs.run }}
         uses: denoland/setup-deno@v1
         with:
           deno-version: v${{ env.TOOL_VERSION_DENO }}
 
       - name: Run Deno tests
+        if: ${{ inputs.run }}
         run: pnpm test:deno
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}

--- a/.github/workflows/python_sdk_tests.yml
+++ b/.github/workflows/python_sdk_tests.yml
@@ -21,7 +21,8 @@ permissions:
 
 jobs:
   test:
-    if: ${{ inputs.run }}
+    # Gate each step (not the job) on `inputs.run` so the matrix always expands
+    # and the per-OS required checks are created even when skipped.
     defaults:
       run:
         working-directory: ./packages/python-sdk
@@ -34,9 +35,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
+        if: ${{ inputs.run }}
         uses: actions/checkout@v4
 
       - name: Parse .tool-versions
+        if: ${{ inputs.run }}
         uses: wistia/parse-tool-versions@v2.1.1
         with:
           filename: '.tool-versions'
@@ -44,11 +47,13 @@ jobs:
           prefix: 'tool_version_'
 
       - name: Set up Python
+        if: ${{ inputs.run }}
         uses: actions/setup-python@v4
         with:
           python-version: '${{ env.TOOL_VERSION_PYTHON }}'
 
       - name: Install and configure Poetry
+        if: ${{ inputs.run }}
         uses: snok/install-poetry@v1
         with:
           version: '${{ env.TOOL_VERSION_POETRY }}'
@@ -57,12 +62,15 @@ jobs:
           installer-parallel: true
 
       - name: Install dependencies
+        if: ${{ inputs.run }}
         run: poetry install
 
       - name: Test build
+        if: ${{ inputs.run }}
         run: poetry build
 
       - name: Run tests
+        if: ${{ inputs.run }}
         run: poetry run pytest --verbose --numprocesses=4
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}


### PR DESCRIPTION
## Problem

The reusable SDK test workflows gated the matrix `test` job with `if: ${{ inputs.run }}`. GitHub evaluates a job's `if` *before* expanding the matrix, so when `run` was `false` the per-OS check contexts (`JS SDK - Build and test (ubuntu-22.04)`, `... (windows-latest)`, and the Python/CLI equivalents) were never created — leaving required branch-protection checks pending forever on path-filtered PRs that don't touch the relevant package.

## Fix

Removed the job-level `if` so the matrix always expands and every per-OS check context is created, and moved `if: ${{ inputs.run }}` onto each step instead. When `run` is false all steps skip and the job reports success, satisfying the required check; when true, behavior is unchanged. Applied to `js_sdk_tests.yml`, `python_sdk_tests.yml`, and `cli_tests.yml`.