### PR TITLE
[skip ci] Release new versions (sync repo with published packages)

### DIFF
--- a/.changeset/fix-logo-pypi-npm.md
+++ b/.changeset/fix-logo-pypi-npm.md
@@ -1,7 +1,0 @@
----
-"@e2b/python-sdk": patch
-"e2b": patch
-"@e2b/cli": patch
----
-
-Fix duplicate logo on NPM/PyPI by switching to `<picture>` element.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2b/cli",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "CLI for managing e2b sandbox templates",
   "homepage": "https://e2b.dev",
   "license": "MIT",
@@ -81,7 +81,7 @@
     "commander": "^11.1.0",
     "console-table-printer": "^2.11.2",
     "dockerfile-ast": "^0.6.1",
-    "e2b": "^2.30.3",
+    "e2b": "^2.30.4",
     "handlebars": "^4.7.9",
     "inquirer": "^12.10.0",
     "simple-update-notifier": "^2.0.0",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2b",
-  "version": "2.30.3",
+  "version": "2.30.4",
   "description": "E2B SDK that give agents cloud environments",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/packages/python-sdk/package.json
+++ b/packages/python-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@e2b/python-sdk",
   "private": true,
-  "version": "2.29.3",
+  "version": "2.29.4",
   "scripts": {
     "example": "poetry run python example.py",
     "test": "poetry run pytest -n 4 --verbose -x",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "e2b"
-version = "2.29.3"
+version = "2.29.4"
 description = "E2B SDK that give agents cloud environments"
 authors = ["e2b <hello@e2b.dev>"]
 license = "MIT"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       e2b:
-        specifier: ^2.30.3
-        version: 2.30.3
+        specifier: ^2.30.4
+        version: 2.30.4
       handlebars:
         specifier: ^4.7.9
         version: 4.7.9
@@ -1795,8 +1795,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  e2b@2.30.3:
-    resolution: {integrity: sha512-LIMXgugX6gN4sh8UnK5UcMCOzZPalz3c9DL3VquD/OW9ds9Mmmgim/vQhLZICufL6MeRzL3Xq1IvAPmxVjYAAQ==}
+  e2b@2.30.4:
+    resolution: {integrity: sha512-uyKaY4zB3cr3wXZD4CFF8EnRheKOZuek7EQsGkyxFhTwkFwg69RGnsorMvO1qrMJCrVf3cyjAEnqxXLKJwtArQ==}
     engines: {node: '>=20.18.1'}
 
   eastasianwidth@0.2.0:
@@ -5247,7 +5247,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  e2b@2.30.3:
+  e2b@2.30.4:
     dependencies:
       '@bufbuild/protobuf': 2.6.2
       '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.6.2)


### PR DESCRIPTION
## Why

The Release run [27844631141](https://github.com/e2b-dev/E2B/actions/runs/27844631141/job/82412481993) **published all packages successfully** but then failed at the final *"Commit new versions"* step — the version-bump commit-back to \`main\` was rejected as non-fast-forward (another PR landed on \`main\` during the release window).

As a result the registries are ahead of the repo:

| Package | Published | Repo (main) before this PR |
|---|---|---|
| \`e2b\` (JS) | 2.30.4 (npm) | 2.30.3 |
| \`@e2b/cli\` | 2.12.2 (npm) | 2.12.1 |
| \`e2b\` (Python) | 2.29.4 (PyPI) | 2.29.3 |

The changeset \`fix-logo-pypi-npm.md\` was also never consumed and is still on \`main\`.

## What this PR does

Replays exactly what the failed *"Commit new versions"* step would have committed — i.e. \`pnpm run version\` (changeset version + \`postVersion\` poetry sync) + lockfile update:

- Bumps \`e2b\` → 2.30.4, \`@e2b/cli\` → 2.12.2, \`@e2b/python-sdk\` → 2.29.4 (matching what's already published)
- Deletes the consumed changeset \`fix-logo-pypi-npm.md\`
- Updates \`pnpm-lock.yaml\` (CLI's \`e2b\` dep → 2.30.4)

No new packages are published by merging this — it only syncs the repo to the registries. **Do not re-run the Release workflow** for this changeset; the versions already exist on npm/PyPI.