### PR TITLE
Add CLI output formats

### DIFF
--- a/.changeset/fair-output-formats.md
+++ b/.changeset/fair-output-formats.md
@@ -1,0 +1,5 @@
+---
+"@e2b/cli": minor
+---
+
+Add kubectl-style `-o/--output` formats for sandbox and template commands.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -86,6 +86,7 @@
     "inquirer": "^12.10.0",
     "simple-update-notifier": "^2.0.0",
     "statuses": "^2.0.1",
+    "yaml": "^2.9.0",
     "yup": "^1.3.2"
   },
   "engines": {

--- a/packages/cli/src/commands/sandbox/info.ts
+++ b/packages/cli/src/commands/sandbox/info.ts
@@ -3,6 +3,14 @@ import { NotFoundError, Sandbox } from 'e2b'
 
 import { ensureAPIKey } from 'src/api'
 import { asBold } from 'src/utils/format'
+import {
+  formatOption,
+  OutputFormat,
+  outputOption,
+  printJson,
+  printYaml,
+  resolveOutputFormat,
+} from 'src/utils/output'
 
 const fieldLabels: Partial<Record<string, string>> = {
   sandboxId: 'Sandbox ID',
@@ -45,31 +53,38 @@ export const infoCommand = new commander.Command('info')
     `show information for sandbox specified by ${asBold('<sandboxID>')}`
   )
   .alias('in')
-  .option('-f, --format <format>', 'output format, eg. json, pretty')
-  .action(async (sandboxID: string, options: { format?: string }) => {
-    try {
-      const format = options.format || 'pretty'
-      const apiKey = ensureAPIKey()
-      const info = await Sandbox.getInfo(sandboxID, { apiKey })
+  .addOption(outputOption)
+  .addOption(formatOption)
+  .action(
+    async (
+      sandboxID: string,
+      options: { output?: string; format?: string }
+    ) => {
+      try {
+        const format = resolveOutputFormat(options)
+        const apiKey = ensureAPIKey()
+        const info = await Sandbox.getInfo(sandboxID, { apiKey })
 
-      if (format === 'pretty') {
-        renderPrettyInfo(info as unknown as Record<string, unknown>)
-      } else if (format === 'json') {
-        console.log(JSON.stringify(info, null, 2))
-      } else {
-        console.error(`Unsupported output format: ${format}`)
+        if (format === OutputFormat.PRETTY) {
+          renderPrettyInfo(info as unknown as Record<string, unknown>)
+        } else if (format === OutputFormat.JSON) {
+          printJson(info)
+        } else if (format === OutputFormat.YAML) {
+          printYaml(info)
+        } else if (format === OutputFormat.NAME) {
+          console.log(`sandbox/${info.sandboxId}`)
+        }
+      } catch (err: any) {
+        if (err instanceof NotFoundError) {
+          console.error(`Sandbox ${asBold(sandboxID)} wasn't found`)
+          process.exit(1)
+          return
+        }
+        console.error(err)
         process.exit(1)
       }
-    } catch (err: any) {
-      if (err instanceof NotFoundError) {
-        console.error(`Sandbox ${asBold(sandboxID)} wasn't found`)
-        process.exit(1)
-        return
-      }
-      console.error(err)
-      process.exit(1)
     }
-  })
+  )
 
 function renderPrettyInfo(info: Record<string, unknown>) {
   console.log(

--- a/packages/cli/src/commands/sandbox/list.ts
+++ b/packages/cli/src/commands/sandbox/list.ts
@@ -4,6 +4,15 @@ import { components, Sandbox, SandboxInfo } from 'e2b'
 
 import { ensureAPIKey } from 'src/api'
 import { parseMetadata } from './utils'
+import {
+  formatOption,
+  OutputFormat,
+  outputOption,
+  printJson,
+  printNames,
+  printYaml,
+  resolveOutputFormat,
+} from 'src/utils/output'
 
 const DEFAULT_LIMIT = 1000
 const PAGE_LIMIT = 100
@@ -30,11 +39,12 @@ export const listCommand = new commander.Command('list')
     `limit the number of sandboxes returned (default: ${DEFAULT_LIMIT}, 0 for no limit)`,
     (value) => parseInt(value)
   )
-  .option('-f, --format <format>', 'output format, eg. json, pretty')
+  .addOption(outputOption)
+  .addOption(formatOption)
   .action(async (options) => {
     try {
       const state = options.state || ['running']
-      const format = options.format || 'pretty'
+      const format = resolveOutputFormat(options)
       const limit =
         options.limit === 0 ? undefined : (options.limit ?? DEFAULT_LIMIT)
       const { sandboxes, hasMore } = await listSandboxes({
@@ -50,11 +60,15 @@ export const listCommand = new commander.Command('list')
             `Showing first ${limit} sandboxes. Use --limit to change.`
           )
         }
-      } else if (format === 'json') {
-        console.log(JSON.stringify(sandboxes, null, 2))
-      } else {
-        console.error(`Unsupported output format: ${format}`)
-        process.exit(1)
+      } else if (format === OutputFormat.JSON) {
+        printJson(sandboxes)
+      } else if (format === OutputFormat.YAML) {
+        printYaml(sandboxes)
+      } else if (format === OutputFormat.NAME) {
+        printNames(sandboxes, (sandbox) => {
+          const sandboxInfo = sandbox as SandboxInfo
+          return `sandbox/${sandboxInfo.sandboxId}`
+        })
       }
     } catch (err: any) {
       console.error(err)

--- a/packages/cli/src/commands/template/list.ts
+++ b/packages/cli/src/commands/template/list.ts
@@ -7,17 +7,26 @@ import { sortTemplatesAliases } from 'src/utils/templateSort'
 import { client, ensureAPIKey, resolveTeamId } from 'src/api'
 import { teamOption } from '../../options'
 import { handleE2BRequestError } from '../../utils/errors'
+import {
+  formatOption,
+  OutputFormat,
+  outputOption,
+  printJson,
+  printNames,
+  printYaml,
+  resolveOutputFormat,
+} from 'src/utils/output'
 
 export const listCommand = new commander.Command('list')
   .description('list sandbox templates')
   .alias('ls')
   .addOption(teamOption)
-  .option('-f, --format <format>', 'output format, eg. json, pretty')
-  .action(async (opts: { team: string; format: string }) => {
+  .addOption(outputOption)
+  .addOption(formatOption)
+  .action(async (opts: { team: string; output?: string; format?: string }) => {
     try {
-      const format = opts.format || 'pretty'
+      const format = resolveOutputFormat(opts)
       ensureAPIKey()
-      process.stdout.write('\n')
 
       const templates = await listSandboxTemplates({
         teamID: resolveTeamId(opts.team),
@@ -27,13 +36,19 @@ export const listCommand = new commander.Command('list')
         sortTemplatesAliases(template.aliases)
       }
 
-      if (format === 'pretty') {
+      if (format === OutputFormat.PRETTY) {
+        process.stdout.write('\n')
         renderTable(templates)
-      } else if (format === 'json') {
-        console.log(JSON.stringify(templates, null, 2))
-      } else {
-        console.error(`Unsupported output format: ${format}`)
-        process.exit(1)
+      } else if (format === OutputFormat.JSON) {
+        printJson(templates)
+      } else if (format === OutputFormat.YAML) {
+        printYaml(templates)
+      } else if (format === OutputFormat.NAME) {
+        printNames(templates, (template) => {
+          const sandboxTemplate =
+            template as e2b.components['schemas']['Template']
+          return `template/${sandboxTemplate.templateID}`
+        })
       }
     } catch (err: any) {
       console.error(err)

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -1,0 +1,66 @@
+import * as commander from 'commander'
+import { stringify as stringifyYaml } from 'yaml'
+
+export enum OutputFormat {
+  PRETTY = 'pretty',
+  JSON = 'json',
+  YAML = 'yaml',
+  NAME = 'name',
+}
+
+const outputFormatAliases: Record<string, OutputFormat> = {
+  table: OutputFormat.PRETTY,
+}
+
+export const supportedOutputFormats = [
+  OutputFormat.PRETTY,
+  'table',
+  OutputFormat.JSON,
+  OutputFormat.YAML,
+  OutputFormat.NAME,
+].join(', ')
+
+export const outputOption = new commander.Option(
+  '-o, --output <format>',
+  `output format (${supportedOutputFormats})`
+).argParser(parseOutputFormat)
+
+export const formatOption = new commander.Option(
+  '-f, --format <format>',
+  `deprecated alias for --output (${supportedOutputFormats})`
+).argParser(parseOutputFormat)
+
+export function resolveOutputFormat(options: {
+  output?: string | OutputFormat
+  format?: string | OutputFormat
+}): OutputFormat {
+  const rawFormat = options.output ?? options.format ?? OutputFormat.PRETTY
+  return parseOutputFormat(rawFormat)
+}
+
+function parseOutputFormat(rawFormat: string): OutputFormat {
+  const normalized = rawFormat.toLowerCase()
+  const format = outputFormatAliases[normalized] ?? (normalized as OutputFormat)
+
+  if (!Object.values(OutputFormat).includes(format)) {
+    throw new commander.InvalidArgumentError(
+      `Unsupported output format: ${rawFormat}. Supported formats: ${supportedOutputFormats}`
+    )
+  }
+
+  return format
+}
+
+export function printJson(data: unknown) {
+  console.log(JSON.stringify(data, null, 2))
+}
+
+export function printYaml(data: unknown) {
+  process.stdout.write(stringifyYaml(data))
+}
+
+export function printNames<T>(items: T[], nameFromItem: (item: T) => string) {
+  for (const item of items) {
+    console.log(nameFromItem(item))
+  }
+}

--- a/packages/cli/tests/utils/output.test.ts
+++ b/packages/cli/tests/utils/output.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import {
+  OutputFormat,
+  printJson,
+  printNames,
+  printYaml,
+  resolveOutputFormat,
+} from '../../src/utils/output'
+
+describe('output helpers', () => {
+  test('resolves default, kubectl-style output, and legacy format values', () => {
+    expect(resolveOutputFormat({})).toBe(OutputFormat.PRETTY)
+    expect(resolveOutputFormat({ output: 'json' })).toBe(OutputFormat.JSON)
+    expect(resolveOutputFormat({ output: 'yaml' })).toBe(OutputFormat.YAML)
+    expect(resolveOutputFormat({ output: 'name' })).toBe(OutputFormat.NAME)
+    expect(resolveOutputFormat({ output: 'table' })).toBe(OutputFormat.PRETTY)
+    expect(resolveOutputFormat({ format: 'json' })).toBe(OutputFormat.JSON)
+  })
+
+  test('prefers output over legacy format', () => {
+    expect(resolveOutputFormat({ output: 'yaml', format: 'json' })).toBe(
+      OutputFormat.YAML
+    )
+  })
+
+  test('throws for unsupported output formats', () => {
+    expect(() => resolveOutputFormat({ output: 'xml' })).toThrow(
+      'Unsupported output format: xml'
+    )
+  })
+
+  test('prints json', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    printJson({ sandboxId: 'sbx_123' })
+
+    expect(log).toHaveBeenCalledWith('{\n  "sandboxId": "sbx_123"\n}')
+    log.mockRestore()
+  })
+
+  test('prints yaml', () => {
+    const write = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true)
+
+    printYaml({ sandboxId: 'sbx_123' })
+
+    expect(write).toHaveBeenCalledWith('sandboxId: sbx_123\n')
+    write.mockRestore()
+  })
+
+  test('prints names', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    printNames([{ sandboxId: 'sbx_123' }], (sandbox) => {
+      return `sandbox/${sandbox.sandboxId}`
+    })
+
+    expect(log).toHaveBeenCalledWith('sandbox/sbx_123')
+    log.mockRestore()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       statuses:
         specifier: ^2.0.1
         version: 2.0.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       yup:
         specifier: ^1.3.2
         version: 1.3.2
@@ -127,7 +130,7 @@ importers:
         version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))
+        version: 4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))
 
   packages/js-sdk:
     dependencies:
@@ -185,13 +188,13 @@ importers:
         version: typescript@7.0.2
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))
+        version: 4.3.4(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))
       '@vitest/browser':
         specifier: ^4.1.0
-        version: 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
+        version: 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/browser-playwright':
         specifier: ^4.1.0
-        version: 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
+        version: 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.8)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -227,7 +230,7 @@ importers:
         version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))
+        version: 4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8)
@@ -3542,6 +3545,11 @@ packages:
   yaml-ast-parser@0.0.43:
     resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -4534,40 +4542,40 @@ snapshots:
     dependencies:
       '@typescript/old': typescript@6.0.3
 
-  '@vitejs/plugin-react@4.3.4(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))':
+  '@vitejs/plugin-react@4.3.4(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.29.7)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.29.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)
+      vite: 6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser-playwright@4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)':
+  '@vitest/browser-playwright@4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
-      '@vitest/browser': 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
-      '@vitest/mocker': 4.1.8(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))
+      '@vitest/browser': 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))
       playwright: 1.55.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))
