### PR TITLE
feat(cli): track CLI usage via ConnectionConfig integration header

### DIFF
--- a/.changeset/cli-integration-user-agent.md
+++ b/.changeset/cli-integration-user-agent.md
@@ -2,4 +2,4 @@
 "@e2b/cli": patch
 ---
 
-Identify CLI traffic to the API by setting the `integration` field on the CLI's `ConnectionConfig`. Every request the CLI makes now carries `e2b-cli/<version>` in the `User-Agent` header, so CLI usage and version distribution can be tracked server-side. No user-facing behavior changes.
+Identify all CLI traffic to the API by tagging every request with an `e2b-cli/<version>` identifier in the `User-Agent` header, so CLI usage and version distribution can be tracked server-side. The integration is threaded through every CLI call site — the shared API client plus the auth, sandbox lifecycle (`create`/`connect`/`resume`/`kill`/`pause`/`list`/`info`/`metrics`/`exec`), and `template build` commands that construct their own connection. No new dependencies and no user-facing behavior changes.

--- a/.changeset/cli-integration-user-agent.md
+++ b/.changeset/cli-integration-user-agent.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+Identify CLI traffic to the API by setting the `integration` field on the CLI's `ConnectionConfig`. Every request the CLI makes now carries `e2b-cli/<version>` in the `User-Agent` header, so CLI usage and version distribution can be tracked server-side. No user-facing behavior changes.

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,6 +1,7 @@
 import * as boxen from 'boxen'
 import * as e2b from 'e2b'
 
+import * as packageJSON from '../package.json'
 import { getUserConfig, UserConfig } from './user'
 import { asBold, asPrimary } from './utils/format'
 
@@ -106,6 +107,9 @@ export const connectionConfig = new e2b.ConnectionConfig({
   apiHeaders: resolvedAccessToken
     ? { Authorization: `Bearer ${resolvedAccessToken}` }
     : undefined,
+  // Identify CLI traffic to the API via the User-Agent header so CLI usage
+  // (and version distribution) can be tracked server-side.
+  integration: `e2b-cli/${packageJSON.version}`,
 })
 // The CLI authenticates team-scoped endpoints (e.g. `/teams`) with the access
 // token instead of an API key, so don't require an API key here.

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -12,6 +12,31 @@ export let apiKey = process.env.E2B_API_KEY
 export let accessToken = process.env.E2B_ACCESS_TOKEN
 export const teamId = process.env.E2B_TEAM_ID
 
