### PR TITLE
fix(python-sdk): cancel HTTP/2 server streams closed before the server ends them

### DIFF
--- a/.changeset/light-poems-refuse.md
+++ b/.changeset/light-poems-refuse.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Cancel HTTP/2 server streams (`RST_STREAM`) when a command/PTY/watch stream is closed before the server finished it (e.g. `disconnect()`), instead of leaving the stream half-open on the shared envd connection. Abandoned half-open streams stay attached server-side and can block envd's process output fan-out for every other consumer of the same process (#1352, #1587).

--- a/packages/python-sdk/e2b_connect/client.py
+++ b/packages/python-sdk/e2b_connect/client.py
@@ -5,6 +5,8 @@ import logging
 import struct
 import typing
 
+import h2.errors
+
 from httpcore import (
     ConnectionPool,
     AsyncConnectionPool,
@@ -106,6 +108,69 @@ def make_error(error):
         status = Code.unknown
 
     return ConnectException(status, error.get("message", ""))
+
+
+def _get_h2_stream_parts(http_resp: Response):
+    """
+    Return ``(connection, request, stream_id)`` for a pooled httpcore HTTP/2
+    response, or ``None`` when the response is not an HTTP/2 stream (e.g. an
+    HTTP/1.1 fallback) or httpcore internals don't match.
+    """
+    inner = getattr(getattr(http_resp, "stream", None), "_stream", None)
+    connection = getattr(inner, "_connection", None)
+    request = getattr(inner, "_request", None)
+    stream_id = getattr(inner, "_stream_id", None)
+    if (
+        getattr(connection, "_h2_state", None) is None
+        or request is None
+        or stream_id is None
+    ):
+        return None
+    return connection, request, stream_id
+
+
+def _reset_h2_stream(http_resp: Response) -> None:
+    """
+    Best-effort ``RST_STREAM`` (CANCEL) for a server stream that is being
+    closed before the server ended it.
+
+    httpcore never cancels an HTTP/2 stream when a response is closed early —
+    it only stops reading it, so the server side stays attached and keeps
+    writing into a receive window nobody drains. On the shared envd
+    connection a stream abandoned that way blocks envd's process output
+    fan-out for every other consumer once its window fills (#1352, #1587).
+    Sending an explicit ``RST_STREAM`` lets the server tear the stream down.
+
+    Failures are swallowed: the stream may already be fully closed (normal
+    completion), the connection may be dead, or the transport may be
+    HTTP/1.1 (where closing the response already closes the connection).
+    """
+    parts = _get_h2_stream_parts(http_resp)
+    if parts is None:
+        return
+    connection, request, stream_id = parts
+    try:
+        connection._h2_state.reset_stream(
+            stream_id, error_code=h2.errors.ErrorCodes.CANCEL
+        )
+        connection._write_outgoing_data(request)
+    except Exception:
+        pass
+
+
+async def _areset_h2_stream(http_resp: Response) -> None:
+    """Async variant of :func:`_reset_h2_stream`."""
+    parts = _get_h2_stream_parts(http_resp)
+    if parts is None:
+        return
+    connection, request, stream_id = parts
+    try:
+        connection._h2_state.reset_stream(
+            stream_id, error_code=h2.errors.ErrorCodes.CANCEL
+        )
+        await connection._write_outgoing_data(request)
+    except Exception:
+        pass
 
 
 def _sync_retry(func, exc, retries):
@@ -415,15 +480,24 @@ class Client:
 
         self._log_request()
         async with self.async_pool.stream(**req_data) as http_resp:
-            if http_resp.status != 200:
-                self._log_response(http_resp.status)
-                await http_resp.aread()
-                raise error_for_response(http_resp)
+            # `completed` means the server ended the stream itself; any other
+            # exit (consumer stops iterating, disconnect, error) leaves the
+            # stream open server-side, so cancel it explicitly.
+            completed = False
+            try:
+                if http_resp.status != 200:
+                    self._log_response(http_resp.status)
+                    await http_resp.aread()
+                    raise error_for_response(http_resp)
 
-            async for chunk in http_resp.aiter_stream():
-                for parsed in parser.parse(chunk):
-                    self._log_stream_message()
-                    yield parsed
+                async for chunk in http_resp.aiter_stream():
+                    for parsed in parser.parse(chunk):
+                        self._log_stream_message()
+                        yield parsed
+                completed = True
+            finally:
+                if not completed:
+                    await _areset_h2_stream(http_resp)
 
     def call_server_stream(
         self,
@@ -451,15 +525,24 @@ class Client:
 
         self._log_request()
         with self.pool.stream(**req_data) as http_resp:
-            if http_resp.status != 200:
-                self._log_response(http_resp.status)
-                http_resp.read()
-                raise error_for_response(http_resp)
+            # `completed` means the server ended the stream itself; any other
+            # exit (consumer stops iterating, disconnect, error) leaves the
+            # stream open server-side, so cancel it explicitly.
+            completed = False
+            try:
+                if http_resp.status != 200:
+                    self._log_response(http_resp.status)
+                    http_resp.read()
+                    raise error_for_response(http_resp)
 
-            for chunk in http_resp.iter_stream():
-                for parsed in parser.parse(chunk):
-                    self._log_stream_message()
-                    yield parsed
+                for chunk in http_resp.iter_stream():
+                    for parsed in parser.parse(chunk):
+                        self._log_stream_message()
+                        yield parsed
+                completed = True
+            finally:
+                if not completed:
+                    _reset_h2_stream(http_resp)
 
     def call_client_stream(self, req, **opts):
         raise NotImplementedError("client stream not supported")

--- a/packages/python-sdk/tests/e2b_connect/test_stream_reset.py
+++ b/packages/python-sdk/tests/e2b_connect/test_stream_reset.py
@@ -1,0 +1,196 @@
+"""
+Server streams closed before the server ends them must send an HTTP/2
+``RST_STREAM`` (CANCEL) so the server tears the stream down.
+
+httpcore itself never cancels a stream on early response close — it only
+stops reading it. On the shared envd connection an abandoned stream then
+stays attached server-side and blocks envd's process output fan-out for
+every other consumer once its flow-control window fills (#1352, #1587).
+"""
+
+import json
+import struct
+
+import hpack
+import httpcore
+import hyperframe.frame
+from httpcore._backends.mock import (
+    AsyncMockBackend,
+    AsyncMockStream,
+    MockBackend,
+    MockStream,
+)
+
+from e2b.envd.process import process_pb2
+from e2b_connect.client import Client, EnvelopeFlags, encode_envelope
+
+URL = "https://mock.e2b.test/process.Process/Connect"
+RST_STREAM_FRAME_TYPE = 0x3
+H2_CANCEL = 0x8
+
+
+class CapturingMockStream(MockStream):
+    def __init__(self, buffer, http2, writes):
+        super().__init__(buffer, http2=http2)
+        self._writes = writes
+
+    def write(self, buffer, timeout=None):
+        self._writes.append(bytes(buffer))
+
+
+class CapturingMockBackend(MockBackend):
+    def __init__(self, buffer, http2, writes):
+        super().__init__(buffer, http2=http2)
+        self._writes = writes
+
+    def connect_tcp(self, *args, **kwargs):
+        return CapturingMockStream(list(self._buffer), self._http2, self._writes)
+
+
+class CapturingAsyncMockStream(AsyncMockStream):
+    def __init__(self, buffer, http2, writes):
+        super().__init__(buffer, http2=http2)
+        self._writes = writes
+
+    async def write(self, buffer, timeout=None):
+        self._writes.append(bytes(buffer))
+
+
+class CapturingAsyncMockBackend(AsyncMockBackend):
+    def __init__(self, buffer, http2, writes):
+        super().__init__(buffer, http2=http2)
+        self._writes = writes
+
+    async def connect_tcp(self, *args, **kwargs):
+        return CapturingAsyncMockStream(list(self._buffer), self._http2, self._writes)
+
+
+def connect_response_envelope() -> bytes:
+    return encode_envelope(
+        flags=EnvelopeFlags(0),
+        data=json.dumps({"event": {"data": {"stdout": "aGk="}}}).encode(),
+    )
+
+
+def end_stream_envelope() -> bytes:
+    return encode_envelope(flags=EnvelopeFlags.end_stream, data=b"{}")
+
+
+def server_frames(server_ends_stream: bool) -> list:
+    encoder = hpack.Encoder()
+    frames = [
+        hyperframe.frame.SettingsFrame(),
+        hyperframe.frame.HeadersFrame(
+            stream_id=1,
+            data=encoder.encode(
+                [
+                    (b":status", b"200"),
+                    (b"content-type", b"application/connect+json"),
+                ]
+            ),
+            flags=["END_HEADERS"],
+        ),
+        hyperframe.frame.DataFrame(stream_id=1, data=connect_response_envelope()),
+    ]
+    if server_ends_stream:
+        frames.append(
+            hyperframe.frame.DataFrame(
+                stream_id=1,
+                data=end_stream_envelope(),
+                flags=["END_STREAM"],
+            )
+        )
+    return [frame.serialize() for frame in frames]
+
+
+def rst_stream_frames(writes: list) -> list:
+    """Parse captured outgoing bytes into (stream_id, error_code) RST frames."""
+    data = b"".join(writes)
+    # Skip the HTTP/2 client connection preface.
+    preface = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+    if data.startswith(preface):
+        data = data[len(preface) :]
+    found = []
+    while len(data) >= 9:
+        length = int.from_bytes(data[0:3], "big")
+        frame_type = data[3]
+        stream_id = int.from_bytes(data[5:9], "big") & 0x7FFFFFFF
+        payload = data[9 : 9 + length]
+        if frame_type == RST_STREAM_FRAME_TYPE:
+            (error_code,) = struct.unpack(">I", payload)
+            found.append((stream_id, error_code))
+        data = data[9 + length :]
+    return found
+
+
+def make_client(pool=None, async_pool=None) -> Client:
+    return Client(
+        pool=pool,
+        async_pool=async_pool,
+        url=URL,
+        response_type=process_pb2.ConnectResponse,
+        json=True,
+    )
+
+
+async def test_async_early_close_sends_rst_stream():
+    writes = []
+    backend = CapturingAsyncMockBackend(
+        server_frames(server_ends_stream=False), http2=True, writes=writes
+    )
+    async with httpcore.AsyncConnectionPool(
+        network_backend=backend, http2=True
+    ) as pool:
+        client = make_client(async_pool=pool)
+        events = client.acall_server_stream(process_pb2.ConnectRequest())
+        event = await events.__anext__()
+        assert event.event.data.stdout == b"hi"
+
+        assert rst_stream_frames(writes) == []
+        await events.aclose()
+        assert rst_stream_frames(writes) == [(1, H2_CANCEL)]
+
+
+async def test_async_completed_stream_does_not_send_rst_stream():
+    writes = []
+    backend = CapturingAsyncMockBackend(
+        server_frames(server_ends_stream=True), http2=True, writes=writes
+    )
+    async with httpcore.AsyncConnectionPool(
+        network_backend=backend, http2=True
+    ) as pool:
+        client = make_client(async_pool=pool)
+        events = [
+            event
+            async for event in client.acall_server_stream(process_pb2.ConnectRequest())
+        ]
+        assert len(events) == 1
+        assert rst_stream_frames(writes) == []
+
+
+def test_sync_early_close_sends_rst_stream():
+    writes = []
+    backend = CapturingMockBackend(
+        server_frames(server_ends_stream=False), http2=True, writes=writes
+    )
+    with httpcore.ConnectionPool(network_backend=backend, http2=True) as pool:
+        client = make_client(pool=pool)
+        events = client.call_server_stream(process_pb2.ConnectRequest())
+        event = next(events)
+        assert event.event.data.stdout == b"hi"
+
+        assert rst_stream_frames(writes) == []
+        events.close()
+        assert rst_stream_frames(writes) == [(1, H2_CANCEL)]
+
+
+def test_sync_completed_stream_does_not_send_rst_stream():
+    writes = []
+    backend = CapturingMockBackend(
+        server_frames(server_ends_stream=True), http2=True, writes=writes
+    )
+    with httpcore.ConnectionPool(network_backend=backend, http2=True) as pool:
+        client = make_client(pool=pool)
+        events = list(client.call_server_stream(process_pb2.ConnectRequest()))
+        assert len(events) == 1
+        assert rst_stream_frames(writes) == []


### PR DESCRIPTION
## Problem

The Python SDK's connect client (`e2b_connect`) talks to envd over a single shared HTTP/2 connection (one `httpcore` pool per event loop, all sandboxes multiplexed). When a command/PTY/watch stream is closed before the server finished it — `disconnect()`, an error, stream-setup failure, or the consumer just stopping — httpcore only stops reading the response; it never sends `RST_STREAM`. The server side therefore keeps the stream attached and keeps writing into a flow-control window nobody drains.

On envd, such a half-open stream becomes a stuck output consumer, and one stuck consumer blocks envd's process output fan-out for **every** consumer of that process (see e2b-dev/infra#3362). That is the mechanism behind #1352 and part of the picture in #1587.

## Fix

`call_server_stream` / `acall_server_stream` now send `RST_STREAM` (CANCEL) whenever the stream ends without the server having completed it, so the proxy/envd tear the stream down and detach the consumer. Normal completions send nothing extra. The reset is best-effort and no-ops on HTTP/1.1 (where closing the response already closes the connection).

## Note on #1587

This fixes the client-side half of the problem (abandoned streams manufacturing dead server-side consumers). The stall reported in #1587 — stdout going silent after **auto-pause/resume** — is primarily caused by consumers captured in the pause snapshot whose restored connections block envd's fan-out after resume; no client-side change can reach those. That is fixed in envd by e2b-dev/infra#3362 and needs a deploy + envd rollout to take effect. Full root-cause analysis in the issue thread.

JS SDK needs no equivalent change: connect-es aborts streams via `AbortController`, which already produces a stream reset/connection teardown.

## Usage example

```python
handle = await sandbox.commands.connect(pid, on_stdout=print)
# Stop receiving events; the H2 stream is now actually cancelled server-side
# instead of lingering half-open on the shared envd connection.
await handle.disconnect()
```

## Testing

- New unit tests (`tests/e2b_connect/test_stream_reset.py`) run the connect client against an in-process mock HTTP/2 transport and assert on emitted frames: early close sends exactly one `RST_STREAM(CANCEL)` for the stream; normal completion sends none (sync + async). They fail without the fix.
- Live: full `commands`, `pty`, and `files watch` suites pass (sync + async, 74 tests); `disconnect()` followed by 2MB of process output to a second consumer works.
- `format`, `lint`, `typecheck` clean.

Fixes #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)