### PR TITLE
feat(cli): remove per-command tag from integration attribution

### DIFF
--- a/.changeset/spotty-berries-clap.md
+++ b/.changeset/spotty-berries-clap.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Remove the per-command `e2b-cli-command/<command>` tag from the User-Agent integration attribution; CLI requests are now attributed with the `e2b-cli/<version>` tag only

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -5,11 +5,9 @@ import * as packageJSON from '../package.json'
 import { getUserConfig, UserConfig } from './user'
 import { asBold, asPrimary } from './utils/format'
 
-const cliIntegration = `e2b-cli/${packageJSON.version}`
-
 // Must run before any ConnectionConfig is constructed (including the
 // module-level one below) — configs read the integration at construction time.
-e2b.ConnectionConfig.setIntegration(cliIntegration)
+e2b.ConnectionConfig.setIntegration(`e2b-cli/${packageJSON.version}`)
 
 export type Teams =
   e2b.paths['/teams']['get']['responses'][200]['content']['application/json']
@@ -108,34 +106,15 @@ const userConfig = getUserConfig()
 const resolvedAccessToken =
   process.env.E2B_ACCESS_TOKEN || userConfig?.tokens.access_token
 
-function buildConnectionConfig() {
-  return new e2b.ConnectionConfig({
-    apiKey: process.env.E2B_API_KEY || userConfig?.teamApiKey,
-    apiHeaders: resolvedAccessToken
-      ? { Authorization: `Bearer ${resolvedAccessToken}` }
-      : undefined,
-  })
-}
+export const connectionConfig = new e2b.ConnectionConfig({
+  apiKey: process.env.E2B_API_KEY || userConfig?.teamApiKey,
+  apiHeaders: resolvedAccessToken
+    ? { Authorization: `Bearer ${resolvedAccessToken}` }
+    : undefined,
+})
 
 // The CLI authenticates team-scoped endpoints (e.g. `/teams`) with the access
 // token instead of an API key, so don't require an API key here.
-function buildClient(config: e2b.ConnectionConfig) {
-  return new e2b.ApiClient(config, { requireApiKey: false })
-}
-
-export let connectionConfig = buildConnectionConfig()
-export let client = buildClient(connectionConfig)
-
-/**
- * Extend the integration tag with the command being run, e.g.
- * `e2b-cli-command/sandbox.list`. Configs capture the User-Agent when
- * constructed, and the shared config and client above are built at import
- * time — before the command is known — so they are rebuilt here.
- */
-export function setCommandAttribution(commandPath: string) {
-  e2b.ConnectionConfig.setIntegration(
-    `${cliIntegration} e2b-cli-command/${commandPath}`
-  )
-  connectionConfig = buildConnectionConfig()
-  client = buildClient(connectionConfig)
-}
+export const client = new e2b.ApiClient(connectionConfig, {
+  requireApiKey: false,
+})

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,29 +1,11 @@
 import * as commander from 'commander'
 
-import { setCommandAttribution } from 'src/api'
 import { asPrimary } from 'src/utils/format'
 import { templateCommand } from './template'
 import { sandboxCommand } from './sandbox'
 import { authCommand } from './auth'
 
-// Canonical dot-joined path of the invoked command (aliases resolved),
-// without the program name, e.g. `sandbox.list`.
-function commandPath(command: commander.Command): string {
-  const names: string[] = []
-  for (
-    let cmd: commander.Command | null = command;
-    cmd?.parent;
-    cmd = cmd.parent
-  ) {
-    names.unshift(cmd.name())
-  }
-  return names.join('.')
-}
-
 export const program = new commander.Command()
-  .hook('preAction', (_, actionCommand) => {
-    setCommandAttribution(commandPath(actionCommand))
-  })
   .description(
     `Create sandbox templates from Dockerfiles by running ${asPrimary(
       'e2b template create'

--- a/packages/cli/tests/attribution.test.ts
+++ b/packages/cli/tests/attribution.test.ts
@@ -49,5 +49,4 @@ test('CLI requests carry SDK and CLI attribution in the User-Agent', async () =>
 
   expect(userAgent).toMatch(/^e2b-js-sdk\/\d/)
   expect(userAgent).toContain(`e2b-cli/${packageJSON.version}`)
-  expect(userAgent).not.toContain('e2b-cli-command/')
 })

--- a/packages/cli/tests/attribution.test.ts
+++ b/packages/cli/tests/attribution.test.ts
@@ -44,16 +44,10 @@ async function captureUserAgent(args: string[]): Promise<string | undefined> {
   return userAgents.find(Boolean)
 }
 
-test('CLI requests carry SDK, CLI, and command attribution in the User-Agent', async () => {
+test('CLI requests carry SDK and CLI attribution in the User-Agent', async () => {
   const userAgent = await captureUserAgent(['sandbox', 'list'])
 
   expect(userAgent).toMatch(/^e2b-js-sdk\/\d/)
   expect(userAgent).toContain(`e2b-cli/${packageJSON.version}`)
-  expect(userAgent).toContain('e2b-cli-command/sandbox.list')
-})
-
-test('command attribution uses the canonical name for aliases', async () => {
-  const userAgent = await captureUserAgent(['sandbox', 'ls'])
-
-  expect(userAgent).toContain('e2b-cli-command/sandbox.list')
+  expect(userAgent).not.toContain('e2b-cli-command/')
 })


### PR DESCRIPTION
## Description

Removes the `e2b-cli-command/<command>` token (added in #1544) from the CLI's User-Agent integration attribution, so CLI traffic is attributed only by tool and version. This also lets `connectionConfig` and `client` in `packages/cli/src/api.ts` go back to plain `const` exports, deleting the per-command config/client rebuild machinery and the `preAction` hook that drove it. The attribution test now only checks the SDK and CLI tags, and a patch changeset for `@e2b/cli` is included.

User-Agent sent by `e2b sandbox list`, before and after:

```
before: e2b-js-sdk/2.9.0 (Node.js/22.11.0) e2b-cli/2.13.3 e2b-cli-command/sandbox.list
after:  e2b-js-sdk/2.9.0 (Node.js/22.11.0) e2b-cli/2.13.3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)