### PR TITLE
fix(js-sdk): detect Bun and Deno connection-dropped errors in health check

### DIFF
--- a/.changeset/terminated-runtime-variants.md
+++ b/.changeset/terminated-runtime-variants.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Recognize Bun and Deno connection-dropped errors in the sandbox health check. When the connection to a sandbox is dropped mid-request, each JS runtime surfaces it with different wording (Node/undici: `terminated`, Bun: `The socket connection was closed unexpectedly`, Deno: `error reading a body from connection`). All known variants are now matched, so a sandbox killed mid-request is reported as a `TimeoutError` on Bun and Deno too, matching Node.

--- a/packages/js-sdk/src/envd/api.ts
+++ b/packages/js-sdk/src/envd/api.ts
@@ -17,7 +17,7 @@ import {
 import { StartResponse, ConnectResponse } from './process/process_pb'
 import { Code, ConnectError } from '@connectrpc/connect'
 import { WatchDirResponse } from './filesystem/filesystem_pb'
-import { SandboxHealthCheck } from './rpc'
+import { isConnectionTerminatedMessage, SandboxHealthCheck } from './rpc'
 
 type ApiError = { message?: string } | string
 
@@ -73,8 +73,9 @@ export async function handleEnvdApiFetchError(
   err: unknown,
   checkHealth?: SandboxHealthCheck
 ): Promise<Error> {
-  // Undici surfaces a connection dropped mid-body as a TypeError with the message 'terminated'
-  if (err instanceof TypeError && err.message === 'terminated') {
+  // A connection dropped mid-body surfaces as a fetch failure whose message varies
+  // by runtime (e.g. undici's 'terminated'); match every known variant.
+  if (err instanceof Error && isConnectionTerminatedMessage(err.message)) {
     const running = checkHealth
       ? await checkHealth().catch(() => undefined)
       : undefined

--- a/packages/js-sdk/src/envd/rpc.ts
+++ b/packages/js-sdk/src/envd/rpc.ts
@@ -21,15 +21,46 @@ import { ENVD_DEFAULT_USER } from './versions'
 export type SandboxHealthCheck = () => Promise<boolean | undefined>
 
 /**
+ * Message fragments different JS runtimes use when the connection to the sandbox
+ * is dropped mid-request. The transport surfaces a dropped connection (e.g. an
+ * HTTP/2 stream reset) with runtime- and version-specific wording, so we match
+ * every known variant:
+ *   - Node (undici): `terminated`
+ *   - Bun:           `The socket connection was closed unexpectedly`
+ *   - Deno:          `error reading a body from connection`
+ */
+const CONNECTION_TERMINATED_MESSAGES = [
+  'terminated',
+  'The socket connection was closed unexpectedly',
+  'error reading a body from connection',
+]
+
+/**
+ * Checks whether a message matches any known runtime variant of the connection to
+ * the sandbox being dropped mid-request (see {@link CONNECTION_TERMINATED_MESSAGES}).
+ */
+export function isConnectionTerminatedMessage(
+  message: string | undefined
+): boolean {
+  if (!message) {
+    return false
+  }
+
+  return CONNECTION_TERMINATED_MESSAGES.some((fragment) =>
+    message.includes(fragment)
+  )
+}
+
+/**
  * Checks whether the error is the signature of the connection to the sandbox being
  * dropped mid-request — an HTTP/2 stream reset surfaced by connect as `Code.Unknown`
- * with the message 'terminated'.
+ * with one of the runtime-specific connection-dropped messages.
  */
 export function isConnectionTerminatedError(err: unknown): boolean {
   return (
     err instanceof ConnectError &&
     err.code === Code.Unknown &&
-    err.rawMessage === 'terminated'
+    isConnectionTerminatedMessage(err.rawMessage)
   )
 }
 

--- a/packages/js-sdk/tests/envd/handleEnvdApiError.test.ts
+++ b/packages/js-sdk/tests/envd/handleEnvdApiError.test.ts
@@ -119,6 +119,25 @@ describe('handleEnvdApiFetchError', () => {
     assert.include(err.message, 'sandbox was killed or reached its end of life')
   })
 
+  // Each JS runtime surfaces a dropped connection with different wording, and not
+  // always as a TypeError (Bun raises a plain Error), so match by message
+  const runtimeTerminatedErrors = {
+    Node: new TypeError('terminated'),
+    Bun: new Error('The socket connection was closed unexpectedly'),
+    Deno: new TypeError('error reading a body from connection'),
+  }
+
+  for (const [runtime, error] of Object.entries(runtimeTerminatedErrors)) {
+    test(`treats the ${runtime} dropped-connection error as terminated`, async () => {
+      const err = await handleEnvdApiFetchError(error, async () => false)
+      assert.instanceOf(err, TimeoutError)
+      assert.include(
+        err.message,
+        'sandbox was killed or reached its end of life'
+      )
+    })
+  }
+
   test('returns the original error when the health check says the sandbox is running', async () => {
     const original = new TypeError('terminated')
     const err = await handleEnvdApiFetchError(original, async () => true)

--- a/packages/js-sdk/tests/envd/handleRpcError.test.ts
+++ b/packages/js-sdk/tests/envd/handleRpcError.test.ts
@@ -64,6 +64,13 @@ describe('handleRpcError', () => {
 describe('handleRpcErrorWithHealthCheck', () => {
   const terminated = () => new ConnectError('terminated', Code.Unknown)
 
+  // Each JS runtime surfaces a dropped connection with different wording
+  const runtimeTerminatedMessages = {
+    Node: 'terminated',
+    Bun: 'The socket connection was closed unexpectedly',
+    Deno: 'error reading a body from connection',
+  }
+
   test('returns a TimeoutError when the health check says the sandbox is not running', async () => {
     const err = await handleRpcErrorWithHealthCheck(
       terminated(),
@@ -72,6 +79,20 @@ describe('handleRpcErrorWithHealthCheck', () => {
     assert.instanceOf(err, TimeoutError)
     assert.include(err.message, 'sandbox was killed or reached its end of life')
   })
+
+  for (const [runtime, message] of Object.entries(runtimeTerminatedMessages)) {
+    test(`treats the ${runtime} dropped-connection message as terminated`, async () => {
+      const err = await handleRpcErrorWithHealthCheck(
+        new ConnectError(message, Code.Unknown),
+        async () => false
+      )
+      assert.instanceOf(err, TimeoutError)
+      assert.include(
+        err.message,
+        'sandbox was killed or reached its end of life'
+      )
+    })
+  }
 
   test('falls back to the generic mapping when the health check says the sandbox is running', async () => {
     const err = await handleRpcErrorWithHealthCheck(


### PR DESCRIPTION
When the connection to a sandbox is dropped mid-request, each JS runtime surfaces it with different wording, but the health check only recognized Node/undici's `terminated` — so on Bun and Deno a sandbox killed mid-request was reported as a raw transport error instead of a `TimeoutError`. This matches every known variant (Node: `terminated`, Bun: `The socket connection was closed unexpectedly`, Deno: `error reading a body from connection`) via a shared list used by both the RPC and fetch error handlers, and broadens the fetch-error type guard from `TypeError` to `Error` since Bun raises a plain `Error`. Added parametrized tests covering all three runtimes; format, lint, and typecheck pass.

No Python SDK change is needed — it detects dropped connections by exception type (`RemoteProtocolError`), which is already runtime-agnostic, and Bun/Deno are JS-only runtimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)