### PR TITLE
fix(python-sdk): strip uppercase AS stage alias from base image in from_dockerfile

### DIFF
--- a/.changeset/python-from-dockerfile-uppercase-as.md
+++ b/.changeset/python-from-dockerfile-uppercase-as.md
@@ -1,0 +1,11 @@
+---
+"@e2b/python-sdk": patch
+---
+
+fix(python-sdk): strip uppercase AS stage alias from base image in from_dockerfile
+
+`from_dockerfile` now removes the stage alias from a `FROM <image> AS <name>`
+line case-insensitively, matching the JavaScript SDK. The Docker `AS` keyword is
+case-insensitive, but the parser only matched a lowercase `as`, so a canonical
+`FROM python:3.11 AS builder` leaked the alias and produced the base image
+`"python:3.11 AS builder"` instead of `"python:3.11"`.

--- a/packages/python-sdk/e2b/template/dockerfile_parser.py
+++ b/packages/python-sdk/e2b/template/dockerfile_parser.py
@@ -98,9 +98,11 @@ def parse_dockerfile(
 
         # Set the base image from the first FROM instruction
         base_image = from_instructions[0]["value"]
-        # Remove AS alias if present (e.g., "node:18 AS builder" -> "node:18")
-        if " as " in base_image.lower():
-            base_image = base_image.split(" as ")[0].strip()
+        # Remove AS alias if present (e.g., "node:18 AS builder" -> "node:18").
+        # The AS keyword is case-insensitive in Dockerfiles, so match it that way.
+        base_image = re.split(r"\s+as\s+", base_image, maxsplit=1, flags=re.IGNORECASE)[
+            0
+        ].strip()
 
         user_changed = False
         workdir_changed = False

--- a/packages/python-sdk/tests/async/template_async/methods/test_from_dockerfile.py
+++ b/packages/python-sdk/tests/async/template_async/methods/test_from_dockerfile.py
@@ -67,6 +67,24 @@ async def test_from_dockerfile_with_custom_user_and_workdir():
 
 
 @pytest.mark.skip_debug()
+async def test_from_dockerfile_strips_uppercase_as_alias():
+    dockerfile = "FROM python:3.11 AS builder\nRUN echo hi"
+
+    template = AsyncTemplate().from_dockerfile(dockerfile)
+
+    assert template._template._base_image == "python:3.11"
+
+
+@pytest.mark.skip_debug()
+async def test_from_dockerfile_strips_lowercase_as_alias():
+    dockerfile = "FROM python:3.11 as builder\nRUN echo hi"
+
+    template = AsyncTemplate().from_dockerfile(dockerfile)
+
+    assert template._template._base_image == "python:3.11"
+
+
+@pytest.mark.skip_debug()
 async def test_from_dockerfile_with_multi_source_copy():
     dockerfile = """FROM node:24
 COPY file1.txt file2.txt file3.txt /dest/"""

--- a/packages/python-sdk/tests/sync/template_sync/methods/test_from_dockerfile.py
+++ b/packages/python-sdk/tests/sync/template_sync/methods/test_from_dockerfile.py
@@ -67,6 +67,24 @@ def test_from_dockerfile_with_custom_user_and_workdir():
 
 
 @pytest.mark.skip_debug()
+def test_from_dockerfile_strips_uppercase_as_alias():
+    dockerfile = "FROM python:3.11 AS builder\nRUN echo hi"
+
+    template = Template().from_dockerfile(dockerfile)
+
+    assert template._template._base_image == "python:3.11"
+
+
+@pytest.mark.skip_debug()
+def test_from_dockerfile_strips_lowercase_as_alias():
+    dockerfile = "FROM python:3.11 as builder\nRUN echo hi"
+
+    template = Template().from_dockerfile(dockerfile)
+
+    assert template._template._base_image == "python:3.11"
+
+
+@pytest.mark.skip_debug()
 def test_from_dockerfile_with_multi_source_copy():
     dockerfile = """FROM node:24
 COPY file1.txt file2.txt file3.txt /dest/"""


### PR DESCRIPTION
## What

`Template().from_dockerfile(...)` only stripped a lowercase `" as "` alias from the
`FROM` line, so `FROM python:3.11 AS builder` produced the base image
`"python:3.11 AS builder"` instead of `"python:3.11"`.

`dockerfile-parse` returns the `FROM` argument verbatim. The Python SDK's guard was
case-insensitive, but its split only matched lowercase `as`. The JavaScript SDK
already handles both forms correctly.

## The fix

Split the stage alias case-insensitively and accept any whitespace around `AS`.
This handles uppercase, lowercase, and mixed-case aliases while preserving the
existing behavior for Dockerfiles without an alias.

## Usage example

```python
from e2b import Template, TemplateBase

template = Template().from_dockerfile(
    "FROM python:3.11 AS builder\nRUN echo hi"
)

print(template._template._base_image)
# Before: python:3.11 AS builder
# After:  python:3.11

print(TemplateBase.to_dockerfile(template).splitlines()[0])
# Before: FROM python:3.11 AS builder
# After:  FROM python:3.11
```

## Tests

Added offline regression coverage to the sync and async Python suites for both
uppercase and lowercase aliases.

```text
.venv/bin/python -m pytest \
  tests/sync/template_sync/methods/test_from_dockerfile.py \
  tests/async/template_async/methods/test_from_dockerfile.py -q
# 16 passed
```

## Changeset

Added a patch changeset for `@e2b/python-sdk`.
