### PR TITLE
ci: split release workflow into production and candidate workflows

### DIFF
--- a/.github/workflows/publish_candidates.yml
+++ b/.github/workflows/publish_candidates.yml
@@ -86,7 +86,7 @@ jobs:
         working-directory: packages/python-sdk
         run: |
           BASE_VERSION=$(poetry version -s)
-          poetry version "${BASE_VERSION}rc${{ github.run_number }}"
+          poetry version "${BASE_VERSION}rc${{ github.run_id }}"
           poetry build
           poetry config pypi-token.pypi ${PYPI_TOKEN} && poetry publish --skip-existing
         env:
@@ -103,7 +103,7 @@ jobs:
           RC_PREID: ${{ inputs.preid }}
           RC_TAG: ${{ inputs.tag }}
         run: |
-          npm version prerelease --preid="${RC_PREID}.${{ github.run_number }}" --no-git-tag-version
+          npm version prerelease --preid="${RC_PREID}.${{ github.run_id }}" --no-git-tag-version
           npm publish --tag "$RC_TAG" --provenance
 
       - name: Reinstall dependencies
@@ -117,5 +117,5 @@ jobs:
           RC_PREID: ${{ inputs.preid }}
           RC_TAG: ${{ inputs.tag }}
         run: |
-          npm version prerelease --preid="${RC_PREID}.${{ github.run_number }}" --no-git-tag-version
+          npm version prerelease --preid="${RC_PREID}.${{ github.run_id }}" --no-git-tag-version
           npm publish --tag "$RC_TAG" --provenance

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,105 @@
+name: Release candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      js-sdk:
+        description: 'Release JS SDK'
+        required: false
+        default: false
+        type: boolean
+      python-sdk:
+        description: 'Release Python SDK'
+        required: false
+        default: false
+        type: boolean
+      cli:
+        description: 'Release CLI'
+        required: false
+        default: false
+        type: boolean
+      tag:
+        description: 'Dist-tag (e.g. rc, beta, snapshot)'
+        required: false
+        default: 'rc'
+        type: string
+      preid:
+        description: 'Prerelease identifier (defaults to branch name)'
+        required: false
+        default: ''
+        type: string
+      skip-tests:
+        description: 'Skip tests'
+        required: false
+        default: false
+        type: boolean
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  rc-validate:
+    name: Validate RC inputs
+    runs-on: ubuntu-latest
+    outputs:
+      preid: ${{ steps.preid.outputs.preid }}
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Sanitize tag
+        id: tag
+        env:
+          RAW_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          SAFE_TAG="$(echo "$RAW_TAG" | sed 's/[^0-9A-Za-z-]/-/g')"
+          echo "tag=$SAFE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Block production tags
+        run: |
+          if [ "${{ steps.tag.outputs.tag }}" = "latest" ]; then
+            echo "::error::Publishing with the 'latest' tag is not allowed for candidates. Use the 'Release' workflow instead."
+            exit 1
+          fi
+
+      - name: Sanitize preid
+        id: preid
+        env:
+          RAW_PREID: ${{ github.event.inputs.preid || github.ref_name }}
+        run: |
+          echo "preid=$(echo "$RAW_PREID" | sed 's/[^0-9A-Za-z-]/-/g')" >> "$GITHUB_OUTPUT"
+
+  rc-python-tests:
+    name: RC Python Tests
+    needs: [rc-validate]
+    if: github.event.inputs.python-sdk == 'true' && github.event.inputs.skip-tests != 'true'
+    uses: ./.github/workflows/python_sdk_tests.yml
+    secrets: inherit
+
+  rc-js-tests:
+    name: RC JS Tests
+    needs: [rc-validate]
+    if: github.event.inputs.js-sdk == 'true' && github.event.inputs.skip-tests != 'true'
+    uses: ./.github/workflows/js_sdk_tests.yml
+    secrets: inherit
+
+  rc-cli-tests:
+    name: RC CLI Tests
+    needs: [rc-validate]
+    if: github.event.inputs.cli == 'true' && github.event.inputs.skip-tests != 'true'
+    uses: ./.github/workflows/cli_tests.yml
+    secrets: inherit
+
+  rc-publish:
+    name: Publish RC
+    needs: [rc-validate, rc-python-tests, rc-js-tests, rc-cli-tests]
+    if: (!cancelled()) && !contains(needs.*.result, 'failure') && needs.rc-validate.result == 'success'
+    uses: ./.github/workflows/publish_candidates.yml
+    with:
+      js-sdk: ${{ github.event.inputs.js-sdk == 'true' }}
+      python-sdk: ${{ github.event.inputs.python-sdk == 'true' }}
+      cli: ${{ github.event.inputs.cli == 'true' }}
+      tag: ${{ needs.rc-validate.outputs.tag }}
+      preid: ${{ needs.rc-validate.outputs.preid }}
+    secrets: inherit

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -34,7 +34,8 @@ on:
         default: false
         type: boolean
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+# Shared literal group so production and candidate releases on the same ref serialize.
+concurrency: release-${{ github.ref }}
 
 permissions:
   id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,45 +1,7 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      mode:
