### PR TITLE
Add periodic volume tests

### DIFF
--- a/.github/workflows/js_sdk_tests.yml
+++ b/.github/workflows/js_sdk_tests.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable-volume-tests:
+        description: 'Run the volume integration tests (sets ENABLE_VOLUME_TESTS)'
+        required: false
+        type: boolean
+        default: false
     secrets:
       E2B_API_KEY:
         required: true
@@ -51,6 +56,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Enable volume tests
+        if: ${{ inputs.enable-volume-tests }}
+        run: echo "ENABLE_VOLUME_TESTS=1" >> "$GITHUB_ENV"
 
       - name: Parse .tool-versions
         uses: wistia/parse-tool-versions@v2.1.1

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -1,0 +1,46 @@
+name: Periodic Tests
+
+# Runs the SDK test suites on a schedule with the volume integration tests
+# enabled, so prod-side regressions (e.g. a broken volume-content auth path)
+# are caught without waiting for a PR. See inc-2026-08-04.
+
+on:
+  schedule:
+    - cron: '19 */6 * * *' # every 6 hours
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  js:
+    name: JS SDK
+    uses: ./.github/workflows/js_sdk_tests.yml
+    with:
+      node-only: true
+      enable-volume-tests: true
+    secrets:
+      E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+
+  python:
+    name: Python SDK
+    uses: ./.github/workflows/python_sdk_tests.yml
+    with:
+      enable-volume-tests: true
+    secrets:
+      E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+
+  notify:
+    name: Notify on failure
+    needs: [js, python]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack notification
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
+        env:
+          SLACK_COLOR: '#ff0000'
+          SLACK_TITLE: Periodic Tests Failed
+          SLACK_MESSAGE: 'Periodic SDK tests failed — check the run.'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: 'monitoring-releases'

--- a/.github/workflows/python_sdk_tests.yml
+++ b/.github/workflows/python_sdk_tests.yml
@@ -7,6 +7,11 @@ on:
         required: false
         type: string
         default: ''
+      enable-volume-tests:
+        description: 'Run the volume integration tests (sets ENABLE_VOLUME_TESTS)'
+        required: false
+        type: boolean
+        default: false
     secrets:
       E2B_API_KEY:
         required: true
@@ -29,6 +34,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Enable volume tests
+        if: ${{ inputs.enable-volume-tests }}
+        run: echo "ENABLE_VOLUME_TESTS=1" >> "$GITHUB_ENV"
 
       - name: Parse .tool-versions
         uses: wistia/parse-tool-versions@v2.1.1


### PR DESCRIPTION
## What
New scheduled workflow (`.github/workflows/periodic_tests.yml`) that runs the JS + Python SDK suites every 6h with the **volume integration tests enabled**, and pings Slack on failure.

## Why
The volume integration tests (standalone volume-content access, no sandbox) are gated behind `ENABLE_VOLUME_TESTS` and never run in CI. When that path broke in prod (`inc-2026-08-04`, invalid token audience), nothing caught it for ~24h. This adds a periodic backstop.

## How
- Adds an `enable-volume-tests` input to the reusable `js_sdk_tests.yml` / `python_sdk_tests.yml`; when set, an extra step exports `ENABLE_VOLUME_TESTS=1`.
- `periodic_tests.yml` calls both with the flag on. **Per-PR CI is unchanged** (input defaults to false).

## Notes (easy to tune / drop)
- Cadence: `19 */6 * * *` (every 6h) — adjust as needed.
- Slack failure alert posts to `monitoring-releases` via the existing `SLACK_WEBHOOK` — change the channel if there's a better one.

Ref: SDK-313