### PR TITLE
chore(js-sdk,cli): modernize tsconfig and bump TypeScript to 6.0

### DIFF
--- a/.changeset/modernize-sdk-tsconfig.md
+++ b/.changeset/modernize-sdk-tsconfig.md
@@ -1,0 +1,6 @@
+---
+"@e2b/cli": patch
+"e2b": patch
+---
+
+Modernize the TypeScript compiler configuration for the JS SDK and CLI. Bump TypeScript to `^6.0.3`, raise the `js-sdk` compile target/lib to `es2022` (the CLI was already there), switch `moduleResolution` to `bundler` (the bundler owns emit; `tsc` is type-check only), and drop redundant options that are implied by `strict`/`esModuleInterop` or deprecated in TS 6.0. This is an internal build-config change with no public API or runtime behavior changes.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "json2md": "^2.0.1",
     "knip": "^5.43.6",
     "tsup": "^8.4.0",
-    "typescript": "^5.4.5",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   },
   "files": [

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -6,25 +6,18 @@
     "allowJs": true,
     "declaration": true,
     "declarationMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "sourceMap": true,
     "strict": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
     "esModuleInterop": true,
     "preserveSymlinks": true,
-    "downlevelIteration": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
-    "outDir": "dist",
-    "baseUrl": ".",
     "rootDirs": ["src"],
     "paths": {
+      "src": ["./src/index.ts"],
+      "src/*": ["./src/*"],
       "e2b": ["../js-sdk/src"]
     }
   }

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -61,7 +61,7 @@
     "playwright": "^1.55.1",
     "react": "^18.3.1",
     "tsup": "^8.4.0",
-    "typescript": "^5.4.5",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8",
     "vitest-browser-react": "^2.2.0"
   },

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -1,23 +1,25 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "target": "es6",
+    "target": "es2022",
+    "module": "esnext",
     "lib": [
       "dom",
-      "ESNext"
+      "es2022"
     ],
     "sourceMap": true,
-    "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "declaration": true,
+    // tsup's d.ts builder always injects `baseUrl` (deprecated in TS 6.0). This
+    // silences that deprecation; remove once we migrate off tsup (tsdown).
+    "ignoreDeprecations": "6.0",
   },
   "include": [
     "src"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,16 +113,16 @@ importers:
         version: 2.0.1
       knip:
         specifier: ^5.43.6
-        version: 5.43.6(@types/node@20.19.19)(typescript@5.5.3)
+        version: 5.43.6(@types/node@20.19.19)(typescript@6.0.3)
       tsup:
         specifier: ^8.4.0
-        version: 8.4.0(jiti@2.4.2)(postcss@8.5.15)(typescript@5.5.3)
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.15)(typescript@6.0.3)
       typescript:
-        specifier: ^5.4.5
-        version: 5.5.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
+        version: 4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
 
   packages/js-sdk:
     dependencies:
@@ -177,10 +177,10 @@ importers:
         version: 4.3.4(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
       '@vitest/browser':
         specifier: ^4.1.0
-        version: 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
+        version: 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
       '@vitest/browser-playwright':
         specifier: ^4.1.0
-        version: 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
+        version: 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -189,16 +189,16 @@ importers:
         version: 15.0.4
       knip:
         specifier: ^5.43.6
-        version: 5.43.6(@types/node@20.19.19)(typescript@5.5.3)
+        version: 5.43.6(@types/node@20.19.19)(typescript@6.0.3)
       msw:
         specifier: ^2.12.10
-        version: 2.12.14(@types/node@20.19.19)(typescript@5.5.3)
+        version: 2.12.14(@types/node@20.19.19)(typescript@6.0.3)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
       openapi-typescript:
         specifier: ^7.9.1
-        version: 7.9.1(typescript@5.5.3)
+        version: 7.9.1(typescript@6.0.3)
       playwright:
         specifier: ^1.55.1
         version: 1.55.1
@@ -207,13 +207,13 @@ importers:
         version: 18.3.1
       tsup:
         specifier: ^8.4.0
-        version: 8.4.0(jiti@2.4.2)(postcss@8.5.15)(typescript@5.5.3)
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.15)(typescript@6.0.3)
       typescript:
