### PR TITLE
fix(js-sdk): stop CommandHandle.disconnect() leaking the output subscription

### DIFF
--- a/.changeset/command-handle-disconnect-leak.md
+++ b/.changeset/command-handle-disconnect-leak.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Fix `CommandHandle.disconnect()` leaking the output subscription in the JS SDK. `disconnect()` now cooperatively stops event handling and resolves only after it has fully ended, so `onStdout`/`onStderr`/`onPty` are guaranteed not to fire for output that arrives after the call resolves (previously they could keep firing when the underlying HTTP/2 abort did not promptly tear down the stream). An in-flight callback is abandoned rather than awaited, which also prevents a deadlock when `disconnect()` is awaited from inside a callback.

--- a/.changeset/command-handle-disconnect-leak.md
+++ b/.changeset/command-handle-disconnect-leak.md
@@ -2,4 +2,4 @@
 "e2b": patch
 ---
 
-Fix `CommandHandle.disconnect()` leaking the output subscription in the JS SDK. `disconnect()` now cooperatively stops event handling and resolves only after it has fully ended, so `onStdout`/`onStderr`/`onPty` are guaranteed not to fire for output that arrives after the call resolves (previously they could keep firing when the underlying HTTP/2 abort did not promptly tear down the stream). An in-flight callback is abandoned rather than awaited, which also prevents a deadlock when `disconnect()` is awaited from inside a callback.
+Fix `CommandHandle.disconnect()` leaking the output subscription in the JS SDK. `disconnect()` now cooperatively gates event handling with a flag that is checked before every dispatch, so `onStdout`/`onStderr`/`onPty` are guaranteed not to fire for output that arrives after the call (previously they could keep firing when the underlying HTTP/2 abort did not promptly tear down the stream). The call returns promptly and never blocks on an idle command's stream.

--- a/.changeset/python-command-result-ordering.md
+++ b/.changeset/python-command-result-ordering.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Fix `CommandHandle` (sync and async) recording the command result after yielding the flushed end-event chunks. The decoders are now flushed and the `CommandResult` is recorded before the trailing chunks are yielded, so a consumer that stops iterating on the first flushed chunk still observes the exit code.

--- a/packages/js-sdk/src/sandbox/commands/commandHandle.ts
+++ b/packages/js-sdk/src/sandbox/commands/commandHandle.ts
@@ -302,12 +302,21 @@ export class CommandHandle
             }
             break
           case 'end': {
-            yield* this.flushDecoders()
+            // Flush trailing decoder bytes into the accumulators and record the
+            // result *before* yielding the flushed chunks. A disconnected
+            // consumer breaks out of `handleEvents` on the first yielded chunk,
+            // which would otherwise abort this generator before `this.result`
+            // is assigned and make `wait()` fail as if the process never
+            // produced a result.
+            const flushed = [...this.flushDecoders()]
             this.result = {
               exitCode: e.value.exitCode,
               error: e.value.error,
               stdout: this.stdout,
               stderr: this.stderr,
+            }
+            for (const chunk of flushed) {
+              yield chunk
             }
             break
           }

--- a/packages/js-sdk/src/sandbox/commands/commandHandle.ts
+++ b/packages/js-sdk/src/sandbox/commands/commandHandle.ts
@@ -98,10 +98,6 @@ export class CommandHandle
   private iterationError?: Error
 
   private disconnected = false
-  private notifyDisconnected!: () => void
-  private readonly disconnectedPromise = new Promise<void>((resolve) => {
-    this.notifyDisconnected = resolve
-  })
 
   private readonly _wait: Promise<void>
 
@@ -191,15 +187,14 @@ export class CommandHandle
    * The command is not killed, but SDK stops receiving events from the command.
    * You can reconnect to the command using {@link Commands.connect}.
    *
