### PR TITLE
fix(python-sdk): strip OSC escape sequences in build logs

### DIFF
--- a/.changeset/python-strip-ansi-osc.md
+++ b/.changeset/python-strip-ansi-osc.md
@@ -1,0 +1,11 @@
+---
+"@e2b/python-sdk": patch
+---
+
+fix(python-sdk): strip OSC escape sequences in build logs
+
+`strip_ansi_escape_codes` now strips OSC sequences (`ESC ] ... ST`) as well as
+CSI ones, matching the JavaScript SDK's `stripAnsi`. Programs commonly emit OSC
+sequences such as the set-terminal-title `\x1b]0;title\x07` and hyperlinks
+`\x1b]8;;url\x07`, which previously leaked the string terminator and payload
+into template build log messages on the Python side.

--- a/packages/python-sdk/e2b/template/utils.py
+++ b/packages/python-sdk/e2b/template/utils.py
@@ -316,11 +316,14 @@ def strip_ansi_escape_codes(text: str) -> str:
     """
     # Valid string terminator sequences are BEL, ESC\, and 0x9c
     st = r"(?:\u0007|\u001B\u005C|\u009C)"
-    pattern = [
-        rf"[\u001B\u009B][\[\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d/#&.:=?%@~_]*)*)?{st})",
-        r"(?:(?:\d{1,4}(?:[;:]\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))",
-    ]
-    ansi_escape = re.compile("|".join(pattern), re.UNICODE)
+    # OSC sequences only: ESC ] ... ST (non-greedy until the first ST)
+    osc = rf"(?:\u001B\][\s\S]*?{st})"
+    # CSI and related: ESC/C1, optional intermediates, optional params
+    # (supports ; and :) then final byte
+    csi = (
+        r"[\u001B\u009B][\[\]()#;?]*(?:\d{1,4}(?:[;:]\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]"
+    )
+    ansi_escape = re.compile(f"{osc}|{csi}", re.UNICODE)
     return ansi_escape.sub("", text)
 
 

--- a/packages/python-sdk/tests/shared/template/utils/test_strip_ansi_escape_codes.py
+++ b/packages/python-sdk/tests/shared/template/utils/test_strip_ansi_escape_codes.py
@@ -27,3 +27,18 @@ def test_strips_colon_curly_underline():
 
 def test_leaves_plain_text_unchanged():
     assert strip_ansi_escape_codes("no escape codes here") == "no escape codes here"
+
+
+def test_strips_osc_set_terminal_title():
+    assert strip_ansi_escape_codes("\x1b]0;my title\x07AFTER") == "AFTER"
+
+
+def test_strips_osc_hyperlink():
+    assert (
+        strip_ansi_escape_codes("\x1b]8;;http://example.com\x07link\x1b]8;;\x07")
+        == "link"
+    )
+
+
+def test_strips_osc_with_st_terminator():
+    assert strip_ansi_escape_codes("\x1b]0;my title\x1b\\AFTER") == "AFTER"


### PR DESCRIPTION

### What

`strip_ansi_escape_codes` in the Python SDK did not reliably match OSC sequences
(`ESC ] ... ST`), so their string terminator and payload leaked into template
build-log messages. The set-terminal-title sequence `\x1b]0;title\x07`, which is
common in npm and other CLI output, left `title\x07` in the log.

This is a follow-up to #1522 (colon-separated SGR), the same
`strip_ansi_escape_codes` vs `stripAnsi` parity gap. That PR widened the CSI
parameter class to match the JS SDK but did not add OSC handling, so OSC
sequences remained a divergence: the JS SDK's `stripAnsi`
(`packages/js-sdk/src/utils.ts`) already strips them via a dedicated OSC branch,
the Python port did not.

`strip_ansi_escape_codes` is consumed by `LogEntry.__post_init__`
(`packages/python-sdk/e2b/template/logger.py`), so the leftover bytes showed up in
Python build logs only.

### The fix

Add the dedicated OSC alternative from `packages/js-sdk/src/utils.ts` before the
Python SDK's existing alternatives. This strips complete OSC sequences while
preserving the Python helper's existing support for other ST-terminated control
strings such as DCS.

```python
# packages/python-sdk/e2b/template/utils.py
st = r"(?:\u0007|\u001B\u005C|\u009C)"
pattern = [
    # OSC sequences only: ESC ] ... ST (non-greedy until the first ST)
    rf"(?:\u001B\][\s\S]*?{st})",
    # Existing ST-terminated control-string alternative
    # Existing CSI and related alternative
]
ansi_escape = re.compile("|".join(pattern), re.UNICODE)
```

This reuses the JS OSC branch, keeps the colon-SGR fix from #1522, and retains
the broader ST-terminated control-string handling already present in Python.

### Usage example (before / after)

```python
from e2b.template.utils import strip_ansi_escape_codes

# set-terminal-title (BEL terminator), common in npm/CLI output
strip_ansi_escape_codes("\x1b]0;my title\x07AFTER")
# before: "y title\x07AFTER"   after: "AFTER"

# set-terminal-title (ESC-backslash terminator)
strip_ansi_escape_codes("\x1b]0;my title\x1b\\AFTER")
# before: "y title\x1b\\AFTER"   after: "AFTER"

# hyperlink
strip_ansi_escape_codes("\x1b]8;;http://example.com\x07link\x1b]8;;\x07")
# after: "link"

# CSI / SGR sequences already worked and still do
strip_ansi_escape_codes("\x1b[38:5:82mX\x1b[0m")  # "X"  (unchanged)
```

### Tests

Extended the offline unit tests at
`packages/python-sdk/tests/shared/template/utils/test_strip_ansi_escape_codes.py`
(no API key or sandbox needed) with OSC cases: set-terminal-title (BEL),
ESC-backslash terminator, and hyperlink. The suite also covers DCS preservation
and the existing CSI/colon regressions from #1522. All pass locally (`pytest` on
the file: 11 passed).

### Changeset

`.changeset/python-strip-ansi-osc.md` (patch on `@e2b/python-sdk`).