-        specifier: ^5.4.5
-        version: 5.5.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
+        version: 4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.2.0(react@18.3.1))(react@18.3.1)(vitest@4.1.8)
@@ -3112,8 +3112,8 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.5.3:
-    resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4309,29 +4309,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser-playwright@4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)':
+  '@vitest/browser-playwright@4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)':
     dependencies:
-      '@vitest/browser': 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
-      '@vitest/mocker': 4.1.8(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
+      '@vitest/browser': 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
       playwright: 1.55.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
+      vitest: 4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)':
+  '@vitest/browser@4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.8(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
+      '@vitest/mocker': 4.1.8(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
       '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
+      vitest: 4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
       ws: 8.21.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - bufferutil
@@ -4351,9 +4351,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
+      vitest: 4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
+      '@vitest/browser': 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -4364,13 +4364,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))':
+  '@vitest/mocker@4.1.8(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.14(@types/node@20.19.19)(typescript@5.5.3)
+      msw: 2.12.14(@types/node@20.19.19)(typescript@6.0.3)
       vite: 6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)
 
   '@vitest/pretty-format@4.1.8':
@@ -5367,7 +5367,7 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  knip@5.43.6(@types/node@20.19.19)(typescript@5.5.3):
+  knip@5.43.6(@types/node@20.19.19)(typescript@6.0.3):
     dependencies:
       '@nodelib/fs.walk': 3.0.1
       '@snyk/github-codeowners': 1.1.0
@@ -5384,7 +5384,7 @@ snapshots:
       smol-toml: 1.6.1
       strip-json-comments: 5.0.1
       summary: 2.1.0
-      typescript: 5.5.3
+      typescript: 6.0.3
       zod: 3.22.4
       zod-validation-error: 3.4.0(zod@3.22.4)
 
@@ -5478,7 +5478,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3):
+  msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 5.1.19(@types/node@20.19.19)
       '@mswjs/interceptors': 0.41.3
@@ -5499,7 +5499,7 @@ snapshots:
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.5.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -5590,14 +5590,14 @@ snapshots:
 
   openapi-typescript-helpers@0.0.15: {}
 
-  openapi-typescript@7.9.1(typescript@5.5.3):
+  openapi-typescript@7.9.1(typescript@6.0.3):
     dependencies:
       '@redocly/openapi-core': 1.34.5(supports-color@10.2.2)
       ansi-colors: 4.1.3
       change-case: 5.4.4
       parse-json: 8.3.0
       supports-color: 10.2.2
-      typescript: 5.5.3
+      typescript: 6.0.3
       yargs-parser: 21.1.1
 
   outvariant@1.4.3: {}
@@ -6240,7 +6240,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.4.0(jiti@2.4.2)(postcss@8.5.15)(typescript@5.5.3):
+  tsup@8.4.0(jiti@2.4.2)(postcss@8.5.15)(typescript@6.0.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.12)
       cac: 6.7.14
@@ -6260,7 +6260,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.15
-      typescript: 5.5.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -6308,7 +6308,7 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript@5.5.3: {}
+  typescript@6.0.3: {}
 
   udc@1.0.1: {}
 
@@ -6372,15 +6372,15 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 18.2.0(react@18.3.1)
-      vitest: 4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
+      vitest: 4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
     optionalDependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
-  vitest@4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)):
+  vitest@4.1.8(@types/node@20.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
+      '@vitest/mocker': 4.1.8(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -6401,7 +6401,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.19
-      '@vitest/browser-playwright': 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@5.5.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.19)(typescript@6.0.3))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.2(@types/node@20.19.19)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
       '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## What & why

Now that the bundler (tsup) owns the actual emit and `tsc` is used only for type-checking / `.d.ts` generation, the compiler options can be modernized. Also bumps TypeScript across both packages.

**Internal build-config change only — no public API or runtime behavior changes.** Verified that `pnpm test` output is byte-identical before/after (the failures present in this workspace are pre-existing and purely from a missing `E2B_API_KEY`).

## Compiler options: before → after

