### PR TITLE
fix(ci): tag releases from the commit that contains the version bump

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -72,10 +72,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release new versions
+        id: changesets
+        # `createGithubReleases` is off because it would push the tags
+        # `changeset publish` just created, and at this point the version bump is
+        # not committed yet, so they point at the commit *before* the release.
+        # "Tag and release" below moves them onto the release commit, pushes them
+        # and cuts the GitHub releases instead.
         uses: changesets/action@v1
         with:
           publish: pnpm run publish
-          createGithubReleases: true
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: "" # See https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
@@ -96,7 +102,13 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "[skip ci] Release new versions" || exit 0
+
+          # The release tags are cut from this commit, so there has to be one.
+          if git diff --quiet HEAD; then
+            echo "::error::Nothing to commit after 'changeset version'. Refusing to continue, since the release tags would point at the commit before the version bump."
+            exit 1
+          fi
+          git commit -am "[skip ci] Release new versions"
 
           # A PR merging mid-release makes this push a non-fast-forward. The
           # artifacts were already published from the checked-out tree, so we
@@ -109,7 +121,7 @@ jobs:
 
           git fetch origin "${GITHUB_REF_NAME}"
           if git diff --name-only "HEAD~1" FETCH_HEAD -- packages/ | grep -q .; then
-            echo "::error::'${GITHUB_REF_NAME}' advanced with changes under packages/ during the release. Refusing to rebase the version bump onto unpublished package code (the source would diverge from the published artifacts). Reconcile manually."
+            echo "::error::'${GITHUB_REF_NAME}' advanced with changes under packages/ during the release. Refusing to rebase the version bump onto unpublished package code (the source would diverge from the published artifacts). Reconcile manually, then tag the release commit and cut the GitHub releases by hand — neither has happened yet."
             exit 1
           fi
 
@@ -117,3 +129,44 @@ jobs:
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and release
+        if: steps.changesets.outputs.published == 'true'
+        # `changeset publish` already created these tags, but on the commit before
+        # the version bump, which is why the action was told not to push them.
+        # Recreate them on the release commit and cut the GitHub releases from the
+        # changelogs `changeset version` generated.
+        run: |
+          for TAG in $(jq -r '.[] | "\(.name)@\(.version)"' <<< "${PUBLISHED_PACKAGES}"); do
+            NAME=${TAG%@*}
+            VERSION=${TAG##*@}
+            DIR=$(dirname "$(jq -r --arg name "$NAME" 'select(.name == $name) | input_filename' packages/*/package.json)")
+            CHANGELOG="${DIR}/CHANGELOG.md"
+            if [ ! -f "${CHANGELOG}" ]; then
+              echo "::error::No changelog at ${CHANGELOG} to write ${TAG}'s release notes from."
+              exit 1
+            fi
+
+            # The generated changelog is a list of "## <version>" sections. Entry
+            # bodies are indented, so only real headings sit at column 0.
+            NOTES="${RUNNER_TEMP}/${VERSION}-notes.md"
+            awk -v heading="## ${VERSION}" '
+              $0 == heading { found = 1; next }
+              found && /^## / { exit }
+              found { print }
+            ' "${CHANGELOG}" > "${NOTES}"
+            if [ ! -s "${NOTES}" ]; then
+              echo "::error::${CHANGELOG} has no entry for ${VERSION}, so ${TAG} has no release notes."
+              exit 1
+            fi
+
+            git tag --force --annotate --message "${TAG}" "${TAG}"
+            git push origin "refs/tags/${TAG}"
+
+            FLAGS=(--title "${TAG}" --notes-file "${NOTES}")
+            case "${VERSION}" in *-*) FLAGS+=(--prerelease) ;; esac
+            gh release create "${TAG}" "${FLAGS[@]}"
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}

--- a/DEV.md
+++ b/DEV.md
@@ -1,3 +1,39 @@
-# Releasing e2b cli
+# Releasing
 
