### PR TITLE
fix(python-sdk): keep get_transport accepting the deprecated http2 argument

### DIFF
--- a/.changeset/python-get-transport-http2-compat.md
+++ b/.changeset/python-get-transport-http2-compat.md
@@ -1,0 +1,12 @@
+---
+"@e2b/python-sdk": patch
+---
+
+Accept and ignore a deprecated `http2` argument on `get_transport` in both the
+sync and async REST API clients. The pyqwest move dropped the parameter because
+ALPN negotiates the HTTP version now, but every published
+`e2b-code-interpreter` calls `get_transport(config, http2=False)`, and its
+`e2b>=2.26.0,<3.0.0` range resolves straight to a version that no longer accepts
+it. The result was a `TypeError` on the first `run_code()` of any fresh
+`pip install e2b-code-interpreter`. The flag is inert, so it is accepted and
+ignored rather than removed.

--- a/packages/python-sdk/e2b/api/client_async/__init__.py
+++ b/packages/python-sdk/e2b/api/client_async/__init__.py
@@ -78,10 +78,20 @@ _transport_lock = threading.Lock()
 _transports: Dict[Optional[ProxyConfig], AsyncPyqwestTransport] = {}
 
 
-def get_transport(config: ConnectionConfig) -> AsyncPyqwestTransport:
+def get_transport(
+    config: ConnectionConfig, http2: Optional[bool] = None
+) -> AsyncPyqwestTransport:
     """The shared pyqwest-backed httpx transport for REST API calls. For TLS
     connections ALPN negotiates the HTTP version (HTTP/2 against the E2B
-    API), like the http2-enabled httpx transport this replaced."""
+    API), like the http2-enabled httpx transport this replaced.
+
+    :param http2: Deprecated and ignored. The httpx transport this replaced
+        took an explicit HTTP/2 switch; ALPN negotiates the version now, so
+        the flag no longer selects anything. Accepted so that callers written
+        against the pre-pyqwest signature keep working - notably every
+        published ``e2b-code-interpreter``, which calls
+        ``get_transport(config, http2=False)``.
+    """
     proxy = proxy_to_config(config.proxy)
     with _transport_lock:
         transport = _transports.get(proxy)

--- a/packages/python-sdk/e2b/api/client_sync/__init__.py
+++ b/packages/python-sdk/e2b/api/client_sync/__init__.py
@@ -77,10 +77,20 @@ _transport_lock = threading.Lock()
 _transports: Dict[Optional[ProxyConfig], PyqwestTransport] = {}
 
 
-def get_transport(config: ConnectionConfig) -> PyqwestTransport:
+def get_transport(
+    config: ConnectionConfig, http2: Optional[bool] = None
+) -> PyqwestTransport:
     """The shared pyqwest-backed httpx transport for REST API calls. For TLS
     connections ALPN negotiates the HTTP version (HTTP/2 against the E2B
-    API), like the http2-enabled httpx transport this replaced."""
+    API), like the http2-enabled httpx transport this replaced.
+
+    :param http2: Deprecated and ignored. The httpx transport this replaced
+        took an explicit HTTP/2 switch; ALPN negotiates the version now, so
+        the flag no longer selects anything. Accepted so that callers written
+        against the pre-pyqwest signature keep working - notably every
+        published ``e2b-code-interpreter``, which calls
+        ``get_transport(config, http2=False)``.
+    """
     proxy = proxy_to_config(config.proxy)
     with _transport_lock:
         transport = _transports.get(proxy)

--- a/packages/python-sdk/tests/test_api_client_transport.py
+++ b/packages/python-sdk/tests/test_api_client_transport.py
@@ -612,7 +612,7 @@ def test_sync_transport_sends_multipart_bodies(test_api_key, echo_server):
         reset_sync_api_transports()
 
 
-def test_get_transport_accepts_the_deprecated_http2_kwarg():
+def test_get_transport_accepts_the_deprecated_http2_kwarg(test_api_key):
     """Every published e2b-code-interpreter calls
     ``get_transport(config, http2=False)``. The pyqwest move dropped that
     parameter, which turned the first ``run_code()`` of any fresh
@@ -623,11 +623,16 @@ def test_get_transport_accepts_the_deprecated_http2_kwarg():
     """
     reset_sync_api_transports()
     reset_async_api_transports()
-    config = ConnectionConfig(api_key="test-key")
+    config = ConnectionConfig(api_key=test_api_key)
 
