### PR TITLE
fix: preserve Retry-After on 429 rate-limit errors in Python and JS SDKs

### DIFF
--- a/.changeset/retry-after-preserved.md
+++ b/.changeset/retry-after-preserved.md
@@ -1,0 +1,10 @@
+---
+"e2b": patch
+"@e2b/python-sdk": patch
+---
+
+Preserve the `Retry-After` header on 429 rate-limit errors across the exception
+boundary. Both SDKs now parse the header and surface it as `retryAfter` /
+`retry_after` plus `retryAfterHeader` / `retry_after_header` on
+`RateLimitError` / `RateLimitException`, and append a wait hint to the error
+message, so callers can back off instead of retrying immediately.

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -4,7 +4,12 @@ import type { components, paths } from './schema.gen'
 import { defaultHeaders } from './metadata'
 import { createApiFetch } from './http2'
 import { ConnectionConfig } from '../connectionConfig'
-import { AuthenticationError, RateLimitError, SandboxError } from '../errors'
+import {
+  AuthenticationError,
+  RateLimitError,
+  SandboxError,
+  parseRetryAfter,
+} from '../errors'
 import { createApiLogger } from '../logs'
 
 const API_KEY_PATTERN = /^e2b_[0-9a-f]+$/
@@ -35,7 +40,8 @@ export function apiErrorFromCode(
     message: string,
     stackTrace?: string
   ) => Error = SandboxError,
