### PR TITLE
ci: add an httpbin template and a dropdown to pick which one to build

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -2,12 +2,24 @@ name: Build and push prepared templates
 
 on:
   workflow_dispatch:
+    inputs:
+      template:
+        description: 'Template to build'
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - base
+          - httpbin
 
 permissions:
   contents: read
 
 jobs:
   buildAndPushImage:
+    # Only the base template has a DockerHub counterpart.
+    if: ${{ inputs.template == 'all' || inputs.template == 'base' }}
     defaults:
       run:
         working-directory: ./templates/base
@@ -46,7 +58,27 @@ jobs:
         uses: ./.github/actions/build-cli
 
       - name: Build and publish base template
+        if: ${{ inputs.template == 'all' || inputs.template == 'base' }}
         working-directory: ./templates/base
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
         run: e2b template create base --memory-mb 512
+
+      # Sidecar the network transform tests spawn as a publicly reachable echo
+      # server. Stays private to the E2B team, like the base template — the
+      # tests that use it need our API key anyway. The ready command doubles as
+      # the build-time smoke test: the build only finishes once go-httpbin
+      # answers on the port the tests connect to.
+      #
+      # The alias is passed unprefixed because the server namespaces it with the
+      # team slug: the template the tests spawn is `e2b/httpbin`. Only `base`
+      # predates namespacing and stays bare.
+      - name: Build httpbin template
+        if: ${{ inputs.template == 'all' || inputs.template == 'httpbin' }}
+        working-directory: ./templates/httpbin
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+        run: |
+          e2b template create httpbin --memory-mb 512 \
+            --cmd 'go-httpbin -host 0.0.0.0 -port 8080' \
+            --ready-cmd 'curl -fsS http://localhost:8080/status/200 > /dev/null'

--- a/templates/httpbin/e2b.Dockerfile
+++ b/templates/httpbin/e2b.Dockerfile
@@ -1,0 +1,32 @@
+# Sidecar template for the SDK network tests, built as `e2b/httpbin`.
+#
+# Firewall transforms are applied by the egress proxy on the way *out* of a
+# sandbox, so asserting them end-to-end needs a request that leaves for a
+# publicly reachable host which echoes back what it received. A sandbox started
+# from this template is that host, which keeps the tests off any externally
+# hosted service.
+#
+# go-httpbin is the maintained Go port of the original httpbin, shipped as a
+# single static binary.
+FROM debian:bookworm-slim
+
+ENV GO_HTTPBIN_VERSION=2.25.0
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates curl && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+  case "$(dpkg --print-architecture)" in \
+    amd64) arch='amd64'; sha256='8ba077dbc2fd86dcd4acde8b17ca7d22763c3bff1e6117fc975a3f66cf8ebcb2';; \
+    arm64) arch='arm64'; sha256='3becba58a8484b57885b3b99231618f82dfd29acbb5d2c021bd61100d8d3363f';; \
+    *) echo "unsupported architecture"; exit 1;; \
+  esac; \
+  archive="go-httpbin-linux-${arch}.tar.gz"; \
+  curl -fsSLO "https://github.com/mccutchen/go-httpbin/releases/download/v${GO_HTTPBIN_VERSION}/${archive}"; \
+  echo "${sha256}  ${archive}" | sha256sum -c -; \
+  tar -xzf "${archive}" -C /usr/local/bin go-httpbin; \
+  rm "${archive}"
+
+# The server itself is smoke-tested by the template's ready command, which has
+# to exit 0 before the build finishes — see .github/workflows/templates.yml.


### PR DESCRIPTION
## Problem

The firewall transform tests assert header injection by curling `httpbin.e2b.team`, an externally hosted service the suite has to keep alive. Transforms are applied by the egress proxy on the way *out* of a sandbox, so the target has to be publicly reachable — which rules out a CI service container, but not another sandbox.

## Change

Adds a `httpbin` template (`templates/httpbin`): go-httpbin on `debian:bookworm-slim`, SHA256-pinned against the release `checksums.txt` the way `templates/base` pins its Node install. Neither official image can serve as an E2B base — `ghcr.io/mccutchen/go-httpbin` is distroless (no shell, and `dockerfileParser.ts:79` rejects multi-stage so the binary can't be copied out), and `kennethreitz/httpbin` is Ubuntu 18.04 whose build fails on E2B's `fuse3` install (both verified by building).

`templates.yml` gains a `template` choice input (`all` / `base` / `httpbin`) rather than a second near-identical workflow file. `all` is the default so a plain dispatch behaves as before, and the DockerHub image job is skipped for `httpbin`, which has no image counterpart.

The template stays **private to the E2B team**, like `base` — publishing would only expose it to other projects, and the tests that spawn it use our API key anyway. The alias is passed unprefixed because the server namespaces it with the team slug, so the name the tests resolve is **`e2b/httpbin`**; only `base` predates namespacing and stays bare.

Merge this, then dispatch **Build and push prepared templates** with `template: httpbin` — #1631 stacks on top and resolves the template as `e2b/httpbin`.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

SDK-304