### PR TITLE
ci: build prepared templates on manual trigger only

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -1,12 +1,7 @@
 name: Build and push prepared templates
 
 on:
-  push:
-    paths:
-      - 'templates/**'
-      - '.github/workflows/templates.yml'
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Changes the **Build and push prepared templates** workflow to run only on manual trigger (`workflow_dispatch`) instead of automatically on every push to `main` touching `templates/**`.

This prevents the base template from being rebuilt and republished to DockerHub/E2B on every change, giving control over when builds happen.

Once merged to `main`, the workflow can be triggered from the Actions UI ("Run workflow") or via `gh workflow run templates.yml`.