### PR TITLE
fix(python-sdk): correct inverted no_install_recommends docstring

### DIFF
--- a/.changeset/python-apt-install-docstring.md
+++ b/.changeset/python-apt-install-docstring.md
@@ -1,0 +1,9 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Fix inverted `no_install_recommends` docstring on `TemplateBuilder.apt_install()`.
+The docstring described the parameter as "Whether to install recommended
+packages", but the code passes apt-get's `--no-install-recommends` flag when the
+argument is `True`, which skips recommended packages, the opposite of what the
+docs claimed. The docstring now describes the real behavior. No behavior change.

--- a/packages/python-sdk/e2b/template/main.py
+++ b/packages/python-sdk/e2b/template/main.py
@@ -478,7 +478,7 @@ class TemplateBuilder:
         Install system packages using apt-get.
 
         :param packages: Package name(s) to install
-        :param no_install_recommends: Whether to install recommended packages
+        :param no_install_recommends: Whether to skip installing recommended packages
         :param fix_missing: Whether to fix missing packages
 
         :return: `TemplateBuilder` class


### PR DESCRIPTION
Promotes the merged #1532 (by @anxkhn) from the staging branch `fix/no-install-recommends-docstring` into `main`.

`TemplateBuilder.apt_install()` documents its `no_install_recommends` parameter as
"Whether to install recommended packages", but the generated command does the
opposite. In `packages/python-sdk/e2b/template/main.py` the command adds apt-get's
`--no-install-recommends` flag when the argument is `True`:

```python
f"... apt-get install -y {'--no-install-recommends ' if no_install_recommends else ''}..."
```

`--no-install-recommends` tells apt to *skip* recommended packages, so
`no_install_recommends=True` skips them rather than installing them. A user who
follows the docstring gets the inverse of the documented behavior. The parameter
name and apt-get's own semantics confirm the code is correct and the docstring was
wrong; this rewords the docstring line to match the real behavior.

The `--no-install-recommends` flag was introduced in #983; the docstring has been
inverted since then.

This is Python-only. The JS twin `aptInstall` applies the same flag but has no
per-parameter JSDoc for `noInstallRecommends` (it appears only inside an
`@example`), so there is nothing contradictory to fix on the JS side. There is a
single Python definition (no sync/async mirror for the template builder).

No behavior change; documentation-only, plus a `@e2b/python-sdk: patch` changeset.

### Usage

```python
from e2b import Template

template = Template().from_image("ubuntu:22.04")

# Install recommended packages as well (apt-get default):
template.apt_install("vim")

# Skip recommended packages (adds apt-get's --no-install-recommends):
template.apt_install("vim", no_install_recommends=True)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
