### PR TITLE
ci: skip CI on docs-only changes

### DIFF
--- a/.github/workflows/generated_files.yml
+++ b/.github/workflows/generated_files.yml
@@ -20,12 +20,13 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          # `**/!(*.md)` excludes Markdown so docs-only changes don't trigger codegen checks.
           filters: |
             generated:
-              - 'spec/**'
+              - 'spec/**/!(*.md)'
               - 'codegen.Dockerfile'
               - 'Makefile'
-              - 'packages/**'
+              - 'packages/**/!(*.md)'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - 'package.json'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,11 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          # `**/!(*.md)` excludes Markdown so docs-only changes don't trigger linting.
           filters: |
             code:
-              - 'packages/**'
-              - 'spec/**'
+              - 'packages/**/!(*.md)'
+              - 'spec/**/!(*.md)'
               - '.eslintrc.cjs'
               - '.prettierrc'
               - '.prettierignore'

--- a/.github/workflows/sdk_tests.yml
+++ b/.github/workflows/sdk_tests.yml
@@ -29,10 +29,11 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          # `**/!(*.md)` excludes Markdown so docs-only changes don't trigger the suites.
           filters: |
             shared: &shared
               - '.github/workflows/sdk_tests.yml'
-              - 'spec/**'
+              - 'spec/**/!(*.md)'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - 'package.json'
@@ -40,17 +41,17 @@ jobs:
             js:
               - *shared
               - '.github/workflows/js_sdk_tests.yml'
-              - 'packages/js-sdk/**'
+              - 'packages/js-sdk/**/!(*.md)'
             python:
               - *shared
               - '.github/workflows/python_sdk_tests.yml'
-              - 'packages/python-sdk/**'
-              - 'packages/connect-python/**'
+              - 'packages/python-sdk/**/!(*.md)'
+              - 'packages/connect-python/**/!(*.md)'
             cli:
               - *shared
               - '.github/workflows/cli_tests.yml'
-              - 'packages/cli/**'
-              - 'packages/js-sdk/**'
+              - 'packages/cli/**/!(*.md)'
+              - 'packages/js-sdk/**/!(*.md)'
 
   js-tests:
     name: Production / JS SDK Tests

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -17,10 +17,11 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          # `**/!(*.md)` excludes Markdown so docs-only changes don't trigger typecheck.
           filters: |
             code:
-              - 'packages/**'
-              - 'spec/**'
+              - 'packages/**/!(*.md)'
+              - 'spec/**/!(*.md)'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - 'package.json'


### PR DESCRIPTION
## Summary

PR-gated workflows filter changed paths to decide whether to run, but their package/spec globs (`packages/**`, `spec/**`) matched every `.md` file in those directories — so docs-only changes (e.g. a package README) triggered full test/lint/typecheck/codegen runs.

This appends the picomatch extglob `**/!(*.md)` to those directory globs so Markdown no longer matches, across:

- **sdk_tests.yml** — JS/Python/CLI suites (prod + staging)
- **lint.yml** — lint/format only touch `src/`, `tests/`, and Python code, never Markdown
- **typecheck.yml** — typecheck only covers `.ts`/`.py`
- **generated_files.yml** — codegen derives from `spec/`, unaffected by docs

The exclusion is baked into each glob rather than added as a `!**/*.md` rule because that only subtracts under `predicate-quantifier: every`, which is global to the step and would break the OR between the shared and package globs. PRs touching code (or code **and** docs together) still run as before.

Note: `pkg_artifacts.yml` builds packages on every PR with no path filter at all — left as-is since gating it would require adding a `changes` job and change its always-runs behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)