### PR TITLE
test(sdk): run firewall transform tests against an httpbin sidecar sandbox

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -69,10 +69,6 @@ jobs:
       # tests that use it need our API key anyway. The ready command doubles as
       # the build-time smoke test: the build only finishes once go-httpbin
       # answers on the port the tests connect to.
-      #
-      # The alias is passed unprefixed because the server namespaces it with the
-      # team slug: the template the tests spawn is `e2b/httpbin`. Only `base`
-      # predates namespacing and stays bare.
       - name: Build httpbin template
         if: ${{ inputs.template == 'all' || inputs.template == 'httpbin' }}
         working-directory: ./templates/httpbin

--- a/packages/js-sdk/tests/sandbox/network.test.ts
+++ b/packages/js-sdk/tests/sandbox/network.test.ts
@@ -1,7 +1,8 @@
 import { assert, expect, describe } from 'vitest'
 
-import { CommandExitError } from '../../src'
-import { sandboxTest, isDebug } from '../setup.js'
+import { CommandExitError, Sandbox } from '../../src'
+import { sandboxTest, isDebug, template } from '../setup.js'
+import { httpbinTemplate } from '../template.js'
 
 describe('allow only 1.1.1.1', () => {
   sandboxTest.override({
@@ -194,44 +195,63 @@ describe('allowPublicTraffic=true', () => {
 })
 
 describe('firewall transform injects headers', () => {
-  const injectedHeader = 'X-E2B-Test-Token'
+  const injectedHeader = 'X-Test-Token'
   const injectedValue = 'e2b-transform-value-123'
-
-  sandboxTest.override({
-    sandboxOpts: {
-      network: {
-        rules: {
-          'httpbin.e2b.team': [
-            {
-              transform: {
-                headers: {
-                  [injectedHeader]: injectedValue,
-                },
-              },
-            },
-          ],
-        },
-      },
-    },
-  })
+  // Port the httpbin template's start command listens on.
+  const httpbinPort = 8080
 
   sandboxTest.skipIf(isDebug)(
-    'injected header is reflected by httpbin.e2b.team/headers',
-    async ({ sandbox }) => {
-      const result = await sandbox.commands.run(
-        'curl -sS --max-time 10 https://httpbin.e2b.team/headers'
-      )
-      assert.equal(result.exitCode, 0)
+    'injected header is reflected by the httpbin sidecar',
+    async ({ sandboxTestId }) => {
+      // The transform is applied by the egress proxy on the way out of the
+      // sandbox, so the target has to be reachable from the public internet —
+      // a CI service container would not be. A sidecar sandbox running the
+      // httpbin template is that target, which keeps the test off any
+      // externally hosted service. Its ready command has already passed by the
+      // time create resolves, so the server is serving.
+      const httpbin = await Sandbox.create(httpbinTemplate, {
+        metadata: { sandboxTestId },
+        network: { allowPublicTraffic: true },
+      })
+      let sandbox: Sandbox | undefined
 
-      const parsed = JSON.parse(result.stdout) as {
-        headers: Record<string, string>
+      try {
+        const httpbinHost = httpbin.getHost(httpbinPort)
+
+        sandbox = await Sandbox.create(template, {
+          metadata: { sandboxTestId },
+          network: {
+            rules: {
+              [httpbinHost]: [
+                {
+                  transform: {
+                    headers: {
+                      [injectedHeader]: injectedValue,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        })
+
+        const result = await sandbox.commands.run(
+          `curl -sS --retry 5 --retry-connrefused --max-time 10 https://${httpbinHost}/headers`
+        )
+        assert.equal(result.exitCode, 0)
+
+        const parsed = JSON.parse(result.stdout) as {
+          headers: Record<string, string[]>
+        }
+        const reflected = parsed.headers[injectedHeader]
+        assert.deepEqual(
+          reflected,
+          [injectedValue],
+          `expected httpbin to reflect ${injectedHeader}=${injectedValue}, got headers: ${JSON.stringify(parsed.headers)}`
+        )
+      } finally {
+        await Promise.allSettled([sandbox?.kill(), httpbin.kill()])
       }
-      const reflected = parsed.headers[injectedHeader]
-      assert.equal(
-        reflected,
-        injectedValue,
-        `expected httpbin to reflect ${injectedHeader}=${injectedValue}, got headers: ${JSON.stringify(parsed.headers)}`
-      )
     }
   )
 })

--- a/packages/js-sdk/tests/template.ts
+++ b/packages/js-sdk/tests/template.ts
@@ -1,1 +1,7 @@
 export const template = 'base'
+
+/**
+ * Template that serves go-httpbin on port 8080, used as a sidecar by tests
+ * that need a publicly reachable echo server — see `templates/httpbin`.
+ */
+export const httpbinTemplate = 'httpbin'

--- a/packages/python-sdk/tests/async/sandbox_async/test_network.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_network.py
@@ -178,14 +178,30 @@ async def test_allow_public_traffic_true(async_sandbox_factory):
 
 
 @pytest.mark.skip_debug()
-async def test_firewall_transform_injects_headers(async_sandbox_factory):
+async def test_firewall_transform_injects_headers(
+    async_sandbox_factory, httpbin_template
+):
     """Test that a firewall rule with a transform injects headers into outbound requests."""
-    injected_header = "X-E2B-Test-Token"
+    injected_header = "X-Test-Token"
     injected_value = "e2b-transform-value-123"
+    # Port the httpbin template's start command listens on.
+    httpbin_port = 8080
+
+    # The transform is applied by the egress proxy on the way out of the
+    # sandbox, so the target has to be reachable from the public internet — a
+    # CI service container would not be. A sidecar sandbox running the httpbin
+    # template is that target, which keeps the test off any externally hosted
+    # service. Its ready command has already passed by the time create returns,
+    # so the server is serving.
+    httpbin = await async_sandbox_factory(
+        template_name=httpbin_template,
+        network=SandboxNetworkOpts(allow_public_traffic=True),
+    )
+    httpbin_host = httpbin.get_host(httpbin_port)
 
     network: SandboxNetworkOpts = {
         "rules": {
-            "httpbin.e2b.team": [
+            httpbin_host: [
                 {"transform": {"headers": {injected_header: injected_value}}},
             ],
         },
@@ -193,13 +209,14 @@ async def test_firewall_transform_injects_headers(async_sandbox_factory):
     async_sandbox = await async_sandbox_factory(network=network)
 
     result = await async_sandbox.commands.run(
-        "curl -sS --max-time 10 https://httpbin.e2b.team/headers"
+        f"curl -sS --retry 5 --retry-connrefused --max-time 10 "
+        f"https://{httpbin_host}/headers"
     )
     assert result.exit_code == 0
 
     parsed = json.loads(result.stdout)
     reflected = parsed["headers"].get(injected_header)
-    assert reflected == injected_value, (
+    assert reflected == [injected_value], (
         f"expected httpbin to reflect {injected_header}={injected_value}, "
         f"got headers: {parsed['headers']}"
     )

--- a/packages/python-sdk/tests/conftest.py
+++ b/packages/python-sdk/tests/conftest.py
@@ -47,6 +47,15 @@ def template():
 
 
 @pytest.fixture()
+def httpbin_template():
+    """Template that serves go-httpbin on port 8080 — see `templates/httpbin`.
+
+    Used as a sidecar by tests that need a publicly reachable echo server.
+    """
+    return "httpbin"
+
+
+@pytest.fixture()
 def sandbox_factory(request, template, sandbox_test_id):
     def factory(*, template_name: str = template, **kwargs):
         metadata = kwargs.setdefault("metadata", dict())

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_network.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_network.py
@@ -177,14 +177,28 @@ def test_allow_public_traffic_true(sandbox_factory):
 
 
 @pytest.mark.skip_debug()
-def test_firewall_transform_injects_headers(sandbox_factory):
+def test_firewall_transform_injects_headers(sandbox_factory, httpbin_template):
     """Test that a firewall rule with a transform injects headers into outbound requests."""
-    injected_header = "X-E2B-Test-Token"
+    injected_header = "X-Test-Token"
     injected_value = "e2b-transform-value-123"
+    # Port the httpbin template's start command listens on.
+    httpbin_port = 8080
+
+    # The transform is applied by the egress proxy on the way out of the
+    # sandbox, so the target has to be reachable from the public internet — a
+    # CI service container would not be. A sidecar sandbox running the httpbin
+    # template is that target, which keeps the test off any externally hosted
+    # service. Its ready command has already passed by the time create returns,
+    # so the server is serving.
+    httpbin = sandbox_factory(
+        template_name=httpbin_template,
+        network=SandboxNetworkOpts(allow_public_traffic=True),
+    )
+    httpbin_host = httpbin.get_host(httpbin_port)
 
     network: SandboxNetworkOpts = {
         "rules": {
-            "httpbin.e2b.team": [
+            httpbin_host: [
                 {"transform": {"headers": {injected_header: injected_value}}},
             ],
         },
@@ -192,13 +206,14 @@ def test_firewall_transform_injects_headers(sandbox_factory):
     sandbox = sandbox_factory(network=network)
 
     result = sandbox.commands.run(
-        "curl -sS --max-time 10 https://httpbin.e2b.team/headers"
+        f"curl -sS --retry 5 --retry-connrefused --max-time 10 "
+        f"https://{httpbin_host}/headers"
     )
     assert result.exit_code == 0
 
     parsed = json.loads(result.stdout)
     reflected = parsed["headers"].get(injected_header)
-    assert reflected == injected_value, (
+    assert reflected == [injected_value], (
         f"expected httpbin to reflect {injected_header}={injected_value}, "
         f"got headers: {parsed['headers']}"
     )

--- a/templates/httpbin/e2b.Dockerfile
+++ b/templates/httpbin/e2b.Dockerfile
@@ -1,4 +1,4 @@
-# Sidecar template for the SDK network tests, built as `e2b/httpbin`.
+# Sidecar template for the SDK network tests, built as `httpbin`.
 #
 # Firewall transforms are applied by the egress proxy on the way *out* of a
 # sandbox, so asserting them end-to-end needs a request that leaves for a


### PR DESCRIPTION
Follow-up to #1632, which added the template this depends on. Now rebased onto `main`, so this is just the test change.

## Problem

The firewall transform tests asserted header injection by curling `httpbin.e2b.team`, an externally hosted service the suite had to keep alive.

## Fix

Starts a sidecar sandbox from the `httpbin` template instead: the rule is keyed on the sidecar's `getHost(8080)` and the assertion reads the injected header back from `/headers`, in the JS, sync Python, and async Python suites. The sidecar's ready command has already passed by the time `create` resolves, so the server is serving and no readiness polling is needed. The template name lives in one fixture per SDK — `httpbinTemplate` in `tests/template.ts` and the `httpbin_template` fixture in `conftest.py`.

Also drops two comments merged in #1632 that claimed the tests spawn `e2b/httpbin`. The bare alias is what resolves, same as `base` — the team slug only appears in the display name.

⚠️ Do not merge before **Build and push prepared templates** has been dispatched with `template: httpbin` — the tests resolve the template by name and fail until it exists on the E2B team.

Verified against production: all three tests pass with the injected header reflected by the sidecar, spawning the template by its bare alias with a key that owns it — the same situation as CI.

SDK-304
