### PR TITLE
feat(python): reconnect commands by tag

### DIFF
--- a/.changeset/quiet-rivers-reconnect.md
+++ b/.changeset/quiet-rivers-reconnect.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Expose command tags in the Python SDK so background commands can be reconnected by tag.

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -54,6 +54,28 @@ with Sandbox.create() as sandbox:
     print(execution.text)  # outputs 2
 ```
 
+### Reconnect to long-running commands
+
+For agent jobs that may outlive a single client connection, start the command in
+the background with a stable tag and reconnect later from another worker.
+
+```py
+from e2b import Sandbox
+
+with Sandbox.create() as sandbox:
+    handle = sandbox.commands.run(
+        "python train_or_simulate.py",
+        background=True,
+        tag="agent-job-42",
+        timeout=0,
+    )
+    handle.disconnect()
+
+    resumed = sandbox.commands.connect(tag="agent-job-42", timeout=0)
+    result = resumed.wait()
+    print(result.exit_code)
+```
+
 ### 5. Check docs
 Visit [E2B documentation](https://e2b.dev/docs).
 

--- a/packages/python-sdk/e2b/sandbox_async/commands/command.py
+++ b/packages/python-sdk/e2b/sandbox_async/commands/command.py
@@ -173,6 +173,7 @@ class Commands:
         self,
         cmd: str,
         background: Union[Literal[False], None] = None,
+        tag: Optional[str] = None,
         envs: Optional[Dict[str, str]] = None,
         user: Optional[Username] = None,
         cwd: Optional[str] = None,
@@ -187,6 +188,7 @@ class Commands:
 
         :param cmd: Command to execute
         :param background: **`False` if the command should be executed in the foreground**, `True` if the command should be executed in the background
+        :param tag: Custom tag used for reconnecting to the command later
         :param envs: Environment variables used for the command
         :param user: User to run the command as
         :param cwd: Working directory to run the command
@@ -205,6 +207,7 @@ class Commands:
         self,
         cmd: str,
         background: Literal[True],
+        tag: Optional[str] = None,
         envs: Optional[Dict[str, str]] = None,
         user: Optional[Username] = None,
         cwd: Optional[str] = None,
@@ -219,6 +222,7 @@ class Commands:
 
         :param cmd: Command to execute
         :param background: `False` if the command should be executed in the foreground, **`True` if the command should be executed in the background**
+        :param tag: Custom tag used for reconnecting to the command later
         :param envs: Environment variables used for the command
         :param user: User to run the command as
         :param cwd: Working directory to run the command
@@ -236,6 +240,7 @@ class Commands:
         self,
         cmd: str,
         background: Union[bool, None] = None,
+        tag: Optional[str] = None,
         envs: Optional[Dict[str, str]] = None,
         user: Optional[Username] = None,
         cwd: Optional[str] = None,
@@ -257,6 +262,7 @@ class Commands:
 
         proc = await self._start(
             cmd,
+            tag,
             envs,
             user,
             cwd,
@@ -272,6 +278,7 @@ class Commands:
     async def _start(
         self,
         cmd: str,
+        tag: Optional[str],
         envs: Optional[Dict[str, str]],
         user: Optional[Username],
         cwd: Optional[str],
@@ -289,6 +296,7 @@ class Commands:
                     args=["-l", "-c", cmd],
                     cwd=cwd,
                 ),
+                tag=tag,
                 stdin=stdin,
             ),
             headers={
@@ -333,7 +341,8 @@ class Commands:
 
     async def connect(
         self,
-        pid: int,
+        pid: Optional[int] = None,
+        tag: Optional[str] = None,
         timeout: Optional[float] = 60,
         request_timeout: Optional[float] = None,
         on_stdout: Optional[OutputHandler[Stdout]] = None,
@@ -344,6 +353,7 @@ class Commands:
         You can use `AsyncCommandHandle.wait()` to wait for the command to finish and get execution results.
 
         :param pid: Process ID of the command to connect to. You can get the list of processes using `sandbox.commands.list()`
+        :param tag: Custom tag of the command to connect to
         :param request_timeout: Request timeout in **seconds**
         :param timeout: Timeout for the command connection in **seconds**. Using `0` will not limit the command connection time
         :param on_stdout: Callback for command stdout output
@@ -351,9 +361,17 @@ class Commands:
 
         :return: `AsyncCommandHandle` handle to interact with the running command
         """
+        if (pid is None) == (tag is None):
+            raise ValueError("Exactly one of pid or tag must be provided")
+
+        selector = (
+            process_pb2.ProcessSelector(pid=pid)
+            if pid is not None
+            else process_pb2.ProcessSelector(tag=tag)
+        )
         events = self._rpc.aconnect(
             process_pb2.ConnectRequest(
-                process=process_pb2.ProcessSelector(pid=pid),
+                process=selector,
             ),
             headers={
                 KEEPALIVE_PING_HEADER: str(KEEPALIVE_PING_INTERVAL_SEC),

--- a/packages/python-sdk/e2b/sandbox_sync/commands/command.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/command.py
@@ -202,6 +202,7 @@ class Commands:
         self,
         cmd: str,
         background: Union[Literal[False], None] = None,
+        tag: Optional[str] = None,
         envs: Optional[Dict[str, str]] = None,
         user: Optional[Username] = None,
         cwd: Optional[str] = None,
@@ -216,6 +217,7 @@ class Commands:
 
         :param cmd: Command to execute
         :param background: **`False` if the command should be executed in the foreground**, `True` if the command should be executed in the background
+        :param tag: Custom tag used for reconnecting to the command later
         :param envs: Environment variables used for the command
         :param user: User to run the command as
         :param cwd: Working directory to run the command
@@ -234,6 +236,7 @@ class Commands:
         self,
         cmd: str,
         background: Literal[True],
+        tag: Optional[str] = None,
         envs: Optional[Dict[str, str]] = None,
         user: Optional[Username] = None,
         cwd: Optional[str] = None,
@@ -248,6 +251,7 @@ class Commands:
 
         :param cmd: Command to execute
         :param background: `False` if the command should be executed in the foreground, **`True` if the command should be executed in the background**
+        :param tag: Custom tag used for reconnecting to the command later
         :param envs: Environment variables used for the command
         :param user: User to run the command as
         :param cwd: Working directory to run the command
@@ -263,6 +267,7 @@ class Commands:
         self,
         cmd: str,
         background: Union[bool, None] = None,
+        tag: Optional[str] = None,
         envs: Optional[Dict[str, str]] = None,
         user: Optional[Username] = None,
         cwd: Optional[str] = None,
@@ -284,6 +289,7 @@ class Commands:
 
         proc = self._start(
             cmd,
+            tag,
             envs,
             user,
             cwd,
@@ -304,6 +310,7 @@ class Commands:
     def _start(
         self,
         cmd: str,
+        tag: Optional[str],
         envs: Optional[Dict[str, str]],
         user: Optional[Username],
         cwd: Optional[str],
@@ -319,6 +326,7 @@ class Commands:
                     args=["-l", "-c", cmd],
                     cwd=cwd,
                 ),
+                tag=tag,
                 stdin=stdin,
             ),
             headers={
@@ -361,7 +369,8 @@ class Commands:
 
     def connect(
         self,
-        pid: int,
+        pid: Optional[int] = None,
+        tag: Optional[str] = None,
         timeout: Optional[float] = 60,
         request_timeout: Optional[float] = None,
     ):
@@ -370,14 +379,23 @@ class Commands:
         You can use `CommandHandle.wait()` to wait for the command to finish and get execution results.
 
         :param pid: Process ID of the command to connect to. You can get the list of processes using `sandbox.commands.list()`
+        :param tag: Custom tag of the command to connect to
         :param timeout: Timeout for the connection in **seconds**. Using `0` will not limit the connection time
         :param request_timeout: Timeout for the request in **seconds**
 
         :return: `CommandHandle` handle to interact with the running command
         """
+        if (pid is None) == (tag is None):
+            raise ValueError("Exactly one of pid or tag must be provided")
+
+        selector = (
+            process_pb2.ProcessSelector(pid=pid)
+            if pid is not None
+            else process_pb2.ProcessSelector(tag=tag)
+        )
         events = self._rpc.connect(
             process_pb2.ConnectRequest(
-                process=process_pb2.ProcessSelector(pid=pid),
+                process=selector,
             ),
             headers={
                 KEEPALIVE_PING_HEADER: str(KEEPALIVE_PING_INTERVAL_SEC),

--- a/packages/python-sdk/examples/long_running_command_reconnect.py
+++ b/packages/python-sdk/examples/long_running_command_reconnect.py
@@ -1,0 +1,36 @@
+"""
+Run a long command as a recoverable agent job.
+
+This pattern lets a worker start a command, disconnect, then let another worker
+reconnect by tag. It is useful for queues, callbacks, and agent supervisors that
+cannot keep one HTTP connection open for the full job.
+"""
+
+from e2b import Sandbox
+
+JOB_TAG = "agent-job-42"
+
+
+def start_job(sandbox: Sandbox) -> int:
+    handle = sandbox.commands.run(
+        "python train_or_simulate.py",
+        background=True,
+        tag=JOB_TAG,
+        timeout=0,
+    )
+    pid = handle.pid
+    handle.disconnect()
+    return pid
+
+
+def collect_job(sandbox: Sandbox) -> None:
+    handle = sandbox.commands.connect(tag=JOB_TAG, timeout=0)
+    result = handle.wait()
+
+    print("exit code", result.exit_code)
+    print(result.stdout)
+
+
+with Sandbox.create() as sandbox:
+    start_job(sandbox)
+    collect_job(sandbox)

--- a/packages/python-sdk/tests/unit/test_command_tags.py
+++ b/packages/python-sdk/tests/unit/test_command_tags.py
@@ -1,0 +1,141 @@
+from packaging.version import Version
+import pytest
+import threading
+
+from e2b.envd.process import process_pb2
+from e2b.sandbox_async.commands.command import Commands as AsyncCommands
+from e2b.sandbox_sync.commands.command import Commands as SyncCommands
+
+
+class _ConnectionConfig:
+    sandbox_headers = {}
+
+    def get_request_timeout(self, request_timeout):
+        return request_timeout
+
+
+def _start_response(pid=123):
+    return process_pb2.StartResponse(
+        event=process_pb2.ProcessEvent(
+            start=process_pb2.ProcessEvent.StartEvent(pid=pid),
+        ),
+    )
+
+
+class _SyncRpc:
+    def __init__(self):
+        self.start_request = None
+        self.connect_request = None
+
+    def start(self, request, **_kwargs):
+        self.start_request = request
+        yield _start_response()
+
+    def connect(self, request, **_kwargs):
+        self.connect_request = request
+        yield _start_response()
+
+
+class _AsyncRpc:
+    def __init__(self):
+        self.start_request = None
+        self.connect_request = None
+
+    async def _events(self):
+        yield _start_response()
+
+    def astart(self, request, **_kwargs):
+        self.start_request = request
+        return self._events()
+
+    def aconnect(self, request, **_kwargs):
+        self.connect_request = request
+        return self._events()
+
+
+def _sync_commands(rpc):
+    commands = object.__new__(SyncCommands)
+    commands._connection_config = _ConnectionConfig()
+    commands._envd_version = Version("0.0.0")
+    commands._thread_local = threading.local()
+    commands._thread_local.rpc = rpc
+    commands._check_health = lambda: None
+    return commands
+
+
+def _async_commands(rpc):
+    commands = object.__new__(AsyncCommands)
+    commands._connection_config = _ConnectionConfig()
+    commands._envd_version = Version("0.0.0")
+    commands._rpc = rpc
+    commands._check_health = lambda: None
+    return commands
+
+
+def test_sync_run_passes_command_tag_to_envd():
+    rpc = _SyncRpc()
+    commands = _sync_commands(rpc)
+
+    handle = commands.run("python long_job.py", background=True, tag="agent-job-42")
+
+    assert handle.pid == 123
+    assert rpc.start_request.tag == "agent-job-42"
+
+
+def test_sync_connect_can_select_command_by_tag():
+    rpc = _SyncRpc()
+    commands = _sync_commands(rpc)
+
+    handle = commands.connect(tag="agent-job-42")
+
+    assert handle.pid == 123
+    assert rpc.connect_request.process.WhichOneof("selector") == "tag"
+    assert rpc.connect_request.process.tag == "agent-job-42"
+
+
+def test_sync_connect_requires_exactly_one_selector():
+    commands = _sync_commands(_SyncRpc())
+
+    with pytest.raises(ValueError, match="Exactly one"):
+        commands.connect()
+
+    with pytest.raises(ValueError, match="Exactly one"):
+        commands.connect(pid=123, tag="agent-job-42")
+
+
+@pytest.mark.asyncio
+async def test_async_run_passes_command_tag_to_envd():
+    rpc = _AsyncRpc()
+    commands = _async_commands(rpc)
+
+    handle = await commands.run(
+        "python long_job.py", background=True, tag="agent-job-42"
+    )
+    await handle.disconnect()
+
+    assert handle.pid == 123
+    assert rpc.start_request.tag == "agent-job-42"
+
+
+@pytest.mark.asyncio
+async def test_async_connect_can_select_command_by_tag():
+    rpc = _AsyncRpc()
+    commands = _async_commands(rpc)
+
+    handle = await commands.connect(tag="agent-job-42")
+    await handle.disconnect()
+
+    assert handle.pid == 123
+    assert rpc.connect_request.process.WhichOneof("selector") == "tag"
+    assert rpc.connect_request.process.tag == "agent-job-42"
+
+
+@pytest.mark.asyncio
+async def test_async_connect_requires_exactly_one_selector():
+    commands = _async_commands(_AsyncRpc())
+
+    with pytest.raises(ValueError, match="Exactly one"):
+        await commands.connect()
+
+    with pytest.raises(ValueError, match="Exactly one"):
+        await commands.connect(pid=123, tag="agent-job-42")


### PR DESCRIPTION
Refs #1069.\n\nThis exposes envd command tags in the Python SDK so long-running agent jobs can be started in the background, disconnected, and later reconnected by a stable tag instead of only by pid.\n\nWhat changed\n\n- Adds tag to sync and async commands.run\n- Allows commands.connect(tag=...) as an alternative to pid\n- Validates that callers pass exactly one selector\n- Adds focused unit coverage for sync and async request construction\n- Adds a small example for recoverable long-running agent jobs\n\nWhy\n\nFor queues, callbacks, and multi-agent supervisors, keeping one client connection open for a long command is fragile. The protocol already has command tags. This makes that stable handle available in the Python SDK without adding a new backend API.\n\nChecks\n\n- uv run --with-editable . --with pytest --with pytest-asyncio --with packaging pytest tests/unit/test_command_tags.py -q\n- uvx ruff format --check packages/python-sdk/e2b/sandbox_sync/commands/command.py packages/python-sdk/e2b/sandbox_async/commands/command.py packages/python-sdk/tests/unit/test_command_tags.py packages/python-sdk/examples/long_running_command_reconnect.py\n- uvx ruff check packages/python-sdk/e2b/sandbox_sync/commands/command.py packages/python-sdk/e2b/sandbox_async/commands/command.py packages/python-sdk/tests/unit/test_command_tags.py packages/python-sdk/examples/long_running_command_reconnect.py\n- git diff --check