+/**
+ * Integration identifier the CLI appends to the SDK `User-Agent` header so CLI
+ * traffic (and its version) can be tracked server-side.
+ */
+export const CLI_INTEGRATION = `e2b-cli/${packageJSON.version}`
+
+/**
+ * Tag SDK call options with the CLI integration.
+ *
+ * The SDK builds a fresh `ConnectionConfig` from the options passed to each
+ * `Sandbox.*` / `Template.*` static method, so there is no single client to
+ * configure—the integration has to be threaded through every call site. The
+ * `integration` field is accepted at runtime by every `ConnectionConfig`, even
+ * though it is not part of the narrower option types those methods declare,
+ * hence the cast.
+ */
+export function withCliIntegration<T extends e2b.ConnectionConfigOpts>(
+  opts?: T
+): T & { integration: string } {
+  return {
+    ...opts,
+    integration: CLI_INTEGRATION,
+  } as T & { integration: string }
+}
+
 const authErrorBox = (keyName: 'E2B_API_KEY' | 'E2B_ACCESS_TOKEN') => {
   const link =
     keyName === 'E2B_API_KEY'
@@ -109,7 +134,7 @@ export const connectionConfig = new e2b.ConnectionConfig({
     : undefined,
   // Identify CLI traffic to the API via the User-Agent header so CLI usage
   // (and version distribution) can be tracked server-side.
-  integration: `e2b-cli/${packageJSON.version}`,
+  integration: CLI_INTEGRATION,
 })
 // The CLI authenticates team-scoped endpoints (e.g. `/teams`) with the access
 // token instead of an API key, so don't require an API key here.

--- a/packages/cli/src/commands/auth/configure.ts
+++ b/packages/cli/src/commands/auth/configure.ts
@@ -8,7 +8,7 @@ import {
   getConfigRefreshTimestamp,
   writeUserConfig,
 } from 'src/user'
-import { ensureUserConfig, Teams } from 'src/api'
+import { CLI_INTEGRATION, ensureUserConfig, Teams } from 'src/api'
 import { ensureValidAccessToken } from 'src/utils/token-refresh'
 import { asBold, asFormattedTeam } from '../../utils/format'
 import { handleE2BRequestError } from '../../utils/errors'
@@ -33,6 +33,7 @@ export const configureCommand = new commander.Command('configure')
 
     const config = new e2b.ConnectionConfig({
       apiHeaders: { Authorization: `Bearer ${accessToken}` },
+      integration: CLI_INTEGRATION,
     })
     const authClient = new e2b.ApiClient(config, { requireApiKey: false })
 

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -14,7 +14,7 @@ import {
 } from 'src/user'
 import { asBold, asFormattedConfig, asFormattedError } from 'src/utils/format'
 import { openUrlInBrowser } from 'src/utils/openBrowser'
-import { connectionConfig, Teams } from 'src/api'
+import { CLI_INTEGRATION, connectionConfig, Teams } from 'src/api'
 import { handleE2BRequestError } from '../../utils/errors'
 
 export const loginCommand = new commander.Command('login')
@@ -47,6 +47,7 @@ export const loginCommand = new commander.Command('login')
       const signal = connectionConfig.getSignal()
       const config = new e2b.ConnectionConfig({
         apiHeaders: { Authorization: `Bearer ${accessToken}` },
+        integration: CLI_INTEGRATION,
       })
       const client = new e2b.ApiClient(config, { requireApiKey: false })
       const res = await client.api.GET('/teams', {

--- a/packages/cli/src/commands/sandbox/connect.ts
+++ b/packages/cli/src/commands/sandbox/connect.ts
@@ -3,7 +3,7 @@ import * as commander from 'commander'
 
 import { spawnConnectedTerminal } from 'src/terminal'
 import { asBold, asPrimary } from 'src/utils/format'
-import { ensureAPIKey } from '../../api'
+import { ensureAPIKey, withCliIntegration } from '../../api'
 import { printDashboardSandboxInspectUrl } from 'src/utils/urls'
 
 export const connectCommand = new commander.Command('connect')
@@ -36,7 +36,10 @@ async function connectToSandbox({
   apiKey: string
   sandboxID: string
 }) {
-  const sandbox = await e2b.Sandbox.connect(sandboxID, { apiKey })
+  const sandbox = await e2b.Sandbox.connect(
+    sandboxID,
+    withCliIntegration({ apiKey })
+  )
 
   printDashboardSandboxInspectUrl(sandbox.sandboxId)
 

--- a/packages/cli/src/commands/sandbox/create.ts
+++ b/packages/cli/src/commands/sandbox/create.ts
@@ -2,7 +2,7 @@ import * as e2b from 'e2b'
 import * as commander from 'commander'
 import * as path from 'path'
 
-import { ensureAPIKey } from 'src/api'
+import { ensureAPIKey, withCliIntegration } from 'src/api'
 import { spawnConnectedTerminal } from 'src/terminal'
 import { asBold, asFormattedSandboxTemplate } from 'src/utils/format'
 import { getRoot } from '../../utils/filesystem'
@@ -96,11 +96,11 @@ export function createCommand(
             opts['lifecycle.ontimeout'],
             opts['lifecycle.autoresume']
           )
-          const sandboxOpts = {
+          const sandboxOpts = withCliIntegration({
             apiKey,
             ...(lifecycle ? { lifecycle } : {}),
             ...(opts.timeout !== undefined ? { timeoutMs: opts.timeout } : {}),
-          }
+          })
           const sandbox = await e2b.Sandbox.create(templateID, sandboxOpts)
           printDashboardSandboxInspectUrl(sandbox.sandboxId)
 

--- a/packages/cli/src/commands/sandbox/exec.ts
+++ b/packages/cli/src/commands/sandbox/exec.ts
@@ -5,7 +5,7 @@
 import { Sandbox, CommandExitError, NotFoundError } from 'e2b'
 import * as commander from 'commander'
 
-import { ensureAPIKey } from '../../api'
+import { ensureAPIKey, withCliIntegration } from '../../api'
 import { setupSignalHandlers } from 'src/utils/signal'
 import { buildCommand, isPipedStdin, streamStdinChunks } from './exec_helpers'
 
@@ -44,7 +44,10 @@ export const execCommand = new commander.Command('exec')
       const command = buildCommand(commandParts)
       try {
         const apiKey = ensureAPIKey()
-        const sandbox = await Sandbox.connect(sandboxID, { apiKey })
+        const sandbox = await Sandbox.connect(
+          sandboxID,
+          withCliIntegration({ apiKey })
+        )
 
         if (hasPipedStdin && !sandbox.commands.supportsStdinClose) {
           console.error(

--- a/packages/cli/src/commands/sandbox/info.ts
+++ b/packages/cli/src/commands/sandbox/info.ts
@@ -1,7 +1,7 @@
 import * as commander from 'commander'
 import { NotFoundError, Sandbox } from 'e2b'
 
-import { ensureAPIKey } from 'src/api'
+import { ensureAPIKey, withCliIntegration } from 'src/api'
 import { asBold } from 'src/utils/format'
 
 const fieldLabels: Partial<Record<string, string>> = {
@@ -50,7 +50,10 @@ export const infoCommand = new commander.Command('info')
     try {
       const format = options.format || 'pretty'
       const apiKey = ensureAPIKey()
-      const info = await Sandbox.getInfo(sandboxID, { apiKey })
+      const info = await Sandbox.getInfo(
+        sandboxID,
+        withCliIntegration({ apiKey })
+      )
 
       if (format === 'pretty') {
         renderPrettyInfo(info as unknown as Record<string, unknown>)

--- a/packages/cli/src/commands/sandbox/kill.ts
+++ b/packages/cli/src/commands/sandbox/kill.ts
@@ -1,13 +1,16 @@
 import * as commander from 'commander'
 
-import { ensureAPIKey } from 'src/api'
+import { ensureAPIKey, withCliIntegration } from 'src/api'
 import { asBold } from 'src/utils/format'
 import * as e2b from 'e2b'
 import { Sandbox, components } from 'e2b'
 import { parseMetadata } from './utils'
 
 async function killSandbox(sandboxID: string, apiKey: string) {
-  const killed = await e2b.Sandbox.kill(sandboxID, { apiKey })
+  const killed = await e2b.Sandbox.kill(
+    sandboxID,
+    withCliIntegration({ apiKey })
+  )
   if (killed) {
     console.log(`Sandbox ${asBold(sandboxID)} has been killed`)
   } else {
@@ -70,13 +73,15 @@ export const killCommand = new commander.Command('kill')
 
         if (all) {
           let total = 0
-          const iterator = Sandbox.list({
-            apiKey,
-            query: {
-              state: sandboxesState,
-              metadata: sandboxesMetadata,
-            },
-          })
+          const iterator = Sandbox.list(
+            withCliIntegration({
+              apiKey,
+              query: {
+                state: sandboxesState,
+                metadata: sandboxesMetadata,
+              },
+            })
+          )
 
           while (iterator.hasNext) {
             const sandboxes = await iterator.nextItems()

--- a/packages/cli/src/commands/sandbox/list.ts
+++ b/packages/cli/src/commands/sandbox/list.ts
@@ -2,7 +2,7 @@ import * as tablePrinter from 'console-table-printer'
 import * as commander from 'commander'
 import { components, Sandbox, SandboxInfo } from 'e2b'
 
-import { ensureAPIKey } from 'src/api'
+import { ensureAPIKey, withCliIntegration } from 'src/api'
 import { parseMetadata } from './utils'
 
 const DEFAULT_LIMIT = 1000
@@ -159,11 +159,13 @@ export async function listSandboxes({
   }
 
   const sandboxes: SandboxInfo[] = []
-  const iterator = Sandbox.list({
-    apiKey: apiKey,
-    limit: pageLimit,
-    query: { state, metadata },
-  })
+  const iterator = Sandbox.list(
+    withCliIntegration({
+      apiKey: apiKey,
+      limit: pageLimit,
+      query: { state, metadata },
+    })
+  )
 
   while (iterator.hasNext && (!limit || sandboxes.length < limit)) {
     const batch = await iterator.nextItems()

--- a/packages/cli/src/commands/sandbox/metrics.ts
+++ b/packages/cli/src/commands/sandbox/metrics.ts
@@ -5,7 +5,7 @@ import { asBold, asTimestamp, withUnderline } from 'src/utils/format'
 import { wait } from 'src/utils/wait'
 import { formatEnum, Format, isRunning } from './utils'
 import { Sandbox } from 'e2b'
-import { ensureAPIKey } from '../../api'
+import { ensureAPIKey, withCliIntegration } from '../../api'
 
 export const metricsCommand = new commander.Command('metrics')
   .description('show metrics for sandbox')
@@ -46,7 +46,10 @@ export const metricsCommand = new commander.Command('metrics')
         const isRunningPromise = isRunning(sandboxID)
 
         do {
-          const metrics = await Sandbox.getMetrics(sandboxID, { start, apiKey })
+          const metrics = await Sandbox.getMetrics(
+            sandboxID,
+            withCliIntegration({ start, apiKey })
+          )
 
           if (metrics.length !== 0 && !firstMetricsPrinted) {
             firstMetricsPrinted = true

--- a/packages/cli/src/commands/sandbox/pause.ts
+++ b/packages/cli/src/commands/sandbox/pause.ts
@@ -1,13 +1,16 @@
 import * as commander from 'commander'
 
-import { ensureAPIKey } from 'src/api'
+import { ensureAPIKey, withCliIntegration } from 'src/api'
 import { asBold } from 'src/utils/format'
 import * as e2b from 'e2b'
 import { NotFoundError } from 'e2b'
 
 async function pauseSandbox(sandboxID: string, apiKey: string) {
   try {
-    const paused = await e2b.Sandbox.betaPause(sandboxID, { apiKey })
+    const paused = await e2b.Sandbox.betaPause(
+      sandboxID,
+      withCliIntegration({ apiKey })
+    )
     if (paused) {
       console.log(`Sandbox ${asBold(sandboxID)} has been paused`)
     } else {

--- a/packages/cli/src/commands/sandbox/resume.ts
+++ b/packages/cli/src/commands/sandbox/resume.ts
@@ -1,13 +1,13 @@
 import * as commander from 'commander'
 
-import { ensureAPIKey } from 'src/api'
+import { ensureAPIKey, withCliIntegration } from 'src/api'
 import { asBold } from 'src/utils/format'
 import * as e2b from 'e2b'
 import { NotFoundError } from 'e2b'
 
 async function resumeSandbox(sandboxID: string, apiKey: string) {
   try {
-    await e2b.Sandbox.connect(sandboxID, { apiKey })
+    await e2b.Sandbox.connect(sandboxID, withCliIntegration({ apiKey }))
     console.log(`Sandbox ${asBold(sandboxID)} has been resumed`)
   } catch (err: unknown) {
     if (err instanceof NotFoundError) {

--- a/packages/cli/src/commands/sandbox/utils.ts
+++ b/packages/cli/src/commands/sandbox/utils.ts
@@ -1,7 +1,7 @@
 import { wait } from '../../utils/wait'
 import { asBold } from '../../utils/format'
 import { Sandbox } from 'e2b'
-import { ensureAPIKey } from 'src/api'
+import { ensureAPIKey, withCliIntegration } from 'src/api'
 
 export function formatEnum(e: { [key: string]: string }) {
   return Object.values(e)
@@ -49,9 +49,10 @@ export function waitForSandboxEnd(sandboxID: string) {
 export async function isRunning(sandboxID: string) {
   try {
     const apiKey = ensureAPIKey()
-    const info = await Sandbox.getInfo(sandboxID, {
-      apiKey,
-    })
+    const info = await Sandbox.getInfo(
+      sandboxID,
+      withCliIntegration({ apiKey })
+    )
     return info.state === 'running'
   } catch (err) {
     console.error(`Failed to check sandbox status: ${err}`)

--- a/packages/cli/src/commands/template/create.ts
+++ b/packages/cli/src/commands/template/create.ts
@@ -1,7 +1,7 @@
 import * as boxen from 'boxen'
 import * as commander from 'commander'
 import { defaultBuildLogger, Template, TemplateClass } from 'e2b'
-import { connectionConfig, ensureAPIKey } from 'src/api'
+import { connectionConfig, ensureAPIKey, withCliIntegration } from 'src/api'
 import {
   defaultDockerfileName,
   fallbackDockerfileName,
@@ -138,15 +138,18 @@ export const createCommand = new commander.Command('create')
 
         // Build the template using SDK
         try {
-          await Template.build(finalTemplate, {
-            alias: templateName,
-            cpuCount: cpuCount,
-            memoryMB: memoryMB,
-            skipCache: opts.noCache,
-            apiKey: apiKey,
-            domain: domain,
-            onBuildLogs: defaultBuildLogger(),
-          })
+          await Template.build(
+            finalTemplate,
+            withCliIntegration({
+              alias: templateName,
+              cpuCount: cpuCount,
+              memoryMB: memoryMB,
+              skipCache: opts.noCache,
+              apiKey: apiKey,
+              domain: domain,
+              onBuildLogs: defaultBuildLogger(),
+            })
+          )
         } catch (error) {
           console.error('\n❌ Template build failed.')
           if (error instanceof Error) {

--- a/packages/cli/tests/api_integration_header.test.ts
+++ b/packages/cli/tests/api_integration_header.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import * as packageJSON from '../package.json'
+import { connectionConfig } from '../src/api'
+
+describe('CLI connection config', () => {
+  it('identifies CLI traffic via the integration field', () => {
+    expect(connectionConfig.integration).toBe(`e2b-cli/${packageJSON.version}`)
+  })
+
+  it('appends the CLI integration to the User-Agent header', () => {
+    expect(connectionConfig.headers?.['User-Agent']).toContain(
+      `e2b-cli/${packageJSON.version}`
+    )
+  })
+})

--- a/packages/cli/tests/api_integration_header.test.ts
+++ b/packages/cli/tests/api_integration_header.test.ts
@@ -1,15 +1,41 @@
 import { describe, expect, it } from 'vitest'
 import * as packageJSON from '../package.json'
-import { connectionConfig } from '../src/api'
+import {
+  CLI_INTEGRATION,
+  connectionConfig,
+  withCliIntegration,
+} from '../src/api'
 
 describe('CLI connection config', () => {
+  it('exposes the CLI integration identifier', () => {
+    expect(CLI_INTEGRATION).toBe(`e2b-cli/${packageJSON.version}`)
+  })
+
   it('identifies CLI traffic via the integration field', () => {
-    expect(connectionConfig.integration).toBe(`e2b-cli/${packageJSON.version}`)
+    expect(connectionConfig.integration).toBe(CLI_INTEGRATION)
   })
 
   it('appends the CLI integration to the User-Agent header', () => {
-    expect(connectionConfig.headers?.['User-Agent']).toContain(
-      `e2b-cli/${packageJSON.version}`
-    )
+    expect(connectionConfig.headers?.['User-Agent']).toContain(CLI_INTEGRATION)
+  })
+})
+
+describe('withCliIntegration', () => {
+  it('tags SDK call options with the CLI integration', () => {
+    expect(withCliIntegration({ apiKey: 'e2b_test' })).toEqual({
+      apiKey: 'e2b_test',
+      integration: CLI_INTEGRATION,
+    })
+  })
+
+  it('preserves existing options and works without any', () => {
+    expect(withCliIntegration()).toEqual({ integration: CLI_INTEGRATION })
+    expect(
+      withCliIntegration({ apiKey: 'e2b_test', query: { state: ['running'] } })
+    ).toMatchObject({
+      apiKey: 'e2b_test',
+      query: { state: ['running'] },
+      integration: CLI_INTEGRATION,
+    })
   })
 })

--- a/packages/cli/tests/commands/sandbox/create_lifecycle.test.ts
+++ b/packages/cli/tests/commands/sandbox/create_lifecycle.test.ts
@@ -20,6 +20,10 @@ vi.mock('e2b', () => ({
 
 vi.mock('../../../src/api', () => ({
   ensureAPIKey: mocks.ensureAPIKey,
+  withCliIntegration: (opts: object) => ({
+    ...opts,
+    integration: 'e2b-cli/test',
+  }),
 }))
 
 vi.mock('src/utils/urls', () => ({
@@ -72,6 +76,7 @@ describe('sandbox create lifecycle options', () => {
         onTimeout: 'pause',
         autoResume: true,
       },
+      integration: 'e2b-cli/test',
     })
     expect(exitSpy).toHaveBeenCalledWith(0)
   })
@@ -94,6 +99,7 @@ describe('sandbox create lifecycle options', () => {
       lifecycle: {
         onTimeout: 'kill',
       },
+      integration: 'e2b-cli/test',
     })
     expect(exitSpy).toHaveBeenCalledWith(0)
   })
@@ -114,6 +120,7 @@ describe('sandbox create lifecycle options', () => {
     expect(mocks.create).toHaveBeenCalledWith('base', {
       apiKey: 'test-api-key',
       timeoutMs: 120_000,
+      integration: 'e2b-cli/test',
     })
     expect(exitSpy).toHaveBeenCalledWith(0)
   })
@@ -258,6 +265,7 @@ describe('sandbox create lifecycle options', () => {
         autoResume: true,
       },
       timeoutMs: 120_000,
+      integration: 'e2b-cli/test',
     })
     expect(exitSpy).toHaveBeenCalledWith(0)
   })

--- a/packages/cli/tests/commands/sandbox/exec_close_stdin.test.ts
+++ b/packages/cli/tests/commands/sandbox/exec_close_stdin.test.ts
@@ -48,6 +48,10 @@ vi.mock('e2b', () => {
 
 vi.mock('../../../src/api', () => ({
   ensureAPIKey: mocks.ensureAPIKey,
+  withCliIntegration: (opts: object) => ({
+    ...opts,
+    integration: 'e2b-cli/test',
+  }),
 }))
 
 vi.mock('src/utils/signal', () => ({

--- a/packages/cli/tests/commands/sandbox/exec_stdin_flag.test.ts
+++ b/packages/cli/tests/commands/sandbox/exec_stdin_flag.test.ts
@@ -44,6 +44,10 @@ vi.mock('e2b', () => {
 
 vi.mock('../../../src/api', () => ({
   ensureAPIKey: mocks.ensureAPIKey,
+  withCliIntegration: (opts: object) => ({
+    ...opts,
+    integration: 'e2b-cli/test',
+  }),
 }))
 
 vi.mock('src/utils/signal', () => ({


### PR DESCRIPTION
Tags all CLI traffic to the API with an `e2b-cli/<version>` identifier in the `User-Agent` header so CLI usage and version distribution can be tracked server-side, with no SDK changes and no new dependencies.

The first commit tagged the shared `ConnectionConfig`, but the auth, sandbox-lifecycle, and `template build` commands build their own connection from per-call options and were still sending untagged requests (flagged by Cursor Bugbot + Codex). This adds a `withCliIntegration` helper (and a `CLI_INTEGRATION` constant) in `packages/cli/src/api.ts` and threads it through every remaining call site: `auth login`/`configure`, `sandbox create`/`connect`/`resume`/`kill`/`pause`/`list`/`info`/`metrics`/`exec`, and `template build`.

`integration` is accepted at runtime by every `ConnectionConfig` the SDK builds internally, but isn't part of the narrower option types the `Sandbox.*`/`Template.*` static methods declare — the helper centralizes that single cast so the call sites stay clean. Direct `new ConnectionConfig(...)` sites (auth) pass `integration` inline since the constructor's type already declares it.

## Usage

```console
$ e2b sandbox create my-template
$ e2b sandbox list
$ e2b auth login
$ e2b template build
# Every request now sends:  User-Agent: e2b-js-sdk/<sdk-version> e2b-cli/<cli-version>
```

Server-side, filter API logs by `User-Agent` containing `e2b-cli/` to measure CLI vs SDK traffic and version distribution, broken down by team/user via the existing auth headers.

## Tests

- `api_integration_header.test.ts` covers `CLI_INTEGRATION`, the module-level config, and the `withCliIntegration` helper.
- `create_lifecycle.test.ts` now asserts `Sandbox.create` is called with the `integration` field, locking in the threading as a regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)