### PR TITLE
fix(python-sdk): stop leaking per-call proxy pools in volume content clients

### DIFF
--- a/.changeset/python-volume-proxy-transport.md
+++ b/.changeset/python-volume-proxy-transport.md
@@ -1,0 +1,11 @@
+---
+"@e2b/python-sdk": patch
+---
+
+fix(python-sdk): stop leaking per-call proxy connection pools in volume content clients
+
+The volume content clients passed both `proxy` and the shared cached
+`transport` to httpx, so with a proxy configured every volume operation mounted
+a fresh, never-closed proxy transport. The proxy is already part of the cached
+transport, so the client-level `proxy` argument is now dropped. Volume
+transports also gained connect-level retries, matching the other transports.

--- a/packages/python-sdk/e2b/volume/client_async/__init__.py
+++ b/packages/python-sdk/e2b/volume/client_async/__init__.py
@@ -7,7 +7,7 @@ import httpx
 from httpx import Limits
 from httpx._types import ProxyTypes
 
-from e2b.api import make_async_logging_event_hooks
+from e2b.api import connection_retries, make_async_logging_event_hooks
 from e2b.api.metadata import default_headers
 from e2b.exceptions import AuthenticationException
 from e2b.volume.client.client import AuthenticatedClient as AsyncVolumeApiClient
@@ -47,7 +47,8 @@ def get_api_client(config: VolumeConnectionConfig, **kwargs) -> AsyncVolumeApiCl
             httpx.Timeout(request_timeout) if request_timeout is not None else None
         ),
         httpx_args={
-            "proxy": config.proxy,
+            # The proxy lives in the cached transport; passing `proxy` here too
+            # would mount a fresh, never-closed proxy transport per client.
             "transport": get_transport(config),
             "event_hooks": make_async_logging_event_hooks(config.logger),
         },
@@ -82,6 +83,7 @@ def get_transport(config: VolumeConnectionConfig) -> AsyncTransportWithLogger:
         transport = AsyncTransportWithLogger(
             limits=limits,
             proxy=config.proxy,
+            retries=connection_retries,
         )
         loop_instances[key] = transport
 

--- a/packages/python-sdk/e2b/volume/client_sync/__init__.py
+++ b/packages/python-sdk/e2b/volume/client_sync/__init__.py
@@ -6,7 +6,7 @@ import httpx
 from httpx import Limits
 from httpx._types import ProxyTypes
 
-from e2b.api import make_logging_event_hooks
+from e2b.api import connection_retries, make_logging_event_hooks
 from e2b.api.metadata import default_headers
 from e2b.exceptions import AuthenticationException
 from e2b.volume.client.client import AuthenticatedClient as VolumeApiClient
@@ -46,7 +46,8 @@ def get_api_client(config: VolumeConnectionConfig, **kwargs) -> VolumeApiClient:
             httpx.Timeout(request_timeout) if request_timeout is not None else None
         ),
         httpx_args={
-            "proxy": config.proxy,
+            # The proxy lives in the cached transport; passing `proxy` here too
+            # would mount a fresh, never-closed proxy transport per client.
             "transport": get_transport(config),
             "event_hooks": make_logging_event_hooks(config.logger),
         },
@@ -74,6 +75,7 @@ def get_transport(config: VolumeConnectionConfig) -> TransportWithLogger:
     transport = TransportWithLogger(
         limits=limits,
         proxy=config.proxy,
+        retries=connection_retries,
     )
     instances[key] = transport
     TransportWithLogger._thread_local.instances = instances


### PR DESCRIPTION
The Python volume content client factories passed both `proxy` and the shared cached `transport` to httpx, so with a proxy configured (e.g. `Volume.connect(volume_id, proxy="http://user:pass@127.0.0.1:8080")`), every volume operation mounted a fresh, never-closed proxy transport that bypassed the cached connection pool. The client-level `proxy` argument is now dropped — the proxy is already baked into the cached transport, so proxied requests keep working but reuse one pooled transport per thread/event loop.

The volume transports also gained connect-level retries (`E2B_CONNECTION_RETRIES`, default 3), matching the core API and envd transports. Includes a changeset for a `@e2b/python-sdk` patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)