### PR TITLE
feat(cli): rename --team flag to --project and add E2B_PROJECT_ID env var

### DIFF
--- a/.changeset/hip-pugs-repeat.md
+++ b/.changeset/hip-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': minor
+---
+
+Rename the `--team` flag to `--project` on `template list`, `template publish`, `template unpublish`, and `template delete`. The `--team` flag keeps working but is hidden from help and prints a deprecation warning. The project ID can also be set via the new `E2B_PROJECT_ID` environment variable; `E2B_TEAM_ID` is still supported and is used when `E2B_PROJECT_ID` is not set.

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -14,7 +14,7 @@ export type Teams =
 
 export let apiKey = process.env.E2B_API_KEY
 export let accessToken = process.env.E2B_ACCESS_TOKEN
-export const teamId = process.env.E2B_TEAM_ID
+export const projectId = process.env.E2B_PROJECT_ID || process.env.E2B_TEAM_ID
 
 const authErrorBox = (keyName: 'E2B_API_KEY' | 'E2B_ACCESS_TOKEN') => {
   const link =
@@ -80,15 +80,15 @@ export function ensureAccessToken() {
 }
 
 /**
- * Resolve team ID with proper precedence:
- * 1. CLI --team flag
- * 2. E2B_TEAM_ID env var
+ * Resolve project ID with proper precedence:
+ * 1. CLI --project flag (or the deprecated --team flag)
+ * 2. E2B_PROJECT_ID env var (or the deprecated E2B_TEAM_ID)
  * 3. ~/.e2b/config.json teamId (only if E2B_API_KEY env var is NOT set,
- *    to avoid mismatch between env var API key and config file team ID)
+ *    to avoid mismatch between env var API key and config file project ID)
  */
-export function resolveTeamId(cliTeamId?: string): string | undefined {
-  if (cliTeamId) return cliTeamId
-  if (teamId) return teamId
+export function resolveProjectId(cliProjectId?: string): string | undefined {
+  if (cliProjectId) return cliProjectId
+  if (projectId) return projectId
   if (!process.env.E2B_API_KEY) {
     const config = getUserConfig()
     return config?.teamId

--- a/packages/cli/src/commands/template/delete.ts
+++ b/packages/cli/src/commands/template/delete.ts
@@ -90,7 +90,7 @@ export const deleteCommand = new commander.Command('delete')
           projectId = resolveProjectId(projectId)
 
           const allTemplates = await listSandboxTemplates({
-            teamID: projectId,
+            projectId,
           })
 
           const selectedTemplates = await getPromptTemplates(

--- a/packages/cli/src/commands/template/delete.ts
+++ b/packages/cli/src/commands/template/delete.ts
@@ -13,7 +13,9 @@ import {
   configOption,
   pathOption,
   selectMultipleOption,
-  teamOption,
+  deprecatedTeamOption,
+  projectIdFromOptions,
+  projectOption,
 } from 'src/options'
 import {
   E2BConfig,
@@ -26,7 +28,7 @@ import { getRoot } from 'src/utils/filesystem'
 import { listSandboxTemplates } from './list'
 import { getPromptTemplates } from 'src/utils/templatePrompt'
 import { confirm } from 'src/utils/confirm'
-import { client, resolveTeamId } from 'src/api'
+import { client, resolveProjectId } from 'src/api'
 import { handleE2BRequestError } from '../../utils/errors'
 
 async function deleteTemplate(templateID: string) {
@@ -55,7 +57,8 @@ export const deleteCommand = new commander.Command('delete')
   .addOption(pathOption)
   .addOption(configOption)
   .addOption(selectMultipleOption)
-  .addOption(teamOption)
+  .addOption(projectOption)
+  .addOption(deprecatedTeamOption)
   .alias('dl')
   .option('-y, --yes', 'skip manual delete confirmation')
   .action(
@@ -66,11 +69,12 @@ export const deleteCommand = new commander.Command('delete')
         config?: string
         yes?: boolean
         select?: boolean
+        project?: string
         team?: string
       }
     ) => {
       try {
-        let teamId = opts.team
+        let projectId = projectIdFromOptions(opts)
 
         const root = getRoot(opts.path)
 
@@ -83,10 +87,10 @@ export const deleteCommand = new commander.Command('delete')
             template_id: template,
           })
         } else if (opts.select) {
-          teamId = resolveTeamId(teamId)
+          projectId = resolveProjectId(projectId)
 
           const allTemplates = await listSandboxTemplates({
-            teamID: teamId,
+            teamID: projectId,
           })
 
           const selectedTemplates = await getPromptTemplates(

--- a/packages/cli/src/commands/template/list.ts
+++ b/packages/cli/src/commands/template/list.ts
@@ -25,7 +25,7 @@ export const listCommand = new commander.Command('list')
       process.stdout.write('\n')
 
       const templates = await listSandboxTemplates({
-        teamID: resolveProjectId(projectIdFromOptions(opts)),
+        projectId: resolveProjectId(projectIdFromOptions(opts)),
       })
 
       for (const template of templates) {
@@ -117,13 +117,14 @@ function renderTable(templates: e2b.components['schemas']['Template'][]) {
 }
 
 export async function listSandboxTemplates({
-  teamID,
+  projectId,
 }: {
-  teamID?: string
+  projectId?: string
 }): Promise<e2b.components['schemas']['Template'][]> {
   const templates = await client.api.GET('/templates', {
     params: {
-      query: { teamID },
+      // the backend API still calls the project ID "teamID"
+      query: { teamID: projectId },
     },
   })
 

--- a/packages/cli/src/commands/template/list.ts
+++ b/packages/cli/src/commands/template/list.ts
@@ -4,23 +4,28 @@ import * as e2b from 'e2b'
 
 import { listAliases } from '../../utils/format'
 import { sortTemplatesAliases } from 'src/utils/templateSort'
-import { client, ensureAPIKey, resolveTeamId } from 'src/api'
-import { teamOption } from '../../options'
+import { client, ensureAPIKey, resolveProjectId } from 'src/api'
+import {
+  deprecatedTeamOption,
+  projectIdFromOptions,
+  projectOption,
+} from '../../options'
 import { handleE2BRequestError } from '../../utils/errors'
 
 export const listCommand = new commander.Command('list')
   .description('list sandbox templates')
   .alias('ls')
-  .addOption(teamOption)
+  .addOption(projectOption)
+  .addOption(deprecatedTeamOption)
   .option('-f, --format <format>', 'output format, eg. json, pretty')
-  .action(async (opts: { team: string; format: string }) => {
+  .action(async (opts: { project?: string; team?: string; format: string }) => {
     try {
       const format = opts.format || 'pretty'
       ensureAPIKey()
       process.stdout.write('\n')
 
       const templates = await listSandboxTemplates({
-        teamID: resolveTeamId(opts.team),
+        teamID: resolveProjectId(projectIdFromOptions(opts)),
       })
 
       for (const template of templates) {

--- a/packages/cli/src/commands/template/publish.ts
+++ b/packages/cli/src/commands/template/publish.ts
@@ -11,16 +11,18 @@ import {
 } from 'src/utils/format'
 import {
   configOption,
+  deprecatedTeamOption,
   pathOption,
+  projectIdFromOptions,
+  projectOption,
   selectMultipleOption,
-  teamOption,
 } from 'src/options'
 import { configName, E2BConfig, getConfigPath, loadConfig } from 'src/config'
 import { getRoot } from 'src/utils/filesystem'
 import { listSandboxTemplates } from './list'
 import { getPromptTemplates } from 'src/utils/templatePrompt'
 import { confirm } from 'src/utils/confirm'
-import { client, resolveTeamId } from 'src/api'
+import { client, resolveProjectId } from 'src/api'
 import { handleE2BRequestError } from '../../utils/errors'
 
 async function publishTemplate(templateID: string, publish: boolean) {
@@ -51,11 +53,12 @@ async function templateAction(
     config?: string
     yes?: boolean
     select?: boolean
+    project?: string
     team?: string
   }
 ) {
   try {
-    let teamId = opts.team
+    let projectId = projectIdFromOptions(opts)
 
     const root = getRoot(opts.path)
 
@@ -68,10 +71,10 @@ async function templateAction(
         template_id: template,
       })
     } else if (opts.select) {
-      teamId = resolveTeamId(teamId)
+      projectId = resolveProjectId(projectId)
 
       const allTemplates = await listSandboxTemplates({
-        teamID: teamId,
+        teamID: projectId,
       })
 
       const filteredTemplates = allTemplates.filter(
@@ -206,7 +209,8 @@ export const publishCommand = new commander.Command('publish')
   .addOption(pathOption)
   .addOption(configOption)
   .addOption(selectMultipleOption)
-  .addOption(teamOption)
+  .addOption(projectOption)
+  .addOption(deprecatedTeamOption)
   .alias('pb')
   .option('-y, --yes', 'skip manual publish confirmation')
   .action(templateAction.bind(null, true))
@@ -226,7 +230,8 @@ export const unPublishCommand = new commander.Command('unpublish')
   .addOption(pathOption)
   .addOption(configOption)
   .addOption(selectMultipleOption)
-  .addOption(teamOption)
+  .addOption(projectOption)
+  .addOption(deprecatedTeamOption)
   .alias('upb')
   .option('-y, --yes', 'skip manual unpublish confirmation')
   .action(templateAction.bind(null, false))

--- a/packages/cli/src/commands/template/publish.ts
+++ b/packages/cli/src/commands/template/publish.ts
@@ -74,7 +74,7 @@ async function templateAction(
       projectId = resolveProjectId(projectId)
 
       const allTemplates = await listSandboxTemplates({
-        teamID: projectId,
+        projectId,
       })
 
       const filteredTemplates = allTemplates.filter(

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -37,7 +37,30 @@ export const selectMultipleOption = new commander.Option(
   'select sandbox template from interactive list'
 )
 
-export const teamOption = new commander.Option(
-  '-t, --team <team-id>',
-  'specify the team ID that the operation will be associated with. You can find team ID in the team settings in the E2B dashboard (https://e2b.dev/dashboard?tab=team).'
+export const projectOption = new commander.Option(
+  '-t, --project <project-id>',
+  'specify the project ID that the operation will be associated with. You can find project ID in the project settings in the E2B dashboard (https://e2b.dev/dashboard?tab=team).'
 )
+
+export const deprecatedTeamOption = new commander.Option(
+  '--team <project-id>',
+  `[deprecated] use ${asBold('--project')} instead`
+).hideHelp()
+
+/**
+ * Read the project ID from parsed command options, honoring the deprecated
+ * --team flag (with a warning) when --project is not set.
+ */
+export function projectIdFromOptions(opts: {
+  project?: string
+  team?: string
+}): string | undefined {
+  if (opts.team && !opts.project) {
+    console.error(
+      `The ${asBold('--team')} flag is deprecated, use ${asBold(
+        '--project'
+      )} instead.`
+    )
+  }
+  return opts.project ?? opts.team
+}

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -48,14 +48,14 @@ export const deprecatedTeamOption = new commander.Option(
 ).hideHelp()
 
 /**
- * Read the project ID from parsed command options, honoring the deprecated
- * --team flag (with a warning) when --project is not set.
+ * Read the project ID from parsed command options, preferring --project and
+ * warning whenever the deprecated --team flag is used.
  */
 export function projectIdFromOptions(opts: {
   project?: string
   team?: string
 }): string | undefined {
-  if (opts.team && !opts.project) {
+  if (opts.team) {
     console.error(
       `The ${asBold('--team')} flag is deprecated, use ${asBold(
         '--project'


### PR DESCRIPTION
Renames the `--team` flag to `-t, --project` on `template list`, `template publish`, `template unpublish`, and `template delete`. `--team` keeps working as a hidden alias that prints a deprecation warning to stderr. The project ID can now also be set via the new `E2B_PROJECT_ID` environment variable, with `E2B_TEAM_ID` still supported as a fallback. Resolution precedence: `--project` > `--team` > `E2B_PROJECT_ID` > `E2B_TEAM_ID` > `~/.e2b/config.json`.

## Usage

```sh
e2b template list --project <project-id>   # new flag (also -t)
e2b template list --team <project-id>      # still works, warns: "The --team flag is deprecated, use --project instead."

E2B_PROJECT_ID=<project-id> e2b template list   # new env var
E2B_TEAM_ID=<project-id> e2b template list      # still supported
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)