### PR TITLE
fix(sdk): align Python Fedora/Alpine image defaults with JS

### DIFF
--- a/.changeset/align-python-distro-image-defaults.md
+++ b/.changeset/align-python-distro-image-defaults.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/python-sdk': patch
+---
+
+Align the Python SDK's `from_fedora_image` and `from_alpine_image` defaults with the JS SDK: `fedora:44` and `alpine:3.24`, replacing `fedora:42` (end-of-life, so its repositories leave the normal mirror network and provisioning can fail) and `alpine:3.22`. Callers that omit the variant now get the same base image in both SDKs, and both tags are the ones the orchestrator's distro build tests cover. Also corrects the JS `TemplateFromImage` type docs, which still named the old defaults.

--- a/packages/js-sdk/src/template/types.ts
+++ b/packages/js-sdk/src/template/types.ts
@@ -247,22 +247,22 @@ export interface TemplateFromImage {
 
   /**
    * Start from a Fedora-based Docker image.
-   * @param variant Fedora variant (default: '42')
+   * @param variant Fedora variant (default: '44')
    *
    * @example
    * ```ts
-   * Template().fromFedoraImage('42')
+   * Template().fromFedoraImage('44')
    * ```
    */
   fromFedoraImage(variant?: string): TemplateBuilder
 
   /**
    * Start from an Alpine-based Docker image.
-   * @param variant Alpine variant (default: '3.22')
+   * @param variant Alpine variant (default: '3.24')
    *
    * @example
    * ```ts
-   * Template().fromAlpineImage('3.22')
+   * Template().fromAlpineImage('3.24')
    * ```
    */
   fromAlpineImage(variant?: string): TemplateBuilder

--- a/packages/python-sdk/e2b/template/main.py
+++ b/packages/python-sdk/e2b/template/main.py
@@ -846,32 +846,32 @@ class TemplateBase:
         """
         return self.from_image(f"ubuntu:{variant}")
 
-    def from_fedora_image(self, variant: str = "42") -> TemplateBuilder:
+    def from_fedora_image(self, variant: str = "44") -> TemplateBuilder:
         """
         Start template from a Fedora base image.
 
-        :param variant: Fedora image variant (default: '42')
+        :param variant: Fedora image variant (default: '44')
 
         :return: `TemplateBuilder` class
 
         Example
         ```python
-        Template().from_fedora_image('42')
+        Template().from_fedora_image('44')
         ```
         """
         return self.from_image(f"fedora:{variant}")
 
-    def from_alpine_image(self, variant: str = "3.22") -> TemplateBuilder:
+    def from_alpine_image(self, variant: str = "3.24") -> TemplateBuilder:
         """
         Start template from an Alpine base image.
 
-        :param variant: Alpine image variant (default: '3.22')
+        :param variant: Alpine image variant (default: '3.24')
 
         :return: `TemplateBuilder` class
 
         Example
         ```python
-        Template().from_alpine_image('3.22')
+        Template().from_alpine_image('3.24')
         ```
         """
         return self.from_image(f"alpine:{variant}")


### PR DESCRIPTION
Python `from_fedora_image` defaulted to `fedora:42` (end-of-life) and `from_alpine_image` to `alpine:3.22`, while JS already pinned `fedora:44`/`alpine:3.24` — the same call produced a different base image per SDK. Aligns Python; also fixes the JS type docs, which still named the old defaults.

```python
Template().from_fedora_image()  # fedora:44 (was fedora:42)
Template().from_alpine_image()  # alpine:3.24 (was alpine:3.22)
```

Follow-up to #1612; both defaults are still unreleased.
