### PR TITLE
fix(cli): sort sandbox list by timestamp instead of locale date string

### DIFF
--- a/.changeset/tricky-months-sort.md
+++ b/.changeset/tricky-months-sort.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Fix `sandbox list` sorting sandboxes by locale-formatted date string instead of the underlying timestamp, which broke chronological order across single-digit/double-digit month and day boundaries

--- a/packages/cli/src/commands/sandbox/list.ts
+++ b/packages/cli/src/commands/sandbox/list.ts
@@ -62,6 +62,23 @@ export const listCommand = new commander.Command('list')
     }
   })
 
+export function buildTableRows(sandboxes: SandboxInfo[]) {
+  return sandboxes
+    .slice()
+    .sort(
+      (a, b) =>
+        new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime() ||
+        a.sandboxId.localeCompare(b.sandboxId)
+    )
+    .map((sandbox) => ({
+      ...sandbox,
+      startedAt: new Date(sandbox.startedAt).toLocaleString(),
+      endAt: new Date(sandbox.endAt).toLocaleString(),
+      state: sandbox.state.charAt(0).toUpperCase() + sandbox.state.slice(1), // capitalize
+      metadata: JSON.stringify(sandbox.metadata),
+    }))
+}
+
 function renderTable(
   sandboxes: SandboxInfo[],
   state: components['schemas']['SandboxState'][]
@@ -91,19 +108,7 @@ function renderTable(
       { name: 'metadata', alignment: 'left', title: 'Metadata' },
     ],
     disabledColumns: ['clientID'],
-    rows: sandboxes
-      .map((sandbox) => ({
-        ...sandbox,
-        startedAt: new Date(sandbox.startedAt).toLocaleString(),
-        endAt: new Date(sandbox.endAt).toLocaleString(),
-        state: sandbox.state.charAt(0).toUpperCase() + sandbox.state.slice(1), // capitalize
-        metadata: JSON.stringify(sandbox.metadata),
-      }))
-      .sort(
-        (a, b) =>
-          a.startedAt.localeCompare(b.startedAt) ||
-          a.sandboxId.localeCompare(b.sandboxId)
-      ),
+    rows: buildTableRows(sandboxes),
     style: {
       headerTop: {
         left: '',

--- a/packages/cli/tests/commands/sandbox/list.test.ts
+++ b/packages/cli/tests/commands/sandbox/list.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest'
+import { SandboxInfo } from 'e2b'
+
+import { buildTableRows } from '../../../src/commands/sandbox/list'
+
+function sandbox(sandboxId: string, startedAt: Date): SandboxInfo {
+  return {
+    sandboxId,
+    templateId: 'template-id',
+    metadata: {},
+    startedAt,
+    endAt: new Date(startedAt.getTime() + 60_000),
+    state: 'running',
+    cpuCount: 2,
+    memoryMB: 512,
+    envdVersion: '0.2.0',
+  }
+}
+
+describe('sandbox list table rows', () => {
+  test('sorts by timestamp, not by locale-formatted date string', () => {
+    // In en-US, "9/1/2026, ..." > "10/1/2026, ..." lexicographically,
+    // so string sorting would put September after October.
+    const september = sandbox('sbx-sep', new Date('2026-09-01T10:00:00Z'))
+    const october = sandbox('sbx-oct', new Date('2026-10-01T09:00:00Z'))
+
+    const rows = buildTableRows([october, september])
+
+    expect(rows.map((r) => r.sandboxId)).toEqual(['sbx-sep', 'sbx-oct'])
+  })
+
+  test('breaks ties on identical timestamps by sandbox ID', () => {
+    const startedAt = new Date('2026-09-01T10:00:00Z')
+    const rows = buildTableRows([
+      sandbox('sbx-b', startedAt),
+      sandbox('sbx-a', startedAt),
+    ])
+
+    expect(rows.map((r) => r.sandboxId)).toEqual(['sbx-a', 'sbx-b'])
+  })
+
+  test('formats dates and state for display', () => {
+    const startedAt = new Date('2026-09-01T10:00:00Z')
+    const [row] = buildTableRows([sandbox('sbx-1', startedAt)])
+
+    expect(row.startedAt).toBe(startedAt.toLocaleString())
+    expect(row.state).toBe('Running')
+    expect(row.metadata).toBe('{}')
+  })
+
+  test('does not mutate the input array', () => {
+    const september = sandbox('sbx-sep', new Date('2026-09-01T10:00:00Z'))
+    const october = sandbox('sbx-oct', new Date('2026-10-01T09:00:00Z'))
+    const input = [october, september]
+
+    buildTableRows(input)
+
+    expect(input.map((s) => s.sandboxId)).toEqual(['sbx-oct', 'sbx-sep'])
+  })
+})


### PR DESCRIPTION
Fixes #1572

## Problem

`e2b sandbox list` sorted rows *after* converting `startedAt` to a locale string, so ordering was lexicographic over strings like `"9/1/2026, 10:00:00 AM"`. In en-US, `"9/..."` sorts after `"10/..."`, so September sandboxes appeared after October ones — chronological order broke at any single-digit/double-digit month or day boundary.

## Fix

Sort by the raw `startedAt` timestamp (with the existing sandbox-ID tiebreak) before formatting for display. The row-building logic is extracted into an exported `buildTableRows` helper and covered by unit tests, including the September/October regression case. The input array is no longer mutated in place.

## Example

```
$ e2b sandbox list --state paused

Paused sandboxes
Sandbox ID   ...  Started at
sbx-sep      ...  9/1/2026, 12:00:00 PM    ← previously listed after October
sbx-oct      ...  10/1/2026, 11:00:00 AM
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/e2b-dev/codesmith/E2B/pr/1573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787240223&installation_model_id=14389&pr_number=1573&repository=e2b-dev%2FE2B&return_to=https%3A%2F%2Fgithub.com%2Fe2b-dev%2FE2B%2Fpull%2F1573&signature=85af1311c0e7aa33bbe8ea331f8bb86f82e89ab6e8ec39b29ab776c3a1466cc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->