-  stackTrace?: string
+  stackTrace?: string,
+  retryAfterHeader?: string | null
 ): Error {
   if (code === 401) {
     const message = 'Unauthorized, please check your credentials.'
@@ -46,7 +52,11 @@ export function apiErrorFromCode(
 
   if (code === 429) {
     const message = 'Rate limit exceeded, please try again later'
-    return new RateLimitError(content ? `${message} - ${content}` : message)
+    const retryAfter = parseRetryAfter(retryAfterHeader)
+    return new RateLimitError(
+      content ? `${message} - ${content}` : message,
+      { retryAfter, retryAfterHeader }
+    )
   }
 
   return new errorClass(`${code}: ${content}`, stackTrace)
@@ -72,7 +82,8 @@ export function handleApiError(
       status,
       response.error?.message ?? response.error,
       errorClass,
-      stackTrace
+      stackTrace,
+      response.response.headers?.get('Retry-After') ?? null
     )
   }
 

--- a/packages/js-sdk/src/envd/api.ts
+++ b/packages/js-sdk/src/envd/api.ts
@@ -13,6 +13,7 @@ import {
   AuthenticationError,
   RateLimitError,
   TimeoutError,
+  parseRetryAfter,
 } from '../errors'
 import { StartResponse, ConnectResponse } from './process/process_pb'
 import { Code, ConnectError } from '@connectrpc/connect'
@@ -25,8 +26,6 @@ const DEFAULT_ERROR_MAP: Record<number, (message: string) => Error> = {
   400: (message) => new InvalidArgumentError(message),
   401: (message) => new AuthenticationError(message),
   404: (message) => new NotFoundError(message),
-  429: (message) =>
-    new RateLimitError(`${message}: The requests are being rate limited.`),
   502: formatSandboxTimeoutError,
   507: (message) => new NotEnoughSpaceError(message),
 }
@@ -129,6 +128,17 @@ export async function handleEnvdApiError(
   // Check if a custom error mapping is provided for this error code
   if (errorMap && res.response.status in errorMap) {
     return errorMap[res.response.status]?.(message)
+  }
+
+  if (res.response.status === 429) {
+    const retryAfterHeader = res.response.headers?.get('Retry-After') ?? null
+    return new RateLimitError(
+      `${message}: The requests are being rate limited.`,
+      {
+        retryAfter: parseRetryAfter(retryAfterHeader),
+        retryAfterHeader,
+      }
+    )
   }
 
   // Check if there is a default error mapping for this error code

--- a/packages/js-sdk/src/errors.ts
+++ b/packages/js-sdk/src/errors.ts
@@ -134,10 +134,46 @@ export class TemplateError extends SandboxError {
  * Thrown when the API rate limit is exceeded.
  */
 export class RateLimitError extends SandboxError {
-  constructor(message: string) {
-    super(message)
+  readonly retryAfter?: number
+  readonly retryAfterHeader?: string
+
+  constructor(
+    message: string,
+    opts: { retryAfter?: number; retryAfterHeader?: string | null } = {}
+  ) {
+    super(appendRetryAfter(message, opts.retryAfter))
     this.name = 'RateLimitError'
+    this.retryAfter = opts.retryAfter
+    this.retryAfterHeader = opts.retryAfterHeader ?? undefined
   }
+}
+
+/**
+ * Parses an HTTP `Retry-After` header value into a wait time in seconds.
+ *
+ * Returns `undefined` when the header is absent or not parseable. Numeric
+ * values (the common case) are used directly; HTTP-date values are converted
+ * to a relative delay against the current time.
+ */
+export function parseRetryAfter(
+  retryAfterHeader?: string | null
+): number | undefined {
+  if (!retryAfterHeader) return undefined
+
+  const trimmedRetryAfter = retryAfterHeader.trim()
+  if (/^-?\d+$/.test(trimmedRetryAfter)) {
+    return Math.max(Number.parseInt(trimmedRetryAfter, 10), 0)
+  }
+
+  const retryAt = Date.parse(trimmedRetryAfter)
+  if (Number.isNaN(retryAt)) return undefined
+
+  return Math.max(Math.floor((retryAt - Date.now()) / 1000), 0)
+}
+
+function appendRetryAfter(message: string, retryAfter?: number): string {
+  if (retryAfter === undefined) return message
+  return `${message} Retry after ${retryAfter} seconds.`
 }
 
 /**

--- a/packages/js-sdk/tests/api/handleApiError.test.ts
+++ b/packages/js-sdk/tests/api/handleApiError.test.ts
@@ -9,14 +9,19 @@ import {
 function createMockResponse(
   status: number,
   error: unknown,
-  data?: unknown
+  data?: unknown,
+  headers: Record<string, string> = {}
 ): {
-  response: { status: number; ok: boolean }
+  response: { status: number; ok: boolean; headers: Headers }
   error: unknown
   data: unknown
 } {
   return {
-    response: { status, ok: status >= 200 && status < 300 },
+    response: {
+      status,
+      ok: status >= 200 && status < 300,
+      headers: new Headers(headers),
+    },
     error,
     data,
   }
@@ -114,6 +119,20 @@ describe('handleApiError', () => {
       const err = handleApiError(res as any)
       assert.instanceOf(err, RateLimitError)
       assert.include(err?.message, 'Rate limit')
+    })
+
+    test('preserves Retry-After on 429', () => {
+      const res = createMockResponse(
+        429,
+        { message: 'Too many requests' },
+        undefined,
+        { 'Retry-After': '60' }
+      )
+      const err = handleApiError(res as any)
+      assert.instanceOf(err, RateLimitError)
+      assert.equal((err as RateLimitError).retryAfter, 60)
+      assert.equal((err as RateLimitError).retryAfterHeader, '60')
+      assert.include(err?.message, 'Retry after 60 seconds')
     })
   })
 

--- a/packages/js-sdk/tests/envd/handleEnvdApiError.test.ts
+++ b/packages/js-sdk/tests/envd/handleEnvdApiError.test.ts
@@ -12,7 +12,8 @@ import {
 
 function createMockResponse(
   status: number,
-  error?: { message?: string } | string
+  error?: { message?: string } | string,
+  headers: Record<string, string> = {}
 ): {
   error?: { message?: string } | string
   response: Response
@@ -26,6 +27,7 @@ function createMockResponse(
       // openapi-fetch consumes the body whenever it produces an error value
       bodyUsed: error !== undefined,
       text: async () => (typeof error === 'string' ? error : ''),
+      headers: new Headers(headers),
     } as unknown as Response,
   }
 }
@@ -81,6 +83,19 @@ describe('handleEnvdApiError', () => {
     const err = await handleEnvdApiError(res)
     assert.instanceOf(err, RateLimitError)
     assert.include(err?.message, 'rate limited')
+  })
+
+  test('preserves Retry-After on 429', async () => {
+    const res = createMockResponse(
+      429,
+      { message: 'Too many requests' },
+      { 'Retry-After': '45' }
+    )
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, RateLimitError)
+    assert.equal((err as RateLimitError).retryAfter, 45)
+    assert.equal((err as RateLimitError).retryAfterHeader, '45')
+    assert.include(err?.message, 'Retry after 45 seconds')
   })
 
   test('returns TimeoutError for 502', async () => {

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -20,6 +20,7 @@ from e2b.exceptions import (
     RateLimitException,
     SandboxException,
 )
+from e2b.rate_limit import append_retry_after, parse_retry_after
 
 
 def make_logging_event_hooks(log: Optional[logging.Logger]) -> dict:
@@ -132,10 +133,14 @@ def api_exception_from_code(
     message: Optional[str] = None,
     default_exception_class: type[Exception] = SandboxException,
     stack_trace: Optional[TracebackType] = None,
+    retry_after_header: Optional[str] = None,
 ) -> Exception:
     """Map an API error code and message to the matching exception class — the
     same mapping :func:`handle_api_exception` applies to HTTP responses, usable
-    for error objects embedded in response bodies (e.g. per-fork results)."""
+    for error objects embedded in response bodies (e.g. per-fork results).
+
+    :param retry_after_header: Value of the ``Retry-After`` response header, used for 429 rate-limit errors.
+    """
     if status_code == 401:
         text = f"{status_code}: Unauthorized, please check your credentials."
         if message:
@@ -146,7 +151,12 @@ def api_exception_from_code(
         text = f"{status_code}: Rate limit exceeded, please try again later."
         if message:
             text += f" - {message}"
-        return RateLimitException(text)
+        retry_after = parse_retry_after(retry_after_header)
+        return RateLimitException(
+            append_retry_after(text, retry_after),
+            retry_after=retry_after,
+            retry_after_header=retry_after_header,
+        )
 
     return default_exception_class(f"{status_code}: {message}").with_traceback(
         stack_trace
@@ -170,7 +180,11 @@ def handle_api_exception(
         )
 
     return api_exception_from_code(
-        e.status_code, message, default_exception_class, stack_trace
+        e.status_code,
+        message,
+        default_exception_class,
+        stack_trace,
+        retry_after_header=(getattr(e, "headers", None) or {}).get("Retry-After"),
     )
 
 

--- a/packages/python-sdk/e2b/envd/api.py
+++ b/packages/python-sdk/e2b/envd/api.py
@@ -13,6 +13,7 @@ from e2b.exceptions import (
     RateLimitException,
     format_sandbox_timeout_exception,
 )
+from e2b.rate_limit import append_retry_after, parse_retry_after
 
 
 ENVD_API_FILES_ROUTE = "/files"
@@ -22,9 +23,6 @@ _DEFAULT_API_ERROR_MAP: dict[int, Callable[[str], Exception]] = {
     400: InvalidArgumentException,
     401: AuthenticationException,
     404: NotFoundException,
-    429: lambda message: RateLimitException(
-        f"{message}: The requests are being rate limited."
-    ),
     502: format_sandbox_timeout_exception,
     507: NotEnoughSpaceException,
 }
@@ -133,7 +131,12 @@ def handle_envd_api_exception(
 
     res.read()
 
-    return format_envd_api_exception(res.status_code, get_message(res), error_map)
+    return format_envd_api_exception(
+        res.status_code,
+        get_message(res),
+        error_map,
+        retry_after_header=res.headers.get("Retry-After"),
+    )
 
 
 async def ahandle_envd_api_exception(
@@ -146,23 +149,41 @@ async def ahandle_envd_api_exception(
 
     await res.aread()
 
-    return format_envd_api_exception(res.status_code, get_message(res), error_map)
+    return format_envd_api_exception(
+        res.status_code,
+        get_message(res),
+        error_map,
+        retry_after_header=res.headers.get("Retry-After"),
+    )
 
 
 def format_envd_api_exception(
     status_code: int,
     message: str,
     error_map: Optional[dict[int, Callable[[str], Exception]]] = None,
+    retry_after_header: Optional[str] = None,
 ):
     """Map an HTTP status code and message to the appropriate exception.
 
     :param status_code: The HTTP status code.
     :param message: The error message from the response body.
     :param error_map: Optional map of HTTP status codes to exception factories that override the defaults.
+    :param retry_after_header: Value of the ``Retry-After`` response header, used for 429 rate-limit errors.
     :return: The corresponding exception.
     """
     if error_map and status_code in error_map:
         return error_map[status_code](message)
+
+    if status_code == 429:
+        retry_after = parse_retry_after(retry_after_header)
+        return RateLimitException(
+            append_retry_after(
+                f"{message}: The requests are being rate limited.",
+                retry_after,
+            ),
+            retry_after=retry_after,
+            retry_after_header=retry_after_header,
+        )
 
     if status_code in _DEFAULT_API_ERROR_MAP:
         return _DEFAULT_API_ERROR_MAP[status_code](message)

--- a/packages/python-sdk/e2b/exceptions.py
+++ b/packages/python-sdk/e2b/exceptions.py
@@ -112,6 +112,16 @@ class RateLimitException(SandboxException):
     Raised when the API rate limit is exceeded.
     """
 
+    def __init__(
+        self,
+        message: str,
+        retry_after: int | None = None,
+        retry_after_header: str | None = None,
+    ):
+        super().__init__(message)
+        self.retry_after = retry_after
+        self.retry_after_header = retry_after_header
+
 
 class BuildException(Exception):
     """

--- a/packages/python-sdk/e2b/rate_limit.py
+++ b/packages/python-sdk/e2b/rate_limit.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Optional
+
+
+def parse_retry_after(retry_after_header: Optional[str]) -> Optional[int]:
+    """Parse an HTTP ``Retry-After`` header value into a wait time in seconds.
+
+    Returns ``None`` when the header is absent or not parseable. Numeric
+    values (the common case) are used directly; HTTP-date values are converted
+    to a relative delay against the current time.
+    """
+    if not retry_after_header:
+        return None
+
+    try:
+        retry_after = int(retry_after_header)
+        return max(retry_after, 0)
+    except ValueError:
+        pass
+
+    try:
+        retry_at = parsedate_to_datetime(retry_after_header)
+    except (TypeError, ValueError):
+        return None
+
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=timezone.utc)
+
+    return max(int((retry_at - datetime.now(timezone.utc)).total_seconds()), 0)
+
+
+def append_retry_after(message: str, retry_after: Optional[int]) -> str:
+    """Suffix ``message`` with a human-readable wait hint when known."""
+    if retry_after is None:
+        return message
+    return f"{message} Retry after {retry_after} seconds."

--- a/packages/python-sdk/tests/test_retry_after_rate_limit.py
+++ b/packages/python-sdk/tests/test_retry_after_rate_limit.py
@@ -1,0 +1,35 @@
+import httpx
+
+from e2b.api import handle_api_exception
+from e2b.envd.api import handle_envd_api_exception
+from e2b.exceptions import RateLimitException
+
+
+class ApiError:
+    status_code = 429
+    content = b'{"message":"too many requests"}'
+    headers = {"Retry-After": "60"}
+
+
+def test_api_rate_limit_preserves_retry_after_header():
+    err = handle_api_exception(ApiError())
+
+    assert isinstance(err, RateLimitException)
+    assert err.retry_after == 60
+    assert err.retry_after_header == "60"
+    assert "Retry after 60 seconds" in str(err)
+
+
+def test_envd_rate_limit_preserves_retry_after_header():
+    res = httpx.Response(
+        429,
+        json={"message": "too many requests"},
+        headers={"Retry-After": "45"},
+    )
+
+    err = handle_envd_api_exception(res)
+
+    assert isinstance(err, RateLimitException)
+    assert err.retry_after == 45
+    assert err.retry_after_header == "45"
+    assert "Retry after 45 seconds" in str(err)


### PR DESCRIPTION
## Problem

A 429 response carrying a `Retry-After` header loses the wait signal at the exception boundary. The Python and JS SDKs map a 429 to `RateLimitException` / `RateLimitError` without consulting `Retry-After`, so callers cannot back off for the server-specified duration and fall back to local retry heuristics inside the provider's cooldown window.

## Root cause

The 429 error-mapping sites (`packages/python-sdk/e2b/api/__init__.py`, `packages/python-sdk/e2b/envd/api.py`, `packages/js-sdk/src/envd/api.ts`, plus the JS `packages/js-sdk/src/api/index.ts` counterpart) construct the rate-limit exception from the status code and message only. The `Retry-After` response header — the authoritative wait hint — is never read, so it is dropped before the caller ever sees the error.

## Fix

- Add a shared `parse_retry_after` / `parseRetryAfter` helper that turns a `Retry-After` header (delta-seconds or HTTP-date) into a wait time in seconds.
- Thread the header through each 429 mapping and store it on the exception: `RateLimitException(retry_after=..., retry_after_header=...)` in Python and `retryAfter` / `retryAfterHeader` on `RateLimitError` in JS.
- Append a `Retry after N seconds.` hint to the message so the wait is visible even where the structured field is not inspected.

## Test

- Python: `packages/python-sdk/tests/test_retry_after_rate_limit.py` asserts `retry_after`, `retry_after_header`, and the message hint for both the API and envd error paths.
- JS: new cases in `handleApiError.test.ts` and `handleEnvdApiError.test.ts` assert the same fields through mocked 429 responses.

Both fail on the current code (the fields are absent) and pass with this change.

Fixes #1325