### PR TITLE
fix(sdk): clean up sandbox when MCP gateway startup fails

### DIFF
--- a/.changeset/quiet-sandboxes-clean.md
+++ b/.changeset/quiet-sandboxes-clean.md
@@ -1,0 +1,6 @@
+---
+"e2b": patch
+"@e2b/python-sdk": patch
+---
+
+Kill newly created sandboxes when MCP gateway startup fails.

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -320,17 +320,22 @@ export class Sandbox extends SandboxApi {
 
     if (sandboxOpts?.mcp) {
       sandbox.mcpToken = crypto.randomUUID()
-      const res = await sandbox.commands.run(
-        `mcp-gateway --config ${shellQuote(JSON.stringify(sandboxOpts.mcp))}`,
-        {
-          user: 'root',
-          envs: {
-            GATEWAY_ACCESS_TOKEN: sandbox.mcpToken ?? '',
-          },
+      try {
+        const res = await sandbox.commands.run(
+          `mcp-gateway --config ${shellQuote(JSON.stringify(sandboxOpts.mcp))}`,
+          {
+            user: 'root',
+            envs: {
+              GATEWAY_ACCESS_TOKEN: sandbox.mcpToken ?? '',
+            },
+          }
+        )
+        if (res.exitCode !== 0) {
+          throw new Error(`Failed to start MCP gateway: ${res.stderr}`)
         }
-      )
-      if (res.exitCode !== 0) {
-        throw new Error(`Failed to start MCP gateway: ${res.stderr}`)
+      } catch (error) {
+        await sandbox.kill().catch(() => undefined)
+        throw error
       }
     }
 

--- a/packages/js-sdk/tests/sandbox/create.test.ts
+++ b/packages/js-sdk/tests/sandbox/create.test.ts
@@ -1,4 +1,4 @@
-import { assert, test } from 'vitest'
+import { assert, expect, test } from 'vitest'
 
 import { Sandbox } from '../../src'
 import { template, isDebug } from '../setup.js'
@@ -32,3 +32,36 @@ test.skipIf(isDebug)('metadata', async () => {
     await sbx.kill()
   }
 })
+
+test.skipIf(isDebug)(
+  'MCP gateway start failure kills the created sandbox',
+  async () => {
+    const metadata = { mcpGatewayCleanupTestId: crypto.randomUUID() }
+    const query = { state: ['running' as const], metadata }
+    let remainingSandboxes: Awaited<
+      ReturnType<ReturnType<typeof Sandbox.list>['nextItems']>
+    > = []
+
+    try {
+      await expect(
+        Sandbox.create({
+          timeoutMs: 60_000,
+          metadata,
+          mcp: { invalid_server: {} } as never,
+        })
+      ).rejects.toThrow('Failed to start MCP gateway')
+
+      remainingSandboxes = await Sandbox.list({ query }).nextItems()
+      expect(remainingSandboxes).toEqual([])
+    } finally {
+      remainingSandboxes = await Sandbox.list({ query })
+        .nextItems()
+        .catch(() => remainingSandboxes)
+      await Promise.all(
+        remainingSandboxes.map((sandbox) =>
+          Sandbox.kill(sandbox.sandboxId).catch(() => false)
+        )
+      )
+    }
+  }
+)

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -242,13 +242,20 @@ class AsyncSandbox(SandboxApi):
             token = str(uuid.uuid4())
             sandbox._mcp_token = token
 
-            res = await sandbox.commands.run(
-                f"mcp-gateway --config {shlex.quote(json.dumps(mcp))}",
-                user="root",
-                envs={"GATEWAY_ACCESS_TOKEN": token},
-            )
-            if res.exit_code != 0:
-                raise Exception(f"Failed to start MCP gateway: {res.stderr}")
+            try:
+                res = await sandbox.commands.run(
+                    f"mcp-gateway --config {shlex.quote(json.dumps(mcp))}",
+                    user="root",
+                    envs={"GATEWAY_ACCESS_TOKEN": token},
+                )
+                if res.exit_code != 0:
+                    raise Exception(f"Failed to start MCP gateway: {res.stderr}")
+            except BaseException:
+                try:
+                    await sandbox.kill()
+                except BaseException:
+                    pass
+                raise
 
         return sandbox
 

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -228,13 +228,20 @@ class Sandbox(SandboxApi):
             token = str(uuid.uuid4())
             sandbox._mcp_token = token
 
-            res = sandbox.commands.run(
-                f"mcp-gateway --config {shlex.quote(json.dumps(mcp))}",
-                user="root",
-                envs={"GATEWAY_ACCESS_TOKEN": token},
-            )
-            if res.exit_code != 0:
-                raise Exception(f"Failed to start MCP gateway: {res.stderr}")
+            try:
+                res = sandbox.commands.run(
+                    f"mcp-gateway --config {shlex.quote(json.dumps(mcp))}",
+                    user="root",
+                    envs={"GATEWAY_ACCESS_TOKEN": token},
+                )
+                if res.exit_code != 0:
+                    raise Exception(f"Failed to start MCP gateway: {res.stderr}")
+            except BaseException:
+                try:
+                    sandbox.kill()
+                except BaseException:
+                    pass
+                raise
 
         return sandbox
 

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import Any, cast
+from uuid import uuid4
 
 import httpx
 import pytest
@@ -34,6 +35,31 @@ async def test_metadata(async_sandbox_factory):
             break
     else:
         assert False, "Sandbox not found"
+
+
+@pytest.mark.skip_debug()
+async def test_mcp_gateway_start_failure_kills_created_sandbox():
+    metadata = {"mcp_gateway_cleanup_test_id": str(uuid4())}
+    query = SandboxQuery(state=[SandboxState.RUNNING], metadata=metadata)
+    remaining_sandboxes = []
+
+    try:
+        with pytest.raises(Exception, match="Failed to start MCP gateway"):
+            await AsyncSandbox.create(
+                timeout=60,
+                metadata=metadata,
+                mcp=cast(Any, {"invalid_server": {}}),
+            )
+
+        remaining_sandboxes = await AsyncSandbox.list(query=query).next_items()
+        assert remaining_sandboxes == []
+    finally:
+        try:
+            remaining_sandboxes = await AsyncSandbox.list(query=query).next_items()
+        except Exception:
+            pass
+        for sandbox in remaining_sandboxes:
+            await AsyncSandbox.kill(sandbox.sandbox_id)
 
 
 def test_create_payload_serializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -1,5 +1,6 @@
 from time import sleep
 from typing import Any, cast
+from uuid import uuid4
 
 import httpx
 import pytest
@@ -35,6 +36,31 @@ def test_metadata(sandbox_factory):
             break
     else:
         assert False, "Sandbox not found"
+
+
+@pytest.mark.skip_debug()
+def test_mcp_gateway_start_failure_kills_created_sandbox():
+    metadata = {"mcp_gateway_cleanup_test_id": str(uuid4())}
+    query = SandboxQuery(state=[SandboxState.RUNNING], metadata=metadata)
+    remaining_sandboxes = []
+
+    try:
+        with pytest.raises(Exception, match="Failed to start MCP gateway"):
+            Sandbox.create(
+                timeout=60,
+                metadata=metadata,
+                mcp=cast(Any, {"invalid_server": {}}),
+            )
+
+        remaining_sandboxes = Sandbox.list(query=query).next_items()
+        assert remaining_sandboxes == []
+    finally:
+        try:
+            remaining_sandboxes = Sandbox.list(query=query).next_items()
+        except Exception:
+            pass
+        for sandbox in remaining_sandboxes:
+            Sandbox.kill(sandbox.sandbox_id)
 
 
 def test_create_payload_serializes_auto_resume_enabled():


### PR DESCRIPTION
## Problem

Fixes #1498.

`Sandbox.create` allocates a remote sandbox before starting `mcp-gateway`. If gateway startup returns a non-zero exit code or throws an exception, creation fails before the sandbox object is returned. As a result, the caller has no sandbox ID to clean up, and the orphaned sandbox continues consuming resources until it times out.

This state transition exists in synchronous Python, asynchronous Python, and JavaScript/TypeScript.

## Changes

- Add a rollback boundary around MCP gateway startup in all three SDK implementations.
- Attempt to kill the newly allocated sandbox when gateway startup fails.
- Keep cleanup best-effort so a failed or cancelled `kill` does not replace the original gateway error.
- Add real integration coverage for synchronous Python, asynchronous Python, and TypeScript.
- Add a patch changeset for `e2b` and `@e2b/python-sdk`.

## Usage Behavior

No API changes are required. Existing code continues to receive the original startup error, but a failed creation will normally no longer leave a sandbox behind.

## Validation

Integration tests have been added and verified successfully.

## Notes

PR #1499 is a friendly competing implementation for the same issue. The maintainer requested that its mocked tests be replaced with real integration tests, but the PR received no further updates for several days. The maintainer subsequently confirmed that an alternative contribution could be submitted as long as it was implemented independently from scratch, so this PR was prepared only after that confirmation.
