### PR TITLE
fix: add retry logic for transient connection errors in wait_for_build_finish

### DIFF
--- a/packages/python-sdk/e2b/template_async/build_api.py
+++ b/packages/python-sdk/e2b/template_async/build_api.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime
 from types import TracebackType
 from typing import Callable, Optional, List, Union
 
@@ -210,11 +211,31 @@ async def wait_for_build_finish(
 ):
     logs_offset = 0
     status = TemplateBuildStatus.BUILDING
+    max_consecutive_errors = 30
+    consecutive_errors = 0
 
     while status in [TemplateBuildStatus.BUILDING, TemplateBuildStatus.WAITING]:
-        build_status = await get_build_status(
-            client, template_id, build_id, logs_offset
-        )
+        try:
+            build_status = await get_build_status(
+                client, template_id, build_id, logs_offset
+            )
+            consecutive_errors = 0
+        except BuildException:
+            raise
+        except Exception as e:
+            consecutive_errors += 1
+            if consecutive_errors >= max_consecutive_errors:
+                raise BuildException(
+                    f"Failed to poll build status after {max_consecutive_errors} consecutive errors: {e}"
+                )
+            if on_build_logs:
+                on_build_logs(LogEntry(
+                    timestamp=datetime.now(),
+                    level="warn",
+                    message=f"Connection error while polling build status (attempt {consecutive_errors}/{max_consecutive_errors}), retrying: {e}",
+                ))
+            await asyncio.sleep(2)
+            continue
 
         logs_offset += len(build_status.log_entries)
 

--- a/packages/python-sdk/e2b/template_sync/build_api.py
+++ b/packages/python-sdk/e2b/template_sync/build_api.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime
 from types import TracebackType
 from typing import Callable, Optional, List, Union
 
@@ -209,9 +210,29 @@ def wait_for_build_finish(
 ):
     logs_offset = 0
     status = TemplateBuildStatus.BUILDING
+    max_consecutive_errors = 30
+    consecutive_errors = 0
 
     while status in [TemplateBuildStatus.BUILDING, TemplateBuildStatus.WAITING]:
-        build_status = get_build_status(client, template_id, build_id, logs_offset)
+        try:
+            build_status = get_build_status(client, template_id, build_id, logs_offset)
+            consecutive_errors = 0
+        except BuildException:
+            raise
+        except Exception as e:
+            consecutive_errors += 1
+            if consecutive_errors >= max_consecutive_errors:
+                raise BuildException(
+                    f"Failed to poll build status after {max_consecutive_errors} consecutive errors: {e}"
+                )
+            if on_build_logs:
+                on_build_logs(LogEntry(
+                    timestamp=datetime.now(),
+                    level="warn",
+                    message=f"Connection error while polling build status (attempt {consecutive_errors}/{max_consecutive_errors}), retrying: {e}",
+                ))
+            time.sleep(2)
+            continue
 
         logs_offset += len(build_status.log_entries)
 


### PR DESCRIPTION
fix   https://github.com/e2b-dev/E2B/issues/1488

## Root Cause

`wait_for_build_finish` calls `get_build_status` without any error handling for transient network/connection errors. Any non-`BuildException` exception (like `h2.exceptions.ConnectionTerminated`, `httpx.RemoteProtocolError`, etc.) immediately kills the polling loop.

## Fix

Wrap the `get_build_status` call in a try/except that:
- Re-raises `BuildException` immediately (real API errors should not be retried)
- Catches all other exceptions (connection/network errors) and retries with a 2-second delay
- Fails after 30 consecutive errors (~60s), converting to a `BuildException`
- Logs retry attempts via the `on_build_logs` callback for visibility

Applied to both sync and async versions:
- `packages/python-sdk/e2b/template_async/build_api.py`
- `packages/python-sdk/e2b/template_sync/build_api.py`

## Testing

Verified locally against a self-hosted E2B deployment where `ConnectionTerminated` errors occur during long builds. After the fix, transient connection drops are retried transparently and the build completes successfully.
/cc @jakubno 