### PR TITLE
ci: add a changeset to Dependabot pull requests automatically

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,9 +1,15 @@
 # Changesets
 
-To add changeset run: 
-    
+To add changeset run:
+
 ```bash
 npx changeset
 ```
 
 in the root of the project. This will create a new changeset in the `.changeset` folder.
+
+Dependabot pull requests get one automatically: `.github/workflows/dependabot_changeset.yml`
+commits a `patch` changeset for every released package whose direct production dependencies the
+bump touches. Dev-only and transitive-only bumps are left alone, and the workflow never overwrites
+a changeset that is already on the branch — so edit or replace the generated file whenever the bump
+deserves a better description or a larger version step.

--- a/.github/workflows/dependabot_changeset.yml
+++ b/.github/workflows/dependabot_changeset.yml
@@ -29,9 +29,12 @@ jobs:
       # `dependency-type` is the highest-precedence type in the pull request
       # (`direct:production` > `direct:development` > `indirect`). Only a direct
       # production dependency reaches users of a published package; dev tooling
-      # and transitive-only lockfile bumps need no release. A changeset already
-      # on the branch is left alone — a maintainer may have written a better one
-      # by hand, and this workflow also reruns on its own commit.
+      # and transitive-only lockfile bumps need no release. That type covers the
+      # whole pull request while the filters are per directory, so a group that
+      # mixes a production bump in one package with a dev-only bump in another
+      # names both — drop the extra line from the committed file if it matters.
+      # A changeset already on the branch is left alone: a maintainer may have
+      # written a better one by hand, and this workflow reruns on its own commit.
       changeset: >-
         ${{ steps.metadata.outputs.dependency-type == 'direct:production'
         && steps.filter.outputs.changeset != 'true'
@@ -50,14 +53,10 @@ jobs:
         || format('Update the `{0}` dependency to {1}.',
         steps.metadata.outputs.dependency-names, steps.metadata.outputs.new-version) }}
     steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Filter changed paths
-        uses: dorny/paths-filter@v3
+        # Pinned rather than floating on `v3`: this is the one third-party
+        # action reached by a `pull_request_target` trigger.
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           # Dependabot edits the manifest of every workspace package it updates,
@@ -71,6 +70,17 @@ jobs:
               - 'packages/cli/**'
             changeset:
               - '.changeset/!(README).md'
+
+      - name: Fetch Dependabot metadata
+        id: metadata
+        # Not needed once a changeset is on the branch, and skipping keeps this
+        # step away from the pull request the workflow has committed to itself:
+        # the action only reports metadata for a pull request whose commits are
+        # all Dependabot's.
+        if: steps.filter.outputs.changeset != 'true'
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   changeset:
     name: Add changeset

