### PR TITLE
fix(js-sdk): bump deprecated glob@^11 to ^13

### DIFF
--- a/.changeset/lucky-pandas-wave.md
+++ b/.changeset/lucky-pandas-wave.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+Bump the `glob` dependency from `^11.1.0` to `^13.0.6`. glob 11 is deprecated on npm, so every install of a project depending on `e2b` printed a `npm warn deprecated glob@11.1.0` warning that downstream packages could not silence (`overrides` and shrinkwrap only apply to the top-level project). glob 12 and 13 only changed the CLI — the `--shell` option and the `glob` bin, which moved to a separate `glob-bin` package — so the programmatic API the SDK uses (`glob(pattern, { ignore, withFileTypes, dot, cwd })` plus `Path#isDirectory()/fullpath()/relative()`) is unchanged. glob 13 also drops the CLI's transitive dependencies, cutting a fresh `npm install e2b` from 37 to 26 packages.

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -98,7 +98,7 @@
     "chalk": "^5.3.0",
     "compare-versions": "^6.1.0",
     "dockerfile-ast": "^0.7.1",
-    "glob": "^11.1.0",
+    "glob": "^13.0.6",
     "openapi-fetch": "^0.14.1",
     "platform": "^1.3.6",
     "tar": "^7.5.19",

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -19,8 +19,7 @@
     "declaration": true,
     // TypeScript 7's native tsc does not auto-include node_modules/@types, so
     // the Node globals the SDK uses (process, Buffer, `node:*` modules) have to
-    // be requested explicitly. They used to leak in through minipass 7.1.2's
-    // `/// <reference types="node" />`, which minipass 7.1.3 dropped.
+    // be requested explicitly.
     "types": [
       "node"
     ],

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -17,6 +17,13 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "declaration": true,
+    // TypeScript 7's native tsc does not auto-include node_modules/@types, so
+    // the Node globals the SDK uses (process, Buffer, `node:*` modules) have to
+    // be requested explicitly. They used to leak in through minipass 7.1.2's
+    // `/// <reference types="node" />`, which minipass 7.1.3 dropped.
+    "types": [
+      "node"
+    ],
   },
   "include": [
     "src"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,8 +152,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       glob:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^13.0.6
+        version: 13.0.6
       openapi-fetch:
         specifier: ^0.14.1
         version: 0.14.1
@@ -2508,6 +2508,10 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
@@ -3148,6 +3152,10 @@ packages:
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -6096,6 +6104,12 @@ snapshots:
       package-json-from-dist: 1.0.0
       path-scurry: 2.0.0
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
@@ -6746,6 +6760,11 @@ snapshots:
     dependencies:
       lru-cache: 11.1.0
       minipass: 7.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.1.0
+      minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
 


### PR DESCRIPTION
Closes #1611.

`e2b` declared `"glob": "^11.1.0"`, and glob 11 is deprecated on npm, so **every** `npm install` of any project that depends on `e2b` — directly or transitively — printed a deprecation warning. Downstream packages can't silence it themselves: npm `overrides` and `npm-shrinkwrap.json` only apply to the top-level project being installed, not to a transitive dependency's own range. It can only be fixed here.

Thanks @clayboby for the report and the verification work.

## Before / after

```console
$ npm install e2b@2.36.0        # before
npm warn deprecated glob@11.1.0: Old versions of glob are not supported, and contain
widely publicized security vulnerabilities, which have been fixed in the current version.
added 37 packages in 1s

$ npm install e2b               # after (this branch, packed locally)
added 26 packages in 1s
```

No API change — this is a dependency bump. The 37 → 26 package drop comes from glob 13 moving its CLI (and `jackspeak`/`@isaacs/cliui`/`string-width`/… ) out to a separate `glob-bin` package.

## Why ^13 is safe

glob 12 and 13 only made **CLI-only** breaking changes, per [glob's changelog](https://github.com/isaacs/node-glob/blob/main/changelog.md):

- **v12** — "Remove the unsafe `--shell` option."
- **v13** — "Move the CLI program out to a separate package, `glob-bin`."

The SDK's only use of glob is `getAllFilesInPath` in the template build path (`src/template/utils.ts`, loaded via `dynamicImport('glob')`), which touches the named async export `glob(pattern, opts)`, the options `ignore` / `withFileTypes` / `dot` / `cwd`, and `Path#isDirectory()` / `#fullpath()` / `#relative()`. All unchanged in 13.

glob 13.0.6's `engines` (`18 || 20 || >=22`) satisfy the SDK's (`>=20.18.1 <21 || >=22`), and it's still dual CJS/ESM, so both build outputs resolve it.

## Also in this PR: `"types": ["node"]` in the js-sdk tsconfig

glob 13 pulls `minipass@^7.1.3`, which removed the `/// <reference types="node" />` that TypeScript 7's native `tsc` was (accidentally) relying on to see Node globals — it doesn't auto-include `node_modules/@types`. Without this, the bump fails `tsc --noEmit` with ~25 `TS2591 Cannot find name 'process'/'Buffer'` errors. Requesting `node` explicitly is the right fix and makes the typecheck independent of a transitive dependency's d.ts.

## Verification

- `tsc --noEmit` clean for js-sdk and cli; `pnpm run lint` / `format` clean; `tsdown` build clean and `glob` still emitted as an external `dynamicImport("glob")`, not inlined.
- `getAllFilesInPath` unit suite (17 tests: ignore patterns, dotfiles/dotdirs, recursive dirs, deterministic sort, `.` pattern) green against the real glob 13.0.6 on Node, **Bun 1.3.14, and Deno 2.8.1**.
- Full `unit` + `connectionConfig` projects: 401 passed / 30 skipped against prod.
- Full `template` project: 133 passed / 3 skipped, including real end-to-end template builds that exercise `COPY` (the glob path).
- Packed the tarball and installed it into a scratch project to confirm the warning is actually gone (output above), plus CJS `require('e2b')` and ESM `import 'e2b'` both load.

## Not fixed here

`@e2b/cli` installs still warn, via `@npmcli/package-json@5.2.1 → glob@10.5.0`. Clearing that needs `@npmcli/package-json@7`, whose `engines` (`^20.17.0 || >=22.9.0`) are narrower than the CLI's own (`>=20.18.1 <21 || >=22`, so Node 22.0–22.8 would drop out) — separate change, separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)