### PR TITLE
test: write test fixtures to temp dirs instead of the repo tree

### DIFF
--- a/packages/cli/tests/commands/template/create.test.ts
+++ b/packages/cli/tests/commands/template/create.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process'
 import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
 import * as path from 'node:path'
 import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
@@ -18,7 +19,7 @@ describe('template create cli backend integration', () => {
         'E2B_API_KEY must be set to run template create backend tests'
       )
     }
-    testDir = await fs.mkdtemp('e2b-create-test-')
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'e2b-create-test-'))
     await fs.writeFile(
       path.join(testDir, 'e2b.Dockerfile'),
       'FROM ubuntu:latest\n'

--- a/packages/cli/tests/commands/template/delete.test.ts
+++ b/packages/cli/tests/commands/template/delete.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises'
+import * as os from 'os'
 import * as path from 'path'
 import { execSync } from 'child_process'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
@@ -7,7 +8,9 @@ describe('Template Delete --config', () => {
     let testDir: string
 
     beforeEach(async () => {
-        testDir = await fs.mkdtemp('e2b-delete-config-test-')
+        testDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'e2b-delete-config-test-')
+        )
 
         const defaultConfig = `template_id = "default-template-id"
 dockerfile = "e2b.Dockerfile"`

--- a/packages/cli/tests/commands/template/init.test.ts
+++ b/packages/cli/tests/commands/template/init.test.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process'
 import { existsSync } from 'fs'
 import * as fs from 'fs/promises'
+import * as os from 'os'
 import * as path from 'path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { Language } from '../../../src/commands/template/generators'
@@ -11,7 +12,7 @@ describe('Template Init', () => {
 
   beforeEach(async () => {
     // Use Node.js built-in temp directory handling
-    testDir = await fs.mkdtemp('e2b-init-test-')
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'e2b-init-test-'))
   })
 
   afterEach(async () => {

--- a/packages/cli/tests/commands/template/migrate.test.ts
+++ b/packages/cli/tests/commands/template/migrate.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import * as fs from 'fs/promises'
+import * as os from 'os'
 import * as path from 'path'
 import { execSync } from 'child_process'
 import { Language } from '../../../src/commands/template/generators'
@@ -39,7 +40,7 @@ describe('Template Migration', () => {
 
   beforeEach(async () => {
     // Use Node.js built-in temp directory handling
-    testDir = await fs.mkdtemp('e2b-migrate-test-')
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'e2b-migrate-test-'))
   })
 
   afterEach(async () => {

--- a/packages/cli/tests/commands/template/publish.test.ts
+++ b/packages/cli/tests/commands/template/publish.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises'
+import * as os from 'os'
 import * as path from 'path'
 import { execSync } from 'child_process'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
@@ -7,7 +8,9 @@ describe('Template Publish --config', () => {
     let testDir: string
 
     beforeEach(async () => {
-        testDir = await fs.mkdtemp('e2b-publish-config-test-')
+        testDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'e2b-publish-config-test-')
+        )
 
         const defaultConfig = `template_id = "default-template-id"
 dockerfile = "e2b.Dockerfile"`

--- a/packages/js-sdk/tests/template/build.test.ts
+++ b/packages/js-sdk/tests/template/build.test.ts
@@ -1,10 +1,14 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { afterAll, beforeAll } from 'vitest'
 import { defaultBuildLogger, Template, waitForTimeout } from '../../src'
 import { buildTemplateTest } from '../setup'
 
-const folderPath = path.join(__dirname, 'folder')
+// The file context lives in a temp directory so a test run never writes into
+// the repository tree.
+const contextPath = fs.mkdtempSync(path.join(os.tmpdir(), 'js-build-test-'))
+const folderPath = path.join(contextPath, 'folder')
 
 beforeAll(async () => {
   fs.mkdirSync(folderPath, { recursive: true })
@@ -24,11 +28,11 @@ beforeAll(async () => {
 })
 
 afterAll(() => {
-  fs.rmSync(folderPath, { recursive: true })
+  fs.rmSync(contextPath, { recursive: true, force: true })
 })
 
 buildTemplateTest('build template', async ({ buildTemplate }) => {
-  const template = Template()
+  const template = Template({ fileContextPath: contextPath })
     // using base image to avoid re-building ubuntu:22.04 image
     .fromBaseImage()
     .copy('folder/*', 'folder', { forceUpload: true })
@@ -48,7 +52,7 @@ buildTemplateTest(
 )
 
 buildTemplateTest('build template with symlinks', async ({ buildTemplate }) => {
-  const template = Template()
+  const template = Template({ fileContextPath: contextPath })
     .fromImage('ubuntu:22.04')
     .skipCache()
     .copy('folder/*', 'folder', { forceUpload: true })
@@ -60,7 +64,7 @@ buildTemplateTest('build template with symlinks', async ({ buildTemplate }) => {
 buildTemplateTest(
   'build template with resolveSymlinks',
   async ({ buildTemplate }) => {
-    const template = Template()
+    const template = Template({ fileContextPath: contextPath })
       .fromImage('ubuntu:22.04')
       .skipCache()
       .copy('folder/symlink.txt', 'folder/symlink.txt', {

--- a/packages/js-sdk/tests/template/utils/getAllFilesInPath.test.ts
+++ b/packages/js-sdk/tests/template/utils/getAllFilesInPath.test.ts
@@ -1,14 +1,15 @@
 import { expect, test, describe, beforeAll, afterAll, beforeEach } from 'vitest'
-import { writeFile, mkdir, rm } from 'fs/promises'
+import { writeFile, mkdir, mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
 import { join, basename } from 'path'
 import { getAllFilesInPath } from '../../../src/template/utils'
 
 describe('getAllFilesInPath', () => {
-  const testDir = join(__dirname, 'folder')
+  // A temp directory, so a test run never writes into the repository tree.
+  let testDir: string
 
   beforeAll(async () => {
-    await rm(testDir, { recursive: true, force: true })
-    await mkdir(testDir, { recursive: true })
+    testDir = await mkdtemp(join(tmpdir(), 'getAllFilesInPath-test-'))
   })
 
   afterAll(async () => {

--- a/packages/js-sdk/tests/template/utils/spoolTarArchive.test.ts
+++ b/packages/js-sdk/tests/template/utils/spoolTarArchive.test.ts
@@ -1,5 +1,13 @@
 import { expect, test, describe, beforeAll, afterAll, beforeEach } from 'vitest'
-import { writeFile, mkdir, rm, symlink, readFile, access } from 'fs/promises'
+import {
+  writeFile,
+  mkdir,
+  mkdtemp,
+  rm,
+  symlink,
+  readFile,
+  access,
+} from 'fs/promises'
 import { join, dirname } from 'path'
 import { tmpdir } from 'os'
 import { spoolTarArchive } from '../../../src/template/utils'
@@ -7,11 +15,11 @@ import * as tar from 'tar'
 import { ReadEntry } from 'tar'
 
 describe('spoolTarArchive', () => {
-  const testDir = join(__dirname, 'tar-test-folder')
+  // A temp directory, so a test run never writes into the repository tree.
+  let testDir: string
 
   beforeAll(async () => {
-    await rm(testDir, { recursive: true, force: true })
-    await mkdir(testDir, { recursive: true })
+    testDir = await mkdtemp(join(tmpdir(), 'spoolTarArchive-test-'))
   })
 
   afterAll(async () => {


### PR DESCRIPTION
Eight test files created their fixtures outside a temporary destination, so running the suite left directories behind in the working tree. The five CLI template tests called `fs.mkdtemp` with a bare relative prefix — `mkdtemp` does not imply `os.tmpdir()`, so a relative prefix resolves against `process.cwd()` and each run created `packages/cli/e2b-<name>-testXXXXXX/`; they now join the prefix onto `os.tmpdir()`. On the JS SDK side `getAllFilesInPath` and `spoolTarArchive` wrote into `__dirname` and now `mkdtemp` under `os.tmpdir()`, while `build.test.ts` built its file context at `tests/template/folder` relying on the implicit caller-directory context — it now creates the context under `os.tmpdir()` and passes it explicitly via `Template({ fileContextPath })`, matching what the Python mirror in `test_build.py` already does with `tempfile.mkdtemp` and `file_context_path`. The Python suite needed no changes: every host-side write already goes through `tmp_path`, `tempfile.mkdtemp`, or `TemporaryDirectory`, verified both by inspection of all 46 write sites and by running the filesystem-touching unit tests and confirming a clean `git status` afterwards.

No usage examples apply — this is a test-only change with no user-facing surface.

## Verification

- `packages/cli`: full suite, 108 passed / 1 skipped. The one failing file is `create.test.ts`, which throws because `E2B_API_KEY` is not set locally — pre-existing and unrelated.
- `packages/js-sdk`: the two util test files, 24 passed.
- `packages/python-sdk`: 88 passed / 1 skipped across the template utils, upload-file, and io-utils suites.
- `pnpm run format`, `pnpm run lint`, `pnpm run typecheck` all clean; no leftover directories anywhere after the runs.

No changeset: test-only changes do not ship in either published package.

Fixes SDK-334

🤖 Generated with [Claude Code](https://claude.com/claude-code)