### PR TITLE
ci: key Playwright browser cache on Playwright version

### DIFF
--- a/.github/workflows/js_sdk_tests.yml
+++ b/.github/workflows/js_sdk_tests.yml
@@ -60,23 +60,15 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
 
-      - name: Cache Playwright binaries (Linux)
-        if: matrix.os == 'ubuntu-22.04'
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ env.TOOL_VERSION_NODEJS }}-${{ hashFiles('packages/js-sdk/package.json') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-${{ env.TOOL_VERSION_NODEJS }}-
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
 
-      - name: Cache Playwright binaries (Windows)
-        if: matrix.os == 'windows-latest'
+      - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
-          path: ~/AppData/Local/ms-playwright
-          key: playwright-${{ runner.os }}-${{ env.TOOL_VERSION_NODEJS }}-${{ hashFiles('packages/js-sdk/package.json') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-${{ env.TOOL_VERSION_NODEJS }}-
+          path: ${{ matrix.os == 'windows-latest' && '~/AppData/Local/ms-playwright' || '~/.cache/ms-playwright' }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Test build
         run: pnpm build


### PR DESCRIPTION
## Why

The Playwright browser cache in `js_sdk_tests.yml` keyed on the Node version + a hash of `packages/js-sdk/package.json`. Node bumps (e.g. #1515) and release-bot version bumps rotated the key, so PRs kept re-downloading Chromium — ~3 minutes per Windows job, twice per run (staging + production) — e.g. [this run](https://github.com/e2b-dev/E2B/actions/runs/29036879724/job/86183938330?pr=1536). The churn also created a fresh ~250 MB cache entry per OS on every release.

## What

Browser binaries depend only on the Playwright version, so the cache is now keyed on the installed Playwright version (read from `node_modules` after `pnpm install`), and the two OS-conditional cache steps are collapsed into one. The key only rotates when Playwright itself is upgraded, which is exactly when a re-download is needed. On a cache hit, the `pretest` `playwright install` becomes a no-op skip instead of a download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)