### PR TITLE
fix(js-sdk): unpin useDefineForClassFields — make caller-directory resolution emit-invariant

### DIFF
--- a/.changeset/lucky-buttons-repair.md
+++ b/.changeset/lucky-buttons-repair.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+Resolve the template builder's default file context path in the constructor instead of a class field initializer. Under `[[Define]]` class-field semantics (the default at `target: es2022+`), field initializers run in an extra `<instance_members_initializer>` stack frame, which threw off the fixed-depth caller-directory resolution — `.copy()` sources resolved against the SDK's own directory instead of the caller's. The constructor-body call is emit-invariant, so the `useDefineForClassFields: false` pin in tsconfig is no longer needed and has been removed.

--- a/packages/js-sdk/src/template/index.ts
+++ b/packages/js-sdk/src/template/index.ts
@@ -66,8 +66,7 @@ export class TemplateBase
   // Force the next layer to be rebuilt
   private forceNextLayer: boolean = false
   private instructions: Instruction[] = []
-  private fileContextPath: PathLike =
-    runtime === 'browser' ? '.' : (getCallerDirectory(STACK_TRACE_DEPTH) ?? '.')
+  private fileContextPath: PathLike
   private fileIgnorePatterns: string[] = []
   private logsRefreshFrequency: number = 200
   private stackTraces: (string | undefined)[] = []
@@ -75,7 +74,11 @@ export class TemplateBase
   private stackTracesOverride: string | undefined = undefined
 
   constructor(options?: TemplateOptions) {
-    this.fileContextPath = options?.fileContextPath ?? this.fileContextPath
+    this.fileContextPath =
+      options?.fileContextPath ??
+      (runtime === 'browser'
+        ? '.'
+        : (getCallerDirectory(STACK_TRACE_DEPTH) ?? '.'))
     this.fileIgnorePatterns =
       options?.fileIgnorePatterns ?? this.fileIgnorePatterns
   }

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -3,12 +3,6 @@
     "outDir": "dist",
     "target": "es2022",
     "module": "esnext",
-    // Keep assignment (not `[[Define]]`) semantics for class fields. `target:
-    // es2022` would default this to `true`, which changes class-field emit and
-    // shifts stack frames — breaking the template builder's fixed-depth caller
-    // resolution (getCallerDirectory / per-step stack traces). Adopting define
-    // semantics should be a separate, deliberately tested change.
-    "useDefineForClassFields": false,
     "lib": [
       "dom",
       "es2022"


### PR DESCRIPTION
Follow-up to #1536, which pinned `useDefineForClassFields: false` in the js-sdk tsconfig because raising `target` to `es2022` flips the default to `true`, and that broke the template builder. This PR fixes the root cause and removes the pin, so the SDK now compiles with the standard es2022 `[[Define]]` class-field semantics.

## Root cause

`TemplateBase` resolved its default `fileContextPath` in a **class field initializer**:

```ts
private fileContextPath: PathLike =
  runtime === 'browser' ? '.' : (getCallerDirectory(STACK_TRACE_DEPTH) ?? '.')
```

With native class fields (define semantics), V8 evaluates field initializers in an extra `<instance_members_initializer>` stack frame:

```
at getCallerDirectory (utils.ts)
at <instance_members_initializer> (index.ts)   ← extra frame under define semantics
at new TemplateBase (index.ts)
at Template (index.ts)
at user code                                    ← fixed-depth walk lands one frame short
```

`getCallerDirectory` walks the stack at a fixed depth, so it landed on the SDK's own `src/template` directory instead of the caller's — `.copy('folder/*', …)` then globbed against the wrong base dir (`Error: No files found in .../src/template/...`), and the resulting client-side failure mis-attributed build-step stack traces (the two `stacktrace.test.ts` failures were cascades of this one bug).

## Fix

Move the default resolution into the constructor body, where the stack shape is identical under both emits:

```ts
constructor(options?: TemplateOptions) {
  this.fileContextPath =
    options?.fileContextPath ??
    (runtime === 'browser' ? '.' : (getCallerDirectory(STACK_TRACE_DEPTH) ?? '.'))
```

The call is now emit-invariant (same `STACK_TRACE_DEPTH`), so the tsconfig pin is removed. The method-level `getCallerFrame` call sites were never affected — method bodies don't change shape with class-field semantics.

Only the js-sdk is touched: the Python SDKs resolve the caller via `inspect` and don't have this failure mode, and the CLI bundle doesn't include `TemplateBase`.

## Usage example

Fixes relative-path resolution for SDK consumers whose toolchain emits native class fields (e.g. esbuild/vitest with `target: es2022+`):

```ts
// user-project/scripts/template.ts
const template = Template()
  .fromBaseImage()
  .copy('assets/*', '/app/assets') // now resolves against user-project/scripts/,
                                   // not the SDK's own directory
```

## Verification

- `tests/template/stacktrace.test.ts` — 30/30 pass with the flag defaulted (`true`), and still 30/30 when explicitly set back to `false` (emit-invariance)
- `tests/template/build.test.ts` — 4/4 pass against the real backend (real `.copy` glob + build)
- Smoke-tested built `dist/index.mjs` and `dist/index.js` from an external directory: `fileContextPath` resolves to the importing script's directory in both
- Unit project A/B: identical results with and without this change (remaining failures are pre-existing `E2B_API_KEY`-gated live tests)
- `pnpm run typecheck`, `lint`, `format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)