-to create a changeset run `pnpm run changeset`
+To queue a package for the next release, describe the change in a changeset:
+`pnpm run changeset`.
+
+## The release pipeline
+
+`Release` (`.github/workflows/release.yml`) is dispatched manually on `main`. It
+only does anything when there are pending changesets, and it runs the test suite
+of every package a changeset touches before publishing.
+
+`Publish Packages` (`.github/workflows/publish_packages.yml`) then does the work,
+in this order:
+
+1. `pnpm run version` — changesets applies the pending changesets: bumps
+   `package.json`/`pyproject.toml`, regenerates the changelogs, deletes the
+   changeset files.
+2. `pnpm run publish`, via `changesets/action` — uploads to npm (using OIDC
+   trusted publishing) and PyPI. `changeset publish` also creates the release tags
+   locally; `createGithubReleases: false` is what stops the action from pushing
+   them here.
+3. `pnpm i` — refreshes `pnpm-lock.yaml` against the versions just published.
+   The npm registry is eventually consistent, so this retries with backoff.
+4. Commits everything as `[skip ci] Release new versions` and pushes it.
+5. Moves the tags from step 2 onto the release commit, pushes them, and cuts a
+   GitHub release per package with its changelog entry as the body.
+
+Steps 4 and 5 are in that order on purpose. The published artifacts have to be
+built before the lockfile can name them, so the release commit can only exist
+after the upload — which means the tags have to be created after the commit, not
+by `changeset publish` while it runs. Tagging first is what made every tag point
+at the commit _before_ its own version bump ([SDK-298]).
+
+Tags from `e2b@2.36.1`, `@e2b/cli@2.16.0` and `@e2b/python-sdk@2.35.0` and
+earlier are still off by one and are not going to be retagged, because moving
+published tags breaks anything that already pinned them. Build those versions
+from the npm tarball or the PyPI sdist rather than from the git tag.
+
+[SDK-298]: https://linear.app/e2b/issue/SDK-298


