### PR TITLE
fix(python-sdk): percent-encode git credentials in clone URL

### DIFF
--- a/.changeset/git-credentials-url-encode.md
+++ b/.changeset/git-credentials-url-encode.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Percent-encode the username and password when embedding HTTP(S) Git credentials into a clone URL. Previously they were inserted raw, so a username or token containing URL-significant characters (`@`, `/`, `:`, spaces, etc.) produced a malformed URL that git could not use. This now matches the JS SDK, which already encodes the credentials.

--- a/packages/python-sdk/e2b/sandbox/_git/auth.py
+++ b/packages/python-sdk/e2b/sandbox/_git/auth.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.commands.command_handle import CommandExitException
@@ -27,7 +27,10 @@ def with_credentials(url: str, username: Optional[str], password: Optional[str])
             "Only http(s) Git URLs support username/password credentials."
         )
 
-    netloc = f"{username}:{password}@{parsed.netloc}"
+    # Percent-encode credentials so URL-significant characters (e.g. "@", "/",
+    # ":") in a username/token don't corrupt the URL. Matches the JS SDK, which
+    # encodes via the URL username/password setters.
+    netloc = f"{quote(username, safe='')}:{quote(password, safe='')}@{parsed.netloc}"
     return urlunparse(parsed._replace(netloc=netloc))
 
 

--- a/packages/python-sdk/tests/shared/git/test_auth.py
+++ b/packages/python-sdk/tests/shared/git/test_auth.py
@@ -1,0 +1,26 @@
+from e2b.sandbox._git.auth import strip_credentials, with_credentials
+
+
+def test_with_credentials_percent_encodes_special_characters():
+    # URL-significant characters in the username/token must be percent-encoded
+    # so they don't corrupt the URL (git would otherwise mis-parse the host).
+    assert (
+        with_credentials("https://github.com/o/r.git", "user", "p@ss")
+        == "https://user:p%40ss@github.com/o/r.git"
+    )
+    assert (
+        with_credentials("https://github.com/o/r.git", "us er", "a/b:c")
+        == "https://us%20er:a%2Fb%3Ac@github.com/o/r.git"
+    )
+
+
+def test_with_credentials_round_trips_through_strip():
+    url = with_credentials("https://github.com/o/r.git", "user", "p@ss")
+    assert strip_credentials(url) == "https://github.com/o/r.git"
+
+
+def test_with_credentials_without_credentials_returns_url_unchanged():
+    assert (
+        with_credentials("https://github.com/o/r.git", None, None)
+        == "https://github.com/o/r.git"
+    )


### PR DESCRIPTION
## Problem

`with_credentials` (`packages/python-sdk/e2b/sandbox/_git/auth.py`) embeds the username and password into the Git URL **raw**:

```python
netloc = f"{username}:{password}@{parsed.netloc}"
```

When the username/token contains URL-significant characters (`@`, `/`, `:`, space, …) the URL is malformed. A password `p@ss` produces `https://user:p@ss@github.com/org/repo.git`, which git parses with host `ss@github.com` and rejects:

```
fatal: unable to access '.../': URL rejected: Bad hostname
```

The JS SDK builds the URL via the `URL` username/password setters, which **do** percent-encode — so the two SDKs disagree and the Python one breaks on real-world tokens.

## Reproduction

`with_credentials("https://github.com/o/r.git", "user", "p@ss")` → `https://user:p@ss@github.com/o/r.git` (before) vs `https://user:p%40ss@github.com/o/r.git` (after, matching JS).

Reachable via `Sandbox.git.clone(url, username=..., password=...)` and `git.dangerously_authenticate(...)`.

## Fix

Percent-encode both credentials with `urllib.parse.quote(..., safe='')`. `strip_credentials` still round-trips the encoded URL back to the clean one.

## Tests

Adds `packages/python-sdk/tests/shared/git/test_auth.py` (encoding of special chars, strip round-trip, no-credentials passthrough). Changeset included.