### PR TITLE
Add kubectl-style CLI table output

### DIFF
--- a/.changeset/soft-tables-join.md
+++ b/.changeset/soft-tables-join.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Render CLI list output with kubectl-style whitespace-separated tables.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -80,7 +80,6 @@
     "chalk": "^5.3.0",
     "cli-highlight": "^2.1.11",
     "commander": "^11.1.0",
-    "console-table-printer": "^2.11.2",
     "e2b": "^2.33.1",
     "handlebars": "^4.7.9",
     "inquirer": "^12.10.0",

--- a/packages/cli/src/commands/sandbox/list.ts
+++ b/packages/cli/src/commands/sandbox/list.ts
@@ -1,20 +1,12 @@
-import * as tablePrinter from 'console-table-printer'
 import * as commander from 'commander'
 import { components, Sandbox, SandboxInfo } from 'e2b'
 
 import { ensureAPIKey } from 'src/api'
+import { printTable, type TableColumn } from 'src/utils/table'
 import { parseMetadata } from './utils'
 
 const DEFAULT_LIMIT = 1000
 const PAGE_LIMIT = 100
-
-function getStateTitle(state?: components['schemas']['SandboxState'][]) {
-  if (state?.length === 1) {
-    if (state?.includes('running')) return 'Running sandboxes'
-    if (state?.includes('paused')) return 'Paused sandboxes'
-  }
-  return 'Sandboxes'
-}
 
 export const listCommand = new commander.Command('list')
   .description('list all sandboxes, by default it list only running ones')
@@ -44,7 +36,7 @@ export const listCommand = new commander.Command('list')
       })
 
       if (format === 'pretty') {
-        renderTable(sandboxes, state)
+        renderTable(sandboxes)
         if (hasMore) {
           console.log(
             `Showing first ${limit} sandboxes. Use --limit to change.`
@@ -62,74 +54,50 @@ export const listCommand = new commander.Command('list')
     }
   })
 
