### PR TITLE
fix(python-sdk): correct Sandbox.list() docstring (also lists paused)

### DIFF
--- a/.changeset/sandbox-list-docstring.md
+++ b/.changeset/sandbox-list-docstring.md
@@ -1,0 +1,6 @@
+---
+"@e2b/python-sdk": patch
+"e2b": patch
+---
+
+Correct `Sandbox.list()` documentation across both SDKs: it returns a paginator (`SandboxPaginator` / `AsyncSandboxPaginator`), not a list, and by default the server returns sandboxes in both `running` and `paused` states. The docstrings now describe the return type accurately and show how to iterate pages via `paginator.next_items()` / `await paginator.nextItems()` while `paginator.has_next` / `paginator.hasNext` is true. No behavior change.

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -227,11 +227,18 @@ export class Sandbox extends SandboxApi {
   }
 
   /**
-   * List all sandboxes.
+   * List sandboxes.
    *
-   * @param opts connection options.
+   * By default (no `query.state` set in `opts`), returns sandboxes in both
+   * `running` and `paused` states. To filter by state, pass
+   * `opts.query.state = [...]`.
    *
-   * @returns paginator for listing sandboxes.
+   * @param opts connection options, plus optional `query` to filter by
+   *   metadata / state and `limit` / `nextToken` for pagination.
+   *
+   * @returns a {@link SandboxPaginator} that yields pages of sandboxes
+   *   (running and paused by default). Iterate pages via
+   *   `await paginator.nextItems()` while `paginator.hasNext` is `true`.
    */
   static list(opts?: SandboxListOpts): SandboxPaginator {
     return new SandboxPaginator(opts)

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -63,13 +63,16 @@ class SandboxApi(SandboxBase):
         **opts: Unpack[ApiParams],
     ) -> AsyncSandboxPaginator:
         """
-        List all running sandboxes.
+        List sandboxes.
+
+        By default (no `query.state` set), returns sandboxes in both `running`
+        and `paused` states. To filter by state, pass `query=SandboxQuery(state=[...])`.
 
         :param query: Filter the list of sandboxes by metadata or state, e.g. `SandboxListQuery(metadata={"key": "value"})` or `SandboxListQuery(state=[SandboxState.RUNNING])`
         :param limit: Maximum number of sandboxes to return per page
         :param next_token: Token for pagination
 
-        :return: List of running sandboxes
+        :return: An `AsyncSandboxPaginator` that yields pages of sandboxes (running and paused by default). Iterate pages via `await paginator.next_items()` while `paginator.has_next` is True.
         """
         return AsyncSandboxPaginator(
             query=query,

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -62,13 +62,16 @@ class SandboxApi(SandboxBase):
         **opts: Unpack[ApiParams],
     ) -> SandboxPaginator:
         """
-        List all running sandboxes.
+        List sandboxes.
+
+        By default (no `query.state` set), returns sandboxes in both `running`
+        and `paused` states. To filter by state, pass `query=SandboxQuery(state=[...])`.
 
         :param query: Filter the list of sandboxes by metadata or state, e.g. `SandboxListQuery(metadata={"key": "value"})` or `SandboxListQuery(state=[SandboxState.RUNNING])`
         :param limit: Maximum number of sandboxes to return per page
         :param next_token: Token for pagination
 
-        :return: List of running sandboxes
+        :return: A `SandboxPaginator` that yields pages of sandboxes (running and paused by default). Iterate pages via `paginator.next_items()` while `paginator.has_next` is True.
         """
         return SandboxPaginator(
             query=query,


### PR DESCRIPTION
Sandbox.list() currently documents itself as "List all running sandboxes", but the server (api/internal/handlers/sandboxes_list.go) defaults to returning both `running` and `paused` sandboxes when no state filter is provided:

    // If no state is provided we want to return both running and paused sandboxes
    states := make([]api.SandboxState, 0)
    if params.State == nil {
        states = append(states, api.Running, api.Paused)
    } else {
        states = append(states, *params.State...)
    }

The docstring change brings the SDK documentation in line with the actual backend behavior, and points users at SandboxQuery(state=[...]) for narrowing the result set. Applied to both sync and async variants for consistency.

No behavior change.