### PR TITLE
fix(python-sdk): drop stream read timeout, enforce command timeout server-side

### DIFF
--- a/.changeset/tidy-streams-relax.md
+++ b/.changeset/tidy-streams-relax.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Drop the HTTP read timeout on streaming calls (commands, PTY, watch). It was set to the command `timeout`, so it raced the server's own `deadline_exceeded` response and could intermittently leak a raw `httpcore.ReadTimeout` instead of a `TimeoutException`. The command `timeout` is now enforced solely server-side via the `connect-timeout-ms` header, matching the JS SDK which has no per-chunk read timeout.

--- a/packages/python-sdk/e2b/envd/rpc.py
+++ b/packages/python-sdk/e2b/envd/rpc.py
@@ -74,11 +74,14 @@ def handle_rpc_exception(
     if isinstance(e, httpcore.RemoteProtocolError):
         return format_terminated_exception(e, sandbox_running)
 
-    # A transport-level timeout from httpcore (e.g. a stream read timeout) means the
-    # configured timeout was exceeded before the server responded. On a streaming call
-    # the read timeout equals the command `timeout`, so it races with the server's own
-    # `deadline_exceeded` response — whichever fires first wins. Map it to a
-    # `TimeoutException` so callers see a consistent timeout error either way.
+    # A transport-level timeout from httpcore means a configured timeout was exceeded
+    # before the server responded: `request_timeout` on a unary call's read phase, or
+    # `connect`/`pool`/`write` on a stream's setup/send phase. Streams have no read
+    # timeout — the command `timeout` is enforced server-side and surfaces as a
+    # `deadline_exceeded` ConnectException instead. Unlike the JS SDK, where the
+    # request timeout is an `AbortSignal` that connect normalizes into a `Code.canceled`
+    # ConnectError, httpcore raises this raw transport error outside the ConnectException
+    # path, so we map it here to a `TimeoutException` for a consistent timeout error.
     if isinstance(e, httpcore.TimeoutException):
         return TimeoutException(
             f"{e}: This error is likely due to exceeding 'timeout' — the total time a long running request (like process or directory watch) can be active — or 'request_timeout'. You can modify these by passing 'timeout' or 'request_timeout' when making the request. Use '0' to disable the timeout."

--- a/packages/python-sdk/e2b_connect/client.py
+++ b/packages/python-sdk/e2b_connect/client.py
@@ -322,16 +322,19 @@ class Client:
         data = self._codec.encode(req)
         flags = EnvelopeFlags(0)
 
+        # `request_timeout` bounds connection setup and request sending, but NOT the
+        # stream read: a stream can stay open for the whole command `timeout` (minutes
+        # or, when disabled, indefinitely), so we deliberately leave `read` unset.
+        # The command `timeout` is enforced server-side via the `connect-timeout-ms`
+        # header (see `_create_stream_timeout`), which returns a clean `deadline_exceeded`.
+        # This mirrors the JS SDK, which has no per-chunk read timeout either — setting
+        # `read` to the command `timeout` would race that server response and surface a
+        # raw transport `ReadTimeout` instead.
         timeout_ext = {}
         if request_timeout is not None:
             timeout_ext["connect"] = request_timeout
             timeout_ext["pool"] = request_timeout
             timeout_ext["write"] = request_timeout
-        if timeout:
-            # This is not actually timeout for the whole stream read, but timeout from the last read chunk.
-            # At worst then, the timeout of a hanging stream could be 2 * timeout (reading body until timeout-ϵ, then waiting for the read timeout).
-            # However, this is still better than no timeout at all and the full timeout in sync python might be way more complicated.
-            timeout_ext["read"] = timeout
         extensions = {"timeout": timeout_ext} if timeout_ext else None
 
         if self._compressor is not None:

--- a/packages/python-sdk/tests/test_envd_rpc_exception.py
+++ b/packages/python-sdk/tests/test_envd_rpc_exception.py
@@ -62,9 +62,8 @@ def test_returns_raw_network_errors():
 
 
 def test_maps_read_timeout_to_timeout():
-    # A stream read timeout fires when the command `timeout` is exceeded before the
-    # server's own `deadline_exceeded` response arrives — it must surface as a
-    # TimeoutException rather than leaking the raw httpcore error.
+    # A transport-level read timeout (e.g. a unary call exceeding `request_timeout`)
+    # must surface as a TimeoutException rather than leaking the raw httpcore error.
     err = handle_rpc_exception(httpcore.ReadTimeout("the read operation timed out"))
     assert isinstance(err, TimeoutException)
 


### PR DESCRIPTION
## Summary

Follow-up to #1444 (the `httpcore` → `TimeoutException` mapping, now merged). That mapping made the flaky timeout deterministic, but the underlying cause remained: the streaming HTTP `read` timeout was set to the command `timeout`, so it raced the server's own `deadline_exceeded` response. This PR removes the read timeout on streaming calls entirely and relies on the server-side `connect-timeout-ms` header to enforce the command timeout — matching the JS SDK, which has no per-chunk read timeout. The race is now structurally impossible rather than mapped over.

## Usage

```python
cmd = sandbox.commands.run("sleep 10", timeout=2, background=True)
try:
    for _ in cmd:
        pass
except TimeoutException:
    print("command timed out")  # server-side deadline_exceeded, no transport race
```

## Tradeoff

A silently dropped connection (no RST) on a command with `timeout=0` (disabled) now has no client-side read backstop and relies on keepalive pings — the same posture as the JS SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)