--- a/.github/workflows/dependabot_changeset.yml
+++ b/.github/workflows/dependabot_changeset.yml
@@ -1,0 +1,122 @@
+name: Dependabot Changeset
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions: {}
+
+# One writer per pull request: Dependabot force-pushes when it rebases, and two
+# runs racing on the same PR would both commit a changeset.
+concurrency:
+  group: dependabot-changeset-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect changes
+    # `pull_request_target` runs this file from the base branch, which is the
+    # only way to reach Actions secrets from a Dependabot pull request: events
+    # raised by Dependabot see a read-only `GITHUB_TOKEN` and the separate
+    # Dependabot secret store.
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # required by dependabot/fetch-metadata and dorny/paths-filter
+    outputs:
+      # `dependency-type` is the highest-precedence type in the pull request
+      # (`direct:production` > `direct:development` > `indirect`). Only a direct
+      # production dependency reaches users of a published package; dev tooling
+      # and transitive-only lockfile bumps need no release. A changeset already
+      # on the branch is left alone — a maintainer may have written a better one
+      # by hand, and this workflow also reruns on its own commit.
+      changeset: >-
+        ${{ steps.metadata.outputs.dependency-type == 'direct:production'
+        && steps.filter.outputs.changeset != 'true'
+        && (steps.filter.outputs.js-sdk == 'true'
+        || steps.filter.outputs.python-sdk == 'true'
+        || steps.filter.outputs.cli == 'true') }}
+      packages: >-
+        ${{ steps.filter.outputs.js-sdk == 'true' && 'e2b' || '' }}
+        ${{ steps.filter.outputs.python-sdk == 'true' && '@e2b/python-sdk' || '' }}
+        ${{ steps.filter.outputs.cli == 'true' && '@e2b/cli' || '' }}
+      # Dependabot reports one `new-version` per bump but none for a group of
+      # them, and joins grouped names with a comma.
+      summary: >-
+        ${{ contains(steps.metadata.outputs.dependency-names, ',')
+        && format('Update dependencies: {0}.', steps.metadata.outputs.dependency-names)
+        || format('Update the `{0}` dependency to {1}.',
+        steps.metadata.outputs.dependency-names, steps.metadata.outputs.new-version) }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Dependabot edits the manifest of every workspace package it updates,
+          # so the changed paths are the mapping from bump to released package.
+          filters: |
+            js-sdk:
+              - 'packages/js-sdk/**'
+            python-sdk:
+              - 'packages/python-sdk/**'
+            cli:
+              - 'packages/cli/**'
+            changeset:
+              - '.changeset/!(README).md'
+
+  changeset:
+    name: Add changeset
+    needs: changes
+    if: needs.changes.outputs.changeset == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      # The default token cannot be used for the push: `GITHUB_TOKEN` is
+      # read-only on Dependabot events, and commits it authors do not start new
+      # workflow runs, so the required checks would never report on the new head
+      # commit and the pull request would be unmergeable.
+      - name: Generate token to push to the pull request branch
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.VERSION_BUMPER_APPID }}
+          private-key: ${{ secrets.VERSION_BUMPER_SECRET }}
+          permission-contents: write
+
+      - name: Checkout the pull request branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      # Always `patch`: bumping a dependency is not itself a change to our own
+      # API, whatever the dependency's semver step was. Edit the committed file
+      # if a bump deserves more than that.
+      - name: Commit the changeset
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          PACKAGES: ${{ needs.changes.outputs.packages }}
+          SUMMARY: ${{ needs.changes.outputs.summary }}
+        run: |
+          file=".changeset/dependabot-$PR.md"
+          {
+            echo '---'
+            for package in $PACKAGES; do echo "'$package': patch"; done
+            echo '---'
+            echo
+            echo "$SUMMARY"
+          } >"$file"
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add "$file"
+          git commit -m "chore: add changeset for #$PR"
+          git push


### PR DESCRIPTION
Dependabot bumps of a direct production dependency of `e2b`, `@e2b/cli` or `@e2b/python-sdk` need a changeset to reach users, and they kept merging without one (#1461, #1443). This workflow commits a `patch` changeset naming every released package the bump touches, and stays out of the way otherwise — dev-only bumps, transitive-only lockfile bumps, and pull requests that already carry a hand-written changeset are all skipped. The push uses the version-bumper App token rather than `GITHUB_TOKEN`, whose commits do not start workflow runs, so the required checks would never report on the new head commit and the pull request would be unmergeable.

For #1461 it would have committed `.changeset/dependabot-1461.md`:

```md
---
'e2b': patch
---

Update the `undici` dependency to 7.28.0.
```

The `changes` job now skips the Dependabot metadata lookup once a changeset is on the branch, so the workflow's own commit never sends `fetch-metadata` looking for metadata on a pull request that is no longer all-Dependabot commits, and `dorny/paths-filter` is SHA-pinned as the one third-party action this trigger reaches.

Verified by running the commit step against a scratch repository with the exact expression outputs for single-package, grouped multi-package and Python-only bumps, then parsing each result with changesets' own `@changesets/parse`. Two things to watch on the first live run: the org-level `verification/cla-signed` check has to accept the App's commit, and adding a commit stops Dependabot auto-rebasing the branch (`@dependabot rebase` still works, and the workflow rewrites the changeset afterwards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

SDK-311