### PR TITLE
fix(sdk): avoid false detached head status

### DIFF
--- a/.changeset/js-git-status-detached-substring.md
+++ b/.changeset/js-git-status-detached-substring.md
@@ -1,0 +1,6 @@
+---
+"e2b": patch
+"@e2b/python-sdk": patch
+---
+
+Fix git status parsing so a branch or upstream whose name merely contains the substring `detached` (for example `main` tracking `origin/detached-work`) is no longer misreported as a detached HEAD. Detached-HEAD detection now keys off the `HEAD (detached at <sha>)` / `HEAD (no branch)` porcelain forms only, so branch and upstream information is preserved in both SDKs.

--- a/packages/js-sdk/src/sandbox/git/utils.ts
+++ b/packages/js-sdk/src/sandbox/git/utils.ts
@@ -381,9 +381,7 @@ export function parseGitStatus(output: string): GitStatus {
       aheadStart === -1 ? undefined : branchInfo.slice(aheadStart + 2, -1)
     const normalizedBranch = normalizeBranchName(branchPart)
     const rawBranch = branchPart
-    const isDetached =
-      rawBranch.startsWith('HEAD (detached at ') ||
-      rawBranch.includes('detached')
+    const isDetached = rawBranch.startsWith('HEAD (detached at ')
 
     if (isDetached || normalizedBranch.startsWith('HEAD')) {
       detached = true

--- a/packages/js-sdk/tests/git.parseStatus.test.ts
+++ b/packages/js-sdk/tests/git.parseStatus.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'vitest'
+
+import { parseGitStatus } from '../src/sandbox/git/utils'
+
+// Twin of the Python fix in PR #1374 (issue #1373): `parseGitStatus` used to flag
+// `detached: true` for any branch/upstream name merely containing the substring
+// "detached", dropping `currentBranch`/`upstream` for ordinary branches.
+
+test('upstream whose name contains "detached" is not a detached HEAD', () => {
+  // Branch 'main' tracking 'origin/detached-work': NOT a detached HEAD.
+  const status = parseGitStatus('## main...origin/detached-work\n')
+  expect(status.detached).toBe(false)
+  expect(status.currentBranch).toBe('main')
+  expect(status.upstream).toBe('origin/detached-work')
+})
+
+test('local branch whose name contains "detached" is not a detached HEAD', () => {
+  const status = parseGitStatus('## feature/detached-session-fix\n')
+  expect(status.detached).toBe(false)
+  expect(status.currentBranch).toBe('feature/detached-session-fix')
+})
+
+test('real detached HEAD ("## HEAD (no branch)") is still detected', () => {
+  const status = parseGitStatus('## HEAD (no branch)\n')
+  expect(status.detached).toBe(true)
+})
+
+test('real detached HEAD ("## HEAD (detached at <sha>)") is still detected', () => {
+  const status = parseGitStatus('## HEAD (detached at 1a2b3c4)\n')
+  expect(status.detached).toBe(true)
+})

--- a/packages/python-sdk/e2b/sandbox/_git/parse.py
+++ b/packages/python-sdk/e2b/sandbox/_git/parse.py
@@ -125,9 +125,7 @@ def parse_git_status(output: str) -> GitStatus:
         ahead_part = None if ahead_start == -1 else branch_info[ahead_start + 2 : -1]
         normalized_branch = _normalize_branch_name(branch_part)
         raw_branch = branch_part
-        is_detached = raw_branch.startswith("HEAD (detached at ") or (
-            "detached" in raw_branch
-        )
+        is_detached = raw_branch.startswith("HEAD (detached at ")
 
         if is_detached or normalized_branch.startswith("HEAD"):
             detached = True

--- a/packages/python-sdk/tests/bugs/test_parse_git_status_detached.py
+++ b/packages/python-sdk/tests/bugs/test_parse_git_status_detached.py
@@ -1,0 +1,28 @@
+from e2b.sandbox._git.parse import parse_git_status
+
+
+def test_upstream_with_detached_in_name_is_not_detached_head():
+    status = parse_git_status("## main...origin/detached-work\n")
+
+    assert not status.detached
+    assert status.current_branch == "main"
+    assert status.upstream == "origin/detached-work"
+
+
+def test_branch_with_detached_in_name_is_not_detached_head():
+    status = parse_git_status("## feature/detached-session-fix\n")
+
+    assert not status.detached
+    assert status.current_branch == "feature/detached-session-fix"
+
+
+def test_head_with_no_branch_is_detached():
+    status = parse_git_status("## HEAD (no branch)\n")
+
+    assert status.detached
+
+
+def test_head_detached_at_commit_is_detached():
+    status = parse_git_status("## HEAD (detached at 1a2b3c4)\n")
+
+    assert status.detached


### PR DESCRIPTION
## description

`git status` parsing in both sdks treated any branch or upstream containing the substring `detached` as a detached head. for example, `main` tracking `origin/detached-work` lost its branch information and incorrectly returned `detached: true`.

this removes the broad substring check from the javascript and python parsers. real detached states remain recognized through the porcelain `HEAD (no branch)` and `HEAD (detached at <sha>)` forms.

## usage example

```ts
const status = await sandbox.git.status(`/path/to/repo`)
status.detached // false
status.currentBranch // `main`
status.upstream // `origin/detached-work`
```

```python
status = sandbox.git.status("/path/to/repo")
status.detached  # false
status.current_branch  # "main"
status.upstream  # "origin/detached-work"
```

## tests

- javascript unit tests cover local and upstream names containing `detached`, plus both real detached-head forms
- python unit tests cover the same four cases
- javascript format, lint, typecheck, and focused unit tests pass
- python ruff format/check, ty check, and focused unit tests pass

## changeset

patch releases for `e2b` and `@e2b/python-sdk`.