### PR TITLE
docs(sdk): rename team to project in snapshot docstrings

### DIFF
--- a/.changeset/witty-moons-rename.md
+++ b/.changeset/witty-moons-rename.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/python-sdk': patch
+---
+
+Update snapshot docstrings to use project terminology instead of team (e.g. "my-project/my-snapshot", project slug)

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -494,7 +494,7 @@ export interface SnapshotListOpts extends Omit<SandboxApiOpts, 'signal'> {
 
   /**
    * Filter snapshots by name or ID, optionally tag-qualified
-   * (e.g. "my-snapshot", "my-team/my-snapshot" or "my-snapshot:v1").
+   * (e.g. "my-snapshot", "my-project/my-snapshot" or "my-snapshot:v1").
    */
   name?: string
 
@@ -522,7 +522,7 @@ export interface SnapshotInfo {
   snapshotId: string
 
   /**
-   * Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-snapshot:v2).
+   * Full names of the snapshot template including project slug and tag (e.g. project-slug/my-snapshot:v2).
    */
   names: string[]
 }

--- a/packages/python-sdk/e2b/sandbox/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox/sandbox_api.py
@@ -597,7 +597,7 @@ class SnapshotInfo:
     snapshot_id: str
     """Snapshot identifier — template ID with tag, or namespaced name with tag (e.g. my-snapshot:latest). Can be used with Sandbox.create() to create a new sandbox from this snapshot."""
     names: List[str] = field(default_factory=list)
-    """Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-snapshot:v2)."""
+    """Full names of the snapshot template including project slug and tag (e.g. project-slug/my-snapshot:v2)."""
 
 
 class SnapshotPaginatorBase(PaginatorBase[SnapshotInfo, ApiParams]):

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -896,7 +896,7 @@ class AsyncSandbox(SandboxApi):
 
         :param limit: Maximum number of snapshots to return per page
         :param next_token: Token for pagination
-        :param name: Filter snapshots by name or ID, optionally tag-qualified (e.g. "my-snapshot", "my-team/my-snapshot" or "my-snapshot:v1")
+        :param name: Filter snapshots by name or ID, optionally tag-qualified (e.g. "my-snapshot", "my-project/my-snapshot" or "my-snapshot:v1")
 
         :return: Paginator for listing snapshots
         """
@@ -917,7 +917,7 @@ class AsyncSandbox(SandboxApi):
         :param sandbox_id: Filter snapshots by source sandbox ID
         :param limit: Maximum number of snapshots to return per page
         :param next_token: Token for pagination
-        :param name: Filter snapshots by name or ID, optionally tag-qualified (e.g. "my-snapshot", "my-team/my-snapshot" or "my-snapshot:v1")
+        :param name: Filter snapshots by name or ID, optionally tag-qualified (e.g. "my-snapshot", "my-project/my-snapshot" or "my-snapshot:v1")
 
         :return: Paginator for listing snapshots
         """
@@ -936,7 +936,7 @@ class AsyncSandbox(SandboxApi):
 
         :param limit: Maximum number of snapshots to return per page
         :param next_token: Token for pagination
-        :param name: Filter snapshots by name or ID, optionally tag-qualified (e.g. "my-snapshot", "my-team/my-snapshot" or "my-snapshot:v1")
+        :param name: Filter snapshots by name or ID, optionally tag-qualified (e.g. "my-snapshot", "my-project/my-snapshot" or "my-snapshot:v1")
 
         :return: Paginator for listing snapshots
         """

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -886,7 +886,7 @@ class Sandbox(SandboxApi):
 
         :param limit: Maximum number of snapshots to return per page
         :param next_token: Token for pagination
-        :param name: Filter snapshots by name or ID, optionally tag-qualified (e.g. "my-snapshot", "my-team/my-snapshot" or "my-snapshot:v1")
+        :param name: Filter snapshots by name or ID, optionally tag-qualified (e.g. "my-snapshot", "my-project/my-snapshot" or "my-snapshot:v1")
 
         :return: Paginator for listing snapshots
         """
@@ -907,7 +907,7 @@ class Sandbox(SandboxApi):
         :param sandbox_id: Filter snapshots by source sandbox ID
         :param limit: Maximum number of snapshots to return per page
         :param next_token: Token for pagination
-        :param name: Filter snapshots by name or ID, optionally tag-qualified (e.g. "my-snapshot", "my-team/my-snapshot" or "my-snapshot:v1")
+        :param name: Filter snapshots by name or ID, optionally tag-qualified (e.g. "my-snapshot", "my-project/my-snapshot" or "my-snapshot:v1")
 
         :return: Paginator for listing snapshots
         """
@@ -926,7 +926,7 @@ class Sandbox(SandboxApi):
 
         :param limit: Maximum number of snapshots to return per page
         :param next_token: Token for pagination
-        :param name: Filter snapshots by name or ID, optionally tag-qualified (e.g. "my-snapshot", "my-team/my-snapshot" or "my-snapshot:v1")
+        :param name: Filter snapshots by name or ID, optionally tag-qualified (e.g. "my-snapshot", "my-project/my-snapshot" or "my-snapshot:v1")
 
         :return: Paginator for listing snapshots
         """


### PR DESCRIPTION
Renames team → project terminology in the JS and Python SDK snapshot docstrings: the `list_snapshots`/snapshot list `name` filter example now reads `"my-project/my-snapshot"`, and `SnapshotInfo.names` is documented as "including project slug and tag (e.g. project-slug/my-snapshot:v2)".

Documentation-only — no exported names, runtime behavior, or wire protocol change; generated API clients and `spec/openapi.yml` are intentionally untouched until the backend exposes project-named endpoints. Includes a patch changeset for `e2b` and `@e2b/python-sdk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)