### PR TITLE
chore(ci): add `dependabot.yml` for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,8 +35,8 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
-  # Python SDK (pyproject.toml managed with uv)
-  - package-ecosystem: "pip"
+  # Python SDK (uv.lock managed with uv)
+  - package-ecosystem: "uv"
     directory: "/packages/python-sdk"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,155 @@
+version: 2
+updates:
+  # Root npm/pnpm workspace (covers spec/, packages/js-sdk, packages/cli, packages/python-sdk JS deps)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      typescript-tooling:
+        patterns:
+          - "typescript"
+          - "@types/*"
+          - "@typescript-eslint/*"
+          - "eslint"
+          - "eslint-*"
+          - "oxlint"
+          - "prettier"
+          - "@changesets/*"
+      dev-deps:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # Python SDK (pyproject.toml managed with uv)
+  - package-ecosystem: "pip"
+    directory: "/packages/python-sdk"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      dev-tools:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # connect-python (pyproject.toml + requirements-dev.txt)
+  - package-ecosystem: "pip"
+    directory: "/packages/connect-python"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      python-dev-tools:
+        patterns:
+          - "ruff"
+          - "build"
+          - "twine"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/packages/connect-python"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # Docker - codegen image (root)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # Docker - sandbox base template
+  - package-ecosystem: "docker"
+    directory: "/templates/base"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # Docker - CLI test demo
+  - package-ecosystem: "docker"
+    directory: "/packages/cli/testground/demo-basic"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
Configure Dependabot to monitor and update dependencies across all ecosystems:
- npm/pnpm (root workspace covering js-sdk, cli, python-sdk, spec)
- pip/uv (python-sdk, connect-python)
- Go modules (connect-python)
- Docker (codegen, sandbox base template, CLI test demo)
- GitHub Actions (13 workflow files)

Features include:
- Dependency grouping (typescript tooling, dev-deps, python dev-tools)
- Conventional commit prefixes: chore(deps) and chore(ci)
- Ignore major semver updates for npm to avoid breaking changes