### PR TITLE
fix(cli): resolve template alias for migrated build scripts

### DIFF
--- a/.changeset/fix-migrate-template-alias.md
+++ b/.changeset/fix-migrate-template-alias.md
@@ -1,0 +1,7 @@
+---
+"@e2b/cli": patch
+---
+
+fix(cli): resolve template alias for migrated build scripts when only template_id is set
+
+`e2b template migrate` now looks up the human-readable template alias from the API (or accepts `--alias`) instead of writing the opaque `template_id` into generated `build_prod.py`, which caused 409 alias collisions when rebuilding existing templates.

--- a/packages/cli/src/commands/template/migrate.ts
+++ b/packages/cli/src/commands/template/migrate.ts
@@ -14,6 +14,7 @@ import {
   Language,
   languageDisplay,
 } from './generators'
+import { resolveTemplateBuildName } from './resolveBuildName'
 
 /**
  * Migrate Dockerfile to a specific target language using SDK
@@ -22,7 +23,8 @@ async function migrateToLanguage(
   root: string,
   config: E2BConfig,
   dockerfileContent: string,
-  language: Language
+  language: Language,
+  opts?: { alias?: string }
 ): Promise<void> {
   // Initialize template with file context
   const template = Template({
@@ -66,7 +68,9 @@ async function migrateToLanguage(
     parsedTemplate = baseTemplate.setReadyCmd(config.ready_cmd)
   }
 
-  const name = config.template_name || config.template_id
+  const name = await resolveTemplateBuildName(config, {
+    alias: opts?.alias,
+  })
   if (!name) {
     throw new Error('Template name or ID is required')
   }
@@ -94,6 +98,10 @@ export const migrateCommand = new commander.Command('migrate')
   )
   .addOption(configOption)
   .option(
+    '--alias <name>',
+    'template alias to use in generated build scripts when e2b.toml has no template_name'
+  )
+  .option(
     '-l, --language <language>',
     `specify target language: ${Object.values(Language).join(', ')}`,
     (value) => {
@@ -114,6 +122,7 @@ export const migrateCommand = new commander.Command('migrate')
       config?: string
       path?: string
       language?: Language
+      alias?: string
     }) => {
       let success = false
       try {
@@ -173,7 +182,9 @@ export const migrateCommand = new commander.Command('migrate')
         }
 
         // Perform migration
-        await migrateToLanguage(root, config, dockerfileContent, language)
+        await migrateToLanguage(root, config, dockerfileContent, language, {
+          alias: opts.alias,
+        })
 
         // Rename old files to .old extensions
         const oldFilesRenamed: { oldPath: string; newPath: string }[] = []

--- a/packages/cli/src/commands/template/resolveBuildName.ts
+++ b/packages/cli/src/commands/template/resolveBuildName.ts
@@ -1,0 +1,90 @@
+import * as e2b from 'e2b'
+
+import { client } from '../../api'
+import { E2BConfig } from '../../config'
+import { getUserConfig } from '../../user'
+import { sortTemplatesAliases } from '../../utils/templateSort'
+
+function getTemplateNames(
+  template: Pick<
+    e2b.components['schemas']['TemplateWithBuilds'],
+    'names' | 'aliases'
+  >
+): string[] {
+  if (template.names?.length) {
+    return template.names
+  }
+  return template.aliases ?? []
+}
+
+function looksLikeOpaqueTemplateId(templateId: string): boolean {
+  return /^[a-z0-9]{10,}$/i.test(templateId) && !templateId.includes('-')
+}
+
+function warnTemplateIdFallback(templateId: string, reason: string) {
+  if (!looksLikeOpaqueTemplateId(templateId)) {
+    return
+  }
+
+  console.warn(`\n⚠️  ${reason}`)
+  console.warn(
+    '   Set template_name in e2b.toml, pass --alias, or run `e2b auth login` so the CLI can resolve the alias from your account.\n'
+  )
+}
+
+/**
+ * Resolve the human-readable template name used in generated build scripts.
+ * `AsyncTemplate.build` / `Template.build` expect an alias, not the opaque template ID.
+ */
+export async function resolveTemplateBuildName(
+  config: E2BConfig,
+  opts?: { alias?: string }
+): Promise<string> {
+  if (config.template_name) {
+    return config.template_name
+  }
+
+  if (opts?.alias) {
+    return opts.alias
+  }
+
+  const apiKey = process.env.E2B_API_KEY || getUserConfig()?.teamApiKey
+  if (!apiKey) {
+    warnTemplateIdFallback(
+      config.template_id,
+      'e2b.toml has template_id but no template_name. Generated build_prod.py will use the template ID as the build name, which may fail with a 409 alias collision when rebuilding an existing template.'
+    )
+    return config.template_id
+  }
+
+  const res = await client.api.GET('/templates/{templateID}', {
+    params: {
+      path: {
+        templateID: config.template_id,
+      },
+      query: {
+        limit: 1,
+      },
+    },
+  })
+
+  if (res.error || !res.data) {
+    warnTemplateIdFallback(
+      config.template_id,
+      `Could not resolve template alias for template_id "${config.template_id}" (${res.error?.message ?? 'unknown error'}). Falling back to template_id in generated build scripts.`
+    )
+    return config.template_id
+  }
+
+  const names = getTemplateNames(res.data)
+  if (!names.length) {
+    warnTemplateIdFallback(
+      config.template_id,
+      `Template "${config.template_id}" has no aliases. Falling back to template_id in generated build scripts.`
+    )
+    return config.template_id
+  }
+
+  sortTemplatesAliases(names)
+  return names[0]
+}

