### PR TITLE
fix(cli): use absolute import in generated Python build scripts

### DIFF
--- a/.changeset/migrate-python-build-import.md
+++ b/.changeset/migrate-python-build-import.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Fix `e2b template migrate` generating Python build scripts that fail to run as instructed. The generated `build_dev.py` / `build_prod.py` used a package-relative import (`from .template import template`) while the command instructs single-file execution (`python build_dev.py`), causing `ImportError: attempted relative import with no known parent package`. The scripts now use a runnable absolute import (`from template import template`).

--- a/packages/cli/src/templates/python-build-async.hbs
+++ b/packages/cli/src/templates/python-build-async.hbs
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/src/templates/python-build-sync.hbs
+++ b/packages/cli/src/templates/python-build-sync.hbs
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/complex-python/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/copy-variations/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/custom-commands/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/minimal-dockerfile/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/multi-stage/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/multiple-env/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-async/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-async/build_dev.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-async/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-async/build_prod.py
@@ -1,6 +1,6 @@
 import asyncio
 from e2b import AsyncTemplate, default_build_logger
-from .template import template
+from template import template
 
 
 async def main():

--- a/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-sync/build_dev.py
+++ b/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-sync/build_dev.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-sync/build_prod.py
+++ b/packages/cli/tests/commands/template/fixtures/start-cmd/expected/python-sync/build_prod.py
@@ -1,5 +1,5 @@
 from e2b import Template, default_build_logger
-from .template import template
+from template import template
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/commands/template/migrate.test.ts
+++ b/packages/cli/tests/commands/template/migrate.test.ts
@@ -125,6 +125,15 @@ describe('Template Migration', () => {
         'utf-8'
       )
       expect(buildProdFile.trim()).toEqual(expectedBuildProd.trim())
+      if (
+        language === Language.PythonSync ||
+        language === Language.PythonAsync
+      ) {
+        for (const content of [buildDevFile, buildProdFile]) {
+          expect(content).toContain('from template import template')
+          expect(content).not.toContain('from .template import template')
+        }
+      }
 
       // Check that old files are renamed to .old extensions
       const oldDockerfilePath = path.join(testDir, 'e2b.Dockerfile.old')


### PR DESCRIPTION
Fixes the generated Python build scripts to use an absolute import (from template import template) instead of a relative one, which broke python build_dev.py with ImportError: attempted relative import with no known parent package since the files are emitted as flat siblings with no package. This reverts an unintended change from #954 that was flagged by Cursor Bugbot at the time but not addressed. Fixes #1477.