### PR TITLE
feat(sdk): filesystem-only auto-pause via lifecycle.onTimeout object form

### DIFF
--- a/.changeset/auto-pause-filesystem-only.md
+++ b/.changeset/auto-pause-filesystem-only.md
@@ -3,25 +3,31 @@
 "@e2b/python-sdk": minor
 ---
 
-Add a `keepMemory` (`keep_memory` in Python) option to the sandbox `lifecycle`
-config, controlling the snapshot kind taken when a sandbox auto-pauses on
-timeout.
+Add an object form to the sandbox `lifecycle.onTimeout` (`on_timeout` in Python)
+that controls the snapshot kind taken when a sandbox auto-pauses on timeout, via
+`keepMemory` (`keep_memory`).
 
-When `keepMemory` is `false`, a timeout auto-pause drops the in-memory state and
-persists only the filesystem (a filesystem-only snapshot); resuming such a
-sandbox cold-boots (reboots) it from disk, losing running processes and open
-connections. Defaults to `true` (full memory snapshot). It only applies when
-`onTimeout`/`on_timeout` is `pause`, and cannot be combined with auto-resume (a
-filesystem-only snapshot must be resumed explicitly).
+`onTimeout` now accepts either the existing bare action (`'pause'` / `'kill'`) or
+the object form. The object form is a discriminated union on `action`:
+`keepMemory` is only accepted alongside `action: 'pause'` — pairing it with
+`action: 'kill'` is a compile-time type error (and is rejected at runtime for
+untyped callers). When `keepMemory` is `false`, a timeout auto-pause drops the
+in-memory state and persists only the filesystem (a filesystem-only snapshot);
+resuming such a sandbox cold-boots (reboots) it from disk, losing running
+processes and open connections. Defaults to `true` (full memory snapshot). It
+cannot be combined with auto-resume (a filesystem-only snapshot must be resumed
+explicitly). The bare string form is unchanged.
 
 ```python
 # Python
-sbx = Sandbox.create(lifecycle={"on_timeout": "pause", "keep_memory": False})
+sbx = Sandbox.create(
+    lifecycle={"on_timeout": {"action": "pause", "keep_memory": False}}
+)
 ```
 
 ```ts
 // JS/TS
 const sbx = await Sandbox.create({
-  lifecycle: { onTimeout: 'pause', keepMemory: false },
+  lifecycle: { onTimeout: { action: 'pause', keepMemory: false } },
 })
 ```

--- a/.changeset/auto-pause-filesystem-only.md
+++ b/.changeset/auto-pause-filesystem-only.md
@@ -15,8 +15,10 @@ untyped callers). When `keepMemory` is `false`, a timeout auto-pause drops the
 in-memory state and persists only the filesystem (a filesystem-only snapshot);
 resuming such a sandbox cold-boots (reboots) it from disk, losing running
 processes and open connections. Defaults to `true` (full memory snapshot). It
-cannot be combined with auto-resume (a filesystem-only snapshot must be resumed
-explicitly). The bare string form is unchanged.
+cannot be combined with auto-resume: auto-resume wakes a paused sandbox on
+inbound traffic by restoring its memory snapshot in place, and a filesystem-only
+snapshot has no memory to restore (resuming cold-boots it), so it must be resumed
+explicitly. The bare string form is unchanged.
 
 ```python
 # Python

--- a/.changeset/auto-pause-filesystem-only.md
+++ b/.changeset/auto-pause-filesystem-only.md
@@ -16,7 +16,7 @@ filesystem-only snapshot must be resumed explicitly).
 
 ```python
 # Python
-sbx = Sandbox(lifecycle={"on_timeout": "pause", "keep_memory": False})
+sbx = Sandbox.create(lifecycle={"on_timeout": "pause", "keep_memory": False})
 ```
 
 ```ts

--- a/.changeset/auto-pause-filesystem-only.md
+++ b/.changeset/auto-pause-filesystem-only.md
@@ -1,0 +1,27 @@
+---
+"e2b": minor
+"@e2b/python-sdk": minor
+---
+
+Add a `keepMemory` (`keep_memory` in Python) option to the sandbox `lifecycle`
+config, controlling the snapshot kind taken when a sandbox auto-pauses on
+timeout.
+
+When `keepMemory` is `false`, a timeout auto-pause drops the in-memory state and
+persists only the filesystem (a filesystem-only snapshot); resuming such a
+sandbox cold-boots (reboots) it from disk, losing running processes and open
+connections. Defaults to `true` (full memory snapshot). It only applies when
+`onTimeout`/`on_timeout` is `pause`, and cannot be combined with auto-resume (a
+filesystem-only snapshot must be resumed explicitly).
+
+```python
+# Python
+sbx = Sandbox(lifecycle={"on_timeout": "pause", "keep_memory": False})
+```
+
+```ts
+// JS/TS
+const sbx = await Sandbox.create({
+  lifecycle: { onTimeout: 'pause', keepMemory: false },
+})
+```