### `packages/js-sdk/tsconfig.json`
| option | before | after |
|---|---|---|
| `target` | `es6` | `es2022` |
| `lib` | `["dom","ESNext"]` | `["dom","es2022"]` |
| `module` | _(unset)_ | `esnext` |
| `moduleResolution` | `node` | `bundler` |
| `allowJs` | `true` | **removed** (no `.js` sources) |
| `allowSyntheticDefaultImports` | `true` | **removed** (implied by `esModuleInterop`) |
| `ignoreDeprecations` | — | `"6.0"` (added — see note) |

### `packages/cli/tsconfig.json`
| option | before | after |
|---|---|---|
| `moduleResolution` | `node` | `bundler` |
| `strictNullChecks`, `strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`, `noImplicitThis`, `alwaysStrict` | `true` | **removed** (all implied by `strict: true`) |
| `downlevelIteration` | `true` | **removed** (deprecated in TS 6.0; no-op at `es2022`) |
| `baseUrl` | `"."` | **removed** (deprecated in TS 6.0) |
| `paths` | `{ e2b }` | `{ src, "src/*", e2b }` (replaces `baseUrl` for the existing `src/...` import style) |
| `outDir` | `"dist"` | **removed** (see note) |

`target`/`lib` for the CLI were already `es2022`, so they're unchanged.

### TypeScript
Both packages: `typescript` `^5.4.5` → `^6.0.3`.

## Decisions & behavior-affecting notes

- **Target stayed at `es2022`, not `es2023`.** The repo is still on Node 20 (`.tool-versions` = `nodejs 20.19.5`, `engines >= 20`, `@types/node ^20`); the Node 22 migration hasn't landed, so I used the agreed `es2022` fallback.

- **`moduleResolution: "bundler"`** is the headline risk. Both packages typecheck and build cleanly under it (`module: es2022`/`esnext` are both compatible with `bundler`). For the CLI, the previous `baseUrl`-based bare imports (`import … from 'src/user'`, `from 'src'`) are preserved by mapping them through `paths`; the bundled output still resolves them (build verified, CLI binary smoke-tested).

- **TS 6.0 fallout (because we picked TS 6 over "latest 5.x"):**
  - `baseUrl` and `downlevelIteration` are deprecated for removal in TS 7.0; removed both.
  - **CLI `outDir` removal:** under `tsc --noEmit`, TS 6.0 now validates the inferred `rootDir` against *all* program files. The `e2b` → `../js-sdk/src` path mapping pulls js-sdk source into the CLI program, which lives outside `packages/cli`, producing `TS6059`. Removing `outDir` (unused by `--noEmit`; tsup has its own output config) stops `rootDir` inference and clears the error with no build impact.
  - **js-sdk `ignoreDeprecations: "6.0"`:** tsup 8.4.0's `.d.ts` builder *hardcodes* a (now-deprecated) `baseUrl` (`baseUrl: compilerOptions.baseUrl || "."`), which fails the DTS build on TS 6.0. There's no way to stop the injection from config, so this silences it. It's commented in the file and **should be removed once we migrate to tsdown** (which is also why the original plan preferred basing this on the tsdown branch).

## Not done (intentionally)

- **`verbatimModuleSyntax`** — would require **177** `import type` conversions (78 js-sdk + 99 cli, all `TS1484`), spreading this config PR across many source files. Left out as excessive churn; can be a follow-up.
- **Shared `tsconfig.base.json`** — the two configs share only ~8 options and diverge on many more (`lib`, `module`, `paths`, `rootDirs`, `isolatedModules`, `preserveSymlinks`, etc.), so it doesn't factor out cleanly. Skipped to avoid forcing it.

## Verification
- `pnpm run typecheck` ✅ both packages
- `pnpm run build` ✅ both packages (js-sdk ESM + CJS + DTS; cli CJS; binary smoke-tested with `--version`)
- `pnpm run lint` ✅ both packages (oxlint)
- `pnpm run format` — no changes
- `pnpm run test` — neutral: identical pass/fail to the pristine tree (`237 failed | 127 passed | 1 skipped`, all failures from missing `E2B_API_KEY` in this workspace; pure-logic unit tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)