### PR TITLE
fix(python-sdk): let api_headers Authorization win over deprecated access_token

### DIFF
--- a/.changeset/strong-apes-bow.md
+++ b/.changeset/strong-apes-bow.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Fix Python SDK header precedence so a custom `Authorization` passed via `api_headers` is no longer overwritten by the deprecated `access_token`. The deprecated access token is now applied before `api_headers`, matching the JS SDK where a custom `Authorization` wins.

--- a/.changeset/strong-apes-bow.md
+++ b/.changeset/strong-apes-bow.md
@@ -1,5 +1,5 @@
 ---
-"e2b": patch
+"@e2b/python-sdk": patch
 ---
 
 Fix Python SDK header precedence so a custom `Authorization` passed via `api_headers` is no longer overwritten by the deprecated `access_token`. The deprecated access token is now applied before `api_headers`, matching the JS SDK where a custom `Authorization` wins.

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -143,13 +143,17 @@ class ApiClient(AuthenticatedClient):
 
         headers = {
             **default_headers,
+            # Deprecated: send the access token alongside the API key when one
+            # is available, mirroring the JS SDK. Prefer `api_headers` instead.
+            # Spread before `config.headers` so a custom `Authorization` in
+            # `api_headers` wins over the deprecated access token, matching JS.
+            **(
+                {"Authorization": f"Bearer {config.access_token}"}
+                if config.access_token is not None
+                else {}
+            ),
             **(config.headers or {}),
         }
-
-        # Deprecated: send the access token alongside the API key when one is
-        # available, mirroring the JS SDK. Prefer `api_headers` instead.
-        if config.access_token is not None:
-            headers["Authorization"] = f"Bearer {config.access_token}"
 
         # Prevent passing these parameters twice
         more_headers: Optional[dict] = kwargs.pop("headers", None)


### PR DESCRIPTION
The Python SDK's `ApiClient` applied the deprecated `access_token` *after* merging `config.headers` (which includes `api_headers`), so a custom `Authorization` passed via `api_headers` was silently overwritten — the opposite of the JS SDK, where a custom `Authorization` wins. This moves the deprecated access token before `config.headers` so `api_headers` now takes precedence, matching JS. No change when only `access_token` is set.

```python
# Custom Authorization via api_headers now wins over the deprecated access_token
ConnectionConfig(api_key="e2b_...", access_token="old", api_headers={"Authorization": "Bearer custom"})
# -> Authorization: Bearer custom
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)