### PR TITLE
fix(js-sdk): avoid createRequire shim that crashes Cloudflare Workers

### DIFF
--- a/.changeset/quiet-panthers-repair.md
+++ b/.changeset/quiet-panthers-repair.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+Fix ESM bundle crashing at import time in Cloudflare Workers (and other edge runtimes) with `The argument 'path' must be a file URL object, a file URL string, or an absolute path string. Received 'undefined'`. Bare `require` calls in the SDK source made the bundler emit an eager `createRequire(import.meta.url)` shim at module scope, which throws in workerd where `import.meta.url` is undefined. Node.js built-ins are now loaded via `process.getBuiltinModule` instead, and the build fails if a `require` shim ever reappears in the ESM bundle.

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -24,7 +24,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "prepublishOnly": "pnpm build",
-    "build": "tsc --noEmit && tsdown",
+    "build": "tsc --noEmit && tsdown && node scripts/check-bundle-edge-compat.mjs",
     "dev": "tsdown --watch",
     "example": "tsx example.mts",
     "test": "vitest run",

--- a/packages/js-sdk/scripts/check-bundle-edge-compat.mjs
+++ b/packages/js-sdk/scripts/check-bundle-edge-compat.mjs
@@ -1,0 +1,32 @@
+// Fails the build if the ESM bundle contains a module-scope `require` shim.
+//
+// Bundlers turn bare `require` references in ESM source into a
+// `createRequire(import.meta.url)` helper that is evaluated eagerly when the
+// module loads. In edge runtimes (e.g. Cloudflare Workers) `import.meta.url`
+// is undefined in bundled code, so importing the SDK crashes before any API
+// call is made. See https://github.com/e2b-dev/E2B/issues/1579
+//
+// Instead of `require`, load Node.js built-ins with `dynamicRequire` from
+// src/utils.ts (backed by `process.getBuiltinModule`).
+import { readFileSync } from 'node:fs'
+
+const bundlePath = new URL('../dist/index.mjs', import.meta.url)
+const bundle = readFileSync(bundlePath, 'utf8')
+
+const forbidden = [
+  /from\s*['"]node:module['"]/,
+  /\bcreateRequire\s*\(/,
+  /\b__require\b/,
+]
+
+const hit = forbidden.find((pattern) => pattern.test(bundle))
+if (hit) {
+  console.error(
+    `dist/index.mjs matches ${hit} — the bundle contains a \`require\` shim ` +
+      'that crashes edge runtimes such as Cloudflare Workers. Remove bare ' +
+      '`require` references from src (use `dynamicRequire` from src/utils.ts).'
+  )
+  process.exit(1)
+}
+
+console.log('dist/index.mjs is free of require shims (edge-runtime safe)')

--- a/packages/js-sdk/src/utils.ts
+++ b/packages/js-sdk/src/utils.ts
@@ -57,8 +57,8 @@ export async function sha256(data: string): Promise<string> {
   }
 
   // Use Node.js crypto if WebCrypto is not available
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { createHash } = require('node:crypto')
+  const { createHash } =
+    dynamicRequire<typeof import('node:crypto')>('node:crypto')
   const hash = createHash('sha256').update(data, 'utf8').digest()
   return hash.toString('base64')
 }
@@ -67,12 +67,28 @@ export function timeoutToSeconds(timeout: number): number {
   return Math.ceil(timeout / 1000)
 }
 
+/**
+ * Synchronously load a built-in Node.js module.
+ *
+ * Implemented with `process.getBuiltinModule` (available on all supported
+ * runtimes) instead of `require`, because a `require` reference in ESM source
+ * makes bundlers emit a `createRequire` shim evaluated at module scope, which
+ * crashes in edge runtimes like Cloudflare Workers where the module URL is
+ * undefined.
+ */
 export function dynamicRequire<T>(module: string): T {
   if (runtime === 'browser') {
     throw new Error('Browser runtime is not supported for require')
   }
 
-  return require(module)
+  const getBuiltinModule = (globalThis as any).process?.getBuiltinModule
+  if (typeof getBuiltinModule !== 'function') {
+    throw new Error(
+      `Cannot load module "${module}": process.getBuiltinModule is not available in this runtime`
+    )
+  }
+
+  return getBuiltinModule(module)
 }
 
 export async function dynamicImport<T>(module: string): Promise<T> {

--- a/packages/js-sdk/tests/utils.test.ts
+++ b/packages/js-sdk/tests/utils.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { fileURLToPath } from 'node:url'
+
+import { dynamicRequire, sha256 } from '../src/utils'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+test('dynamicRequire loads Node.js built-in modules', () => {
+  const url = dynamicRequire<typeof import('node:url')>('node:url')
+  expect(url.fileURLToPath).toBe(fileURLToPath)
+})
+
+test('sha256 uses WebCrypto when available', async () => {
+  expect(await sha256('hello')).toBe(
+    'LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ='
+  )
+})
+
+test('sha256 falls back to node:crypto when WebCrypto is unavailable', async () => {
+  vi.stubGlobal('crypto', undefined)
+  expect(await sha256('hello')).toBe(
+    'LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ='
+  )
+})


### PR DESCRIPTION
Fixes #1579

## Problem

Since the switch from tsup to tsdown, `e2b` ≥2.33 crashes at import time in Cloudflare Workers (`nodejs_compat`):

```text
The argument 'path' The argument must be a file URL object, a file URL string, or an absolute path string.. Received 'undefined'
```

Two bare `require()` calls in `src/utils.ts` (the `sha256` Node fallback and `dynamicRequire`) made Rolldown emit this eager helper at module scope in `dist/index.mjs`:

```js
import { createRequire } from "node:module";
var __require = /* #__PURE__ */ (() => createRequire(import.meta.url))();
```

In workerd's bundled context `import.meta.url` is `undefined`, so `createRequire` throws during module evaluation — before `Sandbox.create()` can make any request. tsup/esbuild emitted a lazy shim that only threw when called, which is why 2.32.0 worked.

## Fix

- `dynamicRequire` now loads Node built-ins via `process.getBuiltinModule` (Node ≥20.16, Bun, Deno 2 — the package already requires Node ≥20.18.1), so no `require` reference exists in ESM source and no shim is emitted.
- The `sha256` WebCrypto fallback goes through `dynamicRequire` instead of a bare `require('node:crypto')`.
- New build step `scripts/check-bundle-edge-compat.mjs` fails `pnpm build` (and therefore `prepublishOnly`) if a `require` shim (`node:module` import, `createRequire(`, or `__require`) ever reappears in `dist/index.mjs`.
- New unit tests cover `dynamicRequire` and both `sha256` paths.

## Usage example

The reproduction from the issue now works — a Worker with `nodejs_compat`:

```ts
export default {
  async fetch() {
    const { Sandbox } = await import('e2b')
    return Response.json({ loaded: typeof Sandbox.create === 'function' })
  },
}
```

## Verification

- `wrangler deploy --dry-run` of a Worker using the packed tarball: `rg 'createRequire\(import\.meta\.url\)'` finds nothing in the production bundle (the reporter's check).
- `wrangler dev` (real workerd): `curl` returns `{"loaded":true}` — module evaluation and `Sandbox.create` reference succeed.
- Node ESM (`dist/index.mjs`) and CJS (`dist/index.js`) both still load.
- `vitest run` over `tests/api`, `tests/template`, `tests/utils.test.ts`, `tests/connectionConfig.test.ts`, `tests/sandbox/signature.test.ts`: 232 passed, 3 skipped.
- CLI (which bundles the workspace SDK from source) still typechecks and builds.

No Python SDK changes needed — this is a JS bundler artifact issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)