### PR TITLE
fix(template): substitute ARG values in FROM when parsing Dockerfiles

### DIFF
--- a/.changeset/dockerfile-arg-in-from.md
+++ b/.changeset/dockerfile-arg-in-from.md
@@ -1,0 +1,6 @@
+---
+"e2b": patch
+"@e2b/python-sdk": patch
+---
+
+Substitute ARG values (including chained ARG defaults) in FROM when parsing Dockerfiles, and fix case-insensitive AS alias stripping in the Python parser.

--- a/packages/js-sdk/src/template/dockerfileParser.ts
+++ b/packages/js-sdk/src/template/dockerfileParser.ts
@@ -322,6 +322,7 @@ function handleCmdEntrypointInstruction(
 /**
  * Expand $VAR / ${VAR} / ${VAR:-default} in a FROM image reference using
  * ARG instructions declared before the first FROM (Docker semantics).
+ * ARG defaults may themselves reference previously declared ARGs.
  */
 function substitutePreFromArgs(
   baseImage: string,
@@ -335,20 +336,30 @@ function substitutePreFromArgs(
       const value = instruction.getArgumentsContent() ?? ''
       const match = value.match(/^\s*(\w+)(?:=(.*))?\s*$/)
       if (match) {
-        args[match[1]] = (match[2] ?? '').replace(/^["']|["']$/g, '')
+        const rawDefault = (match[2] ?? '').replace(/^["']|["']$/g, '')
+        // ARG defaults may reference previously declared ARGs
+        args[match[1]] = substituteArgs(rawDefault, args, false)
       }
     }
   }
 
-  return baseImage.replace(
+  return substituteArgs(baseImage, args, true)
+}
+
+function substituteArgs(
+  value: string,
+  args: Record<string, string>,
+  strict: boolean
+): string {
+  return value.replace(
     /\$(?:(\w+)|\{(\w+)(?::-([^}]*))?\})/g,
     (_, name?: string, braced?: string, defaultValue?: string) => {
       const key = name ?? braced ?? ''
-      const value = args[key] || defaultValue || ''
-      if (!value) {
+      const resolved = args[key] || defaultValue || ''
+      if (!resolved && strict) {
         throw new Error(`FROM references ARG '${key}', which has no value`)
       }
-      return value
+      return resolved
     }
   )
 }

--- a/packages/js-sdk/src/template/dockerfileParser.ts
+++ b/packages/js-sdk/src/template/dockerfileParser.ts
@@ -93,6 +93,10 @@ export function parseDockerfile(
     baseImage = argumentsData[0].getValue()
   }
 
+  // Docker allows ARG declarations before FROM to be referenced in it
+  // (e.g. ARG BASE=node:18 / FROM ${BASE}) — substitute their defaults
+  baseImage = substitutePreFromArgs(baseImage, instructions)
+
   // Set the user and workdir to the Docker defaults
   templateBuilder.setUser('root')
   templateBuilder.setWorkdir('/')
@@ -313,4 +317,38 @@ function handleCmdEntrypointInstruction(
 
     templateBuilder.setStartCmd(command, waitForTimeout(20_000))
   }
+}
+
+/**
+ * Expand $VAR / ${VAR} / ${VAR:-default} in a FROM image reference using
+ * ARG instructions declared before the first FROM (Docker semantics).
+ */
+function substitutePreFromArgs(
+  baseImage: string,
+  instructions: DockerfileInstruction[]
+): string {
+  const args: Record<string, string> = {}
+  for (const instruction of instructions) {
+    const keyword = instruction.getKeyword()
+    if (keyword === 'FROM') break
+    if (keyword === 'ARG') {
+      const value = instruction.getArgumentsContent() ?? ''
+      const match = value.match(/^\s*(\w+)(?:=(.*))?\s*$/)
+      if (match) {
+        args[match[1]] = (match[2] ?? '').replace(/^["']|["']$/g, '')
+      }
+    }
+  }
+
+  return baseImage.replace(
+    /\$(?:(\w+)|\{(\w+)(?::-([^}]*))?\})/g,
+    (_, name?: string, braced?: string, defaultValue?: string) => {
+      const key = name ?? braced ?? ''
+      const value = args[key] || defaultValue || ''
+      if (!value) {
+        throw new Error(`FROM references ARG '${key}', which has no value`)
+      }
+      return value
+    }
+  )
 }

--- a/packages/js-sdk/tests/template/methods/fromDockerfile.test.ts
+++ b/packages/js-sdk/tests/template/methods/fromDockerfile.test.ts
@@ -246,3 +246,17 @@ FROM \${IMG}`
     /has no value/
   )
 })
+
+buildTemplateTest('fromDockerfile with chained ARG defaults in FROM', async () => {
+  const dockerfile = `ARG REGISTRY=ghcr.io
+ARG IMAGE=\${REGISTRY}/org/base:latest
+FROM \${IMAGE}`
+
+  const template = Template().fromDockerfile(dockerfile)
+
+  assert.equal(
+    // @ts-expect-error - baseImage is not a property of TemplateBuilder
+    template.baseImage,
+    'ghcr.io/org/base:latest'
+  )
+})

--- a/packages/js-sdk/tests/template/methods/fromDockerfile.test.ts
+++ b/packages/js-sdk/tests/template/methods/fromDockerfile.test.ts
@@ -196,3 +196,53 @@ COPY --chown=anotheruser config.json /config/`
   assert.equal(copyInstruction2.args[1], '/config/')
   assert.equal(copyInstruction2.args[2], 'anotheruser') // user from --chown (without group)
 })
+
+buildTemplateTest('fromDockerfile with ARG in FROM', async () => {
+  const dockerfile = `ARG BASE_IMAGE=ghcr.io/example/base:latest
+FROM \${BASE_IMAGE}
+WORKDIR /app`
+
+  const template = Template().fromDockerfile(dockerfile)
+
+  assert.equal(
+    // @ts-expect-error - baseImage is not a property of TemplateBuilder
+    template.baseImage,
+    'ghcr.io/example/base:latest'
+  )
+})
+
+buildTemplateTest('fromDockerfile with unbraced ARG in FROM', async () => {
+  const dockerfile = `ARG IMG=python:3.13-slim
+FROM $IMG`
+
+  const template = Template().fromDockerfile(dockerfile)
+
+  assert.equal(
+    // @ts-expect-error - baseImage is not a property of TemplateBuilder
+    template.baseImage,
+    'python:3.13-slim'
+  )
+})
+
+buildTemplateTest('fromDockerfile with ARG default fallback in FROM', async () => {
+  const dockerfile = `ARG IMG
+FROM \${IMG:-ubuntu:24.04}`
+
+  const template = Template().fromDockerfile(dockerfile)
+
+  assert.equal(
+    // @ts-expect-error - baseImage is not a property of TemplateBuilder
+    template.baseImage,
+    'ubuntu:24.04'
+  )
+})
+
+buildTemplateTest('fromDockerfile with valueless ARG in FROM throws', async () => {
+  const dockerfile = `ARG IMG
+FROM \${IMG}`
+
+  assert.throws(
+    () => Template().fromDockerfile(dockerfile),
+    /has no value/
+  )
+})

--- a/packages/python-sdk/e2b/template/dockerfile_parser.py
+++ b/packages/python-sdk/e2b/template/dockerfile_parser.py
@@ -291,24 +291,30 @@ def _handle_cmd_entrypoint_instruction(
 
 def _substitute_pre_from_args(base_image: str, structure: list) -> str:
     """Expand $VAR / ${VAR} / ${VAR:-default} in FROM using ARGs declared before it."""
-    args = {}
+    args: dict = {}
     for ins in structure:
         if ins["instruction"] == "FROM":
             break
         if ins["instruction"] == "ARG":
             m = re.match(r"\s*(\w+)(?:=(.*))?\s*$", ins["value"])
             if m:
-                args[m.group(1)] = (m.group(2) or "").strip("\"'")
+                default = (m.group(2) or "").strip("\"'")
+                # ARG defaults may reference previously declared ARGs
+                args[m.group(1)] = _substitute_args(default, args, strict=False)
 
-    def repl(match):
+    return _substitute_args(base_image, args, strict=True)
+
+
+def _substitute_args(value: str, args: dict, strict: bool) -> str:
+    def repl(match) -> str:
         name = match.group("name") or match.group("braced")
-        value = args.get(name) or match.group("default") or ""
-        if not value:
+        resolved = args.get(name) or match.group("default") or ""
+        if not resolved and strict:
             raise ValueError(f"FROM references ARG {name!r}, which has no value")
-        return value
+        return resolved
 
     return re.sub(
         r"\$(?:(?P<name>\w+)|\{(?P<braced>\w+)(?::-(?P<default>[^}]*))?\})",
         repl,
-        base_image,
+        value,
     )

--- a/packages/python-sdk/e2b/template/dockerfile_parser.py
+++ b/packages/python-sdk/e2b/template/dockerfile_parser.py
@@ -98,9 +98,12 @@ def parse_dockerfile(
 
         # Set the base image from the first FROM instruction
         base_image = from_instructions[0]["value"]
+        # Docker allows ARG declarations before FROM to be referenced in it
+        base_image = _substitute_pre_from_args(base_image, dfp.structure)
         # Remove AS alias if present (e.g., "node:18 AS builder" -> "node:18")
-        if " as " in base_image.lower():
-            base_image = base_image.split(" as ")[0].strip()
+        base_image = re.split(
+            r"\s+as\s+", base_image, maxsplit=1, flags=re.IGNORECASE
+        )[0].strip()
 
         user_changed = False
         workdir_changed = False
@@ -284,3 +287,28 @@ def _handle_cmd_entrypoint_instruction(
         return f"sleep {seconds}"
 
     template_builder.set_start_cmd(command, wait_for_timeout(20_000))
+
+
+def _substitute_pre_from_args(base_image: str, structure: list) -> str:
+    """Expand $VAR / ${VAR} / ${VAR:-default} in FROM using ARGs declared before it."""
+    args = {}
+    for ins in structure:
+        if ins["instruction"] == "FROM":
+            break
+        if ins["instruction"] == "ARG":
+            m = re.match(r"\s*(\w+)(?:=(.*))?\s*$", ins["value"])
+            if m:
+                args[m.group(1)] = (m.group(2) or "").strip("\"'")
+
+    def repl(match):
+        name = match.group("name") or match.group("braced")
+        value = args.get(name) or match.group("default") or ""
+        if not value:
+            raise ValueError(f"FROM references ARG {name!r}, which has no value")
+        return value
+
+    return re.sub(
+        r"\$(?:(?P<name>\w+)|\{(?P<braced>\w+)(?::-(?P<default>[^}]*))?\})",
+        repl,
+        base_image,
+    )

--- a/packages/python-sdk/tests/sync/template_sync/methods/test_from_dockerfile.py
+++ b/packages/python-sdk/tests/sync/template_sync/methods/test_from_dockerfile.py
@@ -131,3 +131,62 @@ COPY --chown=anotheruser config.json /config/"""
     assert (
         copy_instruction2["args"][2] == "anotheruser"
     )  # user from --chown (without group)
+
+
+@pytest.mark.skip_debug()
+def test_from_dockerfile_with_arg_in_from():
+    dockerfile = """ARG BASE_IMAGE=ghcr.io/example/base:latest
+FROM ${BASE_IMAGE}
+WORKDIR /app"""
+
+    template = Template().from_dockerfile(dockerfile)
+
+    assert template._template._base_image == "ghcr.io/example/base:latest"
+
+
+@pytest.mark.skip_debug()
+def test_from_dockerfile_with_unbraced_arg_in_from():
+    dockerfile = """ARG IMG=python:3.13-slim
+FROM $IMG"""
+
+    template = Template().from_dockerfile(dockerfile)
+
+    assert template._template._base_image == "python:3.13-slim"
+
+
+@pytest.mark.skip_debug()
+def test_from_dockerfile_with_arg_default_fallback_in_from():
+    dockerfile = """ARG IMG
+FROM ${IMG:-ubuntu:24.04}"""
+
+    template = Template().from_dockerfile(dockerfile)
+
+    assert template._template._base_image == "ubuntu:24.04"
+
+
+@pytest.mark.skip_debug()
+def test_from_dockerfile_with_valueless_arg_in_from_raises():
+    dockerfile = """ARG IMG
+FROM ${IMG}"""
+
+    with pytest.raises(ValueError, match="has no value"):
+        Template().from_dockerfile(dockerfile)
+
+
+@pytest.mark.skip_debug()
+def test_from_dockerfile_with_uppercase_as_alias():
+    dockerfile = "FROM node:18 AS builder"
+
+    template = Template().from_dockerfile(dockerfile)
+
+    assert template._template._base_image == "node:18"
+
+
+@pytest.mark.skip_debug()
+def test_from_dockerfile_with_arg_in_from_and_alias():
+    dockerfile = """ARG BASE=node:18
+FROM ${BASE} AS builder"""
+
+    template = Template().from_dockerfile(dockerfile)
+
+    assert template._template._base_image == "node:18"

--- a/packages/python-sdk/tests/sync/template_sync/methods/test_from_dockerfile.py
+++ b/packages/python-sdk/tests/sync/template_sync/methods/test_from_dockerfile.py
@@ -190,3 +190,14 @@ FROM ${BASE} AS builder"""
     template = Template().from_dockerfile(dockerfile)
 
     assert template._template._base_image == "node:18"
+
+
+@pytest.mark.skip_debug()
+def test_from_dockerfile_with_chained_arg_defaults_in_from():
+    dockerfile = """ARG REGISTRY=ghcr.io
+ARG IMAGE=${REGISTRY}/org/base:latest
+FROM ${IMAGE}"""
+
+    template = Template().from_dockerfile(dockerfile)
+
+    assert template._template._base_image == "ghcr.io/org/base:latest"


### PR DESCRIPTION
## Problem

Docker allows `ARG` declarations before `FROM` to be referenced in it — a common pattern for parameterizing base images:

```dockerfile
ARG BASE_IMAGE=ghcr.io/millionco/react-bench-base:latest
FROM ${BASE_IMAGE}
```

Both the Python and JS `from_dockerfile`/`fromDockerfile` parsers pass the unexpanded literal through as the base image, so the build fails server-side with:

```
invalid image reference '${BASE_IMAGE}': could not parse reference: ${BASE_IMAGE}
```

Found while running [ReactBench](https://github.com/millionco/reactbench) tasks on the E2B backend of [Harbor](https://github.com/laude-institute/harbor) — every ReactBench task Dockerfile uses this pattern, and any Dockerfile parameterized for CI does too.

## Fix

- **Python + JS parsers**: expand `$VAR`, `${VAR}`, and `${VAR:-default}` in the FROM value using ARG defaults declared before it (Docker semantics: only pre-FROM ARGs participate). Referencing an ARG that ends up with no value now raises a clear client-side error instead of the opaque server-side one.
- **Python parser, bonus fix**: AS alias stripping checked case-insensitively but split case-sensitively, so `FROM node:18 AS builder` kept `' AS builder'` in the base image. Now split with a case-insensitive regex.

## Verification

- 6 new Python test cases in `test_from_dockerfile.py` (braced/unbraced/default-fallback substitution, valueless-ARG raises, uppercase AS, ARG+alias combined); all 12 tests in the file pass.
- 4 mirrored JS test cases in `fromDockerfile.test.ts`.
- End-to-end: with this patch applied to the released SDK, a full Harbor trial of ReactBench `hello-react` on E2B built both task templates from the **unmodified** upstream Dockerfiles and completed with oracle reward 1.0 (previously: immediate BuildException).

Note: a second, independent builder issue affects these Dockerfiles (`COPY file /newdir/` fails — `mkdir` fix in `copy_script.sh`); reporting that separately against e2b-dev/infra.