### PR TITLE
fix(python-sdk): percent-encode git credentials in with_credentials

### DIFF
--- a/.changeset/python-git-credentials-encode.md
+++ b/.changeset/python-git-credentials-encode.md
@@ -1,0 +1,12 @@
+---
+"@e2b/python-sdk": patch
+---
+
+fix(python-sdk): percent-encode git credentials so reserved characters are preserved
+
+`Sandbox.git.clone`/`push` embed credentials into HTTP(S) URLs with
+`with_credentials`, which previously interpolated the username and password
+straight into the URL. A username or token containing URL-reserved characters
+(`@ : / # ?`) produced a corrupted URL and broke git auth. The credentials are
+now percent-encoded, matching the JavaScript SDK, which already encodes via the
+WHATWG `URL` setters. Alphanumeric tokens are unaffected.

--- a/packages/js-sdk/tests/sandbox/git/validation.test.ts
+++ b/packages/js-sdk/tests/sandbox/git/validation.test.ts
@@ -3,6 +3,7 @@ import { test, expect } from 'vitest'
 import { Git } from '../../../src/sandbox/git'
 import type { Commands } from '../../../src/sandbox/commands'
 import { InvalidArgumentError } from '../../../src/errors'
+import { withCredentials } from '../../../src/sandbox/git/utils'
 
 // Stub command runner that fails if a git command is actually executed —
 // validation must throw before reaching it.
@@ -41,4 +42,19 @@ test('git.remoteAdd throws InvalidArgumentError when name or url is missing', as
 test('git.remoteGet throws InvalidArgumentError when name is missing', async () => {
   const git = new Git(failingCommands)
   await expect(git.remoteGet('/repo', '')).rejects.toThrow(InvalidArgumentError)
+})
+
+test('withCredentials percent-encodes reserved characters', () => {
+  expect(
+    withCredentials('https://github.com/o/r.git', 'user', 'p@ss/w:rd')
+  ).toBe('https://user:p%40ss%2Fw%3Ard@github.com/o/r.git')
+  expect(withCredentials('https://github.com/o/r.git', 'user', 'x#y?z')).toBe(
+    'https://user:x%23y%3Fz@github.com/o/r.git'
+  )
+  expect(withCredentials('https://github.com/o/r.git', 'git', 't/k@n')).toBe(
+    'https://git:t%2Fk%40n@github.com/o/r.git'
+  )
+  expect(
+    withCredentials('https://github.com/o/r.git', 'user', 'ghp_AbC123')
+  ).toBe('https://user:ghp_AbC123@github.com/o/r.git')
 })

--- a/packages/python-sdk/e2b/sandbox/_git/auth.py
+++ b/packages/python-sdk/e2b/sandbox/_git/auth.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.commands.command_handle import CommandExitException
@@ -27,7 +27,7 @@ def with_credentials(url: str, username: Optional[str], password: Optional[str])
             "Only http(s) Git URLs support username/password credentials."
         )
 
-    netloc = f"{username}:{password}@{parsed.netloc}"
+    netloc = f"{quote(username, safe='')}:{quote(password, safe='')}@{parsed.netloc}"
     return urlunparse(parsed._replace(netloc=netloc))
 
 