+      vitest: 4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)':
+  '@vitest/browser@4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.8(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))
+      '@vitest/mocker': 4.1.8(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))
       '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))
+      vitest: 4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))
       ws: 8.21.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - bufferutil
@@ -4587,9 +4595,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))
+      vitest: 4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
+      '@vitest/browser': 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.8)
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -4600,14 +4608,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))':
+  '@vitest/mocker@4.1.8(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2)
-      vite: 6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)
+      vite: 6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -6633,7 +6641,7 @@ snapshots:
     dependencies:
       builtins: 5.0.1
 
-  vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0):
+  vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.5)
@@ -6646,20 +6654,21 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       terser: 5.46.0
+      yaml: 2.9.0
 
   vitest-browser-react@2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      vitest: 4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))
+      vitest: 4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  vitest@4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)):
+  vitest@4.1.8(@types/node@20.19.43)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))
+      '@vitest/mocker': 4.1.8(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -6676,11 +6685,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)
+      vite: 6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.43
-      '@vitest/browser-playwright': 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0))(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.8(bufferutil@4.0.8)(msw@2.12.14(@types/node@20.19.43)(@typescript/typescript6@6.0.2))(playwright@1.55.1)(utf-8-validate@6.0.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.4.2)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
     transitivePeerDependencies:
       - msw
@@ -6788,6 +6797,8 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml-ast-parser@0.0.43: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 


### PR DESCRIPTION
Adds kubectl-style `-o/--output` handling to sandbox and template list/info commands while preserving the existing `-f/--format` alias.

Supported outputs now include `pretty`, `table`, `json`, `yaml`, and `name`.

Usage examples:
```sh
e2b sandbox list -o yaml
e2b sandbox info <sandbox-id> -o name
e2b template list --output json
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/e2b-dev/codesmith/E2B/pr/1567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787225843&installation_model_id=14389&pr_number=1567&repository=e2b-dev%2FE2B&return_to=https%3A%2F%2Fgithub.com%2Fe2b-dev%2FE2B%2Fpull%2F1567&signature=8ffe9bfe50d29503a5db2e70c61ed516a462caf9b227ddacdcead9c32ce75e7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->