### PR TITLE
fix(python-sdk): strip colon-separated SGR escape codes in build logs

### DIFF
--- a/.changeset/python-strip-ansi-colon.md
+++ b/.changeset/python-strip-ansi-colon.md
@@ -1,0 +1,11 @@
+---
+"@e2b/python-sdk": patch
+---
+
+fix(python-sdk): strip colon-separated SGR escape codes in build logs
+
+`strip_ansi_escape_codes` now strips CSI parameters that use colons as well as
+semicolons, matching the JavaScript SDK's `stripAnsi`. Modern terminals emit
+colon-separated SGR sequences (e.g. 256-color `\x1b[38:5:82m`, truecolor
+`\x1b[38:2::r:g:bm`, and curly underlines `\x1b[4:3m`), which previously leaked
+literal escape garbage into template build log messages on the Python side.

--- a/packages/python-sdk/e2b/template/utils.py
+++ b/packages/python-sdk/e2b/template/utils.py
@@ -316,7 +316,7 @@ def strip_ansi_escape_codes(text: str) -> str:
     st = r"(?:\u0007|\u001B\u005C|\u009C)"
     pattern = [
         rf"[\u001B\u009B][\[\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d/#&.:=?%@~_]*)*)?{st})",
-        r"(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))",
+        r"(?:(?:\d{1,4}(?:[;:]\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))",
     ]
     ansi_escape = re.compile("|".join(pattern), re.UNICODE)
     return ansi_escape.sub("", text)

--- a/packages/python-sdk/tests/shared/template/utils/test_strip_ansi_escape_codes.py
+++ b/packages/python-sdk/tests/shared/template/utils/test_strip_ansi_escape_codes.py
@@ -1,0 +1,29 @@
+from e2b.template.utils import strip_ansi_escape_codes
+
+
+def test_strips_basic_sgr_color():
+    assert strip_ansi_escape_codes("\x1b[31mred\x1b[0m") == "red"
+
+
+def test_strips_semicolon_separated_params():
+    assert strip_ansi_escape_codes("\x1b[1;31;42mhi\x1b[0m") == "hi"
+
+
+def test_strips_semicolon_256_color():
+    assert strip_ansi_escape_codes("\x1b[38;5;82mX\x1b[0m") == "X"
+
+
+def test_strips_colon_256_color():
+    assert strip_ansi_escape_codes("\x1b[38:5:82mX\x1b[0m") == "X"
+
+
+def test_strips_colon_truecolor():
+    assert strip_ansi_escape_codes("\x1b[38:2::255:0:0mRED\x1b[0m") == "RED"
+
+
+def test_strips_colon_curly_underline():
+    assert strip_ansi_escape_codes("\x1b[4:3mX\x1b[0m") == "X"
+
+
+def test_leaves_plain_text_unchanged():
+    assert strip_ansi_escape_codes("no escape codes here") == "no escape codes here"


### PR DESCRIPTION
### What

`strip_ansi_escape_codes` in the Python SDK only matched semicolon-separated CSI
parameters, so colon-separated SGR sequences leaked literal escape garbage into
template build-log messages. This widens the parameter class from `;` to `[;:]`
so colon-separated sequences are stripped too, matching the JS SDK's `stripAnsi`.

Modern terminals emit colon-separated SGR sequences:

- 256-color: `\x1b[38:5:82m`
- truecolor: `\x1b[38:2::255:0:0m`
- curly underline: `\x1b[4:3m`

The two SDKs share one source (chalk/ansi-regex) and the JS twin was already
updated to support colons (`packages/js-sdk/src/utils.ts:95`, comment: "supports
; and :"); the Python port lagged behind. `strip_ansi_escape_codes` is consumed
by `LogEntry.__post_init__` (`packages/python-sdk/e2b/template/logger.py`), so
the leftover escape bytes showed up in Python build logs only.

### The one-line fix

```python
# packages/python-sdk/e2b/template/utils.py:319
- r"(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))",
+ r"(?:(?:\d{1,4}(?:[;:]\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))",
```

### Usage example (before / after)

```python
from e2b.template.utils import strip_ansi_escape_codes

# 256-color, colon-separated
strip_ansi_escape_codes("\x1b[38:5:82mX\x1b[0m")
# before: ":5:82mX"   after: "X"

# truecolor, colon-separated
strip_ansi_escape_codes("\x1b[38:2::255:0:0mRED\x1b[0m")
# before: ":2::255:0:0mRED"   after: "RED"

# semicolon variants already worked and still do
strip_ansi_escape_codes("\x1b[38;5;82mX\x1b[0m")  # "X"  (unchanged)
```

### Tests

New offline unit tests at
`packages/python-sdk/tests/shared/template/utils/test_strip_ansi_escape_codes.py`
(no API key / sandbox): colon-256, colon-truecolor, curly-underline, plus
basic/semicolon regressions. The three colon cases fail on `main` and pass with
the fix.

### Changeset

`.changeset/python-strip-ansi-colon.md` (patch on `@e2b/python-sdk`), since the
fix is user-facing.

### Notes

No linked issue: found via a JS/Python parity audit. JS is already correct, so
per the repo's separate-PR convention this change is Python-only.
