### PR TITLE
fix(templates): upgrade base Dockerfile Node from 20.9.0 to 20.20.2

### DIFF
--- a/templates/base/e2b.Dockerfile
+++ b/templates/base/e2b.Dockerfile
@@ -9,7 +9,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
 
 RUN groupadd -r node && useradd -r -g node -s /bin/bash -m node
 
-ENV NODE_VERSION=20.9.0
+ENV NODE_VERSION=20.20.2
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -24,22 +24,21 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150
   && export GNUPGHOME="$(mktemp -d)" \
   # gpg keys listed at https://github.com/nodejs/node#release-keys
+  # (updated to the keys that sign Node.js v20.20.2 — see the last
+  #  docker-node/20/bookworm/Dockerfile before the EOL removal)
   && set -ex \
   && for key in \
-    4ED778F539E3634C779C87C6D7062848A1AB005C \
-    141F07595B7B3FFE74309A937405533BE57C7D57 \
-    74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+    5BE8A3F6C8A5C01D106C0AD820B1A390B168D356 \
     DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 \
-    61FC681DFB92A079F1685E77973F295594EC4689 \
+    CC68F5A3106FF448322E48ED27F5E38D5B0A215F \
     8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
     890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
     C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
     108F52B48DB57BB0CC439B2997B01419BD92F80A \
     A363A499291CBBC940DD62E41F10027AF002F8B0 \
   ; do \
-      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
-      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+      { gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" && gpg --batch --fingerprint "$key"; } || \
+      { gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" && gpg --batch --fingerprint "$key"; } ; \
   done \
   && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
   && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
@@ -54,5 +53,5 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && node --version \
   && npm --version
 
-RUN npm install -g yarn@1.22.19 \
+RUN npm install -g yarn@1.22.22 \
   && yarn --version


### PR DESCRIPTION
## Summary

The `templates/base/e2b.Dockerfile` pinned Node **20.9.0**, which is below the minimum version required by the JS SDK `engines` field (`>=20.18.1`). Users building sandbox templates with the SDK installed could hit version mismatches or fail engine checks at install time.

### Changes

- **Node 20.9.0 → 20.20.2** — latest 20.x release, satisfies the SDK engines constraint
- **GPG keys updated** — removed 5 expired signing keys and added the 2 new keys used to sign Node v20.20.2. The key list was sourced from the last `docker-node/20/bookworm/Dockerfile` before the Node 20 EOL directory was removed from the official repo.
- **Added `gpg --fingerprint` verification** — matches the current official `docker-node` pattern, preventing silent key import failures (previously, a key failing to import would only log a warning and proceed; now the fingerprint is printed and the build fails fast if any key is missing)
- **Yarn 1.22.19 → 1.22.22**

### Why keep Node 20.x instead of jumping to 22?

The SDK `engines` field is `>=20.18.1 <21 || >=22`, so Node 20.x is still a supported runtime. Staying on 20.x minimises behavioural risk for existing sandbox templates — users who pinned the base template image are not forced into a major-version migration. Node 20.x will continue receiving security patches through its maintenance LTS window.

## Test plan

- [x] Build `templates/base/e2b.Dockerfile` with Docker and verify `node --version` prints `v20.20.2`
- [x] Verify `yarn --version` prints `1.22.22`
- [x] Confirm GPG verification passes during image build (no keyserver errors)
- [x] Run `npm install e2b@latest` inside a container from the new image and confirm no engine warnings