--- a/packages/js-sdk/src/api/schema.gen.ts
+++ b/packages/js-sdk/src/api/schema.gen.ts
@@ -2013,6 +2013,11 @@ export interface components {
              * @default false
              */
             autoPause?: boolean;
+            /**
+             * @description Controls the snapshot kind taken when the sandbox auto-pauses on timeout (only relevant when autoPause is true). When false, the auto-pause drops the in-memory state and persists only the filesystem (a filesystem-only snapshot); resuming it cold-boots (reboots) the sandbox from disk. Such a snapshot cannot be auto-resumed by traffic and must be resumed explicitly, so it cannot be combined with autoResume. Defaults to true (full memory snapshot).
+             * @default true
+             */
+            autoPauseMemory?: boolean;
             autoResume?: components["schemas"]["SandboxAutoResumeConfig"];
             envVars?: components["schemas"]["EnvVars"];
             mcp?: components["schemas"]["Mcp"];

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -66,6 +66,7 @@ export type {
   SandboxNetworkRules,
   SandboxNetworkTransform,
   SandboxNetworkUpdate,
+  SandboxOnTimeout,
   SandboxLifecycle,
   SandboxInfoLifecycle,
   SnapshotInfo,

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -248,7 +248,9 @@ export type SandboxLifecycle = {
   /**
    * Auto-resume enabled flag.
    * @default false
-   * Can be `true` only when the resolved timeout action is `pause`.
+   * Can be `true` only when `onTimeout` is `pause`. Not supported when
+   * `keepMemory` is `false` (a filesystem-only snapshot must be resumed
+   * explicitly via `connect()`).
    */
   autoResume?: boolean
 }
@@ -1161,8 +1163,6 @@ export class SandboxApi {
       allow_internet_access: opts?.allowInternetAccess ?? true,
       network: buildNetworkBody(opts?.network),
       autoPause: action === 'pause',
-      // Only relevant to a timeout auto-pause; omit it otherwise so the body
-      // matches the field's contract (keepMemory is forced true when not pause).
       autoPauseMemory: action === 'pause' ? keepMemory : undefined,
       autoResume: { enabled: autoResume },
     }

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -210,6 +210,19 @@ export type SandboxLifecycle = {
    * Can be `true` only when `onTimeout` is `pause`.
    */
   autoResume?: boolean
+
+  /**
+   * Whether a timeout auto-pause keeps a full memory snapshot.
+   *
+   * When `false`, the auto-pause drops the in-memory state and persists only the
+   * filesystem (a filesystem-only snapshot); resuming such a sandbox cold-boots
+   * (reboots) it from disk, losing running processes and open connections. Only
+   * relevant when `onTimeout` is `pause`, and cannot be combined with
+   * `autoResume` (a filesystem-only snapshot must be resumed explicitly).
+   *
+   * @default true
+   */
+  keepMemory?: boolean
 }
 
 export type SandboxInfoLifecycle = {
@@ -1081,10 +1094,23 @@ export class SandboxApi {
     const client = new ApiClient(config)
     const onTimeout = opts?.lifecycle?.onTimeout ?? 'kill'
     const autoResume = opts?.lifecycle?.autoResume ?? false
+    const keepMemory = opts?.lifecycle?.keepMemory ?? true
 
     if (autoResume && onTimeout !== 'pause') {
       throw new InvalidArgumentError(
         "autoResume can only be true when the resolved onTimeout is 'pause'."
+      )
+    }
+
+    if (!keepMemory && onTimeout !== 'pause') {
+      throw new InvalidArgumentError(
+        "lifecycle.keepMemory=false only applies when onTimeout is 'pause'."
+      )
+    }
+
+    if (!keepMemory && autoResume) {
+      throw new InvalidArgumentError(
+        'lifecycle.keepMemory=false (filesystem-only auto-pause) cannot be combined with autoResume: a filesystem-only snapshot cannot be auto-resumed by traffic and must be resumed explicitly.'
       )
     }
 
@@ -1098,6 +1124,9 @@ export class SandboxApi {
       allow_internet_access: opts?.allowInternetAccess ?? true,
       network: buildNetworkBody(opts?.network),
       autoPause: onTimeout === 'pause',
+      // Only relevant to a timeout auto-pause; omit it otherwise so the body
+      // matches the field's contract (keepMemory is forced true when not pause).
+      autoPauseMemory: onTimeout === 'pause' ? keepMemory : undefined,
       autoResume: { enabled: autoResume },
     }
 

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -219,8 +219,14 @@ export type SandboxOnTimeout =
        * When `false`, the auto-pause drops the in-memory state and persists only
        * the filesystem (a filesystem-only snapshot); resuming such a sandbox
        * cold-boots (reboots) it from disk, losing running processes and open
-       * connections. Cannot be combined with `autoResume` (a filesystem-only
-       * snapshot must be resumed explicitly).
+       * connections.
+       *
+       * Cannot be combined with `autoResume`: auto-resume wakes a paused sandbox
+       * on inbound traffic by restoring its memory snapshot in place, so the
+       * request that woke it hits an already-running process. A filesystem-only
+       * snapshot has no memory to restore — resuming cold-boots it — so it can't
+       * be woken transparently by traffic and must be resumed explicitly via
+       * `connect()`.
        *
        * @default true
        */

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -1137,19 +1137,19 @@ export class SandboxApi {
 
     if (hasKeepMemory && action !== 'pause') {
       throw new InvalidArgumentError(
-        "onTimeout.keepMemory is not allowed when action is 'kill'."
+        "onTimeout.keepMemory is only allowed when action is 'pause'."
       )
     }
 
     if (autoResume && action !== 'pause') {
       throw new InvalidArgumentError(
-        "autoResume can only be true when the resolved onTimeout action is 'pause'."
+        "autoResume can only be true when onTimeout action is 'pause'."
       )
     }
 
     if (!keepMemory && autoResume) {
       throw new InvalidArgumentError(
-        'onTimeout keepMemory=false (filesystem-only auto-pause) cannot be combined with autoResume: a filesystem-only snapshot cannot be auto-resumed by traffic and must be resumed explicitly.'
+        'autoResume: true is not a valid value when keepMemory: false - a filesystem-only snapshot cannot be auto-resumed by traffic and must be resumed explicitly using Sandbox.connect().'
       )
     }
 

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -197,32 +197,54 @@ export type SandboxNetworkUpdate = {
   allowInternetAccess?: boolean
 }
 
+/**
+ * What happens when the sandbox timeout is reached. Either the bare action
+ * (`'pause'` / `'kill'`), or an object form that also controls the pause
+ * snapshot kind via `keepMemory`.
+ *
+ * The object form is a discriminated union on `action`: `keepMemory` is only
+ * accepted alongside `action: 'pause'`. Passing `keepMemory` with
+ * `action: 'kill'` is a compile-time type error.
+ */
+export type SandboxOnTimeout =
+  | 'pause'
+  | 'kill'
+  | {
+      /** Auto-pause the sandbox when the timeout is reached. */
+      action: 'pause'
+
+      /**
+       * Whether the timeout auto-pause keeps a full memory snapshot.
+       *
+       * When `false`, the auto-pause drops the in-memory state and persists only
+       * the filesystem (a filesystem-only snapshot); resuming such a sandbox
+       * cold-boots (reboots) it from disk, losing running processes and open
+       * connections. Cannot be combined with `autoResume` (a filesystem-only
+       * snapshot must be resumed explicitly).
+       *
+       * @default true
+       */
+      keepMemory?: boolean
+    }
+  | {
+      /** Kill the sandbox when the timeout is reached. */
+      action: 'kill'
+    }
+
 export type SandboxLifecycle = {
   /**
-   * Action to take when sandbox timeout is reached.
+   * Action to take when sandbox timeout is reached. Accepts either `'pause'` /
+   * `'kill'`, or `{ action, keepMemory }` to also control the pause snapshot kind.
    * @default "kill"
    */
-  onTimeout: 'pause' | 'kill'
+  onTimeout: SandboxOnTimeout
 
   /**
    * Auto-resume enabled flag.
    * @default false
-   * Can be `true` only when `onTimeout` is `pause`.
+   * Can be `true` only when the resolved timeout action is `pause`.
    */
   autoResume?: boolean
-
-  /**
-   * Whether a timeout auto-pause keeps a full memory snapshot.
-   *
-   * When `false`, the auto-pause drops the in-memory state and persists only the
-   * filesystem (a filesystem-only snapshot); resuming such a sandbox cold-boots
-   * (reboots) it from disk, losing running processes and open connections. Only
-   * relevant when `onTimeout` is `pause`, and cannot be combined with
-   * `autoResume` (a filesystem-only snapshot must be resumed explicitly).
-   *
-   * @default true
-   */
-  keepMemory?: boolean
 }
 
 export type SandboxInfoLifecycle = {
@@ -1092,25 +1114,34 @@ export class SandboxApi {
   ) {
     const config = new ConnectionConfig(opts)
     const client = new ApiClient(config)
+    // onTimeout accepts a bare action (`'pause'` / `'kill'`) or the object form
+    // `{ action, keepMemory }`. The discriminated union type forbids `keepMemory`
+    // on `action: 'kill'`; re-check at runtime for untyped (JS) callers.
     const onTimeout = opts?.lifecycle?.onTimeout ?? 'kill'
+    const action = typeof onTimeout === 'string' ? onTimeout : onTimeout.action
+    const hasKeepMemory =
+      typeof onTimeout !== 'string' && 'keepMemory' in onTimeout
+    const keepMemory =
+      typeof onTimeout !== 'string' && 'keepMemory' in onTimeout
+        ? (onTimeout.keepMemory ?? true)
+        : true
     const autoResume = opts?.lifecycle?.autoResume ?? false
-    const keepMemory = opts?.lifecycle?.keepMemory ?? true
 
-    if (autoResume && onTimeout !== 'pause') {
+    if (hasKeepMemory && action !== 'pause') {
       throw new InvalidArgumentError(
-        "autoResume can only be true when the resolved onTimeout is 'pause'."
+        "onTimeout.keepMemory is not allowed when action is 'kill'."
       )
     }
 
-    if (!keepMemory && onTimeout !== 'pause') {
+    if (autoResume && action !== 'pause') {
       throw new InvalidArgumentError(
-        "lifecycle.keepMemory=false only applies when onTimeout is 'pause'."
+        "autoResume can only be true when the resolved onTimeout action is 'pause'."
       )
     }
 
     if (!keepMemory && autoResume) {
       throw new InvalidArgumentError(
-        'lifecycle.keepMemory=false (filesystem-only auto-pause) cannot be combined with autoResume: a filesystem-only snapshot cannot be auto-resumed by traffic and must be resumed explicitly.'
+        'onTimeout keepMemory=false (filesystem-only auto-pause) cannot be combined with autoResume: a filesystem-only snapshot cannot be auto-resumed by traffic and must be resumed explicitly.'
       )
     }
 
@@ -1123,10 +1154,10 @@ export class SandboxApi {
       secure: opts?.secure ?? true,
       allow_internet_access: opts?.allowInternetAccess ?? true,
       network: buildNetworkBody(opts?.network),
-      autoPause: onTimeout === 'pause',
+      autoPause: action === 'pause',
       // Only relevant to a timeout auto-pause; omit it otherwise so the body
       // matches the field's contract (keepMemory is forced true when not pause).
-      autoPauseMemory: onTimeout === 'pause' ? keepMemory : undefined,
+      autoPauseMemory: action === 'pause' ? keepMemory : undefined,
       autoResume: { enabled: autoResume },
     }
 

--- a/packages/js-sdk/tests/sandbox/lifecyclePayload.test.ts
+++ b/packages/js-sdk/tests/sandbox/lifecyclePayload.test.ts
@@ -3,18 +3,21 @@ import { assert, expect, test } from 'vitest'
 import { InvalidArgumentError, Sandbox } from '../../src'
 import { isDebug, template, wait } from '../setup.js'
 
-test('filesystem-only auto-pause cannot be combined with auto-resume', async () => {
-  // A filesystem-only auto-pause snapshot can only be resumed explicitly, so
-  // keepMemory:false with autoResume is rejected client-side.
-  await expect(
-    Sandbox.create(template, {
-      timeoutMs: 3_000,
-      lifecycle: { onTimeout: 'pause', autoResume: true, keepMemory: false },
-    })
-  ).rejects.toThrowError(InvalidArgumentError)
-})
+test.skipIf(isDebug)(
+  'filesystem-only auto-pause cannot be combined with auto-resume',
+  async () => {
+    // A filesystem-only auto-pause snapshot can only be resumed explicitly, so
+    // keepMemory:false with autoResume is rejected client-side.
+    await expect(
+      Sandbox.create(template, {
+        timeoutMs: 3_000,
+        lifecycle: { onTimeout: 'pause', autoResume: true, keepMemory: false },
+      })
+    ).rejects.toThrowError(InvalidArgumentError)
+  }
+)
 
-test('keepMemory=false requires onTimeout pause', async () => {
+test.skipIf(isDebug)('keepMemory=false requires onTimeout pause', async () => {
   // keepMemory only governs a timeout auto-pause, so keepMemory:false without
   // onTimeout:'pause' is rejected client-side.
   await expect(

--- a/packages/js-sdk/tests/sandbox/lifecyclePayload.test.ts
+++ b/packages/js-sdk/tests/sandbox/lifecyclePayload.test.ts
@@ -78,31 +78,27 @@ test.skipIf(isDebug)(
 
     try {
       const marker = 'auto-pause-fs-only'
-      await sandbox.commands.run(
-        `echo ${marker} > /home/user/auto-pause-marker.txt`
-      )
+      await sandbox.files.write('/home/user/auto-pause-marker.txt', marker)
       const bootBefore = (
-        await sandbox.commands.run('cat /proc/sys/kernel/random/boot_id')
-      ).stdout.trim()
+        await sandbox.files.read('/proc/sys/kernel/random/boot_id')
+      ).trim()
 
       await wait(5_000)
 
       assert.equal((await sandbox.getInfo()).state, 'paused')
-      assert.isFalse(await sandbox.isRunning())
 
       // A filesystem-only snapshot cannot auto-resume on traffic; connect
       // resumes it by cold-booting.
       await sandbox.connect()
-      assert.isTrue(await sandbox.isRunning())
 
       const persisted = (
-        await sandbox.commands.run('cat /home/user/auto-pause-marker.txt')
-      ).stdout.trim()
+        await sandbox.files.read('/home/user/auto-pause-marker.txt')
+      ).trim()
       assert.equal(persisted, marker)
 
       const bootAfter = (
-        await sandbox.commands.run('cat /proc/sys/kernel/random/boot_id')
-      ).stdout.trim()
+        await sandbox.files.read('/proc/sys/kernel/random/boot_id')
+      ).trim()
       assert.notEqual(bootAfter, bootBefore)
     } finally {
       await sandbox.kill().catch(() => {})

--- a/packages/js-sdk/tests/sandbox/lifecyclePayload.test.ts
+++ b/packages/js-sdk/tests/sandbox/lifecyclePayload.test.ts
@@ -1,7 +1,29 @@
-import { assert, test } from 'vitest'
+import { assert, expect, test } from 'vitest'
 
-import { Sandbox } from '../../src'
+import { InvalidArgumentError, Sandbox } from '../../src'
 import { isDebug, template, wait } from '../setup.js'
+
+test('filesystem-only auto-pause cannot be combined with auto-resume', async () => {
+  // A filesystem-only auto-pause snapshot can only be resumed explicitly, so
+  // keepMemory:false with autoResume is rejected client-side.
+  await expect(
+    Sandbox.create(template, {
+      timeoutMs: 3_000,
+      lifecycle: { onTimeout: 'pause', autoResume: true, keepMemory: false },
+    })
+  ).rejects.toThrowError(InvalidArgumentError)
+})
+
+test('keepMemory=false requires onTimeout pause', async () => {
+  // keepMemory only governs a timeout auto-pause, so keepMemory:false without
+  // onTimeout:'pause' is rejected client-side.
+  await expect(
+    Sandbox.create(template, {
+      timeoutMs: 3_000,
+      lifecycle: { onTimeout: 'kill', keepMemory: false },
+    })
+  ).rejects.toThrowError(InvalidArgumentError)
+})
 
 test.skipIf(isDebug)(
   'auto-pause without auto-resume requires connect to wake',
@@ -24,6 +46,51 @@ test.skipIf(isDebug)(
 
       assert.equal((await sandbox.getInfo()).state, 'running')
       assert.isTrue(await sandbox.isRunning())
+    } finally {
+      await sandbox.kill().catch(() => {})
+    }
+  },
+  60_000
+)
+
+test.skipIf(isDebug)(
+  'filesystem-only auto-pause reboots on connect',
+  async () => {
+    // keepMemory:false makes the timeout auto-pause filesystem-only, so resuming
+    // cold-boots the sandbox from disk.
+    const sandbox = await Sandbox.create(template, {
+      timeoutMs: 3_000,
+      lifecycle: { onTimeout: 'pause', keepMemory: false },
+    })
+
+    try {
+      const marker = 'auto-pause-fs-only'
+      await sandbox.commands.run(
+        `echo ${marker} > /home/user/auto-pause-marker.txt`
+      )
+      const bootBefore = (
+        await sandbox.commands.run('cat /proc/sys/kernel/random/boot_id')
+      ).stdout.trim()
+
+      await wait(5_000)
+
+      assert.equal((await sandbox.getInfo()).state, 'paused')
+      assert.isFalse(await sandbox.isRunning())
+
+      // A filesystem-only snapshot cannot auto-resume on traffic; connect
+      // resumes it by cold-booting.
+      await sandbox.connect()
+      assert.isTrue(await sandbox.isRunning())
+
+      const persisted = (
+        await sandbox.commands.run('cat /home/user/auto-pause-marker.txt')
+      ).stdout.trim()
+      assert.equal(persisted, marker)
+
+      const bootAfter = (
+        await sandbox.commands.run('cat /proc/sys/kernel/random/boot_id')
+      ).stdout.trim()
+      assert.notEqual(bootAfter, bootBefore)
     } finally {
       await sandbox.kill().catch(() => {})
     }

--- a/packages/js-sdk/tests/sandbox/lifecyclePayload.test.ts
+++ b/packages/js-sdk/tests/sandbox/lifecyclePayload.test.ts
@@ -11,22 +11,32 @@ test.skipIf(isDebug)(
     await expect(
       Sandbox.create(template, {
         timeoutMs: 3_000,
-        lifecycle: { onTimeout: 'pause', autoResume: true, keepMemory: false },
+        lifecycle: {
+          onTimeout: { action: 'pause', keepMemory: false },
+          autoResume: true,
+        },
       })
     ).rejects.toThrowError(InvalidArgumentError)
   }
 )
 
-test.skipIf(isDebug)('keepMemory=false requires onTimeout pause', async () => {
-  // keepMemory only governs a timeout auto-pause, so keepMemory:false without
-  // onTimeout:'pause' is rejected client-side.
-  await expect(
-    Sandbox.create(template, {
-      timeoutMs: 3_000,
-      lifecycle: { onTimeout: 'kill', keepMemory: false },
-    })
-  ).rejects.toThrowError(InvalidArgumentError)
-})
+test.skipIf(isDebug)(
+  'keepMemory is not allowed when onTimeout action is kill',
+  async () => {
+    // The discriminated union forbids keepMemory on `action: 'kill'` at compile
+    // time (asserted by @ts-expect-error). The runtime guard below additionally
+    // rejects it for untyped (JS) callers that bypass the type.
+    await expect(
+      Sandbox.create(template, {
+        timeoutMs: 3_000,
+        lifecycle: {
+          // @ts-expect-error keepMemory is not allowed with action: 'kill'
+          onTimeout: { action: 'kill', keepMemory: false },
+        },
+      })
+    ).rejects.toThrowError(InvalidArgumentError)
+  }
+)
 
 test.skipIf(isDebug)(
   'auto-pause without auto-resume requires connect to wake',
@@ -63,7 +73,7 @@ test.skipIf(isDebug)(
     // cold-boots the sandbox from disk.
     const sandbox = await Sandbox.create(template, {
       timeoutMs: 3_000,
-      lifecycle: { onTimeout: 'pause', keepMemory: false },
+      lifecycle: { onTimeout: { action: 'pause', keepMemory: false } },
     })
 
     try {

--- a/packages/python-sdk/e2b/__init__.py
+++ b/packages/python-sdk/e2b/__init__.py
@@ -79,6 +79,7 @@ from .sandbox.sandbox_api import (
     SandboxInfoLifecycle,
     SandboxMetrics,
     SandboxLifecycle,
+    SandboxOnTimeout,
     SandboxNetworkInfo,
     SandboxNetworkOpts,
     SandboxNetworkRule,
@@ -201,6 +202,7 @@ __all__ = [
     "SandboxNetworkTransform",
     "SandboxNetworkUpdate",
     "SandboxLifecycle",
+    "SandboxOnTimeout",
     "ALL_TRAFFIC",
     # Snapshot
     "SnapshotInfo",

--- a/packages/python-sdk/e2b/api/client/models/new_sandbox.py
+++ b/packages/python-sdk/e2b/api/client/models/new_sandbox.py
@@ -24,6 +24,11 @@ class NewSandbox:
         allow_internet_access (Union[Unset, bool]): Allow sandbox to access the internet. When set to false, it behaves
             the same as specifying denyOut to 0.0.0.0/0 in the network config.
         auto_pause (Union[Unset, bool]): Automatically pauses the sandbox after the timeout Default: False.
+        auto_pause_memory (Union[Unset, bool]): Controls the snapshot kind taken when the sandbox auto-pauses on timeout
+            (only relevant when autoPause is true). When false, the auto-pause drops the in-memory state and persists only
+            the filesystem (a filesystem-only snapshot); resuming it cold-boots (reboots) the sandbox from disk. Such a
+            snapshot cannot be auto-resumed by traffic and must be resumed explicitly, so it cannot be combined with
+            autoResume. Defaults to true (full memory snapshot). Default: True.
         auto_resume (Union[Unset, SandboxAutoResumeConfig]): Auto-resume configuration for paused sandboxes.
         env_vars (Union[Unset, Any]):
         mcp (Union['McpType0', None, Unset]): MCP configuration for the sandbox
@@ -37,6 +42,7 @@ class NewSandbox:
     template_id: str
     allow_internet_access: Union[Unset, bool] = UNSET
     auto_pause: Union[Unset, bool] = False
+    auto_pause_memory: Union[Unset, bool] = True
     auto_resume: Union[Unset, "SandboxAutoResumeConfig"] = UNSET
     env_vars: Union[Unset, Any] = UNSET
     mcp: Union["McpType0", None, Unset] = UNSET
@@ -55,6 +61,8 @@ class NewSandbox:
         allow_internet_access = self.allow_internet_access
 
         auto_pause = self.auto_pause
+
+        auto_pause_memory = self.auto_pause_memory
 
         auto_resume: Union[Unset, dict[str, Any]] = UNSET
         if not isinstance(self.auto_resume, Unset):
@@ -98,6 +106,8 @@ class NewSandbox:
             field_dict["allow_internet_access"] = allow_internet_access
         if auto_pause is not UNSET:
             field_dict["autoPause"] = auto_pause
+        if auto_pause_memory is not UNSET:
+            field_dict["autoPauseMemory"] = auto_pause_memory
         if auto_resume is not UNSET:
             field_dict["autoResume"] = auto_resume
         if env_vars is not UNSET:
@@ -130,6 +140,8 @@ class NewSandbox:
         allow_internet_access = d.pop("allow_internet_access", UNSET)
 
         auto_pause = d.pop("autoPause", UNSET)
+
+        auto_pause_memory = d.pop("autoPauseMemory", UNSET)
 
         _auto_resume = d.pop("autoResume", UNSET)
         auto_resume: Union[Unset, SandboxAutoResumeConfig]
@@ -181,6 +193,7 @@ class NewSandbox:
             template_id=template_id,
             allow_internet_access=allow_internet_access,
             auto_pause=auto_pause,
+            auto_pause_memory=auto_pause_memory,
             auto_resume=auto_resume,
             env_vars=env_vars,
             mcp=mcp,

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -239,31 +239,62 @@ class SandboxNetworkInfo(TypedDict, total=False):
     mask_request_host: str
 
 
+class SandboxOnTimeoutPause(TypedDict):
+    """
+    Object form of `on_timeout` that auto-pauses the sandbox when the timeout is
+    reached, optionally controlling the pause snapshot kind via `keep_memory`.
+    """
+
+    action: Literal["pause"]
+    """Auto-pause the sandbox when the timeout is reached."""
+
+    keep_memory: NotRequired[bool]
+    """
+    Whether the timeout auto-pause keeps a full memory snapshot. Defaults to `True`.
+    When `False`, the auto-pause drops the in-memory state and persists only the
+    filesystem (a filesystem-only snapshot); resuming such a sandbox cold-boots
+    (reboots) it from disk, losing running processes and open connections. Cannot
+    be combined with `auto_resume` (a filesystem-only snapshot must be resumed
+    explicitly).
+    """
+
+
+class SandboxOnTimeoutKill(TypedDict):
+    """
+    Object form of `on_timeout` that kills the sandbox when the timeout is reached.
+    """
+
+    action: Literal["kill"]
+    """Kill the sandbox when the timeout is reached."""
+
+
+SandboxOnTimeout = Union[SandboxOnTimeoutPause, SandboxOnTimeoutKill]
+"""
+Object form of `on_timeout`. A discriminated union on `action`: `keep_memory` is
+only accepted alongside `action: "pause"`. Passing `keep_memory` with
+`action: "kill"` is a static type error.
+"""
+
+
 class SandboxLifecycle(TypedDict):
     """
     Sandbox lifecycle configuration; defines post-timeout behavior and auto-resume settings.
     Defaults to `on_timeout="kill"` and `auto_resume=False`.
     """
 
-    on_timeout: Literal["pause", "kill"]
+    on_timeout: Union[Literal["pause", "kill"], SandboxOnTimeout]
     """
-    What should happen to the sandbox when timeout is reached. `"kill"` means the sandbox will be terminated, while `"pause"` means the sandbox will be paused and can be resumed later. Defaults to `"kill"`.
+    What should happen to the sandbox when timeout is reached. `"kill"` terminates
+    the sandbox; `"pause"` pauses it for later resume. Accepts either the bare
+    action or an object `{"action": "pause", "keep_memory": ...}` /
+    `{"action": "kill"}` to also control the pause snapshot kind. Defaults to
+    `"kill"`.
     """
 
     auto_resume: NotRequired[bool]
     """
     Whether activity should cause the sandbox to resume when paused. Defaults to `False`.
-    Can be `True` only when `on_timeout` is `pause`.
-    """
-
-    keep_memory: NotRequired[bool]
-    """
-    Whether a timeout auto-pause keeps a full memory snapshot. Defaults to `True`.
-    When `False`, the auto-pause drops the in-memory state and persists only the
-    filesystem (a filesystem-only snapshot); resuming such a sandbox cold-boots
-    (reboots) it from disk, losing running processes and open connections. Only
-    relevant when `on_timeout` is `pause`, and cannot be combined with
-    `auto_resume` (a filesystem-only snapshot must be resumed explicitly).
+    Can be `True` only when the resolved timeout action is `pause`.
     """
 
 

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -253,9 +253,13 @@ class SandboxOnTimeoutPause(TypedDict):
     Whether the timeout auto-pause keeps a full memory snapshot. Defaults to `True`.
     When `False`, the auto-pause drops the in-memory state and persists only the
     filesystem (a filesystem-only snapshot); resuming such a sandbox cold-boots
-    (reboots) it from disk, losing running processes and open connections. Cannot
-    be combined with `auto_resume` (a filesystem-only snapshot must be resumed
-    explicitly).
+    (reboots) it from disk, losing running processes and open connections.
+
+    Cannot be combined with `auto_resume`: auto-resume wakes a paused sandbox on
+    inbound traffic by restoring its memory snapshot in place, so the request that
+    woke it hits an already-running process. A filesystem-only snapshot has no
+    memory to restore — resuming cold-boots it — so it can't be woken transparently
+    by traffic and must be resumed explicitly via `connect()`.
     """
 
 

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -256,6 +256,16 @@ class SandboxLifecycle(TypedDict):
     Can be `True` only when `on_timeout` is `pause`.
     """
 
+    keep_memory: NotRequired[bool]
+    """
+    Whether a timeout auto-pause keeps a full memory snapshot. Defaults to `True`.
+    When `False`, the auto-pause drops the in-memory state and persists only the
+    filesystem (a filesystem-only snapshot); resuming such a sandbox cold-boots
+    (reboots) it from disk, losing running processes and open connections. Only
+    relevant when `on_timeout` is `pause`, and cannot be combined with
+    `auto_resume` (a filesystem-only snapshot must be resumed explicitly).
+    """
+
 
 class SandboxInfoLifecycle(TypedDict):
     """

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -272,11 +272,15 @@ class SandboxOnTimeoutKill(TypedDict):
     """Kill the sandbox when the timeout is reached."""
 
 
-SandboxOnTimeout = Union[SandboxOnTimeoutPause, SandboxOnTimeoutKill]
+SandboxOnTimeout = Union[
+    Literal["pause", "kill"], SandboxOnTimeoutPause, SandboxOnTimeoutKill
+]
 """
-Object form of `on_timeout`. A discriminated union on `action`: `keep_memory` is
-only accepted alongside `action: "pause"`. Passing `keep_memory` with
-`action: "kill"` is a static type error.
+What should happen to the sandbox when the timeout is reached. Either the bare
+action (`"pause"` / `"kill"`) or the object form. The object form is a
+discriminated union on `action`: `keep_memory` is only accepted alongside
+`action: "pause"`. Passing `keep_memory` with `action: "kill"` is a static type
+error.
 """
 
 
@@ -286,7 +290,7 @@ class SandboxLifecycle(TypedDict):
     Defaults to `on_timeout="kill"` and `auto_resume=False`.
     """
 
-    on_timeout: Union[Literal["pause", "kill"], SandboxOnTimeout]
+    on_timeout: SandboxOnTimeout
     """
     What should happen to the sandbox when timeout is reached. `"kill"` terminates
     the sandbox; `"pause"` pauses it for later resume. Accepts either the bare
@@ -298,7 +302,9 @@ class SandboxLifecycle(TypedDict):
     auto_resume: NotRequired[bool]
     """
     Whether activity should cause the sandbox to resume when paused. Defaults to `False`.
-    Can be `True` only when the resolved timeout action is `pause`.
+    Can be `True` only when `on_timeout` is `pause`. Not supported when
+    `keep_memory` is `False` (a filesystem-only snapshot must be resumed
+    explicitly via `connect()`).
     """
 
 

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -196,7 +196,7 @@ class AsyncSandbox(SandboxApi):
         :param allow_internet_access: Allow sandbox to access the internet, defaults to `True`. If set to `False`, it works the same as setting network `deny_out` to `[0.0.0.0/0]`.
         :param mcp: MCP server to enable in the sandbox
         :param network: Sandbox network configuration. ``allow_out``/``deny_out`` may also be a callable receiving a :class:`SandboxNetworkSelectorContext` (``ctx.all_traffic``, ``ctx.rules``) and returning a list of strings. Per-host transform rules are nested under ``network.rules``.
-        :param lifecycle: Sandbox lifecycle configuration — ``on_timeout``: ``"kill"`` (default) or ``"pause"``, or an object ``{"action": "pause"|"kill", "keep_memory": bool}`` where ``keep_memory`` (default ``True``) set to ``False`` makes a timeout auto-pause filesystem-only (cold-boots on resume; cannot be combined with ``auto_resume``); ``auto_resume``: ``False`` (default) or ``True`` (only when the resolved action is ``"pause"``). Example: ``{"on_timeout": {"action": "pause", "keep_memory": False}}``
+        :param lifecycle: Sandbox lifecycle configuration — ``on_timeout``: ``"kill"`` (default) or ``"pause"``, or an object ``{"action": "pause"|"kill", "keep_memory": bool}`` where ``keep_memory`` (default ``True``) set to ``False`` makes a timeout auto-pause filesystem-only (cold-boots on resume; cannot be combined with ``auto_resume``); ``auto_resume``: ``False`` (default) or ``True`` (only when ``on_timeout`` action is ``"pause"``). Example: ``{"on_timeout": {"action": "pause", "keep_memory": False}}``
         :param volume_mounts: Dictionary mapping mount paths to AsyncVolume instances or volume names
 
         :return: A Sandbox instance for the new sandbox

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -196,7 +196,7 @@ class AsyncSandbox(SandboxApi):
         :param allow_internet_access: Allow sandbox to access the internet, defaults to `True`. If set to `False`, it works the same as setting network `deny_out` to `[0.0.0.0/0]`.
         :param mcp: MCP server to enable in the sandbox
         :param network: Sandbox network configuration. ``allow_out``/``deny_out`` may also be a callable receiving a :class:`SandboxNetworkSelectorContext` (``ctx.all_traffic``, ``ctx.rules``) and returning a list of strings. Per-host transform rules are nested under ``network.rules``.
-        :param lifecycle: Sandbox lifecycle configuration — ``on_timeout``: ``"kill"`` (default) or ``"pause"``; ``auto_resume``: ``False`` (default) or ``True`` (only when ``on_timeout="pause"``). Example: ``{"on_timeout": "pause", "auto_resume": True}``
+        :param lifecycle: Sandbox lifecycle configuration — ``on_timeout``: ``"kill"`` (default) or ``"pause"``; ``auto_resume``: ``False`` (default) or ``True`` (only when ``on_timeout="pause"``); ``keep_memory``: ``True`` (default) or ``False`` for a filesystem-only auto-pause (cold-boots on resume; cannot be combined with ``auto_resume``). Example: ``{"on_timeout": "pause", "keep_memory": False}``
         :param volume_mounts: Dictionary mapping mount paths to AsyncVolume instances or volume names
 
         :return: A Sandbox instance for the new sandbox

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -196,7 +196,7 @@ class AsyncSandbox(SandboxApi):
         :param allow_internet_access: Allow sandbox to access the internet, defaults to `True`. If set to `False`, it works the same as setting network `deny_out` to `[0.0.0.0/0]`.
         :param mcp: MCP server to enable in the sandbox
         :param network: Sandbox network configuration. ``allow_out``/``deny_out`` may also be a callable receiving a :class:`SandboxNetworkSelectorContext` (``ctx.all_traffic``, ``ctx.rules``) and returning a list of strings. Per-host transform rules are nested under ``network.rules``.
-        :param lifecycle: Sandbox lifecycle configuration — ``on_timeout``: ``"kill"`` (default) or ``"pause"``; ``auto_resume``: ``False`` (default) or ``True`` (only when ``on_timeout="pause"``); ``keep_memory``: ``True`` (default) or ``False`` for a filesystem-only auto-pause (cold-boots on resume; cannot be combined with ``auto_resume``). Example: ``{"on_timeout": "pause", "keep_memory": False}``
+        :param lifecycle: Sandbox lifecycle configuration — ``on_timeout``: ``"kill"`` (default) or ``"pause"``, or an object ``{"action": "pause"|"kill", "keep_memory": bool}`` where ``keep_memory`` (default ``True``) set to ``False`` makes a timeout auto-pause filesystem-only (cold-boots on resume; cannot be combined with ``auto_resume``); ``auto_resume``: ``False`` (default) or ``True`` (only when the resolved action is ``"pause"``). Example: ``{"on_timeout": {"action": "pause", "keep_memory": False}}``
         :param volume_mounts: Dictionary mapping mount paths to AsyncVolume instances or volume names
 
         :return: A Sandbox instance for the new sandbox

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -203,15 +203,18 @@ class SandboxApi(SandboxBase):
         config = ConnectionConfig(**opts)
 
         # on_timeout accepts a bare action or {"action", "keep_memory"}; normalize.
+        # Only the object form carries keep_memory; anything else (a bare action
+        # string, or an unexpected value from an untyped caller) passes through as
+        # the action, so a non-"pause" value resolves to kill instead of crashing.
         on_timeout_raw = lifecycle.get("on_timeout", "kill") if lifecycle else "kill"
-        if isinstance(on_timeout_raw, str):
-            on_timeout = on_timeout_raw
-            keep_memory = None
-            keep_memory_provided = False
-        else:
+        if isinstance(on_timeout_raw, dict):
             on_timeout = on_timeout_raw.get("action", "kill")
             keep_memory_provided = "keep_memory" in on_timeout_raw
             keep_memory = on_timeout_raw.get("keep_memory")
+        else:
+            on_timeout = on_timeout_raw
+            keep_memory = None
+            keep_memory_provided = False
 
         # keep_memory only governs a pause action. The discriminated union type
         # forbids it on action="kill"; re-check at runtime for callers that

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -218,7 +218,7 @@ class SandboxApi(SandboxBase):
         # bypass the type.
         if keep_memory_provided and on_timeout != "pause":
             raise InvalidArgumentException(
-                "keep_memory is not allowed when on_timeout action is 'kill'."
+                "keep_memory is only allowed when on_timeout action is 'pause'."
             )
 
         # A missing or explicit None keep_memory defaults to True (full memory),
@@ -229,13 +229,14 @@ class SandboxApi(SandboxBase):
 
         if auto_resume and on_timeout != "pause":
             raise InvalidArgumentException(
-                "auto_resume can only be True when the resolved on_timeout is 'pause'."
+                "auto_resume can only be True when on_timeout action is 'pause'."
             )
 
         if not keep_memory and auto_resume:
             raise InvalidArgumentException(
-                "keep_memory=False (filesystem-only auto-pause) cannot be combined with auto_resume: "
-                "a filesystem-only snapshot cannot be auto-resumed by traffic and must be resumed explicitly."
+                "auto_resume: True is not a valid value when keep_memory: False - "
+                "a filesystem-only snapshot cannot be auto-resumed by traffic and "
+                "must be resumed explicitly using Sandbox.connect()."
             )
 
         network_body = build_network_config(network)

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -202,23 +202,34 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
-        on_timeout = lifecycle.get("on_timeout", "kill") if lifecycle else "kill"
-        auto_resume = lifecycle.get("auto_resume", False) if lifecycle else False
+        # on_timeout accepts a bare action or {"action", "keep_memory"}; normalize.
+        on_timeout_raw = lifecycle.get("on_timeout", "kill") if lifecycle else "kill"
+        if isinstance(on_timeout_raw, str):
+            on_timeout = on_timeout_raw
+            keep_memory = None
+            keep_memory_provided = False
+        else:
+            on_timeout = on_timeout_raw.get("action", "kill")
+            keep_memory_provided = "keep_memory" in on_timeout_raw
+            keep_memory = on_timeout_raw.get("keep_memory")
+
+        # keep_memory only governs a pause action. The discriminated union type
+        # forbids it on action="kill"; re-check at runtime for callers that
+        # bypass the type.
+        if keep_memory_provided and on_timeout != "pause":
+            raise InvalidArgumentException(
+                "keep_memory is not allowed when on_timeout action is 'kill'."
+            )
+
         # A missing or explicit None keep_memory defaults to True (full memory),
-        # mirroring the JS SDK's `?? true`. .get(key, True) would keep an explicit
-        # None, which would wrongly read as filesystem-only and send null on the wire.
-        keep_memory = lifecycle.get("keep_memory") if lifecycle else None
+        # mirroring the JS SDK; sending null would wrongly read as filesystem-only.
         if keep_memory is None:
             keep_memory = True
+        auto_resume = lifecycle.get("auto_resume", False) if lifecycle else False
 
         if auto_resume and on_timeout != "pause":
             raise InvalidArgumentException(
                 "auto_resume can only be True when the resolved on_timeout is 'pause'."
-            )
-
-        if not keep_memory and on_timeout != "pause":
-            raise InvalidArgumentException(
-                "keep_memory=False only applies when on_timeout is 'pause'."
             )
 
         if not keep_memory and auto_resume:

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -204,16 +204,32 @@ class SandboxApi(SandboxBase):
 
         on_timeout = lifecycle.get("on_timeout", "kill") if lifecycle else "kill"
         auto_resume = lifecycle.get("auto_resume", False) if lifecycle else False
+        keep_memory = lifecycle.get("keep_memory", True) if lifecycle else True
 
         if auto_resume and on_timeout != "pause":
             raise InvalidArgumentException(
                 "auto_resume can only be True when the resolved on_timeout is 'pause'."
             )
 
+        if not keep_memory and on_timeout != "pause":
+            raise InvalidArgumentException(
+                "keep_memory=False only applies when on_timeout is 'pause'."
+            )
+
+        if not keep_memory and auto_resume:
+            raise InvalidArgumentException(
+                "keep_memory=False (filesystem-only auto-pause) cannot be combined with auto_resume: "
+                "a filesystem-only snapshot cannot be auto-resumed by traffic and must be resumed explicitly."
+            )
+
         network_body = build_network_config(network)
         body = NewSandbox(
             template_id=template,
             auto_pause=on_timeout == "pause",
+            # Only relevant to a timeout auto-pause; leave it unset otherwise so the
+            # body matches the field's contract (keep_memory is forced True when
+            # on_timeout is not "pause").
+            auto_pause_memory=keep_memory if on_timeout == "pause" else UNSET,
             auto_resume=SandboxAutoResumeConfig(enabled=auto_resume),
             metadata=metadata or {},
             timeout=timeout,

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -204,7 +204,12 @@ class SandboxApi(SandboxBase):
 
         on_timeout = lifecycle.get("on_timeout", "kill") if lifecycle else "kill"
         auto_resume = lifecycle.get("auto_resume", False) if lifecycle else False
-        keep_memory = lifecycle.get("keep_memory", True) if lifecycle else True
+        # A missing or explicit None keep_memory defaults to True (full memory),
+        # mirroring the JS SDK's `?? true`. .get(key, True) would keep an explicit
+        # None, which would wrongly read as filesystem-only and send null on the wire.
+        keep_memory = lifecycle.get("keep_memory") if lifecycle else None
+        if keep_memory is None:
+            keep_memory = True
 
         if auto_resume and on_timeout != "pause":
             raise InvalidArgumentException(

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -242,9 +242,6 @@ class SandboxApi(SandboxBase):
         body = NewSandbox(
             template_id=template,
             auto_pause=on_timeout == "pause",
-            # Only relevant to a timeout auto-pause; leave it unset otherwise so the
-            # body matches the field's contract (keep_memory is forced True when
-            # on_timeout is not "pause").
             auto_pause_memory=keep_memory if on_timeout == "pause" else UNSET,
             auto_resume=SandboxAutoResumeConfig(enabled=auto_resume),
             metadata=metadata or {},

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -184,7 +184,7 @@ class Sandbox(SandboxApi):
         :param allow_internet_access: Allow sandbox to access the internet, defaults to `True`. If set to `False`, it works the same as setting network `deny_out` to `[0.0.0.0/0]`.
         :param mcp: MCP server to enable in the sandbox
         :param network: Sandbox network configuration. ``allow_out``/``deny_out`` may also be a callable receiving a :class:`SandboxNetworkSelectorContext` (``ctx.all_traffic``, ``ctx.rules``) and returning a list of strings. Per-host transform rules are nested under ``network.rules``.
-        :param lifecycle: Sandbox lifecycle configuration — ``on_timeout``: ``"kill"`` (default) or ``"pause"``; ``auto_resume``: ``False`` (default) or ``True`` (only when ``on_timeout="pause"``); ``keep_memory``: ``True`` (default) or ``False`` for a filesystem-only auto-pause (cold-boots on resume; cannot be combined with ``auto_resume``). Example: ``{"on_timeout": "pause", "keep_memory": False}``
+        :param lifecycle: Sandbox lifecycle configuration — ``on_timeout``: ``"kill"`` (default) or ``"pause"``, or an object ``{"action": "pause"|"kill", "keep_memory": bool}`` where ``keep_memory`` (default ``True``) set to ``False`` makes a timeout auto-pause filesystem-only (cold-boots on resume; cannot be combined with ``auto_resume``); ``auto_resume``: ``False`` (default) or ``True`` (only when the resolved action is ``"pause"``). Example: ``{"on_timeout": {"action": "pause", "keep_memory": False}}``
         :param volume_mounts: Dictionary mapping mount paths to Volume instances or volume names
 
         :return: A Sandbox instance for the new sandbox

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -184,7 +184,7 @@ class Sandbox(SandboxApi):
         :param allow_internet_access: Allow sandbox to access the internet, defaults to `True`. If set to `False`, it works the same as setting network `deny_out` to `[0.0.0.0/0]`.
         :param mcp: MCP server to enable in the sandbox
         :param network: Sandbox network configuration. ``allow_out``/``deny_out`` may also be a callable receiving a :class:`SandboxNetworkSelectorContext` (``ctx.all_traffic``, ``ctx.rules``) and returning a list of strings. Per-host transform rules are nested under ``network.rules``.
-        :param lifecycle: Sandbox lifecycle configuration — ``on_timeout``: ``"kill"`` (default) or ``"pause"``; ``auto_resume``: ``False`` (default) or ``True`` (only when ``on_timeout="pause"``). Example: ``{"on_timeout": "pause", "auto_resume": True}``
+        :param lifecycle: Sandbox lifecycle configuration — ``on_timeout``: ``"kill"`` (default) or ``"pause"``; ``auto_resume``: ``False`` (default) or ``True`` (only when ``on_timeout="pause"``); ``keep_memory``: ``True`` (default) or ``False`` for a filesystem-only auto-pause (cold-boots on resume; cannot be combined with ``auto_resume``). Example: ``{"on_timeout": "pause", "keep_memory": False}``
         :param volume_mounts: Dictionary mapping mount paths to Volume instances or volume names
 
         :return: A Sandbox instance for the new sandbox

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -184,7 +184,7 @@ class Sandbox(SandboxApi):
         :param allow_internet_access: Allow sandbox to access the internet, defaults to `True`. If set to `False`, it works the same as setting network `deny_out` to `[0.0.0.0/0]`.
         :param mcp: MCP server to enable in the sandbox
         :param network: Sandbox network configuration. ``allow_out``/``deny_out`` may also be a callable receiving a :class:`SandboxNetworkSelectorContext` (``ctx.all_traffic``, ``ctx.rules``) and returning a list of strings. Per-host transform rules are nested under ``network.rules``.
-        :param lifecycle: Sandbox lifecycle configuration — ``on_timeout``: ``"kill"`` (default) or ``"pause"``, or an object ``{"action": "pause"|"kill", "keep_memory": bool}`` where ``keep_memory`` (default ``True``) set to ``False`` makes a timeout auto-pause filesystem-only (cold-boots on resume; cannot be combined with ``auto_resume``); ``auto_resume``: ``False`` (default) or ``True`` (only when the resolved action is ``"pause"``). Example: ``{"on_timeout": {"action": "pause", "keep_memory": False}}``
+        :param lifecycle: Sandbox lifecycle configuration — ``on_timeout``: ``"kill"`` (default) or ``"pause"``, or an object ``{"action": "pause"|"kill", "keep_memory": bool}`` where ``keep_memory`` (default ``True``) set to ``False`` makes a timeout auto-pause filesystem-only (cold-boots on resume; cannot be combined with ``auto_resume``); ``auto_resume``: ``False`` (default) or ``True`` (only when ``on_timeout`` action is ``"pause"``). Example: ``{"on_timeout": {"action": "pause", "keep_memory": False}}``
         :param volume_mounts: Dictionary mapping mount paths to Volume instances or volume names
 
         :return: A Sandbox instance for the new sandbox

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -201,23 +201,34 @@ class SandboxApi(SandboxBase):
     ) -> SandboxCreateResponse:
         config = ConnectionConfig(**opts)
 
-        on_timeout = lifecycle.get("on_timeout", "kill") if lifecycle else "kill"
-        auto_resume = lifecycle.get("auto_resume", False) if lifecycle else False
+        # on_timeout accepts a bare action or {"action", "keep_memory"}; normalize.
+        on_timeout_raw = lifecycle.get("on_timeout", "kill") if lifecycle else "kill"
+        if isinstance(on_timeout_raw, str):
+            on_timeout = on_timeout_raw
+            keep_memory = None
+            keep_memory_provided = False
+        else:
+            on_timeout = on_timeout_raw.get("action", "kill")
+            keep_memory_provided = "keep_memory" in on_timeout_raw
+            keep_memory = on_timeout_raw.get("keep_memory")
+
+        # keep_memory only governs a pause action. The discriminated union type
+        # forbids it on action="kill"; re-check at runtime for callers that
+        # bypass the type.
+        if keep_memory_provided and on_timeout != "pause":
+            raise InvalidArgumentException(
+                "keep_memory is not allowed when on_timeout action is 'kill'."
+            )
+
         # A missing or explicit None keep_memory defaults to True (full memory),
-        # mirroring the JS SDK's `?? true`. .get(key, True) would keep an explicit
-        # None, which would wrongly read as filesystem-only and send null on the wire.
-        keep_memory = lifecycle.get("keep_memory") if lifecycle else None
+        # mirroring the JS SDK; sending null would wrongly read as filesystem-only.
         if keep_memory is None:
             keep_memory = True
+        auto_resume = lifecycle.get("auto_resume", False) if lifecycle else False
 
         if auto_resume and on_timeout != "pause":
             raise InvalidArgumentException(
                 "auto_resume can only be True when the resolved on_timeout is 'pause'."
-            )
-
-        if not keep_memory and on_timeout != "pause":
-            raise InvalidArgumentException(
-                "keep_memory=False only applies when on_timeout is 'pause'."
             )
 
         if not keep_memory and auto_resume:

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -203,16 +203,32 @@ class SandboxApi(SandboxBase):
 
         on_timeout = lifecycle.get("on_timeout", "kill") if lifecycle else "kill"
         auto_resume = lifecycle.get("auto_resume", False) if lifecycle else False
+        keep_memory = lifecycle.get("keep_memory", True) if lifecycle else True
 
         if auto_resume and on_timeout != "pause":
             raise InvalidArgumentException(
                 "auto_resume can only be True when the resolved on_timeout is 'pause'."
             )
 
+        if not keep_memory and on_timeout != "pause":
+            raise InvalidArgumentException(
+                "keep_memory=False only applies when on_timeout is 'pause'."
+            )
+
+        if not keep_memory and auto_resume:
+            raise InvalidArgumentException(
+                "keep_memory=False (filesystem-only auto-pause) cannot be combined with auto_resume: "
+                "a filesystem-only snapshot cannot be auto-resumed by traffic and must be resumed explicitly."
+            )
+
         network_body = build_network_config(network)
         body = NewSandbox(
             template_id=template,
             auto_pause=on_timeout == "pause",
+            # Only relevant to a timeout auto-pause; leave it unset otherwise so the
+            # body matches the field's contract (keep_memory is forced True when
+            # on_timeout is not "pause").
+            auto_pause_memory=keep_memory if on_timeout == "pause" else UNSET,
             auto_resume=SandboxAutoResumeConfig(enabled=auto_resume),
             metadata=metadata or {},
             timeout=timeout,

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -217,7 +217,7 @@ class SandboxApi(SandboxBase):
         # bypass the type.
         if keep_memory_provided and on_timeout != "pause":
             raise InvalidArgumentException(
-                "keep_memory is not allowed when on_timeout action is 'kill'."
+                "keep_memory is only allowed when on_timeout action is 'pause'."
             )
 
         # A missing or explicit None keep_memory defaults to True (full memory),
@@ -228,13 +228,14 @@ class SandboxApi(SandboxBase):
 
         if auto_resume and on_timeout != "pause":
             raise InvalidArgumentException(
-                "auto_resume can only be True when the resolved on_timeout is 'pause'."
+                "auto_resume can only be True when on_timeout action is 'pause'."
             )
 
         if not keep_memory and auto_resume:
             raise InvalidArgumentException(
-                "keep_memory=False (filesystem-only auto-pause) cannot be combined with auto_resume: "
-                "a filesystem-only snapshot cannot be auto-resumed by traffic and must be resumed explicitly."
+                "auto_resume: True is not a valid value when keep_memory: False - "
+                "a filesystem-only snapshot cannot be auto-resumed by traffic and "
+                "must be resumed explicitly using Sandbox.connect()."
             )
 
         network_body = build_network_config(network)

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -202,15 +202,18 @@ class SandboxApi(SandboxBase):
         config = ConnectionConfig(**opts)
 
         # on_timeout accepts a bare action or {"action", "keep_memory"}; normalize.
+        # Only the object form carries keep_memory; anything else (a bare action
+        # string, or an unexpected value from an untyped caller) passes through as
+        # the action, so a non-"pause" value resolves to kill instead of crashing.
         on_timeout_raw = lifecycle.get("on_timeout", "kill") if lifecycle else "kill"
-        if isinstance(on_timeout_raw, str):
-            on_timeout = on_timeout_raw
-            keep_memory = None
-            keep_memory_provided = False
-        else:
+        if isinstance(on_timeout_raw, dict):
             on_timeout = on_timeout_raw.get("action", "kill")
             keep_memory_provided = "keep_memory" in on_timeout_raw
             keep_memory = on_timeout_raw.get("keep_memory")
+        else:
+            on_timeout = on_timeout_raw
+            keep_memory = None
+            keep_memory_provided = False
 
         # keep_memory only governs a pause action. The discriminated union type
         # forbids it on action="kill"; re-check at runtime for callers that

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -203,7 +203,12 @@ class SandboxApi(SandboxBase):
 
         on_timeout = lifecycle.get("on_timeout", "kill") if lifecycle else "kill"
         auto_resume = lifecycle.get("auto_resume", False) if lifecycle else False
-        keep_memory = lifecycle.get("keep_memory", True) if lifecycle else True
+        # A missing or explicit None keep_memory defaults to True (full memory),
+        # mirroring the JS SDK's `?? true`. .get(key, True) would keep an explicit
+        # None, which would wrongly read as filesystem-only and send null on the wire.
+        keep_memory = lifecycle.get("keep_memory") if lifecycle else None
+        if keep_memory is None:
+            keep_memory = True
 
         if auto_resume and on_timeout != "pause":
             raise InvalidArgumentException(

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -241,9 +241,6 @@ class SandboxApi(SandboxBase):
         body = NewSandbox(
             template_id=template,
             auto_pause=on_timeout == "pause",
-            # Only relevant to a timeout auto-pause; leave it unset otherwise so the
-            # body matches the field's contract (keep_memory is forced True when
-            # on_timeout is not "pause").
             auto_pause_memory=keep_memory if on_timeout == "pause" else UNSET,
             auto_resume=SandboxAutoResumeConfig(enabled=auto_resume),
             metadata=metadata or {},

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -96,6 +96,31 @@ async def test_filesystem_only_auto_pause_requires_pause():
 
 
 @pytest.mark.skip_debug()
+async def test_keep_memory_none_defaults_to_full_memory(async_sandbox_factory):
+    # An explicit None keep_memory must default to full memory (not filesystem-only):
+    # the timeout auto-pause then resumes the SAME sandbox in place (memory restore),
+    # so the boot id is unchanged. A changed boot id would mean None was wrongly
+    # treated as filesystem-only (cold boot).
+    sbx = await async_sandbox_factory(
+        timeout=60,
+        lifecycle={"on_timeout": "pause", "keep_memory": None},
+    )
+    boot_before = (await sbx.files.read("/proc/sys/kernel/random/boot_id")).strip()
+
+    await sbx.set_timeout(0)  # force the timeout auto-pause now
+    for _ in range(150):
+        if not await sbx.is_running():
+            break
+        await asyncio.sleep(0.2)
+    assert not await sbx.is_running()
+
+    resumed = await sbx.connect()
+    assert resumed.sandbox_id == sbx.sandbox_id  # same sandbox
+    boot_after = (await resumed.files.read("/proc/sys/kernel/random/boot_id")).strip()
+    assert boot_after == boot_before  # memory restore in place, not a cold boot
+
+
+@pytest.mark.skip_debug()
 async def test_auto_pause_filesystem_only_reboots(async_sandbox_factory):
     # keep_memory=False makes the timeout auto-pause filesystem-only, so resuming
     # cold-boots the sandbox from disk.

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -69,6 +69,7 @@ def test_create_payload_serializes_auto_pause_memory():
     assert body.to_dict()["autoPauseMemory"] is False
 
 
+@pytest.mark.skip_debug()
 async def test_filesystem_only_auto_pause_rejects_auto_resume():
     # A filesystem-only auto-pause snapshot can only be resumed explicitly, so
     # combining keep_memory=False with auto_resume is rejected client-side.
@@ -83,6 +84,7 @@ async def test_filesystem_only_auto_pause_rejects_auto_resume():
         )
 
 
+@pytest.mark.skip_debug()
 async def test_filesystem_only_auto_pause_requires_pause():
     # keep_memory only governs a timeout auto-pause, so keep_memory=False without
     # on_timeout="pause" is rejected client-side.

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -77,21 +78,23 @@ async def test_filesystem_only_auto_pause_rejects_auto_resume():
         await AsyncSandbox.create(
             timeout=3,
             lifecycle={
-                "on_timeout": "pause",
+                "on_timeout": {"action": "pause", "keep_memory": False},
                 "auto_resume": True,
-                "keep_memory": False,
             },
         )
 
 
 @pytest.mark.skip_debug()
-async def test_filesystem_only_auto_pause_requires_pause():
-    # keep_memory only governs a timeout auto-pause, so keep_memory=False without
-    # on_timeout="pause" is rejected client-side.
+async def test_keep_memory_not_allowed_with_kill():
+    # The discriminated union forbids keep_memory on action="kill" at type-check
+    # time; the runtime guard rejects it for callers that bypass the type
+    # (cast(Any, ...) feeds the deliberately type-invalid input).
     with pytest.raises(InvalidArgumentException):
         await AsyncSandbox.create(
             timeout=3,
-            lifecycle={"on_timeout": "kill", "keep_memory": False},
+            lifecycle=cast(
+                Any, {"on_timeout": {"action": "kill", "keep_memory": False}}
+            ),
         )
 
 
@@ -103,7 +106,7 @@ async def test_keep_memory_none_defaults_to_full_memory(async_sandbox_factory):
     # treated as filesystem-only (cold boot).
     sbx = await async_sandbox_factory(
         timeout=60,
-        lifecycle={"on_timeout": "pause", "keep_memory": None},
+        lifecycle={"on_timeout": {"action": "pause", "keep_memory": None}},
     )
     boot_before = (await sbx.files.read("/proc/sys/kernel/random/boot_id")).strip()
 
@@ -126,7 +129,7 @@ async def test_auto_pause_filesystem_only_reboots(async_sandbox_factory):
     # cold-boots the sandbox from disk.
     sandbox = await async_sandbox_factory(
         timeout=3,
-        lifecycle={"on_timeout": "pause", "keep_memory": False},
+        lifecycle={"on_timeout": {"action": "pause", "keep_memory": False}},
     )
 
     marker = "auto-pause-fs-only"

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -8,6 +8,7 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
+from e2b.exceptions import InvalidArgumentException
 
 
 @pytest.mark.skip_debug()
@@ -56,6 +57,76 @@ def test_create_payload_deserializes_auto_resume_enabled():
 
     assert isinstance(body.auto_resume, SandboxAutoResumeConfig)
     assert body.auto_resume.to_dict() == {"enabled": False}
+
+
+def test_create_payload_serializes_auto_pause_memory():
+    body = NewSandbox(
+        template_id="template-id",
+        auto_pause=True,
+        auto_pause_memory=False,
+    )
+
+    assert body.to_dict()["autoPauseMemory"] is False
+
+
+async def test_filesystem_only_auto_pause_rejects_auto_resume():
+    # A filesystem-only auto-pause snapshot can only be resumed explicitly, so
+    # combining keep_memory=False with auto_resume is rejected client-side.
+    with pytest.raises(InvalidArgumentException):
+        await AsyncSandbox.create(
+            timeout=3,
+            lifecycle={
+                "on_timeout": "pause",
+                "auto_resume": True,
+                "keep_memory": False,
+            },
+        )
+
+
+async def test_filesystem_only_auto_pause_requires_pause():
+    # keep_memory only governs a timeout auto-pause, so keep_memory=False without
+    # on_timeout="pause" is rejected client-side.
+    with pytest.raises(InvalidArgumentException):
+        await AsyncSandbox.create(
+            timeout=3,
+            lifecycle={"on_timeout": "kill", "keep_memory": False},
+        )
+
+
+@pytest.mark.skip_debug()
+async def test_auto_pause_filesystem_only_reboots(async_sandbox_factory):
+    # keep_memory=False makes the timeout auto-pause filesystem-only, so resuming
+    # cold-boots the sandbox from disk.
+    sandbox = await async_sandbox_factory(
+        timeout=3,
+        lifecycle={"on_timeout": "pause", "keep_memory": False},
+    )
+
+    marker = "auto-pause-fs-only"
+    await sandbox.commands.run(f"echo {marker} > /home/user/auto-pause-marker.txt")
+    boot_before = (
+        await sandbox.commands.run("cat /proc/sys/kernel/random/boot_id")
+    ).stdout.strip()
+
+    await asyncio.sleep(5)
+
+    assert (await sandbox.get_info()).state == SandboxState.PAUSED
+    assert not await sandbox.is_running()
+
+    # A filesystem-only snapshot cannot auto-resume on traffic; connect resumes
+    # it by cold-booting.
+    resumed = await sandbox.connect()
+    assert await resumed.is_running()
+
+    persisted = (
+        await resumed.commands.run("cat /home/user/auto-pause-marker.txt")
+    ).stdout.strip()
+    assert persisted == marker
+
+    boot_after = (
+        await resumed.commands.run("cat /proc/sys/kernel/random/boot_id")
+    ).stdout.strip()
+    assert boot_after != boot_before
 
 
 @pytest.mark.skip_debug()

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -60,16 +60,6 @@ def test_create_payload_deserializes_auto_resume_enabled():
     assert body.auto_resume.to_dict() == {"enabled": False}
 
 
-def test_create_payload_serializes_auto_pause_memory():
-    body = NewSandbox(
-        template_id="template-id",
-        auto_pause=True,
-        auto_pause_memory=False,
-    )
-
-    assert body.to_dict()["autoPauseMemory"] is False
-
-
 @pytest.mark.skip_debug()
 async def test_filesystem_only_auto_pause_rejects_auto_resume():
     # A filesystem-only auto-pause snapshot can only be resumed explicitly, so

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -133,29 +133,21 @@ async def test_auto_pause_filesystem_only_reboots(async_sandbox_factory):
     )
 
     marker = "auto-pause-fs-only"
-    await sandbox.commands.run(f"echo {marker} > /home/user/auto-pause-marker.txt")
-    boot_before = (
-        await sandbox.commands.run("cat /proc/sys/kernel/random/boot_id")
-    ).stdout.strip()
+    await sandbox.files.write("/home/user/auto-pause-marker.txt", marker)
+    boot_before = (await sandbox.files.read("/proc/sys/kernel/random/boot_id")).strip()
 
     await asyncio.sleep(5)
 
     assert (await sandbox.get_info()).state == SandboxState.PAUSED
-    assert not await sandbox.is_running()
 
     # A filesystem-only snapshot cannot auto-resume on traffic; connect resumes
     # it by cold-booting.
     resumed = await sandbox.connect()
-    assert await resumed.is_running()
 
-    persisted = (
-        await resumed.commands.run("cat /home/user/auto-pause-marker.txt")
-    ).stdout.strip()
+    persisted = (await resumed.files.read("/home/user/auto-pause-marker.txt")).strip()
     assert persisted == marker
 
-    boot_after = (
-        await resumed.commands.run("cat /proc/sys/kernel/random/boot_id")
-    ).stdout.strip()
+    boot_after = (await resumed.files.read("/proc/sys/kernel/random/boot_id")).strip()
     assert boot_after != boot_before
 
 

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -89,6 +89,16 @@ async def test_keep_memory_not_allowed_with_kill():
 
 
 @pytest.mark.skip_debug()
+async def test_invalid_on_timeout_type_does_not_crash(async_sandbox_factory):
+    # An untyped/invalid on_timeout (e.g. None) must not crash create; it falls
+    # back to kill semantics like a missing on_timeout (the sandbox just starts).
+    sbx = await async_sandbox_factory(
+        timeout=10, lifecycle=cast(Any, {"on_timeout": None})
+    )
+    assert await sbx.is_running()
+
+
+@pytest.mark.skip_debug()
 async def test_keep_memory_none_defaults_to_full_memory(async_sandbox_factory):
     # An explicit None keep_memory must default to full memory (not filesystem-only):
     # the timeout auto-pause then resumes the SAME sandbox in place (memory restore),

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -97,6 +97,31 @@ def test_filesystem_only_auto_pause_requires_pause():
 
 
 @pytest.mark.skip_debug()
+def test_keep_memory_none_defaults_to_full_memory(sandbox_factory):
+    # An explicit None keep_memory must default to full memory (not filesystem-only):
+    # the timeout auto-pause then resumes the SAME sandbox in place (memory restore),
+    # so the boot id is unchanged. A changed boot id would mean None was wrongly
+    # treated as filesystem-only (cold boot).
+    sbx = sandbox_factory(
+        timeout=60,
+        lifecycle={"on_timeout": "pause", "keep_memory": None},
+    )
+    boot_before = sbx.files.read("/proc/sys/kernel/random/boot_id").strip()
+
+    sbx.set_timeout(0)  # force the timeout auto-pause now
+    for _ in range(150):
+        if not sbx.is_running():
+            break
+        sleep(0.2)
+    assert not sbx.is_running()
+
+    resumed = sbx.connect()
+    assert resumed.sandbox_id == sbx.sandbox_id  # same sandbox
+    boot_after = resumed.files.read("/proc/sys/kernel/random/boot_id").strip()
+    assert boot_after == boot_before  # memory restore in place, not a cold boot
+
+
+@pytest.mark.skip_debug()
 def test_auto_pause_filesystem_only_reboots(sandbox_factory):
     # keep_memory=False makes the timeout auto-pause filesystem-only, so resuming
     # cold-boots the sandbox from disk.

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -1,4 +1,5 @@
 from time import sleep
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -78,21 +79,23 @@ def test_filesystem_only_auto_pause_rejects_auto_resume():
         Sandbox.create(
             timeout=3,
             lifecycle={
-                "on_timeout": "pause",
+                "on_timeout": {"action": "pause", "keep_memory": False},
                 "auto_resume": True,
-                "keep_memory": False,
             },
         )
 
 
 @pytest.mark.skip_debug()
-def test_filesystem_only_auto_pause_requires_pause():
-    # keep_memory only governs a timeout auto-pause, so keep_memory=False without
-    # on_timeout="pause" is rejected client-side.
+def test_keep_memory_not_allowed_with_kill():
+    # The discriminated union forbids keep_memory on action="kill" at type-check
+    # time; the runtime guard rejects it for callers that bypass the type
+    # (cast(Any, ...) feeds the deliberately type-invalid input).
     with pytest.raises(InvalidArgumentException):
         Sandbox.create(
             timeout=3,
-            lifecycle={"on_timeout": "kill", "keep_memory": False},
+            lifecycle=cast(
+                Any, {"on_timeout": {"action": "kill", "keep_memory": False}}
+            ),
         )
 
 
@@ -104,7 +107,7 @@ def test_keep_memory_none_defaults_to_full_memory(sandbox_factory):
     # treated as filesystem-only (cold boot).
     sbx = sandbox_factory(
         timeout=60,
-        lifecycle={"on_timeout": "pause", "keep_memory": None},
+        lifecycle={"on_timeout": {"action": "pause", "keep_memory": None}},
     )
     boot_before = sbx.files.read("/proc/sys/kernel/random/boot_id").strip()
 
@@ -127,7 +130,7 @@ def test_auto_pause_filesystem_only_reboots(sandbox_factory):
     # cold-boots the sandbox from disk.
     sandbox = sandbox_factory(
         timeout=3,
-        lifecycle={"on_timeout": "pause", "keep_memory": False},
+        lifecycle={"on_timeout": {"action": "pause", "keep_memory": False}},
     )
 
     marker = "auto-pause-fs-only"

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -61,16 +61,6 @@ def test_create_payload_deserializes_auto_resume_enabled():
     assert body.auto_resume.to_dict() == {"enabled": False}
 
 
-def test_create_payload_serializes_auto_pause_memory():
-    body = NewSandbox(
-        template_id="template-id",
-        auto_pause=True,
-        auto_pause_memory=False,
-    )
-
-    assert body.to_dict()["autoPauseMemory"] is False
-
-
 @pytest.mark.skip_debug()
 def test_filesystem_only_auto_pause_rejects_auto_resume():
     # A filesystem-only auto-pause snapshot can only be resumed explicitly, so

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -134,29 +134,21 @@ def test_auto_pause_filesystem_only_reboots(sandbox_factory):
     )
 
     marker = "auto-pause-fs-only"
-    sandbox.commands.run(f"echo {marker} > /home/user/auto-pause-marker.txt")
-    boot_before = sandbox.commands.run(
-        "cat /proc/sys/kernel/random/boot_id"
-    ).stdout.strip()
+    sandbox.files.write("/home/user/auto-pause-marker.txt", marker)
+    boot_before = sandbox.files.read("/proc/sys/kernel/random/boot_id").strip()
 
     sleep(5)
 
     assert sandbox.get_info().state == SandboxState.PAUSED
-    assert not sandbox.is_running()
 
     # A filesystem-only snapshot cannot auto-resume on traffic; connect resumes
     # it by cold-booting.
     resumed = sandbox.connect()
-    assert resumed.is_running()
 
-    persisted = resumed.commands.run(
-        "cat /home/user/auto-pause-marker.txt"
-    ).stdout.strip()
+    persisted = resumed.files.read("/home/user/auto-pause-marker.txt").strip()
     assert persisted == marker
 
-    boot_after = resumed.commands.run(
-        "cat /proc/sys/kernel/random/boot_id"
-    ).stdout.strip()
+    boot_after = resumed.files.read("/proc/sys/kernel/random/boot_id").strip()
     assert boot_after != boot_before
 
 

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -8,6 +8,7 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
+from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.sandbox_api import SandboxQuery
 
 
@@ -57,6 +58,76 @@ def test_create_payload_deserializes_auto_resume_enabled():
 
     assert isinstance(body.auto_resume, SandboxAutoResumeConfig)
     assert body.auto_resume.to_dict() == {"enabled": False}
+
+
+def test_create_payload_serializes_auto_pause_memory():
+    body = NewSandbox(
+        template_id="template-id",
+        auto_pause=True,
+        auto_pause_memory=False,
+    )
+
+    assert body.to_dict()["autoPauseMemory"] is False
+
+
+def test_filesystem_only_auto_pause_rejects_auto_resume():
+    # A filesystem-only auto-pause snapshot can only be resumed explicitly, so
+    # combining keep_memory=False with auto_resume is rejected client-side.
+    with pytest.raises(InvalidArgumentException):
+        Sandbox.create(
+            timeout=3,
+            lifecycle={
+                "on_timeout": "pause",
+                "auto_resume": True,
+                "keep_memory": False,
+            },
+        )
+
+
+def test_filesystem_only_auto_pause_requires_pause():
+    # keep_memory only governs a timeout auto-pause, so keep_memory=False without
+    # on_timeout="pause" is rejected client-side.
+    with pytest.raises(InvalidArgumentException):
+        Sandbox.create(
+            timeout=3,
+            lifecycle={"on_timeout": "kill", "keep_memory": False},
+        )
+
+
+@pytest.mark.skip_debug()
+def test_auto_pause_filesystem_only_reboots(sandbox_factory):
+    # keep_memory=False makes the timeout auto-pause filesystem-only, so resuming
+    # cold-boots the sandbox from disk.
+    sandbox = sandbox_factory(
+        timeout=3,
+        lifecycle={"on_timeout": "pause", "keep_memory": False},
+    )
+
+    marker = "auto-pause-fs-only"
+    sandbox.commands.run(f"echo {marker} > /home/user/auto-pause-marker.txt")
+    boot_before = sandbox.commands.run(
+        "cat /proc/sys/kernel/random/boot_id"
+    ).stdout.strip()
+
+    sleep(5)
+
+    assert sandbox.get_info().state == SandboxState.PAUSED
+    assert not sandbox.is_running()
+
+    # A filesystem-only snapshot cannot auto-resume on traffic; connect resumes
+    # it by cold-booting.
+    resumed = sandbox.connect()
+    assert resumed.is_running()
+
+    persisted = resumed.commands.run(
+        "cat /home/user/auto-pause-marker.txt"
+    ).stdout.strip()
+    assert persisted == marker
+
+    boot_after = resumed.commands.run(
+        "cat /proc/sys/kernel/random/boot_id"
+    ).stdout.strip()
+    assert boot_after != boot_before
 
 
 @pytest.mark.skip_debug()

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -70,6 +70,7 @@ def test_create_payload_serializes_auto_pause_memory():
     assert body.to_dict()["autoPauseMemory"] is False
 
 
+@pytest.mark.skip_debug()
 def test_filesystem_only_auto_pause_rejects_auto_resume():
     # A filesystem-only auto-pause snapshot can only be resumed explicitly, so
     # combining keep_memory=False with auto_resume is rejected client-side.
@@ -84,6 +85,7 @@ def test_filesystem_only_auto_pause_rejects_auto_resume():
         )
 
 
+@pytest.mark.skip_debug()
 def test_filesystem_only_auto_pause_requires_pause():
     # keep_memory only governs a timeout auto-pause, so keep_memory=False without
     # on_timeout="pause" is rejected client-side.

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -90,6 +90,14 @@ def test_keep_memory_not_allowed_with_kill():
 
 
 @pytest.mark.skip_debug()
+def test_invalid_on_timeout_type_does_not_crash(sandbox_factory):
+    # An untyped/invalid on_timeout (e.g. None) must not crash create; it falls
+    # back to kill semantics like a missing on_timeout (the sandbox just starts).
+    sbx = sandbox_factory(timeout=10, lifecycle=cast(Any, {"on_timeout": None}))
+    assert sbx.is_running()
+
+
+@pytest.mark.skip_debug()
 def test_keep_memory_none_defaults_to_full_memory(sandbox_factory):
     # An explicit None keep_memory must default to full memory (not filesystem-only):
     # the timeout auto-pause then resumes the SAME sandbox in place (memory restore),

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -689,6 +689,17 @@ components:
           type: boolean
           default: false
           description: Automatically pauses the sandbox after the timeout
+        autoPauseMemory:
+          type: boolean
+          default: true
+          description: >-
+            Controls the snapshot kind taken when the sandbox auto-pauses on
+            timeout (only relevant when autoPause is true). When false, the
+            auto-pause drops the in-memory state and persists only the
+            filesystem (a filesystem-only snapshot); resuming it cold-boots
+            (reboots) the sandbox from disk. Such a snapshot cannot be
+            auto-resumed by traffic and must be resumed explicitly, so it cannot
+            be combined with autoResume. Defaults to true (full memory snapshot).
         autoResume:
           $ref: '#/components/schemas/SandboxAutoResumeConfig'
         secure:


### PR DESCRIPTION
## Filesystem-only auto-pause (`onTimeout` object form)

Adds an object form to the sandbox **lifecycle** `onTimeout` (`on_timeout` in Python) that controls the snapshot kind taken when a sandbox auto-pauses on timeout, via `keepMemory` (`keep_memory`).

`onTimeout` now accepts either the existing bare action (`'pause'` / `'kill'`) or the object form `{ action, keepMemory }`. When `keepMemory` is `false` (with `action: 'pause'`), a timeout auto-pause takes a **filesystem-only** snapshot (no memory) instead of a full memory one, so the sandbox cold-boots (reboots) from disk on resume — losing running processes and open connections. Defaults to `true` (full memory snapshot), so existing callers are unaffected. **The bare string form is unchanged.**

It's the create-time / auto-pause counterpart to the explicit `pause(keepMemory=false)` from #1465: same `keepMemory` naming, mapped onto the `autoPauseMemory` create field.

### Type safety
The object form is a **discriminated union** on `action`: `keepMemory` is only valid with `action: 'pause'`. Pairing it with `action: 'kill'` is a **compile-time type error** (TS) / static error (`ty`), and is additionally rejected at runtime (`InvalidArgumentError` / `InvalidArgumentException`) for untyped callers.

### Behavior & validation
- `keepMemory` only applies to a `pause` action.
- **Incompatible with auto-resume** — auto-resume wakes a paused sandbox on inbound traffic by restoring its memory snapshot in place; a filesystem-only snapshot has no memory to restore (resuming cold-boots it), so it must be resumed explicitly via `connect()`. Combining `keepMemory: false` with `autoResume` is rejected client-side.

### Usage
```ts
// JS/TS — filesystem-only auto-pause on timeout
const sbx = await Sandbox.create({
  lifecycle: { onTimeout: { action: 'pause', keepMemory: false } },
})

// bare string form still works (full memory snapshot)
const sbx2 = await Sandbox.create({ lifecycle: { onTimeout: 'pause' } })
```
```python
# Python
sbx = Sandbox.create(
    lifecycle={"on_timeout": {"action": "pause", "keep_memory": False}}
)
```

### Changes
- `spec/openapi.yml`: `autoPauseMemory` on the create body (+ regenerated JS/Python clients).
- JS `SandboxOnTimeout` discriminated union (`'pause' | 'kill' | { action: 'pause'; keepMemory? } | { action: 'kill' }`) and the Python `SandboxOnTimeoutPause` / `SandboxOnTimeoutKill` TypedDicts, wired through `createSandbox` / `_create_sandbox` (sync + async) to `autoPauseMemory`, with the client-side guards.
- Tests: payload serialization + validation (offline, incl. the `action: 'kill'` type/runtime guard) and live cold-boot e2e in both SDKs; changeset (`e2b` + `@e2b/python-sdk`, minor).

### Backend dependency
The live e2e tests exercise the real auto-pause→cold-boot path and require the infra-side `autoPauseMemory` support (e2b-dev/infra#3055), now merged and deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
