### PR TITLE
fix(python): retry transient build status polling failures

### DIFF
--- a/.changeset/bright-build-polls.md
+++ b/.changeset/bright-build-polls.md
@@ -1,0 +1,5 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Retry transient transport failures while polling template build status in both synchronous and asynchronous clients.

--- a/packages/python-sdk/e2b/template_async/build_api.py
+++ b/packages/python-sdk/e2b/template_async/build_api.py
@@ -7,7 +7,7 @@ import httpx
 from pyqwest import HTTPTransport
 from pyqwest.httpx import AsyncPyqwestTransport
 
-from e2b.api import handle_api_exception, proxy_to_config
+from e2b.api import connection_retries, handle_api_exception, proxy_to_config
 from e2b.io_utils import aiter_io_chunks
 from e2b.api.client.api.templates import (
     post_v3_templates,
@@ -265,9 +265,18 @@ async def wait_for_build_finish(
 
     async def poll_status() -> TemplateBuildStatusResponse:
         nonlocal logs_offset
-        build_status = await get_build_status(
-            client, template_id, build_id, logs_offset
-        )
+        retries = 0
+        while True:
+            try:
+                build_status = await get_build_status(
+                    client, template_id, build_id, logs_offset
+                )
+                break
+            except httpx.TransportError:
+                if retries >= connection_retries:
+                    raise
+                retries += 1
+                await asyncio.sleep(logs_refresh_frequency)
 
         logs_offset += len(build_status.log_entries)
 

--- a/packages/python-sdk/e2b/template_sync/build_api.py
+++ b/packages/python-sdk/e2b/template_sync/build_api.py
@@ -6,7 +6,7 @@ import httpx
 from pyqwest import SyncHTTPTransport
 from pyqwest.httpx import PyqwestTransport
 
-from e2b.api import handle_api_exception, proxy_to_config
+from e2b.api import connection_retries, handle_api_exception, proxy_to_config
 from e2b.api.client.api.templates import (
     post_v3_templates,
     get_templates_template_id_files_hash,
@@ -257,7 +257,18 @@ def wait_for_build_finish(
 
     def poll_status() -> TemplateBuildStatusResponse:
         nonlocal logs_offset
-        build_status = get_build_status(client, template_id, build_id, logs_offset)
+        retries = 0
+        while True:
+            try:
+                build_status = get_build_status(
+                    client, template_id, build_id, logs_offset
+                )
+                break
+            except httpx.TransportError:
+                if retries >= connection_retries:
+                    raise
+                retries += 1
+                time.sleep(logs_refresh_frequency)
 
         logs_offset += len(build_status.log_entries)
 

--- a/packages/python-sdk/tests/async/template_async/test_build_status.py
+++ b/packages/python-sdk/tests/async/template_async/test_build_status.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from e2b.template.types import TemplateBuildStatus, TemplateBuildStatusResponse
+from e2b.template_async import build_api
+
+
+def _ready_status() -> TemplateBuildStatusResponse:
+    return TemplateBuildStatusResponse(
+        build_id="build-id",
+        template_id="template-id",
+        status=TemplateBuildStatus.READY,
+        log_entries=[],
+        logs=[],
+    )
+
+
+async def test_wait_for_build_finish_retries_transient_status_transport_error(
+    monkeypatch,
+) -> None:
+    attempts = 0
+
+    async def get_status_once_after_transport_error(
+        *_args, **_kwargs
+    ) -> TemplateBuildStatusResponse:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise httpx.RemoteProtocolError("connection terminated")
+        return _ready_status()
+
+    async def sleep_without_waiting(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(
+        build_api, "get_build_status", get_status_once_after_transport_error
+    )
+    monkeypatch.setattr(build_api.asyncio, "sleep", sleep_without_waiting)
+
+    await build_api.wait_for_build_finish(MagicMock(), "template-id", "build-id")
+
+    assert attempts == 2
+
+
+async def test_wait_for_build_finish_propagates_transport_error_after_retry_budget(
+    monkeypatch,
+) -> None:
+    attempts = 0
+
+    async def always_raise_transport_error(
+        *_args, **_kwargs
+    ) -> TemplateBuildStatusResponse:
+        nonlocal attempts
+        attempts += 1
+        raise httpx.RemoteProtocolError("connection terminated")
+
+    async def sleep_without_waiting(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(build_api, "connection_retries", 1)
+    monkeypatch.setattr(build_api, "get_build_status", always_raise_transport_error)
+    monkeypatch.setattr(build_api.asyncio, "sleep", sleep_without_waiting)
+
+    with pytest.raises(httpx.RemoteProtocolError):
+        await build_api.wait_for_build_finish(MagicMock(), "template-id", "build-id")
+
+    assert attempts == 2

--- a/packages/python-sdk/tests/sync/template_sync/test_build_status.py
+++ b/packages/python-sdk/tests/sync/template_sync/test_build_status.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from e2b.template.types import TemplateBuildStatus, TemplateBuildStatusResponse
+from e2b.template_sync import build_api
+
+
+def _ready_status() -> TemplateBuildStatusResponse:
+    return TemplateBuildStatusResponse(
+        build_id="build-id",
+        template_id="template-id",
+        status=TemplateBuildStatus.READY,
+        log_entries=[],
+        logs=[],
+    )
+
+
+def test_wait_for_build_finish_retries_transient_status_transport_error(
+    monkeypatch,
+) -> None:
+    attempts = 0
+
+    def get_status_once_after_transport_error(
+        *_args, **_kwargs
+    ) -> TemplateBuildStatusResponse:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise httpx.RemoteProtocolError("connection terminated")
+        return _ready_status()
+
+    monkeypatch.setattr(
+        build_api, "get_build_status", get_status_once_after_transport_error
+    )
+    monkeypatch.setattr(build_api.time, "sleep", lambda _delay: None)
+
+    build_api.wait_for_build_finish(MagicMock(), "template-id", "build-id")
+
+    assert attempts == 2
+
+
+def test_wait_for_build_finish_propagates_transport_error_after_retry_budget(
+    monkeypatch,
+) -> None:
+    attempts = 0
+
+    def always_raise_transport_error(*_args, **_kwargs) -> TemplateBuildStatusResponse:
+        nonlocal attempts
+        attempts += 1
+        raise httpx.RemoteProtocolError("connection terminated")
+
+    monkeypatch.setattr(build_api, "connection_retries", 1)
+    monkeypatch.setattr(build_api, "get_build_status", always_raise_transport_error)
+    monkeypatch.setattr(build_api.time, "sleep", lambda _delay: None)
+
+    with pytest.raises(httpx.RemoteProtocolError):
+        build_api.wait_for_build_finish(MagicMock(), "template-id", "build-id")
+
+    assert attempts == 2


### PR DESCRIPTION
## Summary

- Retry transient httpx transport failures while polling template build status.
- Keep retry attempts bounded by the existing E2B_CONNECTION_RETRIES setting.
- Apply the same behavior to synchronous and asynchronous clients, with recovery and retry-budget regression tests.

## Related issue

Fixes #1488

## Validation

- pnpm --dir packages/python-sdk run lint
- pnpm --dir packages/python-sdk run typecheck
- uv run pytest tests/sync/template_sync/test_build_status.py tests/async/template_async/test_build_status.py -q
- E2B_API_KEY=<test placeholder> uv run pytest tests/sync/template_sync/test_stacktrace.py tests/async/template_async/test_stacktrace.py -q

## Disclosure

This change was prepared with AI assistance. The tests above were run locally without calling E2B services.