-function renderTable(
-  sandboxes: SandboxInfo[],
-  state: components['schemas']['SandboxState'][]
-) {
+function renderTable(sandboxes: SandboxInfo[]) {
   if (!sandboxes?.length) {
     console.log('No sandboxes found')
     return
   }
 
-  const table = new tablePrinter.Table({
-    title: getStateTitle(state),
-    columns: [
-      { name: 'sandboxId', alignment: 'left', title: 'Sandbox ID' },
-      {
-        name: 'templateId',
-        alignment: 'left',
-        title: 'Template ID',
-        maxLen: 20,
-      },
-      { name: 'name', alignment: 'left', title: 'Alias' },
-      { name: 'startedAt', alignment: 'left', title: 'Started at' },
-      { name: 'endAt', alignment: 'left', title: 'End at' },
-      { name: 'state', alignment: 'left', title: 'State' },
-      { name: 'cpuCount', alignment: 'left', title: 'vCPUs' },
-      { name: 'memoryMB', alignment: 'left', title: 'RAM MiB' },
-      { name: 'envdVersion', alignment: 'left', title: 'Envd version' },
-      { name: 'metadata', alignment: 'left', title: 'Metadata' },
-    ],
-    disabledColumns: ['clientID'],
-    rows: sandboxes
-      .map((sandbox) => ({
-        ...sandbox,
-        startedAt: new Date(sandbox.startedAt).toLocaleString(),
-        endAt: new Date(sandbox.endAt).toLocaleString(),
-        state: sandbox.state.charAt(0).toUpperCase() + sandbox.state.slice(1), // capitalize
-        metadata: JSON.stringify(sandbox.metadata),
-      }))
-      .sort(
-        (a, b) =>
-          a.startedAt.localeCompare(b.startedAt) ||
-          a.sandboxId.localeCompare(b.sandboxId)
-      ),
-    style: {
-      headerTop: {
-        left: '',
-        right: '',
-        mid: '',
-        other: '',
-      },
-      headerBottom: {
-        left: '',
-        right: '',
-        mid: '',
-        other: '',
-      },
-      tableBottom: {
-        left: '',
-        right: '',
-        mid: '',
-        other: '',
-      },
-      vertical: '',
+  const columns: TableColumn<SandboxInfo>[] = [
+    { name: 'sandboxId', title: 'Sandbox ID' },
+    { name: 'templateId', title: 'Template ID', maxLen: 20 },
+    { name: 'name', title: 'Alias' },
+    {
+      name: 'startedAt',
+      title: 'Started at',
+      getValue: (sandbox) => new Date(sandbox.startedAt).toLocaleString(),
     },
-    colorMap: {
-      orange: '\x1b[38;5;216m',
+    {
+      name: 'endAt',
+      title: 'End at',
+      getValue: (sandbox) => new Date(sandbox.endAt).toLocaleString(),
     },
-  })
-  table.printTable()
+    {
+      name: 'state',
+      title: 'State',
+      getValue: (sandbox) =>
+        sandbox.state.charAt(0).toUpperCase() + sandbox.state.slice(1),
+    },
+    { name: 'cpuCount', title: 'vCPUs' },
+    { name: 'memoryMB', title: 'RAM MiB' },
+    { name: 'envdVersion', title: 'Envd version' },
+    {
+      name: 'metadata',
+      title: 'Metadata',
+      getValue: (sandbox) => JSON.stringify(sandbox.metadata),
+    },
+  ]
+
+  printTable(
+    columns,
+    [...sandboxes].sort(
+      (a, b) =>
+        new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime() ||
+        a.sandboxId.localeCompare(b.sandboxId)
+    )
+  )
 
   process.stdout.write('\n')
 }

--- a/packages/cli/src/commands/template/list.ts
+++ b/packages/cli/src/commands/template/list.ts
@@ -1,8 +1,8 @@
-import * as tablePrinter from 'console-table-printer'
 import * as commander from 'commander'
 import * as e2b from 'e2b'
 
 import { listAliases } from '../../utils/format'
+import { printTable, type TableColumn } from 'src/utils/table'
 import { sortTemplatesAliases } from 'src/utils/templateSort'
 import { client, ensureAPIKey, resolveTeamId } from 'src/api'
 import { teamOption } from '../../options'
@@ -47,66 +47,38 @@ function renderTable(templates: e2b.components['schemas']['Template'][]) {
     return
   }
 
-  const table = new tablePrinter.Table({
-    title: 'Sandbox templates',
-    columns: [
-      { name: 'visibility', alignment: 'left', title: 'Access' },
-      { name: 'templateID', alignment: 'left', title: 'Template ID' },
-      {
-        name: 'aliases',
-        alignment: 'left',
-        title: 'Template Name',
-        color: 'orange',
-        maxLen: 20,
-      },
-      { name: 'cpuCount', alignment: 'right', title: 'vCPUs' },
-      { name: 'memoryMB', alignment: 'right', title: 'RAM MiB' },
-      { name: 'createdBy', alignment: 'right', title: 'Created by' },
-      { name: 'createdAt', alignment: 'right', title: 'Created at' },
-      { name: 'diskSizeMB', alignment: 'right', title: 'Disk size MiB' },
-      { name: 'envdVersion', alignment: 'right', title: 'Envd version' },
-    ],
-    disabledColumns: [
-      'public',
-      'buildID',
-      'buildCount',
-      'lastSpawnedAt',
-      'spawnCount',
-      'updatedAt',
-    ],
-    rows: templates.map((template) => ({
-      ...template,
-      visibility: template.public ? 'Public' : 'Private',
-      aliases: listAliases(template.aliases),
-      createdBy: template.createdBy?.email,
-      createdAt: new Date(template.createdAt).toLocaleDateString(),
-    })),
-    style: {
-      headerTop: {
-        left: '',
-        right: '',
-        mid: '',
-        other: '',
-      },
-      headerBottom: {
-        left: '',
-        right: '',
-        mid: '',
-        other: '',
-      },
-      tableBottom: {
-        left: '',
-        right: '',
-        mid: '',
-        other: '',
-      },
-      vertical: '',
+  const columns: TableColumn<e2b.components['schemas']['Template']>[] = [
+    {
+      name: 'visibility',
+      title: 'Access',
+      getValue: (template) => (template.public ? 'Public' : 'Private'),
     },
-    colorMap: {
-      orange: '\x1b[38;5;216m',
+    { name: 'templateID', title: 'Template ID' },
+    {
+      name: 'aliases',
+      title: 'Template Name',
+      maxLen: 20,
+      getValue: (template) => listAliases(template.aliases),
     },
-  })
-  table.printTable()
+    { name: 'cpuCount', title: 'vCPUs', alignment: 'right' },
+    { name: 'memoryMB', title: 'RAM MiB', alignment: 'right' },
+    {
+      name: 'createdBy',
+      title: 'Created by',
+      alignment: 'right',
+      getValue: (template) => template.createdBy?.email,
+    },
+    {
+      name: 'createdAt',
+      title: 'Created at',
+      alignment: 'right',
+      getValue: (template) => new Date(template.createdAt).toLocaleDateString(),
+    },
+    { name: 'diskSizeMB', title: 'Disk size MiB', alignment: 'right' },
+    { name: 'envdVersion', title: 'Envd version', alignment: 'right' },
+  ]
+
+  printTable(columns, templates)
 
   process.stdout.write('\n')
 }

--- a/packages/cli/src/utils/table.ts
+++ b/packages/cli/src/utils/table.ts
@@ -1,0 +1,81 @@
+type TableAlignment = 'left' | 'right'
+
+export type TableColumn<Row> = {
+  name: string
+  title: string
+  alignment?: TableAlignment
+  maxLen?: number
+  getValue?: (row: Row) => unknown
+}
+
+export function printTable<Row>(columns: TableColumn<Row>[], rows: Row[]) {
+  const output = formatTable(columns, rows)
+  if (output) {
+    console.log(output)
+  }
+}
+
+export function formatTable<Row>(
+  columns: TableColumn<Row>[],
+  rows: Row[]
+): string {
+  const cells = rows.map((row) =>
+    columns.map((column) =>
+      formatCell(getCellValue(row, column), column.maxLen)
+    )
+  )
+  const headers = columns.map((column) => column.title.toUpperCase())
+  const widths = columns.map((_, columnIndex) =>
+    Math.max(
+      headers[columnIndex].length,
+      ...cells.map((row) => row[columnIndex].length)
+    )
+  )
+
+  return [
+    formatRow(headers, columns, widths),
+    ...cells.map((row) => formatRow(row, columns, widths)),
+  ].join('\n')
+}
+
+function getCellValue<Row>(row: Row, column: TableColumn<Row>): unknown {
+  if (column.getValue) {
+    return column.getValue(row)
+  }
+
+  return (row as Record<string, unknown>)[column.name]
+}
+
+function formatCell(value: unknown, maxLen?: number): string {
+  if (value === undefined || value === null) {
+    return ''
+  }
+
+  const stringValue = String(value)
+  if (!maxLen || stringValue.length <= maxLen) {
+    return stringValue
+  }
+
+  if (maxLen <= 3) {
+    return stringValue.slice(0, maxLen)
+  }
+
+  return `${stringValue.slice(0, maxLen - 3)}...`
+}
+
+function formatRow<Row>(
+  values: string[],
+  columns: TableColumn<Row>[],
+  widths: number[]
+): string {
+  return values
+    .map((value, index) => {
+      if (columns[index].alignment === 'right') {
+        return value.padStart(widths[index])
+      }
+
+      return value.padEnd(widths[index])
+    })
+    .join('  ')
+    .trimEnd()
+}

--- a/packages/cli/tests/utils/table.test.ts
+++ b/packages/cli/tests/utils/table.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest'
+
+import { formatTable, type TableColumn } from 'src/utils/table'
+
+type Row = {
+  name: string
+  age: number
+  note?: string
+}
+
+describe('formatTable', () => {
+  test('prints kubectl-style columns', () => {
+    const columns: TableColumn<Row>[] = [
+      { name: 'name', title: 'Name' },
+      { name: 'age', title: 'Age', alignment: 'right' },
+      { name: 'note', title: 'Note', maxLen: 8 },
+    ]
+
+    expect(
+      formatTable(columns, [
+        { name: 'alpha', age: 3, note: 'short' },
+        { name: 'beta', age: 120, note: 'longer-than-limit' },
+      ])
+    ).toBe(
+      [
+        'NAME   AGE  NOTE',
+        'alpha    3  short',
+        'beta   120  longe...',
+      ].join('\n')
+    )
+  })
+
+  test('supports derived values', () => {
+    expect(
+      formatTable<Row>(
+        [
+          { name: 'name', title: 'Name' },
+          {
+            name: 'note',
+            title: 'Upper Note',
+            getValue: (row) => row.note?.toUpperCase(),
+          },
+        ],
+        [{ name: 'alpha', age: 3, note: 'ready' }]
+      )
+    ).toBe(['NAME   UPPER NOTE', 'alpha  READY'].join('\n'))
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,9 +67,6 @@ importers:
       commander:
         specifier: ^11.1.0
         version: 11.1.0
-      console-table-printer:
-        specifier: ^2.11.2
-        version: 2.11.2
       e2b:
         specifier: ^2.33.1
         version: 2.33.1
@@ -1800,9 +1797,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  console-table-printer@2.11.2:
-    resolution: {integrity: sha512-uuUHie0sfPP542TKGzPFal0W1wo1beuKAqIZdaavcONx8OoqdnJRKjkinbRTOta4FaCa1RcIL+7mMJWX3pQGVg==}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -3030,9 +3024,6 @@ packages:
   simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
-
-  simple-wcswidth@1.0.1:
-    resolution: {integrity: sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -4937,10 +4928,6 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  console-table-printer@2.11.2:
-    dependencies:
-      simple-wcswidth: 1.0.1
-
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
@@ -6296,8 +6283,6 @@ snapshots:
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.2
-
-  simple-wcswidth@1.0.1: {}
 
   sirv@3.0.2:
     dependencies:


### PR DESCRIPTION
Render CLI `pretty` list output with kubectl-style whitespace-separated columns instead of the boxed/table-printer format.

Main changes:
- Add a shared CLI table formatter with uppercase headers, fixed column spacing, alignment, derived values, and truncation support.
- Use it for `e2b sandbox list` and `e2b template list`.
- Remove the now-unused `console-table-printer` dependency.

Usage examples:
```sh
e2b sandbox list
e2b template list
```

Verification:
- `pnpm --filter @e2b/cli run format`
- `pnpm --filter @e2b/cli run lint`
- `pnpm --filter @e2b/cli run typecheck`
- `pnpm --filter @e2b/cli exec vitest run tests/utils/table.test.ts`
- `pnpm --filter @e2b/cli exec vitest run --exclude tests/commands/template/create.test.ts`

Notes:
- Root `pnpm run format`, `pnpm run lint`, `pnpm run typecheck`, and `pnpm run test` are blocked in this environment because `uv` is not installed for the Python SDK workspace.
- Full `pnpm --filter @e2b/cli run test` is blocked by `tests/commands/template/create.test.ts` requiring `E2B_API_KEY`; no `.env.local` or `~/.e2b/config.json` credentials are present.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/e2b-dev/codesmith/E2B/pr/1568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787225917&installation_model_id=14389&pr_number=1568&repository=e2b-dev%2FE2B&return_to=https%3A%2F%2Fgithub.com%2Fe2b-dev%2FE2B%2Fpull%2F1568&signature=9024b7468274552b11a4bc7fc452d00154e096636cc6e81cd7c10e546fb0a3d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->