### PR TITLE
feat(js-sdk): expose E2B_ENVD_CONNECTIONS env var for file REST API connection limit

### DIFF
--- a/.changeset/envd-connection-limit-env-var.md
+++ b/.changeset/envd-connection-limit-env-var.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Expose `E2B_ENVD_CONNECTIONS` environment variable to configure the envd REST file API connection pool limit (default remains 10). Previously the connection count was hardcoded with no runtime override, unlike the RPC transport which already supported `E2B_ENVD_RPC_CONNECTIONS`.

--- a/packages/js-sdk/src/envd/http2.ts
+++ b/packages/js-sdk/src/envd/http2.ts
@@ -90,9 +90,8 @@ export function createEnvdFetch(proxy?: string): typeof fetch {
     return cached
   }
 
-  // Keep one origin connection for short envd REST calls. If ALPN falls back
-  // to h1, this favors connection pressure over per-sandbox throughput.
   const envdFetch = createEnvdFetchForRuntime(runtime, {
+    connectionLimit: getEnvdConnectionLimit(),
     inflightLimit: getEnvdInflightLimit(),
     proxy,
   })
@@ -117,6 +116,13 @@ export function createEnvdRpcFetch(proxy?: string): typeof fetch {
   envdRpcFetchers.set(key, envdRpcFetch)
 
   return envdRpcFetch
+}
+
+export function getEnvdConnectionLimit(): number {
+  return parsePositiveIntEnv(
+    'E2B_ENVD_CONNECTIONS',
+    DEFAULT_ENVD_CONNECTION_LIMIT
+  )
 }
 
 export function getEnvdRpcConnectionLimit(): number {

--- a/packages/js-sdk/tests/envd/http2.test.ts
+++ b/packages/js-sdk/tests/envd/http2.test.ts
@@ -5,6 +5,7 @@ afterEach(() => {
   vi.resetModules()
   vi.doUnmock('undici')
   vi.doUnmock('../../src/utils')
+  delete process.env.E2B_ENVD_CONNECTIONS
   delete process.env.E2B_ENVD_RPC_CONNECTIONS
   delete process.env.E2B_ENVD_INFLIGHT_REQUESTS
   delete process.env.E2B_ENVD_RPC_INFLIGHT_REQUESTS
@@ -156,6 +157,22 @@ test('can create a bounded dispatcher for RPC streams', async () => {
   await fetcher('https://example.com/rpc')
 
   expect(agents).toEqual([{ allowH2: true, connections: 100 }])
+})
+
+test('reads envd connection limit from env', async () => {
+  process.env.E2B_ENVD_CONNECTIONS = '50'
+
+  const { getEnvdConnectionLimit } = await import('../../src/envd/http2')
+
+  expect(getEnvdConnectionLimit()).toBe(50)
+})
+
+test('getEnvdConnectionLimit throws on malformed env value', async () => {
+  process.env.E2B_ENVD_CONNECTIONS = 'bogus'
+
+  const { getEnvdConnectionLimit } = await import('../../src/envd/http2')
+
+  expect(() => getEnvdConnectionLimit()).toThrow(/E2B_ENVD_CONNECTIONS/)
 })
 
 test('reads RPC stream dispatcher connection limit from env', async () => {


### PR DESCRIPTION
The envd REST file API (files.read/files.write) had its undici connection\npool hardcoded to 10 connections with no way to override it, while the\nRPC transport (commands) allowed 200 connections configurable via\nE2B_ENVD_RPC_CONNECTIONS. Under high concurrency this 20x gap caused\nsocket write contention and crashes on the file API path.\n\n- Add getEnvdConnectionLimit() reading E2B_ENVD_CONNECTIONS (default 10)\n- Pass connectionLimit into createEnvdFetch() instead of relying on the\n  hardcoded fallback\n- Add tests for the new env var (valid + malformed values)"

/cc @mishushakov please review.