### PR TITLE
kill sandbox on MCP gateway startup failure to prevent orphaned resources

### DIFF
--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -282,17 +282,17 @@ export class Sandbox extends SandboxApi {
     const { template, sandboxOpts } =
       typeof templateOrOpts === 'string'
         ? {
-            template: templateOrOpts,
-            sandboxOpts: opts,
-          }
+          template: templateOrOpts,
+          sandboxOpts: opts,
+        }
         : {
-            template:
-              templateOrOpts?.template ??
-              (templateOrOpts?.mcp
-                ? this.defaultMcpTemplate
-                : this.defaultTemplate),
-            sandboxOpts: templateOrOpts,
-          }
+          template:
+            templateOrOpts?.template ??
+            (templateOrOpts?.mcp
+              ? this.defaultMcpTemplate
+              : this.defaultTemplate),
+          sandboxOpts: templateOrOpts,
+        }
 
     const config = new ConnectionConfig(sandboxOpts)
     if (config.debug) {
@@ -313,17 +313,22 @@ export class Sandbox extends SandboxApi {
 
     if (sandboxOpts?.mcp) {
       sandbox.mcpToken = crypto.randomUUID()
-      const res = await sandbox.commands.run(
-        `mcp-gateway --config ${shellQuote(JSON.stringify(sandboxOpts.mcp))}`,
-        {
-          user: 'root',
-          envs: {
-            GATEWAY_ACCESS_TOKEN: sandbox.mcpToken ?? '',
-          },
+      try {
+        const res = await sandbox.commands.run(
+          `mcp-gateway --config ${shellQuote(JSON.stringify(sandboxOpts.mcp))}`,
+          {
+            user: 'root',
+            envs: {
+              GATEWAY_ACCESS_TOKEN: sandbox.mcpToken ?? '',
+            },
+          }
+        )
+        if (res.exitCode !== 0) {
+          throw new Error(`Failed to start MCP gateway: ${res.stderr}`)
         }
-      )
-      if (res.exitCode !== 0) {
-        throw new Error(`Failed to start MCP gateway: ${res.stderr}`)
+      } catch (err) {
+        await sandbox.kill().catch(() => { })
+        throw err
       }
     }
 

--- a/packages/js-sdk/tests/sandbox/mcpGatewayCleanup.test.ts
+++ b/packages/js-sdk/tests/sandbox/mcpGatewayCleanup.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for MCP gateway startup failure cleanup.
+ *
+ * When the MCP gateway fails to start (non-zero exit code or exception),
+ * the sandbox should be killed to prevent orphaned resources.
+ */
+import { afterEach, assert, describe, expect, test, vi } from 'vitest'
+
+import { Sandbox } from '../../src'
+import { SandboxApi } from '../../src/sandbox/sandboxApi'
+import { Commands } from '../../src/sandbox/commands'
+import { TEST_API_KEY } from '../setup'
+
+const baseConfig = {
+    apiKey: TEST_API_KEY,
+    domain: 'base.e2b.dev',
+}
+
+const fakeSandboxInfo = {
+    sandboxId: 'sbx-test',
+    sandboxDomain: 'sandbox.e2b.dev',
+    envdVersion: '0.2.4',
+    envdAccessToken: 'tok',
+    trafficAccessToken: 'tok',
+}
+
+function mockCreateSandbox() {
+    vi.spyOn(SandboxApi as any, 'createSandbox').mockResolvedValue(fakeSandboxInfo)
+}
+
+describe('MCP gateway cleanup on failure', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('successful MCP gateway startup does not kill sandbox', async () => {
+        mockCreateSandbox()
+
+        vi.spyOn(Commands.prototype, 'run').mockResolvedValue({
+            exitCode: 0,
+            stdout: '',
+            stderr: '',
+        })
+
+        const killSpy = vi
+            .spyOn(Sandbox.prototype, 'kill')
+            .mockResolvedValue(true)
+
+        const result = await Sandbox.create('mcp-gateway', {
+            mcp: { exa: {} } as any,
+            ...baseConfig,
+        })
+
+        assert.isDefined(result)
+        assert.equal(killSpy.mock.calls.length, 0)
+    })
+
+    test('MCP gateway non-zero exit code kills sandbox', async () => {
+        mockCreateSandbox()
+
+        vi.spyOn(Commands.prototype, 'run').mockResolvedValue({
+            exitCode: 1,
+            stdout: '',
+            stderr: 'gateway error',
+        })
+
+        const killSpy = vi
+            .spyOn(Sandbox.prototype, 'kill')
+            .mockResolvedValue(true)
+
+        await expect(
+            Sandbox.create('mcp-gateway', {
+                mcp: { exa: {} } as any,
+                ...baseConfig,
+            })
+        ).rejects.toThrow(/Failed to start MCP gateway/)
+
+        assert.equal(killSpy.mock.calls.length, 1)
+    })
+
+    test('MCP gateway exception kills sandbox', async () => {
+        mockCreateSandbox()
+
+        vi.spyOn(Commands.prototype, 'run').mockRejectedValue(
+            new Error('connection lost')
+        )
+
+        const killSpy = vi
+            .spyOn(Sandbox.prototype, 'kill')
+            .mockResolvedValue(true)
+
+        await expect(
+            Sandbox.create('mcp-gateway', {
+                mcp: { exa: {} } as any,
+                ...baseConfig,
+            })
+        ).rejects.toThrow(/connection lost/)
+
+        assert.equal(killSpy.mock.calls.length, 1)
+    })
+
+    test('original error propagated even when kill fails', async () => {
+        mockCreateSandbox()
+
+        vi.spyOn(Commands.prototype, 'run').mockResolvedValue({
+            exitCode: 1,
+            stdout: '',
+            stderr: 'startup failed',
+        })
+
+        const killSpy = vi
+            .spyOn(Sandbox.prototype, 'kill')
+            .mockRejectedValue(new Error('kill also failed'))
+
+        await expect(
+            Sandbox.create('mcp-gateway', {
+                mcp: { exa: {} } as any,
+                ...baseConfig,
+            })
+        ).rejects.toThrow(/Failed to start MCP gateway/)
+
+        // kill was attempted even though it failed
+        assert.equal(killSpy.mock.calls.length, 1)
+    })
+
+    test('kill failure is suppressed (best-effort cleanup)', async () => {
+        mockCreateSandbox()
+
+        vi.spyOn(Commands.prototype, 'run').mockRejectedValue(
+            new Error('run failed')
+        )
+
+        vi.spyOn(Sandbox.prototype, 'kill').mockRejectedValue(
+            new Error('kill failed too')
+        )
+
+        // Should throw the original error, not the kill error
+        await expect(
+            Sandbox.create('mcp-gateway', {
+                mcp: { exa: {} } as any,
+                ...baseConfig,
+            })
+        ).rejects.toThrow(/run failed/)
+    })
+
+    test('no MCP config means no gateway startup or kill', async () => {
+        mockCreateSandbox()
+
+        const runSpy = vi
+            .spyOn(Commands.prototype, 'run')
+            .mockResolvedValue({
+                exitCode: 0,
+                stdout: '',
+                stderr: '',
+            })
+
+        const killSpy = vi
+            .spyOn(Sandbox.prototype, 'kill')
+            .mockResolvedValue(true)
+
+        const sandbox = await Sandbox.create('base', baseConfig)
+
+        assert.isDefined(sandbox)
+        assert.equal(runSpy.mock.calls.length, 0)
+        assert.equal(killSpy.mock.calls.length, 0)
+    })
+
+    test('MCP token is set on sandbox when MCP is configured', async () => {
+        mockCreateSandbox()
+
+        vi.spyOn(Commands.prototype, 'run').mockResolvedValue({
+            exitCode: 0,
+            stdout: '',
+            stderr: '',
+        })
+
+        vi.spyOn(Sandbox.prototype, 'kill').mockResolvedValue(true)
+
+        const sandbox = await Sandbox.create('mcp-gateway', {
+            mcp: { exa: {} } as any,
+            ...baseConfig,
+        })
+
+        assert.isDefined(sandbox.mcpToken)
+        assert.isString(sandbox.mcpToken)
+    })
+})

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -242,13 +242,20 @@ class AsyncSandbox(SandboxApi):
             token = str(uuid.uuid4())
             sandbox._mcp_token = token
 
-            res = await sandbox.commands.run(
-                f"mcp-gateway --config {shlex.quote(json.dumps(mcp))}",
-                user="root",
-                envs={"GATEWAY_ACCESS_TOKEN": token},
-            )
-            if res.exit_code != 0:
-                raise Exception(f"Failed to start MCP gateway: {res.stderr}")
+            try:
+                res = await sandbox.commands.run(
+                    f"mcp-gateway --config {shlex.quote(json.dumps(mcp))}",
+                    user="root",
+                    envs={"GATEWAY_ACCESS_TOKEN": token},
+                )
+                if res.exit_code != 0:
+                    raise Exception(f"Failed to start MCP gateway: {res.stderr}")
+            except BaseException:
+                try:
+                    await sandbox.kill()
+                except Exception:
+                    pass
+                raise
 
         return sandbox
 

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -228,13 +228,20 @@ class Sandbox(SandboxApi):
             token = str(uuid.uuid4())
             sandbox._mcp_token = token
 
-            res = sandbox.commands.run(
-                f"mcp-gateway --config {shlex.quote(json.dumps(mcp))}",
-                user="root",
-                envs={"GATEWAY_ACCESS_TOKEN": token},
-            )
-            if res.exit_code != 0:
-                raise Exception(f"Failed to start MCP gateway: {res.stderr}")
+            try:
+                res = sandbox.commands.run(
+                    f"mcp-gateway --config {shlex.quote(json.dumps(mcp))}",
+                    user="root",
+                    envs={"GATEWAY_ACCESS_TOKEN": token},
+                )
+                if res.exit_code != 0:
+                    raise Exception(f"Failed to start MCP gateway: {res.stderr}")
+            except BaseException:
+                try:
+                    sandbox.kill()
+                except Exception:
+                    pass
+                raise
 
         return sandbox
 

--- a/packages/python-sdk/tests/test_mcp_gateway_cleanup.py
+++ b/packages/python-sdk/tests/test_mcp_gateway_cleanup.py
@@ -1,0 +1,374 @@
+"""
+Tests for MCP gateway startup failure cleanup.
+
+When the MCP gateway fails to start (non-zero exit code or exception),
+the sandbox should be killed to prevent orphaned resources.
+"""
+
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from e2b.sandbox.commands.command_handle import CommandResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_command_result(exit_code: int, stderr: str = "") -> CommandResult:
+    """Create a minimal CommandResult-like object."""
+    result = types.SimpleNamespace()
+    result.exit_code = exit_code
+    result.stderr = stderr
+    result.stdout = ""
+    result.error = None
+    return result
+
+
+# ===========================================================================
+# AsyncSandbox tests
+# ===========================================================================
+
+
+class TestAsyncSandboxMcpCleanup:
+    """Tests for AsyncSandbox.create MCP gateway cleanup."""
+
+    @pytest.fixture
+    def mock_async_sandbox(self):
+        """Create a mock AsyncSandbox instance with commands.run and kill."""
+        sandbox = AsyncMock()
+        sandbox._mcp_token = None
+        sandbox.commands = AsyncMock()
+        sandbox.kill = AsyncMock(return_value=True)
+        return sandbox
+
+    async def test_mcp_success_no_kill(self, mock_async_sandbox):
+        """When MCP gateway starts successfully, sandbox.kill() should NOT be called."""
+        mock_async_sandbox.commands.run = AsyncMock(
+            return_value=_make_command_result(exit_code=0)
+        )
+
+        with patch(
+            "e2b.sandbox_async.main.AsyncSandbox._create",
+            new_callable=AsyncMock,
+            return_value=mock_async_sandbox,
+        ):
+            from e2b.sandbox_async.main import AsyncSandbox
+
+            sandbox = await AsyncSandbox.create(
+                mcp={"exa": {}},
+                api_key="e2b_" + "0" * 40,
+                debug=True,
+            )
+
+            assert sandbox is mock_async_sandbox
+            mock_async_sandbox.kill.assert_not_called()
+
+    async def test_mcp_nonzero_exit_kills_sandbox(self, mock_async_sandbox):
+        """When MCP gateway exits with non-zero code, sandbox should be killed."""
+        mock_async_sandbox.commands.run = AsyncMock(
+            return_value=_make_command_result(exit_code=1, stderr="gateway error")
+        )
+
+        with patch(
+            "e2b.sandbox_async.main.AsyncSandbox._create",
+            new_callable=AsyncMock,
+            return_value=mock_async_sandbox,
+        ):
+            from e2b.sandbox_async.main import AsyncSandbox
+
+            with pytest.raises(Exception, match="Failed to start MCP gateway"):
+                await AsyncSandbox.create(
+                    mcp={"exa": {}},
+                    api_key="e2b_" + "0" * 40,
+                    debug=True,
+                )
+
+            mock_async_sandbox.kill.assert_awaited_once()
+
+    async def test_mcp_exception_kills_sandbox(self, mock_async_sandbox):
+        """When commands.run raises an exception, sandbox should be killed."""
+        mock_async_sandbox.commands.run = AsyncMock(
+            side_effect=RuntimeError("connection lost")
+        )
+
+        with patch(
+            "e2b.sandbox_async.main.AsyncSandbox._create",
+            new_callable=AsyncMock,
+            return_value=mock_async_sandbox,
+        ):
+            from e2b.sandbox_async.main import AsyncSandbox
+
+            with pytest.raises(RuntimeError, match="connection lost"):
+                await AsyncSandbox.create(
+                    mcp={"exa": {}},
+                    api_key="e2b_" + "0" * 40,
+                    debug=True,
+                )
+
+            mock_async_sandbox.kill.assert_awaited_once()
+
+    async def test_mcp_failure_propagates_original_error(self, mock_async_sandbox):
+        """The original error should be re-raised even if kill also fails."""
+        mock_async_sandbox.commands.run = AsyncMock(
+            return_value=_make_command_result(exit_code=1, stderr="startup failed")
+        )
+        mock_async_sandbox.kill = AsyncMock(
+            side_effect=RuntimeError("kill also failed")
+        )
+
+        with patch(
+            "e2b.sandbox_async.main.AsyncSandbox._create",
+            new_callable=AsyncMock,
+            return_value=mock_async_sandbox,
+        ):
+            from e2b.sandbox_async.main import AsyncSandbox
+
+            with pytest.raises(Exception, match="Failed to start MCP gateway"):
+                await AsyncSandbox.create(
+                    mcp={"exa": {}},
+                    api_key="e2b_" + "0" * 40,
+                    debug=True,
+                )
+
+            # kill was attempted even though it failed
+            mock_async_sandbox.kill.assert_awaited_once()
+
+    async def test_mcp_kill_failure_suppressed(self, mock_async_sandbox):
+        """If kill() raises, the exception should be suppressed (best-effort cleanup)."""
+        mock_async_sandbox.commands.run = AsyncMock(
+            side_effect=RuntimeError("run failed")
+        )
+        mock_async_sandbox.kill = AsyncMock(
+            side_effect=Exception("kill failed too")
+        )
+
+        with patch(
+            "e2b.sandbox_async.main.AsyncSandbox._create",
+            new_callable=AsyncMock,
+            return_value=mock_async_sandbox,
+        ):
+            from e2b.sandbox_async.main import AsyncSandbox
+
+            # Should raise the original error, not the kill error
+            with pytest.raises(RuntimeError, match="run failed"):
+                await AsyncSandbox.create(
+                    mcp={"exa": {}},
+                    api_key="e2b_" + "0" * 40,
+                    debug=True,
+                )
+
+    async def test_no_mcp_no_gateway(self, mock_async_sandbox):
+        """When mcp is None, no gateway startup or kill should happen."""
+        with patch(
+            "e2b.sandbox_async.main.AsyncSandbox._create",
+            new_callable=AsyncMock,
+            return_value=mock_async_sandbox,
+        ):
+            from e2b.sandbox_async.main import AsyncSandbox
+
+            sandbox = await AsyncSandbox.create(
+                api_key="e2b_" + "0" * 40,
+                debug=True,
+            )
+
+            assert sandbox is mock_async_sandbox
+            mock_async_sandbox.commands.run.assert_not_called()
+            mock_async_sandbox.kill.assert_not_called()
+
+    async def test_mcp_token_set_before_run(self, mock_async_sandbox):
+        """The MCP token should be set on the sandbox before commands.run is called."""
+        tokens_seen = []
+
+        async def capture_run(*args, **kwargs):
+            tokens_seen.append(mock_async_sandbox._mcp_token)
+            return _make_command_result(exit_code=0)
+
+        mock_async_sandbox.commands.run = capture_run
+
+        with patch(
+            "e2b.sandbox_async.main.AsyncSandbox._create",
+            new_callable=AsyncMock,
+            return_value=mock_async_sandbox,
+        ):
+            from e2b.sandbox_async.main import AsyncSandbox
+
+            await AsyncSandbox.create(
+                mcp={"exa": {}},
+                api_key="e2b_" + "0" * 40,
+                debug=True,
+            )
+
+            assert len(tokens_seen) == 1
+            assert tokens_seen[0] is not None
+
+
+# ===========================================================================
+# Sandbox (sync) tests
+# ===========================================================================
+
+
+class TestSyncSandboxMcpCleanup:
+    """Tests for Sandbox.create MCP gateway cleanup (sync version)."""
+
+    @pytest.fixture
+    def mock_sync_sandbox(self):
+        """Create a mock Sandbox instance with commands.run and kill."""
+        sandbox = MagicMock()
+        sandbox._mcp_token = None
+        sandbox.commands = MagicMock()
+        sandbox.kill = MagicMock(return_value=True)
+        return sandbox
+
+    def test_mcp_success_no_kill(self, mock_sync_sandbox):
+        """When MCP gateway starts successfully, sandbox.kill() should NOT be called."""
+        mock_sync_sandbox.commands.run = MagicMock(
+            return_value=_make_command_result(exit_code=0)
+        )
+
+        with patch(
+            "e2b.sandbox_sync.main.Sandbox._create",
+            return_value=mock_sync_sandbox,
+        ):
+            from e2b.sandbox_sync.main import Sandbox
+
+            sandbox = Sandbox.create(
+                mcp={"exa": {}},
+                api_key="e2b_" + "0" * 40,
+                debug=True,
+            )
+
+            assert sandbox is mock_sync_sandbox
+            mock_sync_sandbox.kill.assert_not_called()
+
+    def test_mcp_nonzero_exit_kills_sandbox(self, mock_sync_sandbox):
+        """When MCP gateway exits with non-zero code, sandbox should be killed."""
+        mock_sync_sandbox.commands.run = MagicMock(
+            return_value=_make_command_result(exit_code=1, stderr="gateway error")
+        )
+
+        with patch(
+            "e2b.sandbox_sync.main.Sandbox._create",
+            return_value=mock_sync_sandbox,
+        ):
+            from e2b.sandbox_sync.main import Sandbox
+
+            with pytest.raises(Exception, match="Failed to start MCP gateway"):
+                Sandbox.create(
+                    mcp={"exa": {}},
+                    api_key="e2b_" + "0" * 40,
+                    debug=True,
+                )
+
+            mock_sync_sandbox.kill.assert_called_once()
+
+    def test_mcp_exception_kills_sandbox(self, mock_sync_sandbox):
+        """When commands.run raises an exception, sandbox should be killed."""
+        mock_sync_sandbox.commands.run = MagicMock(
+            side_effect=RuntimeError("connection lost")
+        )
+
+        with patch(
+            "e2b.sandbox_sync.main.Sandbox._create",
+            return_value=mock_sync_sandbox,
+        ):
+            from e2b.sandbox_sync.main import Sandbox
+
+            with pytest.raises(RuntimeError, match="connection lost"):
+                Sandbox.create(
+                    mcp={"exa": {}},
+                    api_key="e2b_" + "0" * 40,
+                    debug=True,
+                )
+
+            mock_sync_sandbox.kill.assert_called_once()
+
+    def test_mcp_failure_propagates_original_error(self, mock_sync_sandbox):
+        """The original error should be re-raised even if kill also fails."""
+        mock_sync_sandbox.commands.run = MagicMock(
+            return_value=_make_command_result(exit_code=1, stderr="startup failed")
+        )
+        mock_sync_sandbox.kill = MagicMock(
+            side_effect=RuntimeError("kill also failed")
+        )
+
+        with patch(
+            "e2b.sandbox_sync.main.Sandbox._create",
+            return_value=mock_sync_sandbox,
+        ):
+            from e2b.sandbox_sync.main import Sandbox
+
+            with pytest.raises(Exception, match="Failed to start MCP gateway"):
+                Sandbox.create(
+                    mcp={"exa": {}},
+                    api_key="e2b_" + "0" * 40,
+                    debug=True,
+                )
+
+            mock_sync_sandbox.kill.assert_called_once()
+
+    def test_mcp_kill_failure_suppressed(self, mock_sync_sandbox):
+        """If kill() raises, the exception should be suppressed (best-effort cleanup)."""
+        mock_sync_sandbox.commands.run = MagicMock(
+            side_effect=RuntimeError("run failed")
+        )
+        mock_sync_sandbox.kill = MagicMock(
+            side_effect=Exception("kill failed too")
+        )
+
+        with patch(
+            "e2b.sandbox_sync.main.Sandbox._create",
+            return_value=mock_sync_sandbox,
+        ):
+            from e2b.sandbox_sync.main import Sandbox
+
+            with pytest.raises(RuntimeError, match="run failed"):
+                Sandbox.create(
+                    mcp={"exa": {}},
+                    api_key="e2b_" + "0" * 40,
+                    debug=True,
+                )
+
+    def test_no_mcp_no_gateway(self, mock_sync_sandbox):
+        """When mcp is None, no gateway startup or kill should happen."""
+        with patch(
+            "e2b.sandbox_sync.main.Sandbox._create",
+            return_value=mock_sync_sandbox,
+        ):
+            from e2b.sandbox_sync.main import Sandbox
+
+            sandbox = Sandbox.create(
+                api_key="e2b_" + "0" * 40,
+                debug=True,
+            )
+
+            assert sandbox is mock_sync_sandbox
+            mock_sync_sandbox.commands.run.assert_not_called()
+            mock_sync_sandbox.kill.assert_not_called()
+
+    def test_mcp_token_set_before_run(self, mock_sync_sandbox):
+        """The MCP token should be set on the sandbox before commands.run is called."""
+        tokens_seen = []
+
+        def capture_run(*args, **kwargs):
+            tokens_seen.append(mock_sync_sandbox._mcp_token)
+            return _make_command_result(exit_code=0)
+
+        mock_sync_sandbox.commands.run = capture_run
+
+        with patch(
+            "e2b.sandbox_sync.main.Sandbox._create",
+            return_value=mock_sync_sandbox,
+        ):
+            from e2b.sandbox_sync.main import Sandbox
+
+            Sandbox.create(
+                mcp={"exa": {}},
+                api_key="e2b_" + "0" * 40,
+                debug=True,
+            )
+
+            assert len(tokens_seen) == 1
+            assert tokens_seen[0] is not None


### PR DESCRIPTION
fix https://github.com/e2b-dev/E2B/issues/1498

#### Problem
When Sandbox.create() is called with an mcp configuration, the sandbox is created first, then the MCP gateway is started inside it. If the gateway startup fails (non-zero exit code or exception), the error is raised but the sandbox is never cleaned up, leaving an orphaned sandbox running and consuming resources until it times out.
This issue impacts all three SDK implementations:
Python async: AsyncSandbox.create
Python sync: Sandbox.create
JS/TS: Sandbox.create
#### Fix
Wrap MCP gateway startup logic with try/catch:
On any gateway startup failure, run best-effort sandbox.kill() before re-raising the original error.
Catch errors from kill() separately to guarantee the original failure error is always propagated to the caller.
#### Code Changes
main.py: Add async cleanup with await sandbox.kill()
main.py: Add sync cleanup with sandbox.kill()
index.ts: Add cleanup logic await sandbox.kill().catch(() => {})
test_mcp_gateway_cleanup.py: 14 unit tests (Python async + sync)
mcpGatewayCleanup.test.ts: 7 unit tests (TS)
#### Test Coverage
Total 21 new unit tests, all scenarios verified:
<img width="1031" height="813" alt="image" src="https://github.com/user-attachments/assets/9a70809c-b900-420a-b2f8-6e071a617ca1" />