### PR DESCRIPTION
Closes [SDK-298](https://linear.app/e2b/issue/SDK-298/release-tags-point-at-the-commit-before-the-version-bump).

## The bug

Every published release tag pointed at the commit *preceding* its own version bump:

```console
$ git show '@e2b/python-sdk@2.35.0:packages/python-sdk/pyproject.toml' | head -3
[project]
name = "e2b"
version = "2.34.0"      # ← tagged 2.35.0
```

`changeset publish` creates the release tags from whatever `HEAD` it publishes from, and `publish_packages.yml` ran it *before* committing the version bump. So anything that builds from a git tag rather than from a registry got the previous release: distro packagers, `pip install git+…@tag`, and any bisect over a release regression. `python3Packages.e2b` in nixpkgs has been shipping 1.5.0 under the name 1.5.1 since June 2025 for this reason. The GitHub release pages showed the previous version's diff too.

## Why the tags can't just move earlier

The release commit can't be created before publishing. `pnpm-lock.yaml` records the integrity hashes of the tarballs the release just uploaded (`packages/cli` depends on `e2b` by version range, not `workspace:`), so it can only be refreshed *after* the upload — that's what the retry-with-backoff loop from #1589 is for. Committing the bump first would leave a lockfile in the tagged tree that disagrees with the `package.json` next to it, trading one wrong tag for another.

So the tagging has to move *after* the commit instead, which is what the issue asks for.

## The change

Entirely within `publish_packages.yml`. `changesets/action` keeps doing the publishing; the only thing it stops doing is tagging.

`createGithubReleases: false` is the lever — [`run.ts`](https://github.com/changesets/action/blob/v1/src/run.ts#L120-L128) does the tag push and the release creation inside the same conditional, so turning it off drops exactly the two things that need to move, while `publishedPackages` is still populated from a separate path.

A new `Tag and release` step then runs once the release commit is pushed and, for each entry in that output, repoints the tag `changeset publish` left behind onto the release commit, pushes it, and cuts the GitHub release with its changelog section as the body — what `createGithubReleases: true` did.

The step order is now:

| | before | after |
|---|---|---|
| 1 | `pnpm run version` | `pnpm run version` |
| 2 | publish **+ tag + release** | publish (tags stay local) |
| 3 | refresh `pnpm-lock.yaml` | refresh `pnpm-lock.yaml` |
| 4 | commit + push | commit + push |
| 5 | — | **tag + release** |

Two smaller fixes fall out of it:

- `git commit -am … || exit 0` silently swallowed a failed commit, which would now produce wrong tags, so it's an explicit hard failure with a message that says why.
- The non-fast-forward rebase fallback used to leave the tags on a commit that the rebase then rewrote. Tagging after the push means the rebase path gets correct tags too.

## Not retagging the past

Tags up to `e2b@2.36.1` / `@e2b/cli@2.16.0` / `@e2b/python-sdk@2.35.0` stay off by one — moving published tags breaks anyone who already pinned them. `DEV.md` grew a section documenting the pipeline and that caveat, so packagers reaching for those versions know to use the npm tarball or the PyPI sdist.

## Verification

CI workflows can't be exercised without cutting a real release, so the flow was simulated against a clone of `main`: a changeset added, `pnpm run version` run for real, the action's tagging and `publishedPackages` output stubbed — then the `Tag and release` step body parsed back out of the YAML and executed **verbatim**, so what ran is what will run.

```
=== extracted workflow step, verbatim ===
Updated tag 'e2b@2.35.1' (was 7a3493af4)
 * [new tag]  e2b@2.35.1 -> e2b@2.35.1
GH release create: e2b@2.35.1
  notes=### Patch Changes||- 0bda3c3: A test change with a `code` span.
Updated tag '@e2b/cli@2.13.4' (was 3541297f2)
 * [new tag]  @e2b/cli@2.13.4 -> @e2b/cli@2.13.4
GH release create: @e2b/cli@2.13.4
Updated tag '@e2b/python-sdk@2.35.0' (was 9d2b08c76)
 * [new tag]  @e2b/python-sdk@2.35.0 -> @e2b/python-sdk@2.35.0
GH release create: @e2b/python-sdk@2.35.0
--- assertions (pre-bump=0bda3c309f1f release=255da99bb12d)
PASS annotated tag on release commit: e2b@2.35.1
PASS annotated tag on release commit: @e2b/cli@2.13.4
PASS annotated tag on release commit: @e2b/python-sdk@2.35.0
  "version": "2.35.1",   # packages/js-sdk/package.json at e2b@2.35.1
version = "2.35.0"       # packages/python-sdk/pyproject.toml at @e2b/python-sdk@2.35.0
pushed annotated tags: 3
```

The `Updated tag 'X' (was <pre-bump sha>)` lines are the fix itself, visible in the release log.

Failure paths, each checked against the same extracted step:

| case | result |
|---|---|
| changelog has no `## <version>` section | `::error::…has no entry for 2.35.1, so e2b@2.35.1 has no release notes.` exit 1 |
| `CHANGELOG.md` missing | `::error::No changelog at packages/js-sdk/CHANGELOG.md to write e2b@2.35.1's release notes from.` exit 1 |
| prerelease version (`9.9.9-rc.1`) | `gh release create … --prerelease` |
| stable version | no `--prerelease` |
| nothing published | step skipped by `if: …published == 'true'` |

No changeset: this touches no package under `packages/`.

## Follow-up, not in this PR

SDK-298 also notes that `packages/python-sdk/pyproject.toml` pins `uv_build>=0.10.0,<0.11.0`, so packagers on uv 0.11.x have to patch `pyproject.toml` to build the SDK at all. Widening that bound wants a matching `.tool-versions` uv bump and a check that the 0.11 backend produces an equivalent wheel — separate change.

The same bug exists in `e2b-dev/code-interpreter` (per the issue's evidence) and needs the same change to its own publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)