### PR TITLE
feat(sdk): deprecate list form of files.write in favor of write_files

### DIFF
--- a/.changeset/js-write-array-overload-deprecated.md
+++ b/.changeset/js-write-array-overload-deprecated.md
@@ -1,0 +1,7 @@
+---
+"e2b": patch
+---
+
+Mark the array overload of `files.write()` as `@deprecated` in favor of
+`files.writeFiles()`. The overload keeps working; it will be removed in the
+next major version.

--- a/.changeset/python-write-list-deprecation.md
+++ b/.changeset/python-write-list-deprecation.md
@@ -3,8 +3,8 @@
 ---
 
 Restore backwards compatibility for the SDK v1 list form of `files.write()`:
-passing a list of `WriteEntry` objects now emits a `DeprecationWarning` and
-delegates to `files.write_files()` instead of failing with a `TypeError`. The
-typed signature of `write()` stays single-file only (`path` + `data`) — use
-`write_files()` for batch writes. Calling `write()` without `data` now raises
-`InvalidArgumentException`.
+passing a list of `WriteEntry` objects now delegates to `files.write_files()`
+instead of failing with a `TypeError`. The list form is deprecated and will be
+removed in the next major version — the typed signature of `write()` stays
+single-file only (`path` + `data`); use `write_files()` for batch writes.
+Calling `write()` without `data` now raises `InvalidArgumentException`.

--- a/.changeset/python-write-list-deprecation.md
+++ b/.changeset/python-write-list-deprecation.md
@@ -1,0 +1,10 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Restore backwards compatibility for the SDK v1 list form of `files.write()`:
+passing a list of `WriteEntry` objects now emits a `DeprecationWarning` and
+delegates to `files.write_files()` instead of failing with a `TypeError`. The
+typed signature of `write()` stays single-file only (`path` + `data`) — use
+`write_files()` for batch writes. Calling `write()` without `data` now raises
+`InvalidArgumentException`.

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -583,6 +583,16 @@ export class Filesystem {
     data: string | ArrayBuffer | Blob | ReadableStream,
     opts?: FilesystemWriteOpts
   ): Promise<WriteInfo>
