### PR TITLE
ci: seed codegen image cache from main instead of per-PR scopes

### DIFF
--- a/.github/workflows/codegen_image_cache.yml
+++ b/.github/workflows/codegen_image_cache.yml
@@ -1,0 +1,35 @@
+name: Codegen image cache
+
+# Seeds the buildkit cache for codegen.Dockerfile from main so pull request
+# runs of generated_files.yml warm-start. PR-scoped cache writes are not
+# readable by other PRs, so main is the only scope worth writing to.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'codegen.Dockerfile'
+      - 'packages/connect-python/**'
+      - '.github/workflows/codegen_image_cache.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  seed:
+    name: Seed codegen image cache
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build codegen image and export cache
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: codegen.Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/generated_files.yml
+++ b/.github/workflows/generated_files.yml
@@ -81,8 +81,10 @@ jobs:
           file: codegen.Dockerfile
           tags: codegen-env:latest
           load: true # makes the image available for `docker run`
+          # Cache is seeded from main by codegen_image_cache.yml. No cache-to
+          # here: PR-scoped writes are unreadable by other PRs and only fill
+          # the repo's 10 GB Actions cache, evicting other caches.
           cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Run codegen
         run: CODEGEN_IMAGE=codegen-env:latest make codegen


### PR DESCRIPTION
## Why

`generated_files.yml` only runs on `pull_request`, so its `cache-to: type=gha,mode=max` wrote buildkit blobs into per-PR scopes that other PRs cannot read — every new PR cold-built the codegen image (235–365s in 11 of 17 runs over the past week vs ~65s warm), and ~6 GB of duplicate blobs pushed the repo's Actions cache to 9.9 GB of the 10 GB limit, evicting the Playwright and pnpm caches that #1538 relies on.

## What

Adds `codegen_image_cache.yml`, which builds the image on pushes to `main` touching its actual inputs (`codegen.Dockerfile`, `packages/connect-python/**`, or the workflow itself) and exports the cache to main's scope, readable by all PRs; it also supports `workflow_dispatch` for manual re-seeding. The PR-side build in `generated_files.yml` keeps `cache-from` but drops `cache-to`. Merging this PR triggers the first seed automatically, since the new workflow file matches its own paths filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)