--- a/packages/python-sdk/tests/shared/git/test_auth.py
+++ b/packages/python-sdk/tests/shared/git/test_auth.py
@@ -1,0 +1,46 @@
+import pytest
+
+from e2b.exceptions import InvalidArgumentException
+from e2b.sandbox._git import with_credentials
+
+
+def test_with_credentials_percent_encodes_reserved_characters():
+    # Reserved characters in user/password must be percent-encoded so the
+    # credential URL stays well-formed (parity with the JS SDK's WHATWG URL).
+    assert (
+        with_credentials("https://github.com/o/r.git", "user", "p@ss/w:rd")
+        == "https://user:p%40ss%2Fw%3Ard@github.com/o/r.git"
+    )
+    assert (
+        with_credentials("https://github.com/o/r.git", "user", "x#y?z")
+        == "https://user:x%23y%3Fz@github.com/o/r.git"
+    )
+    assert (
+        with_credentials("https://github.com/o/r.git", "git", "t/k@n")
+        == "https://git:t%2Fk%40n@github.com/o/r.git"
+    )
+
+
+def test_with_credentials_keeps_alphanumeric_token_unchanged():
+    assert (
+        with_credentials("https://github.com/o/r.git", "user", "ghp_AbC123")
+        == "https://user:ghp_AbC123@github.com/o/r.git"
+    )
+
+
+def test_with_credentials_without_credentials_passes_url_through():
+    assert with_credentials("https://github.com/o/r.git", None, None) == (
+        "https://github.com/o/r.git"
+    )
+
+
+def test_with_credentials_requires_both_parts():
+    with pytest.raises(InvalidArgumentException):
+        with_credentials("https://github.com/o/r.git", "user", None)
+    with pytest.raises(InvalidArgumentException):
+        with_credentials("https://github.com/o/r.git", None, "token")
+
+
+def test_with_credentials_rejects_non_http_urls():
+    with pytest.raises(InvalidArgumentException):
+        with_credentials("ssh://git@github.com/o/r.git", "user", "token")


### PR DESCRIPTION

### What

`Sandbox.git.clone` and `Sandbox.git.pull` embed HTTP(S) credentials by passing them
through `with_credentials` (`packages/python-sdk/e2b/sandbox/_git/auth.py`), which built
the URL netloc by raw string interpolation:

```python
netloc = f"{username}:{password}@{parsed.netloc}"
```

A username, password, or token that contains URL-reserved characters (`@ : / # ?`) is
spliced straight into the netloc, so the resulting URL is corrupted and git auth fails.
Common GitHub PATs are alphanumeric and unaffected, but GitLab/Bitbucket app passwords
and many tokens do contain reserved characters.

The JavaScript SDK does not have this problem: `withCredentials`
(`packages/js-sdk/src/sandbox/git/utils.ts`) assigns `parsed.username` / `parsed.password`
through the WHATWG `URL` setters, which percent-encode automatically. So the two SDKs
disagree on identical input.

| password     | Python (before)                 | JS / Python (after)                   |
|--------------|---------------------------------|---------------------------------------|
| `p@ss/w:rd`  | `user:p@ss/w:rd@github.com/...` | `user:p%40ss%2Fw%3Ard@github.com/...` |
| `x#y?z`      | `user:x#y?z@github.com/...`     | `user:x%23y%3Fz@github.com/...`       |
| `ghp_AbC123` | `user:ghp_AbC123@...` (ok)      | `user:ghp_AbC123@...` (unchanged)     |

### Fix

Percent-encode both parts with `quote(safe='')` before building the netloc, matching the
JS SDK byte-for-byte. Alphanumeric tokens are unchanged.

```python
netloc = f"{quote(username, safe='')}:{quote(password, safe='')}@{parsed.netloc}"
```

This is the only behavior change. Sync and async share this single helper, so both clone
and pull are fixed by the one-line edit.

### Usage example (now works)

```python
from e2b import Sandbox

sbx = Sandbox()
# token with reserved characters no longer corrupts the URL
sbx.git.clone(
    "https://github.com/org/private.git",
    username="user",
    password="p@ss/w:rd",
)
```

### Tests

- `packages/python-sdk/tests/shared/git/test_auth.py` (new, 5 offline cases): reserved
  chars encode, alnum token unchanged, no-cred passthrough, partial creds raise,
  non-http(s) raises. Runs without a sandbox (imports `e2b.sandbox._git`).
- `packages/js-sdk/tests/sandbox/git/validation.test.ts` (+1 case): locks the JS encoded
  output so the two SDKs stay in parity.

Changeset: `@e2b/python-sdk` patch.