--- a/packages/cli/tests/commands/template/resolveBuildName.test.ts
+++ b/packages/cli/tests/commands/template/resolveBuildName.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import * as e2b from 'e2b'
+
+import { resolveTemplateBuildName } from '../../../src/commands/template/resolveBuildName'
+import { E2BConfig } from '../../../src/config'
+
+const mockGet = vi.fn()
+
+vi.mock('../../../src/api', () => ({
+  client: {
+    api: {
+      GET: (...args: unknown[]) => mockGet(...args),
+    },
+  },
+  resolveTeamId: vi.fn(),
+}))
+
+vi.mock('../../../src/user', () => ({
+  getUserConfig: vi.fn(),
+}))
+
+import { getUserConfig } from '../../../src/user'
+
+describe('resolveTemplateBuildName', () => {
+  const baseConfig: E2BConfig = {
+    template_id: 'abc1234567890xyz',
+    dockerfile: 'e2b.Dockerfile',
+  }
+
+  beforeEach(() => {
+    mockGet.mockReset()
+    delete process.env.E2B_API_KEY
+    vi.mocked(getUserConfig).mockReturnValue({ teamApiKey: 'test-api-key' } as any)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('prefers template_name from config', async () => {
+    const name = await resolveTemplateBuildName({
+      ...baseConfig,
+      template_name: 'my-template',
+    })
+
+    expect(name).toBe('my-template')
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  test('uses --alias override when template_name is missing', async () => {
+    const name = await resolveTemplateBuildName(baseConfig, {
+      alias: 'cli-alias',
+    })
+
+    expect(name).toBe('cli-alias')
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  test('resolves alias from API when only template_id is present', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        templateID: baseConfig.template_id,
+        names: ['my-template', 'my-template:prod'],
+        aliases: ['legacy-alias'],
+      } satisfies Pick<
+        e2b.components['schemas']['TemplateWithBuilds'],
+        'templateID' | 'names' | 'aliases'
+      >,
+    })
+
+    const name = await resolveTemplateBuildName(baseConfig)
+
+    expect(name).toBe('my-template')
+    expect(mockGet).toHaveBeenCalledWith('/templates/{templateID}', {
+      params: {
+        path: { templateID: baseConfig.template_id },
+        query: { limit: 1 },
+      },
+    })
+  })
+
+  test('falls back to template_id when API lookup fails', async () => {
+    mockGet.mockResolvedValue({
+      error: { code: 404, message: 'not found' },
+    })
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const name = await resolveTemplateBuildName(baseConfig)
+
+    expect(name).toBe(baseConfig.template_id)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  test('falls back to template_id without API call when unauthenticated', async () => {
+    vi.mocked(getUserConfig).mockReturnValue(undefined)
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const name = await resolveTemplateBuildName(baseConfig)
+
+    expect(name).toBe(baseConfig.template_id)
+    expect(mockGet).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  test('uses deprecated aliases when names are empty', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        templateID: baseConfig.template_id,
+        names: [],
+        aliases: ['legacy-alias'],
+      },
+    })
+
+    const name = await resolveTemplateBuildName(baseConfig)
+
+    expect(name).toBe('legacy-alias')
+  })
+})


### PR DESCRIPTION
## Summary

When `e2b template migrate` runs against an existing `e2b.toml` that only has `template_id` (no `template_name`), the generated `build_prod.py` / `build.prod.ts` previously wrote the opaque template ID into the `Template.build` name argument. That causes a 409 alias collision when rebuilding the existing template.

This change resolves the human-readable alias before generating build scripts.

Fixes #1478

## Motivation

`Template.build` expects a template alias/name, not the internal `template_id`. Migrating legacy configs that only stored the ID therefore produced scripts that could not rebuild the template in place.

Related: #1477 (separate import fix in #1487).

## Changes

- Add `resolveTemplateBuildName()` to resolve build script names in this order:
  1. `template_name` from `e2b.toml`
  2. `--alias` CLI flag
  3. `GET /templates/{templateID}` (first sorted name/alias)
  4. Fallback to `template_id` with a targeted warning for opaque IDs
- Wire resolution into `template migrate`
- Add unit tests for resolution paths
- Add changeset for `@e2b/cli`

## Tests

- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm test tests/commands/template/resolveBuildName.test.ts` — 6/6 pass
- `pnpm test tests/commands/template/migrate.test.ts` — 24/24 pass

## Notes

- When unauthenticated and no `--alias` is provided, behavior falls back to the previous `template_id` value (with a warning for opaque-looking IDs). Logged-in users get the correct alias automatically.
- Does not change generated file contents for configs that already include `template_name`.
