### PR TITLE
fix(cli): make migrated Python build scripts runnable

### DIFF
--- a/.changeset/fix-python-migrate-build-import.md
+++ b/.changeset/fix-python-migrate-build-import.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Fix Python template migration build scripts so the generated `build_dev.py` and `build_prod.py` files can be run directly with `python build_dev.py` as instructed.

--- a/packages/cli/src/templates/python-build-async.hbs
+++ b/packages/cli/src/templates/python-build-async.hbs
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/src/templates/python-build-sync.hbs
+++ b/packages/cli/src/templates/python-build-sync.hbs
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/migrate.test.ts
+++ b/packages/cli/tests/commands/template/migrate.test.ts
@@ -126,6 +126,16 @@ describe('Template Migration', () => {
       )
       expect(buildProdFile.trim()).toEqual(expectedBuildProd.trim())
 
+      if (
+        language === Language.PythonSync ||
+        language === Language.PythonAsync
+      ) {
+        expect(buildDevFile).toContain('from template import template')
+        expect(buildProdFile).toContain('from template import template')
+        expect(buildDevFile).not.toContain('from .template import template')
+        expect(buildProdFile).not.toContain('from .template import template')
+      }
+
       // Check that old files are renamed to .old extensions
       const oldDockerfilePath = path.join(testDir, 'e2b.Dockerfile.old')
       const oldConfigPath = path.join(testDir, 'e2b.toml.old')


### PR DESCRIPTION
## Summary

Fixes #1477.

The Python build scripts emitted by `e2b template migrate --language python-sync` and `python-async` are documented as directly runnable with `python build_dev.py` / `python build_prod.py`, but they used a package-relative import (`from .template import template`) that fails outside package execution.

This changes the generated Python build scripts to import the sibling generated `template.py` directly, updates the migration fixtures, and adds an assertion so the migration test covers the intended standalone import behavior.

## Changes

- Use `from template import template` in the Python sync and async build templates.
- Update all Python sync/async migrate expected fixtures.
- Add migrate-test assertions that Python outputs do not contain the relative import.
- Add a patch changeset for `@e2b/cli`.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @e2b/cli build`
- [x] `pnpm --filter @e2b/cli test -- tests/commands/template/migrate.test.ts` (24 passed)
- [x] `pnpm --filter @e2b/cli test -- tests/commands/template/init.test.ts` (14 passed)
- [x] `pnpm --filter @e2b/cli lint`
- [x] Python smoke test importing generated `build_dev.py` / `build_prod.py` for python-sync and python-async
- [x] `git diff --check`
- [ ] `pnpm --filter @e2b/cli test` fails in this environment because `tests/commands/template/create.test.ts` requires `E2B_API_KEY`; other CLI test files reported 10 passed / 2 skipped before that environment-gated failure.