-        description: 'Release mode'
-        type: choice
-        options:
-          - release
-          - candidate
-        default: release
-      js-sdk:
-        description: 'Release JS SDK (candidate only)'
-        required: false
-        default: false
-        type: boolean
-      python-sdk:
-        description: 'Release Python SDK (candidate only)'
-        required: false
-        default: false
-        type: boolean
-      cli:
-        description: 'Release CLI (candidate only)'
-        required: false
-        default: false
-        type: boolean
-      tag:
-        description: 'Dist-tag for candidate (e.g. rc, beta, snapshot)'
-        required: false
-        default: 'rc'
-        type: string
-      preid:
-        description: 'Prerelease identifier (defaults to branch name, candidate only)'
-        required: false
-        default: ''
-        type: string
-      skip-tests:
-        description: 'Skip tests (candidate only)'
-        required: false
-        default: false
-        type: boolean
+  workflow_dispatch: {}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -48,10 +10,8 @@ permissions:
   contents: write
 
 jobs:
-  # ── Production release ───────────────────────────────────
   preflight:
     name: Release preflight
-    if: github.event.inputs.mode != 'candidate'
     runs-on: ubuntu-latest
     outputs:
       release: ${{ steps.version.outputs.release }}
@@ -219,68 +179,3 @@ jobs:
           SLACK_TITLE: Release Succeeded
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: 'monitoring-releases'
-
-  # ── Release candidate ────────────────────────────────────
-  rc-validate:
-    name: Validate RC inputs
-    if: github.event.inputs.mode == 'candidate'
-    runs-on: ubuntu-latest
-    outputs:
-      preid: ${{ steps.preid.outputs.preid }}
-      tag: ${{ steps.tag.outputs.tag }}
-    steps:
-      - name: Sanitize tag
-        id: tag
-        env:
-          RAW_TAG: ${{ github.event.inputs.tag }}
-        run: |
-          SAFE_TAG="$(echo "$RAW_TAG" | sed 's/[^0-9A-Za-z-]/-/g')"
-          echo "tag=$SAFE_TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Block production tags
-        run: |
-          if [ "${{ steps.tag.outputs.tag }}" = "latest" ]; then
-            echo "::error::Publishing with the 'latest' tag is not allowed for candidates. Use 'release' mode instead."
-            exit 1
-          fi
-
-      - name: Sanitize preid
-        id: preid
-        env:
-          RAW_PREID: ${{ github.event.inputs.preid || github.ref_name }}
-        run: |
-          echo "preid=$(echo "$RAW_PREID" | sed 's/[^0-9A-Za-z-]/-/g')" >> "$GITHUB_OUTPUT"
-
-  rc-python-tests:
-    name: RC Python Tests
-    needs: [rc-validate]
-    if: github.event.inputs.python-sdk == 'true' && github.event.inputs.skip-tests != 'true'
-    uses: ./.github/workflows/python_sdk_tests.yml
-    secrets: inherit
-
-  rc-js-tests:
-    name: RC JS Tests
-    needs: [rc-validate]
-    if: github.event.inputs.js-sdk == 'true' && github.event.inputs.skip-tests != 'true'
-    uses: ./.github/workflows/js_sdk_tests.yml
-    secrets: inherit
-
-  rc-cli-tests:
-    name: RC CLI Tests
-    needs: [rc-validate]
-    if: github.event.inputs.cli == 'true' && github.event.inputs.skip-tests != 'true'
-    uses: ./.github/workflows/cli_tests.yml
-    secrets: inherit
-
-  rc-publish:
-    name: Publish RC
-    needs: [rc-validate, rc-python-tests, rc-js-tests, rc-cli-tests]
-    if: (!cancelled()) && !contains(needs.*.result, 'failure') && needs.rc-validate.result == 'success'
-    uses: ./.github/workflows/publish_candidates.yml
-    with:
-      js-sdk: ${{ github.event.inputs.js-sdk == 'true' }}
-      python-sdk: ${{ github.event.inputs.python-sdk == 'true' }}
-      cli: ${{ github.event.inputs.cli == 'true' }}
-      tag: ${{ needs.rc-validate.outputs.tag }}
-      preid: ${{ needs.rc-validate.outputs.preid }}
-    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   workflow_dispatch: {}
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+# Shared literal group so production and candidate releases on the same ref serialize.
+concurrency: release-${{ github.ref }}
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Why

GitHub Actions cannot conditionally show `workflow_dispatch` inputs based on other inputs, so the single **Release** form always displayed the six candidate-only fields even when running a production release — confusing for anyone doing their first release.

## What

Split the combined workflow into two so each form matches its intent:
- **`release.yml` ("Release")** — production only; the `mode` dropdown and all candidate fields are removed, leaving a form with no inputs.
- **`release-candidate.yml` ("Release candidate")** — new file containing only the RC inputs (js-sdk, python-sdk, cli, tag, preid, skip-tests), with the now-redundant "(candidate only)" label suffixes dropped.

People choose by sidebar name instead of a dropdown, and the `mode ==/!= 'candidate'` job guards are gone since workflow selection does that job.

Two follow-ups from review to keep behavior intact across the split:
- **Concurrency:** both files use a shared literal group `release-${{ github.ref }}` (instead of `${{ github.workflow }}-…`) so production and candidate releases on the same ref still serialize.
- **RC versioning:** `publish_candidates.yml` now derives RC version suffixes from `github.run_id` instead of `github.run_number`. `run_number` is per-workflow-file and would reset to 1 for the new workflow, causing RC versions to go backwards (npm dist-tag downgrade / publish collisions); `run_id` is globally unique and monotonic.

> [!NOTE]
> Any automation or docs that ran the old workflow with `-f mode=candidate` must now target `release-candidate.yml` (no `mode` field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)