### PR TITLE
chore(cli): migrate dashboard links to project-era tab entrypoints

### DIFF
--- a/.changeset/dashboard-project-tab-link.md
+++ b/.changeset/dashboard-project-tab-link.md
@@ -2,4 +2,4 @@
 '@e2b/cli': patch
 ---
 
-Point the `--project` flag help at the dashboard's new `?tab=project` entrypoint (was `?tab=team`)
+Point the `--project` flag help at the dashboard's `?tab=general` entrypoint (was `?tab=team`)

--- a/.changeset/dashboard-project-tab-link.md
+++ b/.changeset/dashboard-project-tab-link.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Point the `--project` flag help at the dashboard's new `?tab=project` entrypoint (was `?tab=team`)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,15 +30,6 @@ npm install -g @e2b/cli
 e2b auth login
 ```
 
-> [!NOTE]
-> To authenticate without the ability to open the browser, provide
-> `E2B_ACCESS_TOKEN` as an environment variable. You can find your token
-> in [Account Settings](https://e2b.dev/dashboard?tab=account) in the E2B dashboard. Then use the CLI like this:
-> `E2B_ACCESS_TOKEN=sk_e2b_... e2b template create`.
-
-> [!IMPORTANT]  
-> Note the distinction between `E2B_ACCESS_TOKEN` and `E2B_API_KEY`.
-
 ### 3. Check out docs
 
 Visit our [CLI documentation](https://e2b.dev/docs) to learn more.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,6 +30,12 @@ npm install -g @e2b/cli
 e2b auth login
 ```
 
+> [!NOTE]
+> To authenticate without the ability to open the browser (e.g. in CI/CD),
+> provide `E2B_API_KEY` as an environment variable. You can find your API key
+> in the [API Keys](https://e2b.dev/dashboard?tab=keys) tab in the E2B dashboard.
+> Then use the CLI like this: `E2B_API_KEY=e2b_... e2b template create`.
+
 ### 3. Check out docs
 
 Visit our [CLI documentation](https://e2b.dev/docs) to learn more.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,7 +33,7 @@ e2b auth login
 > [!NOTE]
 > To authenticate without the ability to open the browser, provide
 > `E2B_ACCESS_TOKEN` as an environment variable. You can find your token
-> in Account Settings under the Team selector at [e2b.dev/dashboard](https://e2b.dev/dashboard). Then use the CLI like this:
+> in [Account Settings](https://e2b.dev/dashboard?tab=account) in the E2B dashboard. Then use the CLI like this:
 > `E2B_ACCESS_TOKEN=sk_e2b_... e2b template create`.
 
 > [!IMPORTANT]  

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -39,7 +39,7 @@ export const selectMultipleOption = new commander.Option(
 
 export const projectOption = new commander.Option(
   '-t, --project <project-id>',
-  'specify the project ID that the operation will be associated with. You can find project ID in the project settings in the E2B dashboard (https://e2b.dev/dashboard?tab=team).'
+  'specify the project ID that the operation will be associated with. You can find project ID in the project settings in the E2B dashboard (https://e2b.dev/dashboard?tab=project).'
 )
 
 export const deprecatedTeamOption = new commander.Option(

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -39,7 +39,7 @@ export const selectMultipleOption = new commander.Option(
 
 export const projectOption = new commander.Option(
   '-t, --project <project-id>',
-  'specify the project ID that the operation will be associated with. You can find project ID in the project settings in the E2B dashboard (https://e2b.dev/dashboard?tab=project).'
+  'specify the project ID that the operation will be associated with. You can find project ID in the project settings in the E2B dashboard (https://e2b.dev/dashboard?tab=general).'
 )
 
 export const deprecatedTeamOption = new commander.Option(


### PR DESCRIPTION
## Summary

Following the dashboard's teams→projects rename (e2b-dev/dashboard#521), this PR points the `--project` flag help at the dashboard's `?tab=general` entrypoint (General settings, where the project ID lives) instead of the old `?tab=team`, and adds a `@e2b/cli` patch changeset. It also rewrites the CLI README's headless-auth note to use `E2B_API_KEY` (the supported browserless path) instead of `E2B_ACCESS_TOKEN`, pointing at the dashboard's API Keys tab, and drops the now-redundant `E2B_ACCESS_TOKEN` vs `E2B_API_KEY` callout. The SDKs' `?tab=keys` and the CLI's `?tab=personal` links stay unchanged — those tabs remain valid entrypoints.

## Example

```
$ e2b template create --help
  -t, --project <project-id>  specify the project ID that the operation will be associated with.
                              You can find project ID in the project settings in the E2B dashboard
                              (https://e2b.dev/dashboard?tab=general).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)