### PR TITLE
chore(cli): remove unused dockerfile-ast dependency

### DIFF
--- a/.changeset/remove-unused-dockerfile-ast.md
+++ b/.changeset/remove-unused-dockerfile-ast.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Remove the unused `dockerfile-ast` dependency from the CLI. The CLI never imported it directly — all Dockerfile parsing goes through the `e2b` SDK, which keeps its own `dockerfile-ast` dependency. No behavior change.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -80,7 +80,6 @@
     "cli-highlight": "^2.1.11",
     "commander": "^11.1.0",
     "console-table-printer": "^2.11.2",
-    "dockerfile-ast": "^0.6.1",
     "e2b": "^2.30.6",
     "handlebars": "^4.7.9",
     "inquirer": "^12.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       console-table-printer:
         specifier: ^2.11.2
         version: 2.11.2
-      dockerfile-ast:
-        specifier: ^0.6.1
-        version: 0.6.1
       e2b:
         specifier: ^2.30.6
         version: 2.30.6
@@ -1773,9 +1770,6 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
-
-  dockerfile-ast@0.6.1:
-    resolution: {integrity: sha512-m3rH2qHHU2pSTCppXgJT+1KLxhvkdROOxVPof5Yz4IPGSw6K+x0B0/RFdYgXN5zsIUTlbOSRyfDCv3/uVhnNmg==}
 
   dockerfile-ast@0.7.1:
     resolution: {integrity: sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==}
@@ -5222,11 +5216,6 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
-
-  dockerfile-ast@0.6.1:
-    dependencies:
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-languageserver-types: 3.17.5
 
   dockerfile-ast@0.7.1:
     dependencies:


### PR DESCRIPTION
The CLI declared `dockerfile-ast` as a dependency but never imported it — all Dockerfile parsing in the CLI goes through the `e2b` SDK, which keeps its own (newer) `dockerfile-ast` dependency. This drops the redundant copy from `packages/cli/package.json`, removing `dockerfile-ast@0.6.1` and its sub-deps from the lockfile while `dockerfile-ast@0.7.1` (used by the js-sdk) stays. No behavior change; CLI typecheck and lint pass, and a `@e2b/cli` patch changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)