### PR TITLE
fix(python): avoid quadratic stdout/stderr accumulation in command ha…

### DIFF
--- a/.changeset/quick-pumas-grow.md
+++ b/.changeset/quick-pumas-grow.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Avoid quadratic-time stdout/stderr accumulation in command handles by buffering decoded chunks in a list and joining on read instead of repeatedly concatenating onto an instance attribute.

--- a/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
+++ b/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
@@ -45,14 +45,14 @@ class AsyncCommandHandle:
         """
         Command stdout output.
         """
-        return self._stdout
+        return "".join(self._stdout_chunks)
 
     @property
     def stderr(self):
         """
         Command stderr output.
         """
-        return self._stderr
+        return "".join(self._stderr_chunks)
 
     @property
     def error(self):
@@ -101,8 +101,8 @@ class AsyncCommandHandle:
         self._check_health = check_health
         self._events = events
 
-        self._stdout: str = ""
-        self._stderr: str = ""
+        self._stdout_chunks: List[str] = []
+        self._stderr_chunks: List[str] = []
 
         self._stdout_decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         self._stderr_decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
@@ -128,11 +128,11 @@ class AsyncCommandHandle:
         events: List[Union[Tuple[Stdout, None, None], Tuple[None, Stderr, None]]] = []
         out = self._stdout_decoder.decode(b"", final=True)
         if out:
-            self._stdout += out
+            self._stdout_chunks.append(out)
             events.append((out, None, None))
         err = self._stderr_decoder.decode(b"", final=True)
         if err:
-            self._stderr += err
+            self._stderr_chunks.append(err)
             events.append((None, err, None))
         return events
 
@@ -152,12 +152,12 @@ class AsyncCommandHandle:
                     if event.event.data.stdout:
                         out = self._stdout_decoder.decode(event.event.data.stdout)
                         if out:
-                            self._stdout += out
+                            self._stdout_chunks.append(out)
                             yield out, None, None
                     if event.event.data.stderr:
                         out = self._stderr_decoder.decode(event.event.data.stderr)
                         if out:
-                            self._stderr += out
+                            self._stderr_chunks.append(out)
                             yield None, out, None
                     if event.event.data.pty:
                         yield None, None, event.event.data.pty
@@ -165,8 +165,8 @@ class AsyncCommandHandle:
                     for flushed in self._flush_decoders():
                         yield flushed
                     self._result = CommandResult(
-                        stdout=self._stdout,
-                        stderr=self._stderr,
+                        stdout="".join(self._stdout_chunks),
+                        stderr="".join(self._stderr_chunks),
                         exit_code=event.event.end.exit_code,
                         error=event.event.end.error,
                     )
@@ -240,8 +240,8 @@ class AsyncCommandHandle:
 
         if self._result.exit_code != 0:
             raise CommandExitException(
-                stdout=self._stdout,
-                stderr=self._stderr,
+                stdout="".join(self._stdout_chunks),
+                stderr="".join(self._stderr_chunks),
                 exit_code=self._result.exit_code,
                 error=self._result.error,
             )

--- a/packages/python-sdk/e2b/sandbox_sync/commands/command_handle.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/command_handle.py
@@ -48,8 +48,8 @@ class CommandHandle:
         self._check_health = check_health
         self._events = events
 
-        self._stdout: str = ""
-        self._stderr: str = ""
+        self._stdout_chunks: List[str] = []
+        self._stderr_chunks: List[str] = []
 
         self._stdout_decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         self._stderr_decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
@@ -77,11 +77,11 @@ class CommandHandle:
         events: List[Union[Tuple[Stdout, None, None], Tuple[None, Stderr, None]]] = []
         out = self._stdout_decoder.decode(b"", final=True)
         if out:
-            self._stdout += out
+            self._stdout_chunks.append(out)
             events.append((out, None, None))
         err = self._stderr_decoder.decode(b"", final=True)
         if err:
-            self._stderr += err
+            self._stderr_chunks.append(err)
             events.append((None, err, None))
         return events
 
@@ -102,20 +102,20 @@ class CommandHandle:
                     if event.event.data.stdout:
                         out = self._stdout_decoder.decode(event.event.data.stdout)
                         if out:
-                            self._stdout += out
+                            self._stdout_chunks.append(out)
                             yield out, None, None
                     if event.event.data.stderr:
                         out = self._stderr_decoder.decode(event.event.data.stderr)
                         if out:
-                            self._stderr += out
+                            self._stderr_chunks.append(out)
                             yield None, out, None
                     if event.event.data.pty:
                         yield None, None, event.event.data.pty
                 if event.event.HasField("end"):
                     yield from self._flush_decoders()
                     self._result = CommandResult(
-                        stdout=self._stdout,
-                        stderr=self._stderr,
+                        stdout="".join(self._stdout_chunks),
+                        stderr="".join(self._stderr_chunks),
                         exit_code=event.event.end.exit_code,
                         error=event.event.end.error,
                     )
@@ -182,8 +182,8 @@ class CommandHandle:
 
         if self._result.exit_code != 0:
             raise CommandExitException(
-                stdout=self._stdout,
-                stderr=self._stderr,
+                stdout="".join(self._stdout_chunks),
+                stderr="".join(self._stderr_chunks),
                 exit_code=self._result.exit_code,
                 error=self._result.error,
             )


### PR DESCRIPTION
merged from https://github.com/e2b-dev/E2B/pull/1457

## Problem

`AsyncCommandHandle` / `CommandHandle` accumulate streamed output with `self._stdout += out` per chunk. Because `self._stdout` is an instance attribute (`STORE_ATTR`), CPython's in-place string-concatenation optimization — which only applies to local `STORE_FAST` targets — doesn't apply, so each append re-copies the entire buffer. For commands that emit large volumes of output this becomes O(n²) in total bytes, and in async contexts it stalls the event loop for hundreds of ms per chunk near the tail.

## Fix

Buffer decoded chunks in a `list[str]` and `"".join()` them on read. This restores linear-time accumulation and keeps streaming responsive, with no change to the resulting `stdout`/`stderr` values or the public API.

## Notes

- Applies the same change to both the sync and async command handles.
- Pure internal change; the incremental UTF-8 decoding behavior is preserved.
- Changeset included (`@e2b/python-sdk`, patch).