### PR TITLE
ci: guard release commit push against concurrent merges

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -96,13 +96,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "[skip ci] Release new versions" || exit 0
 
-          # A PR can merge into the branch while this release is running, making
-          # the push a non-fast-forward. The artifacts were already published
-          # from the checked-out tree, so we can only safely rebase the version
-          # bump on top of incoming changes that are NOT part of any published
-          # package. Otherwise the source tree would claim the just-published
-          # version contains code that never made it into the published
-          # artifacts, so we fail loudly for manual reconciliation instead.
+          # A PR merging mid-release makes this push a non-fast-forward. The
+          # artifacts were already published from the checked-out tree, so we
+          # only rebase the version bump over incoming changes that don't touch
+          # packages/. Otherwise the source would claim the published version
+          # contains code that isn't in the artifacts, so we fail loudly.
           if git push; then
             exit 0
           fi

--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -95,6 +95,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "[skip ci] Release new versions" || exit 0
+
+          # A PR can merge into the target branch while this release is running,
+          # making the push a non-fast-forward. Rebase onto the latest remote
+          # state before pushing to avoid a failed release.
+          git pull --rebase origin "${GITHUB_REF_NAME}"
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -96,9 +96,23 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "[skip ci] Release new versions" || exit 0
 
-          # A PR can merge into the target branch while this release is running,
-          # making the push a non-fast-forward. Rebase onto the latest remote
-          # state before pushing to avoid a failed release.
+          # A PR can merge into the branch while this release is running, making
+          # the push a non-fast-forward. The artifacts were already published
+          # from the checked-out tree, so we can only safely rebase the version
+          # bump on top of incoming changes that are NOT part of any published
+          # package. Otherwise the source tree would claim the just-published
+          # version contains code that never made it into the published
+          # artifacts, so we fail loudly for manual reconciliation instead.
+          if git push; then
+            exit 0
+          fi
+
+          git fetch origin "${GITHUB_REF_NAME}"
+          if git diff --name-only "HEAD~1" FETCH_HEAD -- packages/ | grep -q .; then
+            echo "::error::'${GITHUB_REF_NAME}' advanced with changes under packages/ during the release. Refusing to rebase the version bump onto unpublished package code (the source would diverge from the published artifacts). Reconcile manually."
+            exit 1
+          fi
+
           git pull --rebase origin "${GITHUB_REF_NAME}"
           git push
         env:


### PR DESCRIPTION
The release "Commit new versions" step pushed without a rebase, so a PR merging mid-release failed the push and the whole release. A plain `git pull --rebase` would fix that but could rebase the version bump onto concurrently-merged package code that was never in the published artifacts — a silent source↔artifact divergence.

This guards the rebase: on a non-fast-forward push, it only rebases when the incoming changes don't touch `packages/`; if they do, it fails loudly for manual reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)