-    assert get_sync_transport(config, http2=False) is get_sync_transport(config)
-    assert get_async_transport(config, http2=False) is get_async_transport(config)
+    try:
+        # Ignored, so it must not key a separate cache entry.
+        assert get_sync_transport(config, http2=False) is get_sync_transport(config)
+        assert get_async_transport(config, http2=False) is get_async_transport(config)
 
-    # Positional still works, and so does omitting it entirely.
-    assert isinstance(get_sync_transport(config, False), PyqwestTransport)
-    assert isinstance(get_async_transport(config), AsyncPyqwestTransport)
+        # Positional still works, and so does omitting it entirely.
+        assert isinstance(get_sync_transport(config, False), PyqwestTransport)
+        assert isinstance(get_async_transport(config), AsyncPyqwestTransport)
+    finally:
+        reset_sync_api_transports()
+        reset_async_api_transports()

--- a/packages/python-sdk/tests/test_api_client_transport.py
+++ b/packages/python-sdk/tests/test_api_client_transport.py
@@ -610,3 +610,24 @@ def test_sync_transport_sends_multipart_bodies(test_api_key, echo_server):
     finally:
         client.close()
         reset_sync_api_transports()
+
+
+def test_get_transport_accepts_the_deprecated_http2_kwarg():
+    """Every published e2b-code-interpreter calls
+    ``get_transport(config, http2=False)``. The pyqwest move dropped that
+    parameter, which turned the first ``run_code()`` of any fresh
+    ``pip install e2b-code-interpreter`` into a TypeError, because
+    e2b-code-interpreter's ``e2b>=2.26.0,<3.0.0`` range resolves to a version
+    that no longer accepts it. The flag is inert now (ALPN negotiates), so it
+    is accepted and ignored rather than removed.
+    """
+    reset_sync_api_transports()
+    reset_async_api_transports()
+    config = ConnectionConfig(api_key="test-key")
+
+    assert get_sync_transport(config, http2=False) is get_sync_transport(config)
+    assert get_async_transport(config, http2=False) is get_async_transport(config)
+
+    # Positional still works, and so does omitting it entirely.
+    assert isinstance(get_sync_transport(config, False), PyqwestTransport)
+    assert isinstance(get_async_transport(config), AsyncPyqwestTransport)


### PR DESCRIPTION
## Summary

Any fresh `pip install e2b-code-interpreter` currently raises on the first `run_code()`:

```
TypeError: get_transport() got an unexpected keyword argument 'http2'
```

`e2b_code_interpreter/code_interpreter_sync.py:84` builds its streaming client with `get_transport(self.connection_config, http2=False)`. Moving the REST API client onto pyqwest (#1601) dropped that parameter — correctly, since ALPN negotiates the HTTP version now and the flag no longer selects anything. But `e2b-code-interpreter` declares `e2b>=2.26.0,<3.0.0`, so pip and poetry resolve the broken pair by default. `e2b` 2.37.0 works, 2.38.0 does not, and code-interpreter 2.9.0, 2.8.1, 2.8.0 and 2.7.0 all call it the same way — so there is no currently-publishable combination a user gets by default that works.

This accepts `http2` again on both the sync and async `get_transport`, documented as deprecated and ignored.

`get_transport` is not re-exported at the package root, so it reads as internal — but a sibling package we ship depends on it, and the declared version range says the combination is supported. Since the flag is genuinely inert, accepting and ignoring it costs nothing and unbreaks every already-published code-interpreter without users having to upgrade two packages in lockstep.

Repro, before and after:

```bash
python3 -m venv .venv && . .venv/bin/activate
pip install -q e2b-code-interpreter==2.9.0   # resolves e2b 2.38.0

E2B_API_KEY=... python -c "
from e2b_code_interpreter import Sandbox
Sandbox.create().run_code(\"print('hello')\")
"
# TypeError: get_transport() got an unexpected keyword argument 'http2'
```

Verified end to end: with this branch installed alongside an unmodified `e2b-code-interpreter==2.9.0`, that same script returns `['hello\n']` against live E2B. The existing `tests/test_api_client_transport.py` suite passes (26 tests), plus one added case covering the keyword, positional and omitted forms.

The real follow-up belongs in `e2b-dev/code-interpreter` rather than here: that call site is envd streaming traffic, so `get_envd_transport(config, for_streaming=True)` from #1623 is what it actually wants, and its `e2b` floor should move to `>=2.38` once it does. This PR is the compatibility half, so existing installs stop failing in the meantime. Happy to close it in favour of a code-interpreter-only fix if you would rather not carry the shim — the tradeoff is that everyone stays broken until they upgrade both packages.
