### PR TITLE
chore(cli): remove dead e2b.toml write path

### DIFF
--- a/.changeset/wise-donuts-refuse.md
+++ b/.changeset/wise-donuts-refuse.md
@@ -2,4 +2,4 @@
 '@e2b/cli': patch
 ---
 
-Remove dead `saveConfig` code path — the CLI no longer writes `e2b.toml` anywhere; parsing stays for legacy projects (`template migrate`, `template publish`, `template delete`, `sandbox create`)
+Remove dead `e2b.toml` code paths — the CLI no longer writes the file, so `saveConfig` is gone, and the unused `team_id` field is no longer part of the config schema or team ID resolution. Parsing stays for legacy projects (`template migrate`, `template publish`, `template delete`, `sandbox create`)

--- a/.changeset/wise-donuts-refuse.md
+++ b/.changeset/wise-donuts-refuse.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Remove dead `saveConfig` code path — the CLI no longer writes `e2b.toml` anywhere; parsing stays for legacy projects (`template migrate`, `template publish`, `template delete`, `sandbox create`)

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -83,17 +83,12 @@ export function ensureAccessToken() {
  * Resolve team ID with proper precedence:
  * 1. CLI --team flag
  * 2. E2B_TEAM_ID env var
- * 3. Local e2b.toml team_id (if provided)
- * 4. ~/.e2b/config.json teamId (only if E2B_API_KEY env var is NOT set,
+ * 3. ~/.e2b/config.json teamId (only if E2B_API_KEY env var is NOT set,
  *    to avoid mismatch between env var API key and config file team ID)
  */
-export function resolveTeamId(
-  cliTeamId?: string,
-  localConfigTeamId?: string
-): string | undefined {
+export function resolveTeamId(cliTeamId?: string): string | undefined {
   if (cliTeamId) return cliTeamId
   if (teamId) return teamId
-  if (localConfigTeamId) return localConfigTeamId
   if (!process.env.E2B_API_KEY) {
     const config = getUserConfig()
     return config?.teamId

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -13,7 +13,6 @@ export const configSchema = yup.object({
   ready_cmd: yup.string().optional(),
   cpu_count: yup.number().integer().min(1).optional(),
   memory_mb: yup.number().integer().min(128).optional(),
-  team_id: yup.string().optional(),
 })
 
 export type E2BConfig = yup.InferType<typeof configSchema>

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -1,36 +1,9 @@
 import * as yup from 'yup'
 import * as toml from '@iarna/toml'
 import * as fsPromise from 'fs/promises'
-import * as fs from 'fs'
 import * as path from 'path'
 
-import { asFormattedSandboxTemplate, asLocalRelative } from 'src/utils/format'
-
 export const configName = 'e2b.toml'
-
-function getConfigHeader(config: E2BConfig) {
-  return `# This is a config for E2B sandbox template.
-# You can use template ID (${config.template_id}) ${
-    config.template_name ? `or template name (${config.template_name}) ` : ''
-  }to create a sandbox:
-
-# Python SDK
-# from e2b import Sandbox, AsyncSandbox
-# sandbox = Sandbox.create("${
-    config.template_name || config.template_id
-  }") # Sync sandbox
-# sandbox = await AsyncSandbox.create("${
-    config.template_name || config.template_id
-  }") # Async sandbox
-
-# JS SDK
-# import { Sandbox } from 'e2b'
-# const sandbox = await Sandbox.create('${
-    config.template_name || config.template_id
-  }')
-
-`
-}
 
 export const configSchema = yup.object({
   template_id: yup.string().required(),
@@ -83,39 +56,6 @@ export async function loadConfig(configPath: string) {
   const migratedConfig = applyMigrations(config, migrations)
 
   return (await configSchema.validate(migratedConfig)) as E2BConfig
-}
-
-export async function saveConfig(
-  configPath: string,
-  config: E2BConfig,
-  overwrite?: boolean
-) {
-  try {
-    if (!overwrite) {
-      const configExists = fs.existsSync(configPath)
-      if (configExists) {
-        throw new Error(
-          `Config already exists on path ${asLocalRelative(configPath)}`
-        )
-      }
-    }
-
-    const validatedConfig: any = await configSchema.validate(config, {
-      stripUnknown: true,
-    })
-
-    const tomlRaw = toml.stringify(validatedConfig)
-    await fsPromise.writeFile(configPath, getConfigHeader(config) + tomlRaw)
-  } catch (err: any) {
-    throw new Error(
-      `E2B sandbox template config ${asFormattedSandboxTemplate(
-        {
-          templateID: config.template_id,
-        },
-        configPath
-      )} cannot be saved: ${err.message}`
-    )
-  }
 }
 
 export async function deleteConfig(configPath: string) {


### PR DESCRIPTION
## Description

The CLI no longer writes `e2b.toml` anywhere, so this removes the dead code around it:

- `saveConfig` and its `getConfigHeader` helper in `packages/cli/src/config/index.ts` had zero callers — removed along with now-unused imports.
- The `team_id` field is dropped from the config schema and the unused `localConfigTeamId` parameter from `resolveTeamId` — nothing consumed it since the legacy `template build` command was removed. Team resolution is now: `--team` flag → `E2B_TEAM_ID` env → `~/.e2b/config.json` (the last only when `E2B_API_KEY` isn't set). yup ignores unknown keys, so legacy tomls containing `team_id` still parse.

Parsing (`loadConfig`, `deleteConfig`, `getConfigPath`) is intentionally kept as the backward-compatibility read path for legacy projects: `template migrate` (its whole purpose), `template publish`, `template delete`, and `sandbox create`. No user-facing behavior changes; includes a `@e2b/cli` patch changeset.

## Test

Format, lint, and typecheck pass; CLI tests: 88 passed, 8 skipped (one pre-existing backend integration suite fails only due to missing `E2B_API_KEY` in the environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)