### PR TITLE
fix(cli): correct memory-mb help default and use non-deprecated pause

### DIFF
--- a/.changeset/cli-pause-and-memory-help.md
+++ b/.changeset/cli-pause-and-memory-help.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Fix `e2b template create --memory-mb` help text to reflect the real default of 1024 MB (was incorrectly stated as 512), and switch `e2b sandbox pause` to call the non-deprecated `Sandbox.pause()` instead of the deprecated `Sandbox.betaPause()` alias.

--- a/packages/cli/src/commands/sandbox/pause.ts
+++ b/packages/cli/src/commands/sandbox/pause.ts
@@ -7,7 +7,7 @@ import { NotFoundError } from 'e2b'
 
 async function pauseSandbox(sandboxID: string, apiKey: string) {
   try {
-    const paused = await e2b.Sandbox.betaPause(sandboxID, { apiKey })
+    const paused = await e2b.Sandbox.pause(sandboxID, { apiKey })
     if (paused) {
       console.log(`Sandbox ${asBold(sandboxID)} has been paused`)
     } else {

--- a/packages/cli/src/commands/template/create.ts
+++ b/packages/cli/src/commands/template/create.ts
@@ -50,7 +50,7 @@ export const createCommand = new commander.Command('create')
   )
   .option(
     '--memory-mb <memory-mb>',
-    'specify the amount of memory in megabytes that will be used to run the sandbox. Must be an even number. The default value is 512.',
+    'specify the amount of memory in megabytes that will be used to run the sandbox. Must be an even number. The default value is 1024.',
     parsePositiveInt('Memory in megabytes')
   )
   .option('--no-cache', 'skip cache when building the template.')


### PR DESCRIPTION
Fixes two small CLI issues. The `e2b template create --memory-mb` help text claimed a default of 512 MB, but the real default is 1024 MB — the help now reflects that. The `e2b sandbox pause` command was calling the deprecated `Sandbox.betaPause()` alias and now calls `Sandbox.pause()` directly.

## Usage

```sh
e2b template create --help   # --memory-mb now shows "The default value is 1024."
e2b sandbox pause <sandboxID>  # behaves the same, no longer uses the deprecated method
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)