-   * Resolves after event handling has fully ended: once it returns, the
-   * `onStdout`/`onStderr`/`onPty` callbacks are guaranteed not to fire again.
-   * An in-flight callback is abandoned, its result ignored.
+   * Once it returns, the `onStdout`/`onStderr`/`onPty` callbacks are guaranteed
+   * not to fire for output produced after this call. It does not wait for the
+   * event handler to drain, so it returns promptly even for an idle command
+   * whose stream produces no further output.
    */
   async disconnect() {
     this.disconnected = true
-    this.notifyDisconnected()
     this.handleDisconnect()
-    await this._wait
   }
 
   /**
@@ -340,56 +335,23 @@ export class CommandHandle
   private async handleEvents() {
     try {
       for await (const [stdout, stderr, pty] of this.iterateEvents()) {
-        // The handle was disconnected — stop dispatching to the callbacks even
-        // if late output still arrives on the stream before the underlying
-        // abort tears it down.
+        // The handle was disconnected — stop dispatching to the callbacks. The
+        // flag is checked before every dispatch, so no callback fires for
+        // output that arrives (or was buffered) after disconnect() was called,
+        // even if the underlying abort hasn't torn the stream down yet. There
+        // is no synchronous suspension point between this check and the
+        // dispatch below, so disconnect() cannot interleave to let a late event
+        // slip through.
         if (this.disconnected) {
           break
         }
 
-        let callback: void | Promise<void> | undefined
         if (stdout !== null) {
-          callback = this.onStdout?.(stdout)
+          await this.onStdout?.(stdout)
         } else if (stderr !== null) {
-          callback = this.onStderr?.(stderr)
+          await this.onStderr?.(stderr)
         } else if (pty) {
-          callback = this.onPty?.(pty)
-        }
-
-        if (callback) {
-          // Track the callback's settlement so a callback that has already
-          // resolved or rejected always wins over a concurrent disconnect();
-          // only a callback that is still pending when disconnect() wins is
-          // abandoned. The tracking promise never rejects (both outcomes are
-          // handled), so an abandoned callback's later rejection cannot crash
-          // the process.
-          let settled = false
-          let callbackError: Error | undefined
-          const tracked = Promise.resolve(callback).then(
-            () => {
-              settled = true
-            },
-            (err) => {
-              settled = true
-              callbackError = err as Error
-            }
-          )
-
-          await Promise.race([tracked, this.disconnectedPromise])
-
-          if (settled) {
-            if (callbackError) {
-              // Surface a callback error the same way as before: route it
-              // through the stream error handling so `wait()` re-throws it.
-              throw callbackError
-            }
-          } else {
-            // Disconnected while the callback was still in flight — abandon it
-            // (the JS equivalent of the cancelled handler task in the Python
-            // SDK). Awaiting it here could deadlock when disconnect() is
-            // awaited from inside the callback itself.
-            break
-          }
+          await this.onPty?.(pty)
         }
       }
     } catch (e) {

--- a/packages/js-sdk/src/sandbox/commands/commandHandle.ts
+++ b/packages/js-sdk/src/sandbox/commands/commandHandle.ts
@@ -97,6 +97,12 @@ export class CommandHandle
   private result?: CommandResult
   private iterationError?: Error
 
+  private disconnected = false
+  private notifyDisconnected!: () => void
+  private readonly disconnectedPromise = new Promise<void>((resolve) => {
+    this.notifyDisconnected = resolve
+  })
+
   private readonly _wait: Promise<void>
 
   /**
@@ -184,9 +190,16 @@ export class CommandHandle
    *
    * The command is not killed, but SDK stops receiving events from the command.
    * You can reconnect to the command using {@link Commands.connect}.
+   *
+   * Resolves after event handling has fully ended: once it returns, the
+   * `onStdout`/`onStderr`/`onPty` callbacks are guaranteed not to fire again.
+   * An in-flight callback is abandoned, its result ignored.
    */
   async disconnect() {
+    this.disconnected = true
+    this.notifyDisconnected()
     this.handleDisconnect()
+    await this._wait
   }
 
   /**
@@ -327,12 +340,56 @@ export class CommandHandle
   private async handleEvents() {
     try {
       for await (const [stdout, stderr, pty] of this.iterateEvents()) {
+        // The handle was disconnected — stop dispatching to the callbacks even
+        // if late output still arrives on the stream before the underlying
+        // abort tears it down.
+        if (this.disconnected) {
+          break
+        }
+
+        let callback: void | Promise<void> | undefined
         if (stdout !== null) {
-          await this.onStdout?.(stdout)
+          callback = this.onStdout?.(stdout)
         } else if (stderr !== null) {
-          await this.onStderr?.(stderr)
+          callback = this.onStderr?.(stderr)
         } else if (pty) {
-          await this.onPty?.(pty)
+          callback = this.onPty?.(pty)
+        }
+
+        if (callback) {
+          // Track the callback's settlement so a callback that has already
+          // resolved or rejected always wins over a concurrent disconnect();
+          // only a callback that is still pending when disconnect() wins is
+          // abandoned. The tracking promise never rejects (both outcomes are
+          // handled), so an abandoned callback's later rejection cannot crash
+          // the process.
+          let settled = false
+          let callbackError: Error | undefined
+          const tracked = Promise.resolve(callback).then(
+            () => {
+              settled = true
+            },
+            (err) => {
+              settled = true
+              callbackError = err as Error
+            }
+          )
+
+          await Promise.race([tracked, this.disconnectedPromise])
+
+          if (settled) {
+            if (callbackError) {
+              // Surface a callback error the same way as before: route it
+              // through the stream error handling so `wait()` re-throws it.
+              throw callbackError
+            }
+          } else {
+            // Disconnected while the callback was still in flight — abandon it
+            // (the JS equivalent of the cancelled handler task in the Python
+            // SDK). Awaiting it here could deadlock when disconnect() is
+            // awaited from inside the callback itself.
+            break
+          }
         }
       }
     } catch (e) {

--- a/packages/js-sdk/tests/sandbox/commands/commandHandle.test.ts
+++ b/packages/js-sdk/tests/sandbox/commands/commandHandle.test.ts
@@ -412,6 +412,50 @@ describe('CommandHandle', () => {
     })
   })
 
+  it('records the exit code when disconnected before an end event with trailing bytes', async () => {
+    const controllable = createControllableEvents()
+    const emojiBytes = new TextEncoder().encode('😀')
+    const chunks: string[] = []
+
+    const handle = new CommandHandle(
+      1,
+      () => {},
+      async () => true,
+      controllable.events,
+      (out) => {
+        chunks.push(out)
+      }
+    )
+
+    // First chunk leaves an incomplete multibyte sequence buffered in the
+    // decoder, so the end event will flush a trailing replacement character.
+    controllable.push(
+      dataEvent(
+        'stdout',
+        new Uint8Array([
+          ...new TextEncoder().encode('a'),
+          ...emojiBytes.slice(0, 2),
+        ])
+      )
+    )
+    await vi.waitFor(() => {
+      expect(chunks).toEqual(['a'])
+    })
+
+    // Disconnect, then the process exits. The end event carries a flushed
+    // chunk; wait() must still surface the exit code instead of failing as if
+    // the process never produced a result.
+    await handle.disconnect()
+    controllable.push(endEvent(0))
+
+    const result = await handle.wait()
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe('a�')
+    // The flushed chunk was produced after disconnect, so it must not reach
+    // the live callback.
+    expect(chunks).toEqual(['a'])
+  })
+
   it('surfaces an async callback error through wait()', async () => {
     async function* events() {
       yield dataEvent('stdout', new TextEncoder().encode('a'))

--- a/packages/js-sdk/tests/sandbox/commands/commandHandle.test.ts
+++ b/packages/js-sdk/tests/sandbox/commands/commandHandle.test.ts
@@ -82,6 +82,54 @@ function endEvent(exitCode = 0) {
   }
 }
 
+// An async iterable whose events are delivered on demand. Lets a test hold the
+// handle's event loop blocked on `next()` (idle between bursts) and then push a
+// late event to simulate stdout arriving after `disconnect()` — the transport
+// condition that triggers the production leak. `return()` (called when the
+// handle's `for await` breaks) unblocks any pending read, mirroring the stream
+// being torn down from the client side.
+function createControllableEvents() {
+  const queue: any[] = []
+  let pending: ((result: IteratorResult<any>) => void) | undefined
+  let closed = false
+
+  const iterator: AsyncIterator<any> = {
+    next() {
+      if (queue.length > 0) {
+        return Promise.resolve({ value: queue.shift(), done: false })
+      }
+      if (closed) {
+        return Promise.resolve({ value: undefined, done: true })
+      }
+      return new Promise((resolve) => {
+        pending = resolve
+      })
+    },
+    return() {
+      closed = true
+      if (pending) {
+        const resolve = pending
+        pending = undefined
+        resolve({ value: undefined, done: true })
+      }
+      return Promise.resolve({ value: undefined, done: true })
+    },
+  }
+
+  return {
+    events: { [Symbol.asyncIterator]: () => iterator } as AsyncIterable<any>,
+    push(event: any) {
+      if (pending) {
+        const resolve = pending
+        pending = undefined
+        resolve({ value: event, done: false })
+      } else {
+        queue.push(event)
+      }
+    },
+  }
+}
+
 describe('CommandHandle', () => {
   it.each<EventKind>(['stdout', 'stderr', 'pty'])(
     'wait awaits async %s callbacks',
@@ -256,5 +304,113 @@ describe('CommandHandle', () => {
     await expect(handle.wait()).rejects.toThrow()
 
     expect(stdoutChunks.join('')).toBe('a�')
+  })
+
+  it('onStdout stops firing after await disconnect()', async () => {
+    const controllable = createControllableEvents()
+    const chunks: string[] = []
+
+    const handle = new CommandHandle(
+      1,
+      () => {},
+      async () => true,
+      controllable.events,
+      (out) => {
+        chunks.push(out)
+      }
+    )
+
+    // First burst is delivered to the live subscriber.
+    controllable.push(dataEvent('stdout', new TextEncoder().encode('a')))
+    await vi.waitFor(() => {
+      expect(chunks).toEqual(['a'])
+    })
+
+    // Disconnect while the event loop is idle (blocked on the next read), then
+    // push a late event — as if stdout arrived after the abort but before the
+    // stream was torn down. disconnect() must not resolve until handling has
+    // ended, and the late event must never reach the callback.
+    const disconnected = handle.disconnect()
+    controllable.push(dataEvent('stdout', new TextEncoder().encode('b')))
+    await disconnected
+
+    expect(chunks).toEqual(['a'])
+
+    // Any further output is ignored too.
+    controllable.push(dataEvent('stdout', new TextEncoder().encode('c')))
+    await new Promise((r) => setTimeout(r, 0))
+    expect(chunks).toEqual(['a'])
+  })
+
+  it('disconnect() abandons an in-flight callback instead of deadlocking', async () => {
+    const controllable = createControllableEvents()
+    let callbackStarted = false
+    let releaseCallback: (() => void) | undefined
+    const callbackBlocked = new Promise<void>((resolve) => {
+      releaseCallback = resolve
+    })
+
+    const handle = new CommandHandle(
+      1,
+      () => {},
+      async () => true,
+      controllable.events,
+      async () => {
+        callbackStarted = true
+        await callbackBlocked
+      }
+    )
+
+    controllable.push(dataEvent('stdout', new TextEncoder().encode('a')))
+    await vi.waitFor(() => {
+      expect(callbackStarted).toBe(true)
+    })
+
+    // The callback is still in flight; disconnect() must resolve without
+    // waiting for it to settle.
+    await handle.disconnect()
+
+    // Releasing the abandoned callback afterwards is harmless.
+    releaseCallback?.()
+  })
+
+  it('disconnect() resolves when awaited from inside a callback', async () => {
+    const controllable = createControllableEvents()
+    let disconnectReturned = false
+
+    const handle: CommandHandle = new CommandHandle(
+      1,
+      () => {},
+      async () => true,
+      controllable.events,
+      async () => {
+        await handle.disconnect()
+        disconnectReturned = true
+      }
+    )
+
+    controllable.push(dataEvent('stdout', new TextEncoder().encode('a')))
+    await vi.waitFor(() => {
+      expect(disconnectReturned).toBe(true)
+    })
+  })
+
+  it('surfaces an async callback error through wait()', async () => {
+    async function* events() {
+      yield dataEvent('stdout', new TextEncoder().encode('a'))
+      yield endEvent()
+    }
+
+    const handle = new CommandHandle(
+      1,
+      () => {},
+      async () => true,
+      events(),
+      async () => {
+        throw new Error('callback failed')
+      }
+    )
+
+    await expect(handle.wait()).rejects.toThrow('callback failed')
   })
 })

--- a/packages/js-sdk/tests/sandbox/commands/commandHandle.test.ts
+++ b/packages/js-sdk/tests/sandbox/commands/commandHandle.test.ts
@@ -328,11 +328,10 @@ describe('CommandHandle', () => {
 
     // Disconnect while the event loop is idle (blocked on the next read), then
     // push a late event — as if stdout arrived after the abort but before the
-    // stream was torn down. disconnect() must not resolve until handling has
-    // ended, and the late event must never reach the callback.
-    const disconnected = handle.disconnect()
+    // stream was torn down. The late event must never reach the callback.
+    await handle.disconnect()
     controllable.push(dataEvent('stdout', new TextEncoder().encode('b')))
-    await disconnected
+    await new Promise((r) => setTimeout(r, 0))
 
     expect(chunks).toEqual(['a'])
 
@@ -342,7 +341,25 @@ describe('CommandHandle', () => {
     expect(chunks).toEqual(['a'])
   })
 
-  it('disconnect() abandons an in-flight callback instead of deadlocking', async () => {
+  it('disconnect() resolves promptly when a stream is idle', async () => {
+    // An idle long-running command (e.g. `sleep`) produces no further output,
+    // so the event handler stays blocked on the next read. disconnect() must
+    // not wait for that read and must resolve right away.
+    const controllable = createControllableEvents()
+    const handle = new CommandHandle(
+      1,
+      () => {},
+      async () => true,
+      controllable.events,
+      () => {}
+    )
+
+    // No event is ever pushed; this would hang if disconnect() awaited the
+    // event handler.
+    await handle.disconnect()
+  })
+
+  it('disconnect() does not block on an in-flight callback', async () => {
     const controllable = createControllableEvents()
     let callbackStarted = false
     let releaseCallback: (() => void) | undefined
@@ -370,11 +387,11 @@ describe('CommandHandle', () => {
     // waiting for it to settle.
     await handle.disconnect()
 
-    // Releasing the abandoned callback afterwards is harmless.
+    // Releasing the callback afterwards is harmless.
     releaseCallback?.()
   })
 
-  it('disconnect() resolves when awaited from inside a callback', async () => {
+  it('disconnect() resolves when called from inside a callback', async () => {
     const controllable = createControllableEvents()
     let disconnectReturned = false
 

--- a/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
+++ b/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
@@ -162,14 +162,19 @@ class AsyncCommandHandle:
                     if event.event.data.pty:
                         yield None, None, event.event.data.pty
                 if event.event.HasField("end"):
-                    for flushed in self._flush_decoders():
-                        yield flushed
+                    # Flush trailing decoder bytes into the accumulators and
+                    # record the result before yielding the flushed chunks, so a
+                    # consumer that stops iterating on the first flushed chunk
+                    # still observes the exit code.
+                    flushed = list(self._flush_decoders())
                     self._result = CommandResult(
                         stdout="".join(self._stdout_chunks),
                         stderr="".join(self._stderr_chunks),
                         exit_code=event.event.end.exit_code,
                         error=event.event.end.error,
                     )
+                    for f in flushed:
+                        yield f
         except Exception:
             # The stream raised before an end event (e.g. disconnect or RPC
             # failure). Flush any bytes still buffered in the decoders so

--- a/packages/python-sdk/e2b/sandbox_sync/commands/command_handle.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/command_handle.py
@@ -112,13 +112,18 @@ class CommandHandle:
                     if event.event.data.pty:
                         yield None, None, event.event.data.pty
                 if event.event.HasField("end"):
-                    yield from self._flush_decoders()
+                    # Flush trailing decoder bytes into the accumulators and
+                    # record the result before yielding the flushed chunks, so a
+                    # consumer that stops iterating on the first flushed chunk
+                    # still observes the exit code.
+                    flushed = list(self._flush_decoders())
                     self._result = CommandResult(
                         stdout="".join(self._stdout_chunks),
                         stderr="".join(self._stderr_chunks),
                         exit_code=event.event.end.exit_code,
                         error=event.event.end.error,
                     )
+                    yield from flushed
 
             # If the stream closed without an end event (e.g. disconnect or a
             # dropped connection), flush any bytes still buffered in the

--- a/packages/python-sdk/tests/test_command_handle.py
+++ b/packages/python-sdk/tests/test_command_handle.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from e2b.envd.process import process_pb2
@@ -36,6 +38,91 @@ def _end_event(exit_code: int = 0) -> process_pb2.StartResponse:
 
 async def _kill() -> bool:
     return True
+
+
+class _AsyncControllableEvents:
+    """Async event source that delivers items on demand.
+
+    Lets a test hold the handle's event-handling task blocked waiting for the
+    next event (idle between bursts), then push a late event after
+    ``disconnect()`` to confirm it never reaches the callback — the transport
+    condition that triggers the JS SDK leak.
+    """
+
+    def __init__(self):
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self._closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._closed and self._queue.empty():
+            raise StopAsyncIteration
+        item = await self._queue.get()
+        if item is None:
+            raise StopAsyncIteration
+        return item
+
+    def push(self, event):
+        self._queue.put_nowait(event)
+
+    async def aclose(self):
+        # Intentionally does NOT unblock a read that is already suspended on
+        # the queue: this models the JS-leak transport condition where the
+        # stream stays open past the close request. The only thing that stops
+        # the handle's event loop here is task cancellation in disconnect().
+        self._closed = True
+
+
+async def test_async_disconnect_stops_callbacks():
+    events = _AsyncControllableEvents()
+    chunks = []
+    handle = AsyncCommandHandle(
+        pid=1,
+        handle_kill=_kill,
+        events=events,
+        on_stdout=chunks.append,
+    )
+
+    # First burst is delivered to the live subscriber.
+    events.push(_stdout_event(b"a"))
+    for _ in range(200):
+        if chunks == ["a"]:
+            break
+        await asyncio.sleep(0.005)
+    assert chunks == ["a"]
+
+    # disconnect() cancels the event-handling task and closes the stream, so
+    # once it returns the callback must not fire again.
+    await handle.disconnect()
+
+    # A late event (stdout arriving after disconnect) must never reach the
+    # callback.
+    events.push(_stdout_event(b"b"))
+    await asyncio.sleep(0.05)
+    assert chunks == ["a"]
+
+
+def test_sync_has_no_background_subscription():
+    # The sync handle has no detached event-handling task: events are consumed
+    # only while the caller iterates (e.g. inside wait()), so there is no
+    # subscription that could keep firing after disconnect().
+    consumed = []
+
+    def events():
+        consumed.append("started")
+        yield _stdout_event(b"a")
+        yield _end_event()
+
+    handle = CommandHandle(pid=1, handle_kill=lambda: True, events=events())
+
+    # Nothing is consumed until the caller iterates.
+    assert consumed == []
+
+    # disconnect() just closes the (un-started) stream — still nothing consumed.
+    handle.disconnect()
+    assert consumed == []
 
 
 def test_sync_decodes_multibyte_chars_split_across_chunks():

--- a/packages/python-sdk/tests/test_command_handle.py
+++ b/packages/python-sdk/tests/test_command_handle.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any, cast
 
 import pytest
 
@@ -81,7 +82,9 @@ async def test_async_disconnect_stops_callbacks():
     handle = AsyncCommandHandle(
         pid=1,
         handle_kill=_kill,
-        events=events,
+        # The handle only async-iterates and aclose()s the stream; this stand-in
+        # satisfies both without being a real async generator.
+        events=cast(Any, events),
         on_stdout=chunks.append,
     )
 

--- a/packages/python-sdk/tests/test_command_handle.py
+++ b/packages/python-sdk/tests/test_command_handle.py
@@ -128,6 +128,27 @@ def test_sync_has_no_background_subscription():
     assert consumed == []
 
 
+def test_sync_records_result_before_yielding_flushed_chunk():
+    # A consumer that stops iterating right after the end event's flushed chunk
+    # must still observe the exit code: the result is recorded before the
+    # flushed chunk is yielded.
+    def events():
+        yield _stdout_event(b"a" + EMOJI_BYTES[:2])
+        yield _end_event(0)
+
+    handle = CommandHandle(pid=1, handle_kill=lambda: True, events=events())
+    iterator = iter(handle)
+    assert next(iterator) == ("a", None, None)
+    # The end event flushes a trailing replacement character; pull just that
+    # chunk and then stop iterating.
+    next(iterator)
+    iterator.close()
+
+    assert handle._result is not None
+    assert handle._result.exit_code == 0
+    assert handle._result.stdout == "a�"
+
+
 def test_sync_decodes_multibyte_chars_split_across_chunks():
     def events():
         yield _stdout_event(b"a" + EMOJI_BYTES[:2])


### PR DESCRIPTION
## Description

This PR fixes two related issues in the command handle's event handling.

### 1. JS `CommandHandle.disconnect()` leaked the output subscription

`disconnect()` was fire-and-forget — it only triggered the transport abort and relied entirely on HTTP/2 abort propagation to stop events, which is unreliable under keepalive: `onStdout`/`onStderr`/`onPty` could keep firing for output produced after `disconnect()` returned.

`disconnect()` now sets a cooperative `disconnected` flag and aborts the transport. The flag is checked before every callback dispatch in the event loop, so once `disconnect()` returns no callback fires for output that arrives (or was buffered) after the call — even if the underlying abort hasn't torn the stream down yet. It does **not** wait for the event handler to drain, so it returns promptly even for an idle command (e.g. `sleep`) whose stream produces no further output, never blocks on an in-flight callback, and does not deadlock when awaited from inside a callback.

The async Python SDK was already correct here (`disconnect()` cancels the event-handling task), and the sync Python SDK has no background subscription (events are consumed only while the caller iterates). The added Python tests confirm both.

### 2. Exit code was lost when a disconnected consumer stopped on a flushed `end`-event chunk

When the `end` event flushes trailing decoder bytes (an incomplete multibyte sequence → replacement character) and the consumer stops iterating on the first flushed chunk, the generator was aborted before the result was assigned, so `wait()` failed as if the process never produced a result. The `end` handler now records the result **before** yielding the flushed chunks, across the JS, async Python, and sync Python SDKs.

## Usage

```js
const handle = await sandbox.commands.run(daemon, { background: true, stdin: true, onStdout })
await sandbox.commands.sendStdin(handle.pid, 'turn1\n')
await handle.disconnect() // resolves promptly; onStdout will not fire again
await sandbox.commands.sendStdin(handle.pid, 'turn2\n') // turn2 output never reaches onStdout
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
