### PR TITLE
feat(cli): rename user-visible "team" wording to "project" in terminal output

### DIFF
--- a/.changeset/cli-teams-to-projects-copy.md
+++ b/.changeset/cli-teams-to-projects-copy.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Rename user-visible "team" wording to "project" in CLI terminal output: auth login confirmation and hints, `auth info` status line and fallback, `auth configure` picker and confirmation, error messages, and the template publish/unpublish visibility prompt. Copy-only change — no flag, env var, config key, or API behavior changes.

--- a/packages/cli/src/commands/auth/configure.ts
+++ b/packages/cli/src/commands/auth/configure.ts
@@ -40,14 +40,14 @@ export const configureCommand = new commander.Command('configure')
       signal: config.getSignal(),
     })
 
-    handleE2BRequestError(res, 'Error getting teams')
+    handleE2BRequestError(res, 'Error getting projects')
     const teams = res.data as Teams
 
     const team = (
       await inquirer.default.prompt([
         {
           name: 'team',
-          message: chalk.default.underline('Select team'),
+          message: chalk.default.underline('Select project'),
           type: 'list',
           pageSize: 50,
           choices: teams.map((team) => ({
@@ -64,5 +64,5 @@ export const configureCommand = new commander.Command('configure')
     userConfig.last_refresh = getConfigRefreshTimestamp()
     writeUserConfig(USER_CONFIG_PATH, userConfig)
 
-    console.log(`Team ${asBold(team.name)} (${team.teamID}) selected.\n`)
+    console.log(`Project ${asBold(team.name)} (${team.teamID}) selected.\n`)
   })

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -31,7 +31,7 @@ export const loginCommand = new commander.Command('login')
       console.log(
         `\nAlready logged in. ${asFormattedConfig(
           userConfig
-        )}.\n\nIf you want to log in as a different user, log out first by running 'e2b auth logout'.\nTo change the team, run 'e2b auth configure'.\n`
+        )}.\n\nIf you want to log in as a different user, log out first by running 'e2b auth logout'.\nTo change the project, run 'e2b auth configure'.\n`
       )
       return
     } else if (!userConfig) {
@@ -53,13 +53,13 @@ export const loginCommand = new commander.Command('login')
         signal,
       })
 
-      handleE2BRequestError(res, 'Error getting teams')
+      handleE2BRequestError(res, 'Error getting projects')
       const teams = res.data as Teams
 
       const defaultTeam = teams.find((team) => team.isDefault)
       if (!defaultTeam) {
         console.error(
-          asFormattedError('No default team found, please contact support')
+          asFormattedError('No default project found, please contact support')
         )
         process.exit(1)
       }
@@ -90,7 +90,7 @@ export const loginCommand = new commander.Command('login')
     console.log(
       `Logged in as ${asBold(
         userConfig.identity.email
-      )} with selected team ${asBold(userConfig.teamName)}`
+      )} with selected project ${asBold(userConfig.teamName)}`
     )
     process.exit(0)
   })

--- a/packages/cli/src/commands/template/publish.ts
+++ b/packages/cli/src/commands/template/publish.ts
@@ -157,8 +157,8 @@ async function templateAction(
           templates.length === 1 ? 'template' : 'templates'
         } ${
           publish
-            ? 'public to everyone outside your team'
-            : 'private to your team'
+            ? 'public to everyone outside your project'
+            : 'private to your project'
         }`
       )
 

--- a/packages/cli/src/utils/format.ts
+++ b/packages/cli/src/utils/format.ts
@@ -12,9 +12,9 @@ export function asFormattedConfig(config: UserConfig) {
   const email = asBold(config.identity.email)
   const team = config.teamName
     ? asBold(config.teamName)
-    : asRed('Log out and log in to get team name')
+    : asRed('Log out and log in to get project name')
   const teamId = asBold(config.teamId)
-  return `You are logged in as ${email},\nSelected team: ${team} (${teamId})`
+  return `You are logged in as ${email},\nSelected project: ${team} (${teamId})`
 }
 
 export function asFormattedTeam(
@@ -24,7 +24,7 @@ export function asFormattedTeam(
   const name = asBold(team.name)
   const id = asBold(team.teamID)
   const isSelected =
-    team.teamID == selected ? asPrimary(' (currently selected team)') : ''
+    team.teamID == selected ? asPrimary(' (currently selected project)') : ''
   return `${name} (${id})${isSelected}`
 }
 

--- a/packages/cli/tests/commands/auth/info.test.ts
+++ b/packages/cli/tests/commands/auth/info.test.ts
@@ -1,0 +1,84 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { bufferToText, runCli } from '../../setup'
+
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (text: string) => text.replace(/\x1B\[[0-9;]*m/g, '')
+
+const tmpDirs: string[] = []
+
+afterEach(() => {
+  for (const tmpDir of tmpDirs.splice(0)) {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+function writeConfigInTempHome(config: Record<string, unknown>): string {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2b-auth-info-test-'))
+  tmpDirs.push(homeDir)
+  const configDir = path.join(homeDir, '.e2b')
+  fs.mkdirSync(configDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(configDir, 'config.json'),
+    JSON.stringify(config, null, 2)
+  )
+  return homeDir
+}
+
+function runAuthInfo(homeDir: string) {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+  }
+  delete env.E2B_API_KEY
+  delete env.E2B_ACCESS_TOKEN
+  return runCli(['auth', 'info'], { timeoutMs: 20_000, env })
+}
+
+const baseConfig = {
+  version: 1,
+  identity: {
+    email: 'user@example.com',
+  },
+  oauth: {
+    token_endpoint: 'https://hydra.example.com/oauth2/token',
+    revoke_endpoint: 'https://hydra.example.com/oauth2/revoke',
+    client_id: 'cli-client-id',
+  },
+  tokens: {
+    access_token: 'access-token',
+    refresh_token: 'refresh-token',
+  },
+  last_refresh: '2026-07-22T12:00:00.000Z',
+  teamName: 'Acme Project',
+  teamId: 'a1b2c3d4',
+  teamApiKey: 'e2b_' + '0'.repeat(40),
+}
+
+describe('auth info', () => {
+  test('prints the selected project name and ID', () => {
+    const homeDir = writeConfigInTempHome(baseConfig)
+    const result = runAuthInfo(homeDir)
+
+    const output = stripAnsi(bufferToText(result.stdout))
+    expect(result.status).toBe(0)
+    expect(output).toContain('You are logged in as user@example.com')
+    expect(output).toContain('Selected project: Acme Project (a1b2c3d4)')
+    expect(output).not.toContain('team')
+  })
+
+  test('prints a project-worded fallback when the name is missing', () => {
+    const { teamName: _teamName, ...configWithoutName } = baseConfig
+    const homeDir = writeConfigInTempHome(configWithoutName)
+    const result = runAuthInfo(homeDir)
+
+    const output = stripAnsi(bufferToText(result.stdout))
+    expect(result.status).toBe(0)
+    expect(output).toContain('Log out and log in to get project name')
+    expect(output).not.toContain('team')
+  })
+})

--- a/packages/cli/tests/utils/format.test.ts
+++ b/packages/cli/tests/utils/format.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest'
+
+import { asFormattedConfig, asFormattedTeam } from '../../src/utils/format'
+import type { UserConfig } from '../../src/user'
+
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (text: string) => text.replace(/\x1B\[[0-9;]*m/g, '')
+
+const baseConfig: UserConfig = {
+  version: 1,
+  identity: {
+    email: 'user@example.com',
+  },
+  oauth: {
+    token_endpoint: 'https://hydra.example.com/oauth2/token',
+    revoke_endpoint: 'https://hydra.example.com/oauth2/revoke',
+    client_id: 'cli-client-id',
+  },
+  tokens: {
+    access_token: 'access-token',
+    refresh_token: 'refresh-token',
+  },
+  last_refresh: '2026-07-22T12:00:00.000Z',
+  teamName: 'Acme Project',
+  teamId: 'a1b2c3d4',
+  teamApiKey: 'e2b_' + '0'.repeat(40),
+}
+
+describe('asFormattedConfig', () => {
+  test('prints the selected project name and ID', () => {
+    const output = stripAnsi(asFormattedConfig(baseConfig))
+    expect(output).toContain('Selected project: Acme Project (a1b2c3d4)')
+    expect(output).not.toContain('team')
+  })
+
+  test('falls back to a project-worded hint when the name is missing', () => {
+    const config = { ...baseConfig, teamName: '' }
+    const output = stripAnsi(asFormattedConfig(config))
+    expect(output).toContain('Log out and log in to get project name')
+    expect(output).not.toContain('team')
+  })
+})
+
+describe('asFormattedTeam', () => {
+  const team = {
+    name: 'Acme Project',
+    teamID: 'a1b2c3d4',
+    apiKey: 'e2b_' + '0'.repeat(40),
+    isDefault: true,
+  }
+
+  test('marks the active entry as the currently selected project', () => {
+    const output = stripAnsi(asFormattedTeam(team, 'a1b2c3d4'))
+    expect(output).toContain('Acme Project (a1b2c3d4)')
+    expect(output).toContain('(currently selected project)')
+    expect(output).not.toContain('team')
+  })
+
+  test('leaves non-selected entries unmarked', () => {
+    const output = stripAnsi(asFormattedTeam(team, 'other-id'))
+    expect(output).toBe('Acme Project (a1b2c3d4)')
+  })
+})


### PR DESCRIPTION
## What

Copy-only pass renaming the remaining user-visible "team" strings to "project" across the CLI's auth and template commands — 12 string literals, zero behavior change. Part of the Teams → Projects rename initiative (follows the dashboard copy pass, dashboard-api strings, and data migration PRs).

**Renamed strings:**

| Command | Before | After |
|---|---|---|
| `auth login` | `Logged in as <email> with selected team <name>` | `…with selected project <name>` |
| `auth login` (already logged in) | `To change the team, run 'e2b auth configure'.` | `To change the project, …` |
| `auth login` / `auth configure` | `Error getting teams` | `Error getting projects` |
| `auth login` | `No default team found, please contact support` | `No default project found, …` |
| `auth info` | `Selected team: <name> (<id>)` | `Selected project: <name> (<id>)` |
| `auth info` (missing name) | `Log out and log in to get team name` | `…to get project name` |
| `auth configure` | `Select team` | `Select project` |
| `auth configure` (picker) | `(currently selected team)` | `(currently selected project)` |
| `auth configure` | `Team <name> (<id>) selected.` | `Project <name> (<id>) selected.` |
| `template publish` | `public to everyone outside your team` / `private to your team` | `…your project` |

## What is NOT changed

- No flag, env var, config key, API call, or exit-code behavior — the diff is string literals, tests, and a patch changeset.
- `--team` flag help text and deprecation (#1571), `~/.e2b/config.json` keys (#1570), `e2b.toml` `team_id` (#1569).
- `E2B_TEAM_ID` (deferred by decision), API/OpenAPI `Team` types, `X-Team-ID`, SDK docstrings, docs.
- Internal identifiers (`asFormattedTeam`, `Teams` type, etc.) — they follow the API spec rename later.

## Dependencies

⚠️ **Draft until #1569, #1570, and #1571 merge** — they touch adjacent lines in the same files; this branch is cut from main and will be rebased after they land (expect trivial conflicts around the auth commands and shared formatter).

## Usage examples

```
$ e2b auth login
Logged in as jakub.kracina@e2b.dev with selected project Jakub's Project

$ e2b auth info
You are logged in as jakub.kracina@e2b.dev,
Selected project: Jakub's Project (a1b2c3d4)

$ e2b auth configure
? Select project
  Jakub's Project (a1b2c3d4) (currently selected project)
Project Jakub's Project (a1b2c3d4) selected.
```

## Testing

- New `tests/utils/format.test.ts`: unit tests for `asFormattedConfig` (project line + missing-name fallback) and `asFormattedTeam` (picker selection suffix).
- New `tests/commands/auth/info.test.ts`: command-level output assertions for `e2b auth info` against a temp `$HOME` config — asserts the printed text contains "project" and no "team".
- Full suite: 99 passed, 1 skipped; the only failures are the pre-existing backend-integration suites that need live sandbox access (verified they fail identically on clean main).
- Manual smoke against staging still pending (login/configure/publish screenshots) — will attach before marking ready.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/e2b-dev/codesmith/E2B/pr/1576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787314714&installation_model_id=14389&pr_number=1576&repository=e2b-dev%2FE2B&return_to=https%3A%2F%2Fgithub.com%2Fe2b-dev%2FE2B%2Fpull%2F1576&signature=43246901d57870484bd1c9a6a809d53508158e5dd2523f46684ae7b2641f0284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->