### PR TITLE
refactor(sdks): tidy SDK auth and deprecate ConnectionConfig access token

### DIFF
--- a/.changeset/quick-spoons-remove.md
+++ b/.changeset/quick-spoons-remove.md
@@ -1,12 +1,12 @@
 ---
-"@e2b/python-sdk": minor
-"e2b": minor
+"@e2b/python-sdk": patch
+"e2b": patch
 "@e2b/cli": patch
 ---
 
-Remove access-token auth from the SDKs; it was only ever used by the CLI, never by an SDK operation.
+Tidy up SDK authentication and deprecate the access token in `ConnectionConfig`.
 
-- Removed the unused auth toggles from the API clients: `requireAccessToken` (JS) / `require_access_token` (Python), and `requireApiKey` (JS) / `require_api_key` (Python). No caller set these to a non-default value, so behavior is unchanged — the API key is still required for all SDK operations.
-- **Breaking:** removed the `accessToken` (JS) / `access_token` (Python) option from `ConnectionConfig`, along with the SDK-level `E2B_ACCESS_TOKEN` environment variable lookup. No SDK method (sandbox, template, or volume) used it — those authenticate with the API key. If you need to send a custom `Authorization` header, pass it via `apiHeaders` instead, e.g. `new ConnectionConfig({ apiHeaders: { Authorization: 'Bearer <token>' } })`.
-
-The CLI continues to authenticate against the `/teams` endpoint with the access token, now passed through `apiHeaders` instead of the dedicated option.
+- Deprecated the `accessToken` (JS) / `access_token` (Python) option on `ConnectionConfig`. It still works exactly as before — when set (or via `E2B_ACCESS_TOKEN`), the `Authorization: Bearer` header is still sent — but you should pass custom auth through `apiHeaders` instead, e.g. `new ConnectionConfig({ apiHeaders: { Authorization: 'Bearer <token>' } })`.
+- Removed the unused auth toggles from the API clients: `requireAccessToken`/`requireApiKey` (JS) and `require_access_token`/`require_api_key` (Python). No caller ever set them to a non-default value, so behavior is unchanged.
+- The CLI now passes the access token to the `/teams` endpoint through `apiHeaders` instead of the deprecated option.
+- Decoupled the sandbox-scoped envd access token from `ConnectionConfig`: `EnvdApiClient` now owns its own `accessToken` field and sets the `X-Access-Token` header itself.

--- a/.changeset/quick-spoons-remove.md
+++ b/.changeset/quick-spoons-remove.md
@@ -7,6 +7,7 @@
 Tidy up SDK authentication and deprecate the access token in `ConnectionConfig`.
 
 - Deprecated the `accessToken` (JS) / `access_token` (Python) option on `ConnectionConfig`. It still works exactly as before — when set (or via `E2B_ACCESS_TOKEN`), the `Authorization: Bearer` header is still sent — but you should pass custom auth through `apiHeaders` instead, e.g. `new ConnectionConfig({ apiHeaders: { Authorization: 'Bearer <token>' } })`.
-- Removed the unused auth toggles from the API clients: `requireAccessToken`/`requireApiKey` (JS) and `require_access_token`/`require_api_key` (Python). No caller ever set them to a non-default value, so behavior is unchanged.
+- The SDK now raises a clear error when no API key is supplied, pointing to the API Keys tab (`https://e2b.dev/dashboard?tab=keys`). In JS this is controlled by a `requireApiKey` option (default `true`) so callers that authenticate differently — like the CLI hitting `/teams` with an access token — can opt out; in Python the API key is always required.
+- Removed the unused access-token toggle from the API clients: `requireAccessToken` (JS) and `require_access_token` (Python). No caller ever set it to a non-default value, so behavior is unchanged.
 - The CLI now passes the access token to the `/teams` endpoint through `apiHeaders` instead of the deprecated option.
 - Decoupled the sandbox-scoped envd access token from `ConnectionConfig`: `EnvdApiClient` now owns its own `accessToken` field and sets the `X-Access-Token` header itself.