+  /**
+   * Write multiple files.
+   *
+   * @deprecated Use {@link Filesystem.writeFiles} instead. This overload will be removed in the next major version.
+   *
+   * @param files list of files to write as `WriteEntry` objects, each containing `path` and `data`.
+   * @param opts connection options.
+   *
+   * @returns information about the written files
+   */
   async write(
     files: WriteEntry[],
     opts?: FilesystemWriteOpts

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import IO, Dict, List, Literal, Optional, Union, overload
+import warnings
+from typing import IO, Dict, List, Literal, Optional, Union, cast, overload
 
 
 import httpcore
@@ -262,7 +263,7 @@ class Filesystem:
     async def write(
         self,
         path: str,
-        data: Union[str, bytes, IO],
+        data: Optional[Union[str, bytes, IO]] = None,
         user: Optional[Username] = None,
         request_timeout: Optional[float] = None,
         gzip: bool = False,
@@ -284,7 +285,36 @@ class Filesystem:
         :param metadata: User-defined metadata to persist on the uploaded file as extended attributes. Keys are lowercased by the sandbox; invalid keys or values raise an `InvalidArgumentException`. Requires envd 0.6.2 or later.
 
         :return: Information about the written file
+
+        .. deprecated::
+            Passing a list of `WriteEntry` objects as `path` still works but is
+            deprecated — use `write_files()` to write multiple files.
         """
+        if isinstance(path, list):
+            warnings.warn(
+                "Passing a list of files to `write()` is deprecated, use `write_files()` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if data is not None:
+                raise InvalidArgumentException(
+                    "Cannot specify both a list of files and `data`. Use `write_files()` to write multiple files."
+                )
+            results = await self.write_files(
+                cast(List[WriteEntry], path),
+                user=user,
+                request_timeout=request_timeout,
+                gzip=gzip,
+                use_octet_stream=use_octet_stream,
+                metadata=metadata,
+            )
+            return results  # type: ignore[invalid-return-type]
+
+        if data is None:
+            raise InvalidArgumentException(
+                "`data` is required when writing a single file."
+            )
+
         result = await self.write_files(
             [WriteEntry(path=path, data=data)],
             user=user,

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
@@ -1,5 +1,4 @@
 import asyncio
-import warnings
 from typing import IO, Dict, List, Literal, Optional, Union, cast, overload
 
 
@@ -291,11 +290,6 @@ class Filesystem:
             deprecated — use `write_files()` to write multiple files.
         """
         if isinstance(path, list):
-            warnings.warn(
-                "Passing a list of files to `write()` is deprecated, use `write_files()` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             if data is not None:
                 raise InvalidArgumentException(
                     "Cannot specify both a list of files and `data`. Use `write_files()` to write multiple files."

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -1,5 +1,4 @@
 import threading
-import warnings
 from typing import IO, Dict, List, Literal, Optional, Union, cast, overload
 
 import httpx
@@ -307,11 +306,6 @@ class Filesystem:
             deprecated — use `write_files()` to write multiple files.
         """
         if isinstance(path, list):
-            warnings.warn(
-                "Passing a list of files to `write()` is deprecated, use `write_files()` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             if data is not None:
                 raise InvalidArgumentException(
                     "Cannot specify both a list of files and `data`. Use `write_files()` to write multiple files."

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -1,5 +1,6 @@
 import threading
-from typing import IO, Dict, List, Literal, Optional, Union, overload
+import warnings
+from typing import IO, Dict, List, Literal, Optional, Union, cast, overload
 
 import httpx
 from packaging.version import Version
@@ -278,7 +279,7 @@ class Filesystem:
     def write(
         self,
         path: str,
-        data: Union[str, bytes, IO],
+        data: Optional[Union[str, bytes, IO]] = None,
         user: Optional[Username] = None,
         request_timeout: Optional[float] = None,
         gzip: bool = False,
@@ -300,7 +301,36 @@ class Filesystem:
         :param metadata: User-defined metadata to persist on the uploaded file as extended attributes. Keys are lowercased by the sandbox; invalid keys or values raise an `InvalidArgumentException`. Requires envd 0.6.2 or later.
 
         :return: Information about the written file
+
+        .. deprecated::
+            Passing a list of `WriteEntry` objects as `path` still works but is
+            deprecated — use `write_files()` to write multiple files.
         """
+        if isinstance(path, list):
+            warnings.warn(
+                "Passing a list of files to `write()` is deprecated, use `write_files()` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if data is not None:
+                raise InvalidArgumentException(
+                    "Cannot specify both a list of files and `data`. Use `write_files()` to write multiple files."
+                )
+            results = self.write_files(
+                cast(List[WriteEntry], path),
+                user=user,
+                request_timeout=request_timeout,
+                gzip=gzip,
+                use_octet_stream=use_octet_stream,
+                metadata=metadata,
+            )
+            return results  # type: ignore[invalid-return-type]
+
+        if data is None:
+            raise InvalidArgumentException(
+                "`data` is required when writing a single file."
+            )
+
         result = self.write_files(
             [WriteEntry(path=path, data=data)],
             user=user,

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_write.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_write.py
@@ -1,7 +1,10 @@
 import io
 import uuid
 
+import pytest
+
 from e2b import AsyncSandbox
+from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.filesystem.filesystem import FileType, WriteEntry
 from e2b.sandbox_async.filesystem.filesystem import WriteInfo
 
@@ -92,6 +95,30 @@ async def test_write_multiple_files(async_sandbox: AsyncSandbox, debug):
         await async_sandbox.files.remove(one_file_path)
         for i in range(num_test_files):
             await async_sandbox.files.remove(f"test_write_{i}.txt")
+
+
+async def test_write_list_form_is_deprecated(async_sandbox: AsyncSandbox, debug):
+    files = [
+        WriteEntry(path="deprecated_write_0.txt", data="File 0."),
+        WriteEntry(path="deprecated_write_1.txt", data="File 1."),
+    ]
+
+    with pytest.warns(DeprecationWarning, match="write_files"):
+        infos = await async_sandbox.files.write(files)  # type: ignore[invalid-argument-type]
+
+    assert isinstance(infos, list)
+    assert len(infos) == len(files)
+    for i, file in enumerate(files):
+        assert await async_sandbox.files.read(file["path"]) == f"File {i}."
+
+    if debug:
+        for file in files:
+            await async_sandbox.files.remove(file["path"])
+
+
+async def test_write_without_data_raises(async_sandbox: AsyncSandbox):
+    with pytest.raises(InvalidArgumentException, match="data"):
+        await async_sandbox.files.write("test_write_no_data.txt")
 
 
 async def test_overwrite_file(async_sandbox: AsyncSandbox, debug):

--- a/packages/python-sdk/tests/async/sandbox_async/files/test_write.py
+++ b/packages/python-sdk/tests/async/sandbox_async/files/test_write.py
@@ -97,14 +97,15 @@ async def test_write_multiple_files(async_sandbox: AsyncSandbox, debug):
             await async_sandbox.files.remove(f"test_write_{i}.txt")
 
 
-async def test_write_list_form_is_deprecated(async_sandbox: AsyncSandbox, debug):
+async def test_write_deprecated_list_form_still_works(
+    async_sandbox: AsyncSandbox, debug
+):
     files = [
         WriteEntry(path="deprecated_write_0.txt", data="File 0."),
         WriteEntry(path="deprecated_write_1.txt", data="File 1."),
     ]
 
-    with pytest.warns(DeprecationWarning, match="write_files"):
-        infos = await async_sandbox.files.write(files)  # type: ignore[invalid-argument-type]
+    infos = await async_sandbox.files.write(files)  # type: ignore[invalid-argument-type]
 
     assert isinstance(infos, list)
     assert len(infos) == len(files)

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_write.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_write.py
@@ -1,6 +1,9 @@
 import io
 import uuid
 
+import pytest
+
+from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.filesystem.filesystem import FileType, WriteInfo, WriteEntry
 
 
@@ -93,6 +96,30 @@ def test_write_multiple_files(sandbox, debug):
         sandbox.files.remove(one_file_path)
         for i in range(num_test_files):
             sandbox.files.remove(f"test_write_{i}.txt")
+
+
+def test_write_list_form_is_deprecated(sandbox, debug):
+    files = [
+        WriteEntry(path="deprecated_write_0.txt", data="File 0."),
+        WriteEntry(path="deprecated_write_1.txt", data="File 1."),
+    ]
+
+    with pytest.warns(DeprecationWarning, match="write_files"):
+        infos = sandbox.files.write(files)
+
+    assert isinstance(infos, list)
+    assert len(infos) == len(files)
+    for i, file in enumerate(files):
+        assert sandbox.files.read(file["path"]) == f"File {i}."
+
+    if debug:
+        for file in files:
+            sandbox.files.remove(file["path"])
+
+
+def test_write_without_data_raises(sandbox):
+    with pytest.raises(InvalidArgumentException, match="data"):
+        sandbox.files.write("test_write_no_data.txt")
 
 
 def test_overwrite_file(sandbox, debug):

--- a/packages/python-sdk/tests/sync/sandbox_sync/files/test_write.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/files/test_write.py
@@ -98,14 +98,13 @@ def test_write_multiple_files(sandbox, debug):
             sandbox.files.remove(f"test_write_{i}.txt")
 
 
-def test_write_list_form_is_deprecated(sandbox, debug):
+def test_write_deprecated_list_form_still_works(sandbox, debug):
     files = [
         WriteEntry(path="deprecated_write_0.txt", data="File 0."),
         WriteEntry(path="deprecated_write_1.txt", data="File 1."),
     ]
 
-    with pytest.warns(DeprecationWarning, match="write_files"):
-        infos = sandbox.files.write(files)
+    infos = sandbox.files.write(files)
 
     assert isinstance(infos, list)
     assert len(infos) == len(files)


### PR DESCRIPTION
## Description

Closes [SDK-239](https://linear.app/e2b/issue/SDK-239/python-sdk-deprecate-fileswrite-overload-add-write-files-for-batch). The SDK v2 split of Python's `files.write` into `write`/`write_files` dropped the v1 list overload with no migration path, so v1-style calls failed with a confusing `TypeError` — this restores the list form as a runtime-only compatibility shim that delegates to `write_files()`, while the typed signature stays single-file only with fixed return types. The deprecation is carried by docstrings/JSDoc only (no runtime warnings), matching the SDK's existing deprecation convention. Calling `write()` without `data` now raises `InvalidArgumentException` instead of `TypeError`. For JS parity, the array overload of `files.write()` is marked `@deprecated` in favor of `writeFiles()`, to be removed in the next major. Includes sync/async tests (verified against a real sandbox) and changesets for both SDKs; docs live outside this repo and need a follow-up there.

## Usage

```python
# Deprecated (still works via compatibility shim):
sandbox.files.write([{"path": "a.txt", "data": "A"}, {"path": "b.txt", "data": "B"}])

# Use instead:
sandbox.files.write_files([
    WriteEntry(path="a.txt", data="A"),
    WriteEntry(path="b.txt", data="B"),
])
sandbox.files.write("a.txt", "A")  # single file, returns WriteInfo
```

```ts
// Deprecated overload (JSDoc @deprecated, still works):
await sandbox.files.write([{ path: 'a.txt', data: 'A' }])

// Use instead:
await sandbox.files.writeFiles([{ path: 'a.txt', data: 'A' }])
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)