### PR TITLE
ci(js-sdk): make the Cloudflare deploy test leg advisory

### DIFF
--- a/.github/workflows/js_sdk_tests.yml
+++ b/.github/workflows/js_sdk_tests.yml
@@ -38,6 +38,16 @@ jobs:
             && fromJSON('[{"runtime": "node", "os": "ubuntu-22.04"}, {"runtime": "node", "os": "windows-latest"}]')
             || fromJSON('[{"runtime": "node", "os": "ubuntu-22.04"}, {"runtime": "node", "os": "windows-latest"}, {"runtime": "bun", "os": "ubuntu-22.04"}, {"runtime": "deno", "os": "ubuntu-22.04"}, {"runtime": "cloudflare", "os": "ubuntu-22.04"}, {"runtime": "cloudflare-deploy", "os": "ubuntu-22.04"}]') }}
     runs-on: ${{ matrix.os }}
+    # The cloudflare-deploy leg is advisory: it deploys to a brand-new
+    # Cloudflare preview account on every run, so it inherits that account's
+    # propagation and read-after-write races (the fresh workers.dev subdomain
+    # 404s until the route reaches the edge; the subdomain API can 404 the
+    # script it just accepted). Those fail ~1 run in 8 without saying anything
+    # about the SDK, and this job gates both the required `SDK Tests Status`
+    # check and the release workflow's publish step. It still runs and still
+    # reports — a genuine bundle regression (e.g. a Workers startup crash) is
+    # rejected at upload deterministically, not intermittently.
+    continue-on-error: ${{ matrix.runtime == 'cloudflare-deploy' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The `cloudflare-deploy` leg deploys to a brand-new Cloudflare preview account on every run, so it inherits that account's propagation and read-after-write races — the fresh `workers.dev` subdomain 404s until the route reaches the edge, and the subdomain API can 404 the script it just accepted (`This Worker does not exist on your account [code: 10007]`). That fails ~1 run in 8 (6 of ~46 runs since 2026-07-24) without saying anything about the SDK, and the job gates both the required `SDK Tests Status` check and the release workflow's `publish` step — both of today's release runs were blocked by it ([30473411814](https://github.com/e2b-dev/E2B/actions/runs/30473411814), [30474175682](https://github.com/e2b-dev/E2B/actions/runs/30474175682)).

## Fix

`continue-on-error` on that matrix leg only, so it still runs and still reports on every PR but no longer blocks merges or releases. The signal survives: a genuine bundle regression (e.g. the #1579 Workers startup crash) is rejected at upload deterministically, not intermittently.

Follow-ups to make the leg reliably green again: #1592 (propagation poll, still open) plus a retry around `wrangler deploy --temporary` for the 10007 race.

CI-only change — no changeset, no user-facing surface.

Closes SDK-301

🤖 Generated with [Claude Code](https://claude.com/claude-code)