### PR TITLE
test(js-sdk): rename deprecated test.scoped() to test.override()

### DIFF
--- a/packages/js-sdk/tests/sandbox/commands/envVars.test.ts
+++ b/packages/js-sdk/tests/sandbox/commands/envVars.test.ts
@@ -3,7 +3,7 @@ import { assert, describe } from 'vitest'
 import { sandboxTest, isDebug } from '../../setup.js'
 
 describe('sandbox global env vars', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       envs: { FOO: 'bar' },
     },

--- a/packages/js-sdk/tests/sandbox/files/signing.test.ts
+++ b/packages/js-sdk/tests/sandbox/files/signing.test.ts
@@ -3,7 +3,7 @@ import { assert, describe } from 'vitest'
 import { sandboxTest, isDebug } from '../../setup'
 
 describe('file signing', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       secure: true,
     },

--- a/packages/js-sdk/tests/sandbox/internetAccess.test.ts
+++ b/packages/js-sdk/tests/sandbox/internetAccess.test.ts
@@ -4,7 +4,7 @@ import { CommandExitError } from '../../src'
 import { sandboxTest, isDebug } from '../setup.js'
 
 describe('internet access enabled', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       allowInternetAccess: true,
     },
@@ -24,7 +24,7 @@ describe('internet access enabled', () => {
 })
 
 describe('internet access disabled', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       allowInternetAccess: false,
     },

--- a/packages/js-sdk/tests/sandbox/network.test.ts
+++ b/packages/js-sdk/tests/sandbox/network.test.ts
@@ -4,7 +4,7 @@ import { CommandExitError } from '../../src'
 import { sandboxTest, isDebug } from '../setup.js'
 
 describe('allow only 1.1.1.1', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       network: {
         denyOut: ({ allTraffic }) => [allTraffic],
@@ -34,7 +34,7 @@ describe('allow only 1.1.1.1', () => {
 })
 
 describe('deny specific IP address', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       network: {
         denyOut: ['8.8.8.8'],
@@ -63,7 +63,7 @@ describe('deny specific IP address', () => {
 })
 
 describe('deny all traffic using allTraffic selector', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       network: {
         denyOut: ({ allTraffic }) => [allTraffic],
@@ -91,7 +91,7 @@ describe('deny all traffic using allTraffic selector', () => {
 })
 
 describe('allow takes precedence over deny', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       network: {
         denyOut: ({ allTraffic }) => [allTraffic],
@@ -121,7 +121,7 @@ describe('allow takes precedence over deny', () => {
 })
 
 describe('allowPublicTraffic=false', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       network: {
         allowPublicTraffic: false,
@@ -163,7 +163,7 @@ describe('allowPublicTraffic=false', () => {
 })
 
 describe('allowPublicTraffic=true', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       network: {
         allowPublicTraffic: true,
@@ -197,7 +197,7 @@ describe('firewall transform injects headers', () => {
   const injectedHeader = 'X-E2B-Test-Token'
   const injectedValue = 'e2b-transform-value-123'
 
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       network: {
         rules: {
@@ -265,7 +265,7 @@ describe('updateNetwork applies new egress rules', () => {
 })
 
 describe('updateNetwork clears existing rules when fields are omitted', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       network: {
         denyOut: ({ allTraffic }) => [allTraffic],
@@ -301,7 +301,7 @@ describe('updateNetwork clears existing rules when fields are omitted', () => {
 })
 
 describe('maskRequestHost option', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       network: {
         maskRequestHost: 'custom-host.example.com:${PORT}',

--- a/packages/js-sdk/tests/sandbox/secure.test.ts
+++ b/packages/js-sdk/tests/sandbox/secure.test.ts
@@ -4,7 +4,7 @@ import { sandboxTest, isDebug } from '../setup'
 import { randomUUID, createHash } from 'node:crypto'
 
 describe('secure sandbox', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       secure: true,
     },

--- a/packages/js-sdk/tests/sandbox/snapshot.test.ts
+++ b/packages/js-sdk/tests/sandbox/snapshot.test.ts
@@ -19,7 +19,7 @@ sandboxTest.skipIf(isDebug)(
 )
 
 describe('pause and resume with env vars', () => {
-  sandboxTest.scoped({
+  sandboxTest.override({
     sandboxOpts: {
       envs: { TEST_VAR: 'sfisback' },
     },


### PR DESCRIPTION
vitest 4.1 deprecates `test.scoped()` in favor of `test.override()`, emitting 15 warnings during test collection in CI. This renames all `sandboxTest.scoped()` fixture overrides to `sandboxTest.override()` across the six affected test files (network, snapshot, internetAccess, secure, files/signing, commands/envVars). It's a pure rename — the vitest 4.1.8 types confirm an identical signature — and `vitest list` on all six files now collects with zero deprecation warnings. Test-only change, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)