### PR TITLE
test: skip live volume tests unless ENABLE_VOLUME_TESTS is set

### DIFF
--- a/packages/js-sdk/tests/setup.ts
+++ b/packages/js-sdk/tests/setup.ts
@@ -115,27 +115,29 @@ export const buildTemplateTest = base.extend<BuildTemplateFixture>({
   ],
 })
 
-export const volumeTest = base.extend<VolumeFixture>({
-  volume: [
-    // eslint-disable-next-line no-empty-pattern
-    async ({}, use) => {
-      const volume = await Volume.create(`test-vol-${generateRandomString()}`)
-      onTestFailed(() => {
-        console.error(`\n[TEST FAILED] Volume ID: ${volume.volumeId}`)
-      })
-      try {
-        await use(volume)
-      } finally {
+export const volumeTest = base
+  .extend<VolumeFixture>({
+    volume: [
+      // eslint-disable-next-line no-empty-pattern
+      async ({}, use) => {
+        const volume = await Volume.create(`test-vol-${generateRandomString()}`)
+        onTestFailed(() => {
+          console.error(`\n[TEST FAILED] Volume ID: ${volume.volumeId}`)
+        })
         try {
-          await Volume.destroy(volume.volumeId)
-        } catch {
-          // Ignore cleanup errors
+          await use(volume)
+        } finally {
+          try {
+            await Volume.destroy(volume.volumeId)
+          } catch {
+            // Ignore cleanup errors
+          }
         }
-      }
-    },
-    { auto: false },
-  ],
-})
+      },
+      { auto: false },
+    ],
+  })
+  .skipIf(process.env.ENABLE_VOLUME_TESTS === undefined)
 
 export const isDebug = process.env.E2B_DEBUG !== undefined
 export const isIntegrationTest = process.env.E2B_INTEGRATION_TEST !== undefined

--- a/packages/python-sdk/tests/conftest.py
+++ b/packages/python-sdk/tests/conftest.py
@@ -243,8 +243,14 @@ def _generate_random_string(length: int = 8) -> str:
     return "".join(random.choices(string.ascii_lowercase + string.digits, k=length))
 
 
+def _skip_unless_volume_tests_enabled():
+    if os.getenv("ENABLE_VOLUME_TESTS") is None:
+        pytest.skip("skipped because ENABLE_VOLUME_TESTS is not set")
+
+
 @pytest.fixture
 def volume(request):
+    _skip_unless_volume_tests_enabled()
     vol = Volume.create(f"test-vol-{_generate_random_string()}")
 
     def finalizer():
@@ -261,6 +267,7 @@ def volume(request):
 
 @pytest_asyncio.fixture
 async def async_volume(request):
+    _skip_unless_volume_tests_enabled()
     vol = await AsyncVolume.create(f"test-vol-{_generate_random_string()}")
     try:
         yield vol


### PR DESCRIPTION
Live volume tests create real volumes against the API; this gates them behind an `ENABLE_VOLUME_TESTS` env var so they skip by default. In the JS SDK, the `volumeTest` fixture is chained with `.skipIf(process.env.ENABLE_VOLUME_TESTS === undefined)`, skipping all of `tests/volume/file.test.ts`. In the Python SDK, the `volume` and `async_volume` fixtures call `pytest.skip` when the env var is unset, gating `tests/{sync/volume_sync,async/volume_async}/test_file.py`. Mocked and unit volume tests (msw-based `volume.test.ts`, `test_volume.py`, `test_volume_content.py`, `test_volume_client.py`, `test_volume_connection_config.py`) still run unconditionally. To run the live tests: `ENABLE_VOLUME_TESTS=1 pnpm run test` or `ENABLE_VOLUME_TESTS=1 poetry run pytest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)