### PR TITLE
ci: guard production releases to main, harden the itinerary step

### DIFF
--- a/.github/scripts/build_release_itinerary.cjs
+++ b/.github/scripts/build_release_itinerary.cjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+// This script formats the JSON written by `changeset status --output=<file>`
+// as the package list that goes into the release's Slack notifications.
+
+const path = require('path')
+
+// Packages are listed in this order; anything not named here still shows up,
+// under its workspace name, after the ones that are.
+const labels = {
+  e2b: 'JS SDK (e2b)',
+  '@e2b/python-sdk': 'Python SDK (e2b)',
+  '@e2b/cli': 'CLI (@e2b/cli)',
+}
+
+const statusFile = process.argv[2]
+if (!statusFile) {
+  console.error('Usage: build_release_itinerary.cjs <changeset-status.json>')
+  process.exit(1)
+}
+
+const order = Object.keys(labels)
+const rank = (release) => {
+  const index = order.indexOf(release.name)
+  return index === -1 ? order.length : index
+}
+
+const { releases } = require(path.resolve(statusFile))
+const lines = [...releases]
+  .sort((a, b) => rank(a) - rank(b))
+  .map(
+    (release) =>
+      `• ${labels[release.name] ?? release.name} v${release.newVersion}`
+  )
+
+process.stdout.write(lines.join('\n') || '• No packages were published')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,18 @@ jobs:
       cli: ${{ steps.cli.outputs.release }}
       itinerary: ${{ steps.itinerary.outputs.itinerary }}
     steps:
+      - name: Check the ref
+        # `workflow_dispatch` offers every branch in the picker, and a feature
+        # branch carrying changesets would otherwise publish real packages and
+        # push the version bump to that branch. Candidates cut from a branch go
+        # through release-candidate.yml.
+        if: github.ref != 'refs/heads/main'
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          echo "::error::Releases must run on main; this run is on ${REF}."
+          exit 1
+
       - name: Checkout Repo
         uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
@@ -83,16 +95,12 @@ jobs:
       - name: Build release itinerary
         id: itinerary
         if: steps.version.outputs.release == 'true'
+        # This only feeds the Slack notifications, so it must never be the thing
+        # that blocks a release; the messages fall back to a placeholder.
+        continue-on-error: true
         run: |
           pnpm changeset status --output=.cs-status.json
-          ITINERARY=$(node -e '
-            const data = require("./.cs-status.json");
-            const labels = { "e2b": "JS SDK (e2b)", "@e2b/python-sdk": "Python SDK (e2b)", "@e2b/cli": "CLI (@e2b/cli)" };
-            const order = ["e2b", "@e2b/python-sdk", "@e2b/cli"];
-            const byName = Object.fromEntries(data.releases.map(r => [r.name, r]));
-            const lines = order.filter(n => byName[n]).map(n => `• ${labels[n]} v${byName[n].newVersion}`);
-            process.stdout.write(lines.join("\n") || "• No packages were published");
-          ')
+          ITINERARY=$(node ./.github/scripts/build_release_itinerary.cjs .cs-status.json)
           rm -f .cs-status.json
           {
             echo "itinerary<<EOF"
@@ -142,13 +150,15 @@ jobs:
             :rocket: A new release has been triggered :hourglass_flowing_sand:
 
             *Releasing:*
-            ${{ needs.preflight.outputs.itinerary }}
+            ${{ needs.preflight.outputs.itinerary || '• (itinerary unavailable)' }}
           SLACK_TITLE: Release Started
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: 'monitoring-releases'
 
   report-failure:
-    needs: [python-tests, js-tests, cli-tests, publish]
+    # `preflight` included so a failure there is reported too, whether or not
+    # `failure()` looks past this job's direct dependencies.
+    needs: [preflight, python-tests, js-tests, cli-tests, publish]
     if: failure()
     name: Release Failed - Slack Notification
     runs-on: ubuntu-latest
@@ -176,7 +186,7 @@ jobs:
             :tada: A new version has been released successfully! :ship-it-parrot:
 
             *Released:*
-            ${{ needs.preflight.outputs.itinerary }}
+            ${{ needs.preflight.outputs.itinerary || '• (itinerary unavailable)' }}
           SLACK_TITLE: Release Succeeded
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: 'monitoring-releases'


### PR DESCRIPTION
Three fixes found while porting this workflow to `e2b-dev/code-interpreter` ([#327](https://github.com/e2b-dev/code-interpreter/pull/327)).

**`release.yml` can be dispatched from any branch.** It is dispatch-only and `workflow_dispatch` offers every branch in the picker, so a feature branch carrying changesets would publish real packages to npm and PyPI and push the version bump to itself. `preflight` now fails fast unless the run is on `main`; candidates cut from a branch already go through `release-candidate.yml`.

**The itinerary step can block a release.** It only feeds the Slack messages, but a `changeset status` hiccup — or a typo in a future edit to that inline `node -e` block, which no YAML validation catches — fails `preflight` and stops the release. It is now `continue-on-error` with a placeholder fallback in both messages, and the transform moved to `.github/scripts/build_release_itinerary.cjs` next to `is_release.sh`, where it can be run against fixture JSON. A package missing from the label map now shows under its workspace name instead of being dropped by `order.filter`, so a fourth publishable package would not silently vanish from the notification.

**`report-failure` did not list `preflight`**, so whether a broken preflight pings `#monitoring-releases` rested on `failure()` looking past the job's direct dependencies — not documented either way, so the job now depends on it explicitly.

Verified: the extracted script reproduces the current output exactly for `e2b` / `@e2b/python-sdk` / `@e2b/cli`, in the same order, and handles the empty and unlabeled-package cases; workflow validated against the Actions schema; the script matches the repo's prettier config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)