--- a/.changeset/quick-spoons-remove.md
+++ b/.changeset/quick-spoons-remove.md
@@ -1,0 +1,12 @@
+---
+"@e2b/python-sdk": minor
+"e2b": minor
+"@e2b/cli": patch
+---
+
+Remove access-token auth from the SDKs; it was only ever used by the CLI, never by an SDK operation.
+
+- Removed the unused auth toggles from the API clients: `requireAccessToken` (JS) / `require_access_token` (Python), and `requireApiKey` (JS) / `require_api_key` (Python). No caller set these to a non-default value, so behavior is unchanged — the API key is still required for all SDK operations.
+- **Breaking:** removed the `accessToken` (JS) / `access_token` (Python) option from `ConnectionConfig`, along with the SDK-level `E2B_ACCESS_TOKEN` environment variable lookup. No SDK method (sandbox, template, or volume) used it — those authenticate with the API key. If you need to send a custom `Authorization` header, pass it via `apiHeaders` instead, e.g. `new ConnectionConfig({ apiHeaders: { Authorization: 'Bearer <token>' } })`.
+
+The CLI continues to authenticate against the `/teams` endpoint with the access token, now passed through `apiHeaders` instead of the dedicated option.

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -104,4 +104,8 @@ export const connectionConfig = new e2b.ConnectionConfig({
     ? { Authorization: `Bearer ${resolvedAccessToken}` }
     : undefined,
 })
