### PR TITLE
fix(js-sdk): export the Git argument and status types

### DIFF
--- a/.changeset/tricky-hoops-repeat.md
+++ b/.changeset/tricky-hoops-repeat.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+Export `GitResetMode`, `GitResetOpts`, `GitRestoreOpts` and `GitStatusLabel` from the JS SDK entry point, so the argument and status types of the public `git.reset()`, `git.restore()` and `git.status()` methods can be named by callers

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -101,6 +101,9 @@ export type {
   GitRemoteAddOpts,
   GitCommitOpts,
   GitAddOpts,
+  GitResetMode,
+  GitResetOpts,
+  GitRestoreOpts,
   GitDeleteBranchOpts,
   GitPushOpts,
   GitPullOpts,
@@ -110,6 +113,7 @@ export type {
   GitBranches,
   GitFileStatus,
   GitStatus,
+  GitStatusLabel,
 } from './sandbox/git'
 
 export { Volume, VolumeFileType } from './volume'

--- a/packages/js-sdk/src/sandbox/git/index.ts
+++ b/packages/js-sdk/src/sandbox/git/index.ts
@@ -1051,4 +1051,5 @@ export type {
   GitConfigScope,
   GitFileStatus,
   GitStatus,
+  GitStatusLabel,
 } from './utils'


### PR DESCRIPTION
Carries the change from #1635 (by @karpovantonme) into `main` as a single squash commit — #1635 was retargeted at `fix/export-git-argument-types`, merged there, and this PR promotes that branch.

`Git.reset()`, `Git.restore()` and `Git.status()` are public, but the types naming their arguments and results were not reachable from the package entry point.

`src/index.ts` re-exported fifteen `Git*` types and omitted `GitResetMode`, `GitResetOpts` and `GitRestoreOpts`. `GitStatusLabel` was worse off — `src/sandbox/git/index.ts` re-exported `GitBranches`, `GitConfigScope`, `GitFileStatus` and `GitStatus` from `./utils` but not `GitStatusLabel`, so it was unreachable from anywhere in the package, even though it is the type of `GitFileStatus.status`.

The practical effect: you could call the methods, but you could not name what you pass them, so you could not write a typed wrapper.

```ts
// before — all four fail
import type {
  GitResetMode,
  GitResetOpts,
  GitRestoreOpts,
  GitStatusLabel,
} from 'e2b'

// the workaround people end up with
type ResetMode = Parameters<Git['reset']>[0] extends { mode?: infer M } ? M : never
```

```ts
// after
import { Sandbox } from 'e2b'
import type { GitResetMode, GitResetOpts, GitStatusLabel } from 'e2b'

async function hardResetTo(sbx: Sandbox, repo: string, target: string) {
  const mode: GitResetMode = 'hard'
  const opts: GitResetOpts = { mode, target, cwd: repo }
  return sbx.git.reset(opts)
}

function isBlocking(status: GitStatusLabel) {
  return status === 'conflict' || status === 'deleted'
}
```

## On SDK parity

Python already exports `GitResetMode` (`e2b.GitResetMode`), so this brings JS up to it. The other three have no Python counterpart by design: the sync and async implementations take keyword arguments rather than option objects, so there is nothing shaped like `GitResetOpts`/`GitRestoreOpts`, and `GitFileStatus.status` is typed as a plain `str` there, so there is no `GitStatusLabel` either. Nothing to mirror on the Python side.

## Notes

- Type-only re-exports, no runtime change. Changeset included (`e2b`: patch).
- No test: a missing re-export is invisible to `tsc --noEmit` because `packages/js-sdk/tsconfig.json` includes only `src`, so an `import type … from '../src'` test passes either way. A declaration-reading test was dropped from #1635 during review.

## Not touched

The same gap exists for a few non-Git types — `FilesystemListOpts`, `WatchOpts`, `PtyCreateOpts` and `PtyConnectOpts` are exported from their own modules but not from `src/index.ts`. Scope kept to the Git surface, as in #1635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
