### PR TITLE
fix(cli): resolve template alias instead of writing template_id as name in migrate

### DIFF
--- a/.changeset/migrate-resolve-template-name.md
+++ b/.changeset/migrate-resolve-template-name.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": patch
+---
+
+`e2b template migrate` no longer silently writes the template ID into the template name slot of the generated build files when `e2b.toml` has no `template_name`. The CLI now resolves the template's alias via the API and uses it as the name. When the alias cannot be resolved (offline, not logged in, or the template has no alias), it falls back to the previous behavior and prints a warning explaining that building with the ID as the name fails with a 409 alias collision, and how to fix it (`--name` or editing the generated files).

--- a/packages/cli/src/commands/template/migrate.ts
+++ b/packages/cli/src/commands/template/migrate.ts
@@ -3,18 +3,62 @@ import * as commander from 'commander'
 import { Template, TemplateBuilder, TemplateClass } from 'e2b'
 import * as fs from 'fs'
 import * as path from 'path'
+import { resolveTeamId } from '../../api'
 import { E2BConfig, getConfigPath, loadConfig } from '../../config'
 import { defaultDockerfileName } from '../../docker/constants'
 import { configOption, parsePositiveInt, pathOption } from '../../options'
 import { getRoot } from '../../utils/filesystem'
 import { asLocal, asLocalRelative, asPrimary } from '../../utils/format'
 import { getDockerfile } from './dockerfile'
+import { listSandboxTemplates } from './list'
 import { validateTemplateName } from '../../utils/templateName'
 import {
   generateAndWriteTemplateFiles,
   Language,
   languageDisplay,
 } from './generators'