-export const client = new e2b.ApiClient(connectionConfig)
+// The CLI authenticates team-scoped endpoints (e.g. `/teams`) with the access
+// token instead of an API key, so don't require an API key here.
+export const client = new e2b.ApiClient(connectionConfig, {
+  requireApiKey: false,
+})

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -95,8 +95,13 @@ export function resolveTeamId(
 
 const userConfig = getUserConfig()
 
+const resolvedAccessToken =
+  process.env.E2B_ACCESS_TOKEN || userConfig?.accessToken
+
 export const connectionConfig = new e2b.ConnectionConfig({
-  accessToken: process.env.E2B_ACCESS_TOKEN || userConfig?.accessToken,
   apiKey: process.env.E2B_API_KEY || userConfig?.teamApiKey,
+  apiHeaders: resolvedAccessToken
+    ? { Authorization: `Bearer ${resolvedAccessToken}` }
+    : undefined,
 })
 export const client = new e2b.ApiClient(connectionConfig)

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -46,7 +46,7 @@ export const loginCommand = new commander.Command('login')
 
       const signal = connectionConfig.getSignal()
       const config = new e2b.ConnectionConfig({
-        accessToken,
+        apiHeaders: { Authorization: `Bearer ${accessToken}` },
       })
       const client = new e2b.ApiClient(config)
       const res = await client.api.GET('/teams', { signal })

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -48,7 +48,7 @@ export const loginCommand = new commander.Command('login')
       const config = new e2b.ConnectionConfig({
         apiHeaders: { Authorization: `Bearer ${accessToken}` },
       })
-      const client = new e2b.ApiClient(config)
+      const client = new e2b.ApiClient(config, { requireApiKey: false })
       const res = await client.api.GET('/teams', { signal })
 
       handleE2BRequestError(res, 'Error getting teams')

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -68,30 +68,9 @@ export function handleApiError(
 class ApiClient {
   readonly api: ReturnType<typeof createClient<paths>>
 
-  constructor(
-    config: ConnectionConfig,
-    opts: {
-      requireAccessToken?: boolean
-      requireApiKey?: boolean
-    } = { requireAccessToken: false, requireApiKey: false }
-  ) {
-    if (opts?.requireApiKey && !config.apiKey) {
-      throw new AuthenticationError(
-        'API key is required, please visit the Team tab at https://e2b.dev/dashboard to get your API key. ' +
-          'You can either set the environment variable `E2B_API_KEY` ' +
-          "or you can pass it directly to the sandbox like Sandbox.create({ apiKey: 'e2b_...' })"
-      )
-    }
-
+  constructor(config: ConnectionConfig) {
     if (config.apiKey && config.validateApiKey) {
       validateApiKey(config.apiKey)
-    }
-
-    if (opts?.requireAccessToken && !config.accessToken) {
-      throw new AuthenticationError(
-        'Access token is required, please visit the Personal tab at https://e2b.dev/dashboard to get your access token. ' +
-          'You can set the environment variable `E2B_ACCESS_TOKEN` or pass the `accessToken` in options.'
-      )
     }
 
     this.api = createClient<paths>({
@@ -102,9 +81,6 @@ class ApiClient {
       headers: {
         ...defaultHeaders,
         ...(config.apiKey && { 'X-API-KEY': config.apiKey }),
-        ...(config.accessToken && {
-          Authorization: `Bearer ${config.accessToken}`,
-        }),
         ...config.headers,
       },
       querySerializer: {

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -81,6 +81,9 @@ class ApiClient {
       headers: {
         ...defaultHeaders,
         ...(config.apiKey && { 'X-API-KEY': config.apiKey }),
+        ...(config.accessToken && {
+          Authorization: `Bearer ${config.accessToken}`,
+        }),
         ...config.headers,
       },
       querySerializer: {

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -68,7 +68,20 @@ export function handleApiError(
 class ApiClient {
   readonly api: ReturnType<typeof createClient<paths>>
 
-  constructor(config: ConnectionConfig) {
+  constructor(
+    config: ConnectionConfig,
+    opts: {
+      requireApiKey?: boolean
+    } = {}
+  ) {
+    if ((opts.requireApiKey ?? true) && !config.apiKey) {
+      throw new AuthenticationError(
+        'API key is required, please visit the API Keys tab at https://e2b.dev/dashboard?tab=keys to get your API key. ' +
+          'You can either set the environment variable `E2B_API_KEY` ' +
+          "or you can pass it directly to the sandbox like Sandbox.create({ apiKey: 'e2b_...' })"
+      )
+    }
+
     if (config.apiKey && config.validateApiKey) {
       validateApiKey(config.apiKey)
     }

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -30,6 +30,15 @@ export interface ConnectionOpts {
    */
   validateApiKey?: boolean
   /**
+   * E2B access token to use for authentication.
+   *
+   * @deprecated Pass the token through `apiHeaders` instead, e.g.
+   * `apiHeaders: { Authorization: \`Bearer ${token}\` }`.
+   *
+   * @default E2B_ACCESS_TOKEN // environment variable
+   */
+  accessToken?: string
+  /**
    * Domain to use for the API.
    *
    * @default E2B_DOMAIN // environment variable or `e2b.app`
@@ -201,6 +210,10 @@ export class ConnectionConfig {
 
   readonly apiKey?: string
   readonly validateApiKey: boolean
+  /**
+   * @deprecated Pass the token through `apiHeaders` instead.
+   */
+  readonly accessToken?: string
 
   readonly headers?: Record<string, string>
 
@@ -212,6 +225,7 @@ export class ConnectionConfig {
       opts?.validateApiKey ?? ConnectionConfig.validateApiKey
     this.debug = opts?.debug ?? ConnectionConfig.debug
     this.domain = opts?.domain || ConnectionConfig.domain
+    this.accessToken = opts?.accessToken || ConnectionConfig.accessToken
     this.requestTimeoutMs = opts?.requestTimeoutMs ?? REQUEST_TIMEOUT_MS
     this.logger = opts?.logger
     this.headers = { ...(opts?.headers ?? {}), ...(opts?.apiHeaders ?? {}) }
@@ -250,6 +264,10 @@ export class ConnectionConfig {
     return (
       (getEnvVar('E2B_VALIDATE_API_KEY') || 'true').toLowerCase() !== 'false'
     )
+  }
+
+  private static get accessToken() {
+    return getEnvVar('E2B_ACCESS_TOKEN')
   }
 
   getSignal(requestTimeoutMs?: number, signal?: AbortSignal) {

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -30,12 +30,6 @@ export interface ConnectionOpts {
    */
   validateApiKey?: boolean
   /**
-   * E2B access token to use for authentication.
-   *
-   * @default E2B_ACCESS_TOKEN // environment variable
-   */
-  accessToken?: string
-  /**
    * Domain to use for the API.
    *
    * @default E2B_DOMAIN // environment variable or `e2b.app`
@@ -207,7 +201,6 @@ export class ConnectionConfig {
 
   readonly apiKey?: string
   readonly validateApiKey: boolean
-  readonly accessToken?: string
 
   readonly headers?: Record<string, string>
 
@@ -219,7 +212,6 @@ export class ConnectionConfig {
       opts?.validateApiKey ?? ConnectionConfig.validateApiKey
     this.debug = opts?.debug ?? ConnectionConfig.debug
     this.domain = opts?.domain || ConnectionConfig.domain
-    this.accessToken = opts?.accessToken || ConnectionConfig.accessToken
     this.requestTimeoutMs = opts?.requestTimeoutMs ?? REQUEST_TIMEOUT_MS
     this.logger = opts?.logger
     this.headers = { ...(opts?.headers ?? {}), ...(opts?.apiHeaders ?? {}) }
@@ -258,10 +250,6 @@ export class ConnectionConfig {
     return (
       (getEnvVar('E2B_VALIDATE_API_KEY') || 'true').toLowerCase() !== 'false'
     )
-  }
-
-  private static get accessToken() {
-    return getEnvVar('E2B_ACCESS_TOKEN')
   }
 
   getSignal(requestTimeoutMs?: number, signal?: AbortSignal) {

--- a/packages/js-sdk/src/envd/api.ts
+++ b/packages/js-sdk/src/envd/api.ts
@@ -194,7 +194,7 @@ class EnvdApiClient {
   readonly version: string
 
   constructor(
-    config: Pick<ConnectionConfig, 'apiUrl' | 'logger' | 'accessToken'> & {
+    config: Pick<ConnectionConfig, 'apiUrl' | 'logger'> & {
       fetch?: (request: Request) => ReturnType<typeof fetch>
       headers?: Record<string, string>
     },

--- a/packages/js-sdk/src/envd/api.ts
+++ b/packages/js-sdk/src/envd/api.ts
@@ -198,7 +198,7 @@ class EnvdApiClient {
       /**
        * Sandbox-scoped envd access token, sent as the `X-Access-Token` header.
        */
-      accessToken?: string
+      envdAccessToken?: string
       fetch?: (request: Request) => ReturnType<typeof fetch>
       headers?: Record<string, string>
     },
@@ -211,8 +211,8 @@ class EnvdApiClient {
       fetch: config?.fetch,
       headers: {
         ...config?.headers,
-        ...(config.accessToken && {
-          'X-Access-Token': config.accessToken,
+        ...(config.envdAccessToken && {
+          'X-Access-Token': config.envdAccessToken,
         }),
       },
       // In HTTP 1.1, all connections are considered persistent unless declared otherwise

--- a/packages/js-sdk/src/envd/api.ts
+++ b/packages/js-sdk/src/envd/api.ts
@@ -195,6 +195,10 @@ class EnvdApiClient {
 
   constructor(
     config: Pick<ConnectionConfig, 'apiUrl' | 'logger'> & {
+      /**
+       * Sandbox-scoped envd access token, sent as the `X-Access-Token` header.
+       */
+      accessToken?: string
       fetch?: (request: Request) => ReturnType<typeof fetch>
       headers?: Record<string, string>
     },
@@ -205,7 +209,12 @@ class EnvdApiClient {
     this.api = createClient({
       baseUrl: config.apiUrl,
       fetch: config?.fetch,
-      headers: config?.headers,
+      headers: {
+        ...config?.headers,
+        ...(config.accessToken && {
+          'X-Access-Token': config.accessToken,
+        }),
+      },
       // In HTTP 1.1, all connections are considered persistent unless declared otherwise
       // keepalive: true,
     })

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -200,7 +200,7 @@ export class Sandbox extends SandboxApi {
       {
         apiUrl: this.envdApiUrl,
         logger: opts?.logger,
-        accessToken: this.envdAccessToken,
+        envdAccessToken: this.envdAccessToken,
         headers: {
           'User-Agent': this.connectionConfig.headers?.['User-Agent'] ?? '',
           ...sandboxHeaders,

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -200,7 +200,6 @@ export class Sandbox extends SandboxApi {
       {
         apiUrl: this.envdApiUrl,
         logger: opts?.logger,
-        accessToken: this.envdAccessToken,
         headers: {
           'User-Agent': this.connectionConfig.headers?.['User-Agent'] ?? '',
           ...sandboxHeaders,

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -200,12 +200,10 @@ export class Sandbox extends SandboxApi {
       {
         apiUrl: this.envdApiUrl,
         logger: opts?.logger,
+        accessToken: this.envdAccessToken,
         headers: {
           'User-Agent': this.connectionConfig.headers?.['User-Agent'] ?? '',
           ...sandboxHeaders,
-          ...(this.envdAccessToken
-            ? { 'X-Access-Token': this.envdAccessToken }
-            : {}),
         },
         fetch: (request) => envdFetch(request),
       },

--- a/packages/js-sdk/tests/api/validateApiKey.test.ts
+++ b/packages/js-sdk/tests/api/validateApiKey.test.ts
@@ -1,4 +1,4 @@
-import { assert, test, describe } from 'vitest'
+import { assert, test, describe, vi, afterEach } from 'vitest'
 import { ApiClient, validateApiKey } from '../../src/api'
 import { ConnectionConfig } from '../../src/connectionConfig'
 import { AuthenticationError } from '../../src/errors'
@@ -65,5 +65,27 @@ describe('ApiClient API key validation', () => {
       validateApiKey: false,
     })
     assert.doesNotThrow(() => new ApiClient(config))
+  })
+})
+
+describe('ApiClient API key requirement', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  test('throws when no API key is supplied', () => {
+    vi.stubEnv('E2B_API_KEY', '')
+    const config = new ConnectionConfig({})
+    assert.throws(
+      () => new ApiClient(config),
+      AuthenticationError,
+      /API key is required/
+    )
+  })
+
+  test('does not require an API key when requireApiKey is false', () => {
+    vi.stubEnv('E2B_API_KEY', '')
+    const config = new ConnectionConfig({})
+    assert.doesNotThrow(() => new ApiClient(config, { requireApiKey: false }))
   })
 })

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -146,6 +146,11 @@ class ApiClient(AuthenticatedClient):
             **(config.headers or {}),
         }
 
+        # Deprecated: send the access token alongside the API key when one is
+        # available, mirroring the JS SDK. Prefer `api_headers` instead.
+        if config.access_token is not None:
+            headers["Authorization"] = f"Bearer {config.access_token}"
+
         # Prevent passing these parameters twice
         more_headers: Optional[dict] = kwargs.pop("headers", None)
         if more_headers:

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -129,7 +129,7 @@ class ApiClient(AuthenticatedClient):
 
         if config.api_key is None:
             raise AuthenticationException(
-                "API key is required, please visit the Team tab at https://e2b.dev/dashboard to get your API key. "
+                "API key is required, please visit the API Keys tab at https://e2b.dev/dashboard?tab=keys to get your API key. "
                 "You can either set the environment variable `E2B_API_KEY` "
                 'or you can pass it directly to the method like api_key="e2b_..."',
             )

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -105,8 +105,6 @@ class ApiClient(AuthenticatedClient):
     def __init__(
         self,
         config: ConnectionConfig,
-        require_api_key: bool = True,
-        require_access_token: bool = False,
         transport: Optional[Union[BaseTransport, AsyncBaseTransport]] = None,
         transport_factory: Optional[Callable[[], BaseTransport]] = None,
         async_transport_factory: Optional[Callable[[], AsyncBaseTransport]] = None,
@@ -129,39 +127,19 @@ class ApiClient(AuthenticatedClient):
         ] = weakref.WeakKeyDictionary()
         self._proxy = config.proxy
 
-        if require_api_key and require_access_token:
+        if config.api_key is None:
             raise AuthenticationException(
-                "Only one of api_key or access_token can be required, not both",
+                "API key is required, please visit the Team tab at https://e2b.dev/dashboard to get your API key. "
+                "You can either set the environment variable `E2B_API_KEY` "
+                'or you can pass it directly to the method like api_key="e2b_..."',
             )
-
-        if not require_api_key and not require_access_token:
-            raise AuthenticationException(
-                "Either api_key or access_token is required",
-            )
-
-        token = None
-        if require_api_key:
-            if config.api_key is None:
-                raise AuthenticationException(
-                    "API key is required, please visit the Team tab at https://e2b.dev/dashboard to get your API key. "
-                    "You can either set the environment variable `E2B_API_KEY` "
-                    'or you can pass it directly to the method like api_key="e2b_..."',
-                )
-            token = config.api_key
 
         if config.api_key is not None and config.validate_api_key:
             validate_api_key(config.api_key)
 
-        if require_access_token:
-            if config.access_token is None:
-                raise AuthenticationException(
-                    "Access token is required, please visit the Personal tab at https://e2b.dev/dashboard to get your access token. "
-                    "You can set the environment variable `E2B_ACCESS_TOKEN` or pass the `access_token` in options.",
-                )
-            token = config.access_token
-
-        auth_header_name = "X-API-KEY" if require_api_key else "Authorization"
-        prefix = "" if require_api_key else "Bearer"
+        token = config.api_key
+        auth_header_name = "X-API-KEY"
+        prefix = ""
 
         headers = {
             **default_headers,

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -86,10 +86,6 @@ class ConnectionConfig:
     def _sandbox_url():
         return os.getenv("E2B_SANDBOX_URL")
 
-    @staticmethod
-    def _access_token():
-        return os.getenv("E2B_ACCESS_TOKEN")
-
     def __init__(
         self,
         domain: Optional[str] = None,
@@ -98,7 +94,6 @@ class ConnectionConfig:
         validate_api_key: Optional[bool] = None,
         api_url: Optional[str] = None,
         sandbox_url: Optional[str] = None,
-        access_token: Optional[str] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
         api_headers: Optional[Dict[str, str]] = None,
@@ -113,7 +108,6 @@ class ConnectionConfig:
             if validate_api_key is not None
             else ConnectionConfig._validate_api_key()
         )
-        self.access_token = access_token or ConnectionConfig._access_token()
         self.headers = {**(headers or {}), **(api_headers or {})}
         self.headers["User-Agent"] = f"e2b-python-sdk/{package_version}"
         self.__extra_sandbox_headers = extra_sandbox_headers or {}
@@ -196,7 +190,6 @@ class ConnectionConfig:
         Get the parameters for the API call.
 
         This is used to avoid passing the following attributes to the API call:
-        - access_token
         - api_url
 
         It also returns a copy, so the original object is not modified.

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -86,6 +86,10 @@ class ConnectionConfig:
     def _sandbox_url():
         return os.getenv("E2B_SANDBOX_URL")
 
+    @staticmethod
+    def _access_token():
+        return os.getenv("E2B_ACCESS_TOKEN")
+
     def __init__(
         self,
         domain: Optional[str] = None,
@@ -94,6 +98,7 @@ class ConnectionConfig:
         validate_api_key: Optional[bool] = None,
         api_url: Optional[str] = None,
         sandbox_url: Optional[str] = None,
+        access_token: Optional[str] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
         api_headers: Optional[Dict[str, str]] = None,
@@ -108,6 +113,9 @@ class ConnectionConfig:
             if validate_api_key is not None
             else ConnectionConfig._validate_api_key()
         )
+        # Deprecated: pass the token through `api_headers` instead, e.g.
+        # api_headers={"Authorization": f"Bearer {token}"}.
+        self.access_token = access_token or ConnectionConfig._access_token()
         self.headers = {**(headers or {}), **(api_headers or {})}
         self.headers["User-Agent"] = f"e2b-python-sdk/{package_version}"
         self.__extra_sandbox_headers = extra_sandbox_headers or {}
@@ -190,6 +198,7 @@ class ConnectionConfig:
         Get the parameters for the API call.
 
         This is used to avoid passing the following attributes to the API call:
+        - access_token
         - api_url
 
         It also returns a copy, so the original object is not modified.

--- a/packages/python-sdk/e2b/template_async/main.py
+++ b/packages/python-sdk/e2b/template_async/main.py
@@ -237,8 +237,6 @@ class AsyncTemplate(TemplateBase):
             config = ConnectionConfig(**opts)
             api_client = get_api_client(
                 config,
-                require_api_key=True,
-                require_access_token=False,
             )
 
             data = await AsyncTemplate._build(
@@ -328,8 +326,6 @@ class AsyncTemplate(TemplateBase):
         config = ConnectionConfig(**opts)
         api_client = get_api_client(
             config,
-            require_api_key=True,
-            require_access_token=False,
         )
 
         return await AsyncTemplate._build(
@@ -367,8 +363,6 @@ class AsyncTemplate(TemplateBase):
         config = ConnectionConfig(**opts)
         api_client = get_api_client(
             config,
-            require_api_key=True,
-            require_access_token=False,
         )
         return await get_build_status(
             api_client,
@@ -425,8 +419,6 @@ class AsyncTemplate(TemplateBase):
         config = ConnectionConfig(**opts)
         api_client = get_api_client(
             config,
-            require_api_key=True,
-            require_access_token=False,
         )
 
         return await check_alias_exists(api_client, alias)
@@ -458,8 +450,6 @@ class AsyncTemplate(TemplateBase):
         config = ConnectionConfig(**opts)
         api_client = get_api_client(
             config,
-            require_api_key=True,
-            require_access_token=False,
         )
 
         normalized_tags = [tags] if isinstance(tags, str) else tags
@@ -491,8 +481,6 @@ class AsyncTemplate(TemplateBase):
         config = ConnectionConfig(**opts)
         api_client = get_api_client(
             config,
-            require_api_key=True,
-            require_access_token=False,
         )
 
         normalized_tags = [tags] if isinstance(tags, str) else tags
@@ -521,8 +509,6 @@ class AsyncTemplate(TemplateBase):
         config = ConnectionConfig(**opts)
         api_client = get_api_client(
             config,
-            require_api_key=True,
-            require_access_token=False,
         )
 
         return await get_template_tags(api_client, template_id)

--- a/packages/python-sdk/e2b/template_sync/main.py
+++ b/packages/python-sdk/e2b/template_sync/main.py
@@ -237,8 +237,6 @@ class Template(TemplateBase):
             config = ConnectionConfig(**opts)
             api_client = get_api_client(
                 config,
-                require_api_key=True,
-                require_access_token=False,
             )
 
             data = Template._build(
@@ -328,8 +326,6 @@ class Template(TemplateBase):
         config = ConnectionConfig(**opts)
         api_client = get_api_client(
             config,
-            require_api_key=True,
-            require_access_token=False,
         )
 
         return Template._build(
@@ -367,8 +363,6 @@ class Template(TemplateBase):
         config = ConnectionConfig(**opts)
         api_client = get_api_client(
             config,
-            require_api_key=True,
-            require_access_token=False,
         )
 
         return get_build_status(
@@ -426,8 +420,6 @@ class Template(TemplateBase):
         config = ConnectionConfig(**opts)
         api_client = get_api_client(
             config,
-            require_api_key=True,
-            require_access_token=False,
         )
 
         return check_alias_exists(api_client, alias)
@@ -459,8 +451,6 @@ class Template(TemplateBase):
         config = ConnectionConfig(**opts)
         api_client = get_api_client(
             config,
-            require_api_key=True,
-            require_access_token=False,
         )
 
         normalized_tags = [tags] if isinstance(tags, str) else tags
@@ -492,8 +482,6 @@ class Template(TemplateBase):
         config = ConnectionConfig(**opts)
         api_client = get_api_client(
             config,
-            require_api_key=True,
-            require_access_token=False,
         )
 
         normalized_tags = [tags] if isinstance(tags, str) else tags
@@ -522,8 +510,6 @@ class Template(TemplateBase):
         config = ConnectionConfig(**opts)
         api_client = get_api_client(
             config,
-            require_api_key=True,
-            require_access_token=False,
         )
 
         return get_template_tags(api_client, template_id)

--- a/packages/python-sdk/tests/test_validate_api_key.py
+++ b/packages/python-sdk/tests/test_validate_api_key.py
@@ -49,3 +49,10 @@ def test_api_client_skips_validation_when_disabled():
     config = ConnectionConfig(api_key="not-a-valid-key", validate_api_key=False)
     # Should not raise: validation is disabled.
     ApiClient(config)
+
+
+def test_api_client_requires_api_key(monkeypatch):
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    config = ConnectionConfig()
+    with pytest.raises(AuthenticationException, match=r"API key is required"):
+        ApiClient(config)


### PR DESCRIPTION
## Summary

The access token was only ever used by the CLI, never by any SDK operation — sandbox, template, and volume calls all authenticate with the API key. This cleans up the auth plumbing and **deprecates** (rather than removes) the access token on `ConnectionConfig`, so there's no breaking change for direct SDK consumers.

## Changes

- **Deprecated** the `accessToken` (JS) / `access_token` (Python) option on `ConnectionConfig`. It still works exactly as before — when set (or via `E2B_ACCESS_TOKEN`) the `Authorization: Bearer` header is still sent — but `apiHeaders` is now the recommended way to pass custom auth.
- **Clear error when the API key is missing**, pointing to the API Keys tab (`https://e2b.dev/dashboard?tab=keys`). In JS this is gated by a `requireApiKey` option (default `true`) so callers that authenticate differently — like the CLI hitting `/teams` with an access token — can opt out; in Python the API key is always required.
- Removed the unused access-token toggle from the API clients: `requireAccessToken` (JS) / `require_access_token` (Python). No caller ever set it to a non-default value, so behavior is unchanged.
- The CLI now passes the access token to the `/teams` endpoint via `apiHeaders` instead of the deprecated option, and opts out of the API-key requirement on its own clients.
- Decoupled the sandbox-scoped envd access token from `ConnectionConfig`: `EnvdApiClient` now owns its own `envdAccessToken` field and sets the `X-Access-Token` header itself, removing a redundant manually-set header.

## Recommended usage

```ts
// Deprecated
new ConnectionConfig({ accessToken: 'my-token' })

// Preferred
new ConnectionConfig({ apiHeaders: { Authorization: 'Bearer my-token' } })
```

```python
# Deprecated
ConnectionConfig(access_token="my-token")

# Preferred
ConnectionConfig(api_headers={"Authorization": "Bearer my-token"})
```

## Verification

`pnpm run typecheck`, `pnpm run lint`, Python `make typecheck`, and the unit tests all pass — including new tests for the API-key requirement (and its opt-out) in both SDKs. Confirmed the `Authorization: Bearer` header is still sent for both the deprecated option and `E2B_ACCESS_TOKEN`.