### PR TITLE
fix(build): honor CODEGEN_IMAGE in Makefile codegen target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 .PHONY: codegen
 codegen:
-	@echo "Building codegen image"
-	docker build -q -t codegen-env . -f codegen.Dockerfile
+	@if [ -z "$$CODEGEN_IMAGE" ]; then \
+		echo "Building codegen image"; \
+		docker build -q -t codegen-env . -f codegen.Dockerfile; \
+	else \
+		echo "Using pre-built image $$CODEGEN_IMAGE (skipping build)"; \
+	fi
 	@echo "Generating code"
-	docker run -v $$PWD:/workspace codegen-env make generate
+	docker run -v $$PWD:/workspace $${CODEGEN_IMAGE:-codegen-env} make generate
 
 generate: generate-js generate-python
 


### PR DESCRIPTION
### What

Carries #1529 by @anxkhn (squash-merged into this branch), plus a review follow-up making the build-skip visible.

The `generated_files.yml` workflow pre-builds the codegen image with GHA layer caching and runs `CODEGEN_IMAGE=codegen-env:latest make codegen`, but the `codegen` target stopped reading `CODEGEN_IMAGE` — it always rebuilt the image from scratch, making the workflow's buildx cache step a no-op.

The `codegen` target now skips its local `docker build` and runs the caller-supplied image when `CODEGEN_IMAGE` is set, announcing the skip; behavior with the variable unset is unchanged.

### Usage

Local (unchanged):

```console
$ make codegen
Building codegen image
...
Generating code
```

CI / pre-built image:

```console
$ CODEGEN_IMAGE=codegen-env:latest make codegen
Using pre-built image codegen-env:latest (skipping build)
Generating code
```

### Why the skip is announced

If `CODEGEN_IMAGE` were ever ambiently set in a dev shell and pointed at a stale local image, the build would be skipped silently and codegen would run an old toolchain with exit 0. The echo makes that state visible in the output.

Generated output is identical either way (same image contents, same `make generate`), so the "Check for uncommitted changes" gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)