+
+/**
+ * Resolve a template name (alias) for a config that only carries a template
+ * ID. The name written into the generated build files must be an alias, not
+ * the internal template ID: `Template.build` treats it as a new alias, and
+ * registering the template ID as an alias collides with the template itself
+ * (409 "alias already used").
+ *
+ * Tries to look the alias up via the API and returns undefined when that is
+ * not possible (offline, not logged in, or the template has no alias), so
+ * the caller can fall back to the previous behavior with a warning.
+ */
+async function resolveNameFromTemplateId(
+  config: E2BConfig
+): Promise<string | undefined> {
+  try {
+    const templates = await listSandboxTemplates({
+      teamID: resolveTeamId(undefined, config.team_id),
+    })
+    const template = templates.find((t) => t.templateID === config.template_id)
+    const alias = template?.aliases?.slice().sort()[0]
+    if (alias) {
+      console.log(
+        `Using template name ${asLocal(alias)} resolved from template ID ${asLocal(config.template_id)}.`
+      )
+      return alias
+    }
+  } catch {
+    // Offline or unauthenticated: fall through to the warning below.
+  }
+
+  console.warn(
+    `\n⚠️  Could not resolve a template name for template ID ${asLocal(config.template_id)}.`
+  )
+  console.warn(
+    'The generated files will use the template ID as the template name. Building them will fail with a 409 "alias already used" error, because the ID cannot be registered as a new alias for the same template.'
+  )
+  console.warn(
+    `Re-run with ${asLocal('--name <name>')}, or replace the name in the generated files with your template's name before building.`
+  )
+  return undefined
+}
 
 /**
  * Migrate Dockerfile to a specific target language using SDK
@@ -178,7 +222,8 @@ export const migrateCommand = new commander.Command('migrate')
         }
 
         // Validate config file exists
-        if (fs.existsSync(configPath)) {
+        const configExists = fs.existsSync(configPath)
+        if (configExists) {
           config = await loadConfig(configPath)
         } else {
           console.error(
@@ -233,13 +278,21 @@ export const migrateCommand = new commander.Command('migrate')
           })
         }
 
+        // Resolve the template name: an explicit override or a configured
+        // name wins; a config that only has a template ID needs the alias
+        // looked up, because the ID is not usable as a template name.
+        let templateName = opts.name
+        if (!templateName && !config.template_name && configExists) {
+          templateName = await resolveNameFromTemplateId(config)
+        }
+
         // Perform migration
         await migrateToLanguage(
           root,
           config,
           dockerfileContent,
           language,
-          opts.name
+          templateName
         )
 
         // Rename old files to .old extensions

--- a/packages/cli/tests/commands/template/migrate.test.ts
+++ b/packages/cli/tests/commands/template/migrate.test.ts
@@ -283,6 +283,61 @@ dockerfile = "e2b.Dockerfile"`
     })
   })
 
+  describe('Template Name Resolution', () => {
+    test('should warn and fall back to the template ID when no name can be resolved', async () => {
+      const dockerfile = 'FROM node:18'
+      await fs.writeFile(path.join(testDir, 'e2b.Dockerfile'), dockerfile)
+
+      const config = `template_id = "tmpl-id-without-alias"
+dockerfile = "e2b.Dockerfile"`
+      await fs.writeFile(path.join(testDir, 'e2b.toml'), config)
+
+      const output = execSync(
+        `node ${cliPath} template migrate --language typescript 2>&1`,
+        {
+          cwd: testDir,
+          encoding: 'utf-8',
+        }
+      )
+
+      expect(output).toContain('Could not resolve a template name')
+      expect(output).toContain('Migration completed successfully')
+
+      const buildProdFile = await fs.readFile(
+        path.join(testDir, 'build.prod.ts'),
+        'utf-8'
+      )
+      expect(buildProdFile).toContain("'tmpl-id-without-alias'")
+    })
+
+    test('should use the configured template name without a warning', async () => {
+      const dockerfile = 'FROM node:18'
+      await fs.writeFile(path.join(testDir, 'e2b.Dockerfile'), dockerfile)
+
+      const config = `template_id = "tmpl-id"
+template_name = "my-app"
+dockerfile = "e2b.Dockerfile"`
+      await fs.writeFile(path.join(testDir, 'e2b.toml'), config)
+
+      const output = execSync(
+        `node ${cliPath} template migrate --language typescript 2>&1`,
+        {
+          cwd: testDir,
+          encoding: 'utf-8',
+        }
+      )
+
+      expect(output).not.toContain('Could not resolve a template name')
+
+      const buildProdFile = await fs.readFile(
+        path.join(testDir, 'build.prod.ts'),
+        'utf-8'
+      )
+      expect(buildProdFile).toContain("'my-app'")
+      expect(buildProdFile).not.toContain("'tmpl-id'")
+    })
+  })
+
   describe('Error Cases', () => {
     test('should succeed with warning when config file is missing', async () => {
       // Create only Dockerfile, no config


### PR DESCRIPTION
Fixes #1478

## Problem

When `e2b.toml` has no `template_name`, `e2b template migrate` falls back to `config.template_id` for the name written into the generated build files. `Template.build` treats that argument as a new alias, and the template ID cannot be registered as an alias for the same template, so the first `build_prod` run fails with `409: Alias '<template_id>' is already used`. The `dev` variant masks the bug because `<template_id>-dev` happens to be a fresh alias, so users only hit it when pushing to prod.

This is a follow-up to #1494, which added the `--name` override but kept the broken default fallback.

## Fix

- When the config has a `template_id` but no `template_name` and no `--name` override is given, resolve the template's alias via the API (`GET /templates` for the config's `team_id`, matching on `templateID`) and use it as the generated name.
- When resolution is not possible (offline, not logged in, template not found, or the template has no alias), keep the previous fallback so `migrate` still works offline, but print a warning that names the 409 failure mode and tells the user to either re-run with `--name` or replace the name in the generated files.

The resolution is best-effort on purpose: `migrate` is usable without authentication today (the whole e2e test suite runs offline), and a hard failure would break that. The warning turns the current silent time bomb into an explicit, actionable message at migration time.

## Tests

Two new e2e tests in `migrate.test.ts` (30 total pass):
- config with only a `template_id`: migration succeeds, prints the resolution warning, and the generated `build.prod.ts` still contains the ID fallback
- config with a `template_name`: no warning, generated files use the name, not the ID

`pnpm typecheck`, `pnpm build`, `pnpm lint`, and `prettier --check` pass on the touched files. Changeset included (patch on `@e2b/cli`).
