### PR TITLE
fix(sdk): omit autoPause when unset

### DIFF
--- a/.changeset/omit-default-auto-pause.md
+++ b/.changeset/omit-default-auto-pause.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/python-sdk': patch
+---
+
+Omit `autoPause` from sandbox creation requests when the timeout lifecycle is not configured, while continuing to send `false` for an explicit `kill` action. This preserves the distinction between an unset client preference and an explicit opt-out so the API can apply its own default.

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -1455,7 +1455,10 @@ export class SandboxApi {
       allow_internet_access: opts?.allowInternetAccess ?? true,
       network: buildNetworkBody(opts?.network, iam),
       iam,
-      autoPause: action === 'pause',
+      autoPause:
+        opts?.lifecycle?.onTimeout === undefined
+          ? undefined
+          : action === 'pause',
       autoPauseMemory: action === 'pause' ? keepMemory : undefined,
       autoResume: { enabled: autoResume },
     }

--- a/packages/js-sdk/tests/sandbox/autoPausePayload.test.ts
+++ b/packages/js-sdk/tests/sandbox/autoPausePayload.test.ts
@@ -1,0 +1,52 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { Sandbox } from '../../src'
+import { TEST_API_KEY, apiUrl } from '../setup'
+
+let lastCreateBody: Record<string, unknown> | undefined
+
+const server = setupServer(
+  http.post(apiUrl('/sandboxes'), async ({ request }) => {
+    lastCreateBody = (await request.json()) as Record<string, unknown>
+    return HttpResponse.json({
+      sandboxID: 'test-sandbox-id',
+      templateID: 'base',
+      envdVersion: '0.2.4',
+    })
+  })
+)
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterAll(() => server.close())
+
+afterEach(() => {
+  lastCreateBody = undefined
+  server.resetHandlers()
+})
+
+test('Sandbox.create omits autoPause when lifecycle.onTimeout is not provided', async () => {
+  await Sandbox.create('base', { apiKey: TEST_API_KEY })
+
+  expect(lastCreateBody).toBeDefined()
+  expect(lastCreateBody).not.toHaveProperty('autoPause')
+})
+
+test('Sandbox.create sends autoPause false for an explicit kill action', async () => {
+  await Sandbox.create('base', {
+    apiKey: TEST_API_KEY,
+    lifecycle: { onTimeout: 'kill' },
+  })
+
+  expect(lastCreateBody?.autoPause).toBe(false)
+})
+
+test('Sandbox.create sends autoPause true for an explicit pause action', async () => {
+  await Sandbox.create('base', {
+    apiKey: TEST_API_KEY,
+    lifecycle: { onTimeout: 'pause' },
+  })
+
+  expect(lastCreateBody?.autoPause).toBe(true)
+})

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -263,7 +263,11 @@ class SandboxApi(SandboxBase):
         network_body = build_network_config(network, iam_body)
         body = NewSandbox(
             template_id=template,
-            auto_pause=on_timeout == "pause",
+            auto_pause=(
+                on_timeout == "pause"
+                if lifecycle is not None and "on_timeout" in lifecycle
+                else UNSET
+            ),
             auto_pause_memory=keep_memory if on_timeout == "pause" else UNSET,
             auto_resume=SandboxAutoResumeConfig(enabled=auto_resume),
             metadata=metadata or {},

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -262,7 +262,11 @@ class SandboxApi(SandboxBase):
         network_body = build_network_config(network, iam_body)
         body = NewSandbox(
             template_id=template,
-            auto_pause=on_timeout == "pause",
+            auto_pause=(
+                on_timeout == "pause"
+                if lifecycle is not None and "on_timeout" in lifecycle
+                else UNSET
+            ),
             auto_pause_memory=keep_memory if on_timeout == "pause" else UNSET,
             auto_resume=SandboxAutoResumeConfig(enabled=auto_resume),
             metadata=metadata or {},

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from e2b import AsyncSandbox, SandboxException, SandboxQuery, SandboxState, Secret
+from e2b.api.client.models.sandbox import Sandbox as ApiSandbox
 from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
@@ -13,6 +14,8 @@ from e2b.api.client.models import (
 from e2b.api.client.types import UNSET
 from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.sandbox_api import build_iam_config
+from e2b.api.client.types import Response
+from http import HTTPStatus
 
 
 @pytest.mark.skip_debug()
@@ -76,6 +79,64 @@ def test_create_payload_serializes_auto_resume_enabled():
 
     assert body.to_dict()["autoPause"] is True
     assert body.to_dict()["autoResume"] == {"enabled": True}
+
+
+def test_create_payload_omits_auto_pause_when_unset():
+    body = NewSandbox(template_id="template-id", auto_pause=UNSET)
+
+    assert "autoPause" not in body.to_dict()
+
+
+def test_create_payload_serializes_explicit_auto_pause_false():
+    body = NewSandbox(template_id="template-id", auto_pause=False)
+
+    assert body.to_dict()["autoPause"] is False
+
+
+@pytest.mark.parametrize(
+    ("lifecycle", "expected_auto_pause"),
+    [(None, UNSET), ({"on_timeout": "kill"}, False), ({"on_timeout": "pause"}, True)],
+)
+async def test_create_sends_auto_pause_only_when_configured(
+    monkeypatch, test_api_key, lifecycle, expected_auto_pause
+):
+    captured_body = None
+
+    async def mock_create(*, body, client):
+        nonlocal captured_body
+        captured_body = body
+        return Response(
+            status_code=HTTPStatus.CREATED,
+            content=b"",
+            headers={},
+            parsed=ApiSandbox(
+                template_id="base",
+                sandbox_id="test-sandbox-id",
+                client_id="test-client-id",
+                envd_version="0.2.4",
+            ),
+        )
+
+    monkeypatch.setattr(
+        "e2b.sandbox_async.sandbox_api.post_sandboxes.asyncio_detailed", mock_create
+    )
+
+    await AsyncSandbox._create_sandbox(
+        template="base",
+        timeout=15,
+        allow_internet_access=True,
+        metadata=None,
+        env_vars=None,
+        secure=True,
+        lifecycle=lifecycle,
+        api_key=test_api_key,
+    )
+
+    assert captured_body is not None
+    if expected_auto_pause is UNSET:
+        assert "autoPause" not in captured_body.to_dict()
+    else:
+        assert captured_body.to_dict()["autoPause"] is expected_auto_pause
 
 
 def test_create_payload_deserializes_auto_resume_enabled():

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from e2b import Sandbox, SandboxException, SandboxState, Secret
+from e2b.api.client.models.sandbox import Sandbox as ApiSandbox
 from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
@@ -13,6 +14,8 @@ from e2b.api.client.models import (
 from e2b.api.client.types import UNSET
 from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.sandbox_api import SandboxQuery, build_iam_config
+from e2b.api.client.types import Response
+from http import HTTPStatus
 
 
 @pytest.mark.skip_debug()
@@ -76,6 +79,64 @@ def test_create_payload_serializes_auto_resume_enabled():
 
     assert body.to_dict()["autoPause"] is True
     assert body.to_dict()["autoResume"] == {"enabled": True}
+
+
+def test_create_payload_omits_auto_pause_when_unset():
+    body = NewSandbox(template_id="template-id", auto_pause=UNSET)
+
+    assert "autoPause" not in body.to_dict()
+
+
+def test_create_payload_serializes_explicit_auto_pause_false():
+    body = NewSandbox(template_id="template-id", auto_pause=False)
+
+    assert body.to_dict()["autoPause"] is False
+
+
+@pytest.mark.parametrize(
+    ("lifecycle", "expected_auto_pause"),
+    [(None, UNSET), ({"on_timeout": "kill"}, False), ({"on_timeout": "pause"}, True)],
+)
+def test_create_sends_auto_pause_only_when_configured(
+    monkeypatch, test_api_key, lifecycle, expected_auto_pause
+):
+    captured_body = None
+
+    def mock_create(*, body, client):
+        nonlocal captured_body
+        captured_body = body
+        return Response(
+            status_code=HTTPStatus.CREATED,
+            content=b"",
+            headers={},
+            parsed=ApiSandbox(
+                template_id="base",
+                sandbox_id="test-sandbox-id",
+                client_id="test-client-id",
+                envd_version="0.2.4",
+            ),
+        )
+
+    monkeypatch.setattr(
+        "e2b.sandbox_sync.sandbox_api.post_sandboxes.sync_detailed", mock_create
+    )
+
+    Sandbox._create_sandbox(
+        template="base",
+        timeout=15,
+        allow_internet_access=True,
+        metadata=None,
+        env_vars=None,
+        secure=True,
+        lifecycle=lifecycle,
+        api_key=test_api_key,
+    )
+
+    assert captured_body is not None
+    if expected_auto_pause is UNSET:
+        assert "autoPause" not in captured_body.to_dict()
+    else:
+        assert captured_body.to_dict()["autoPause"] is expected_auto_pause
 
 
 def test_create_payload_deserializes_auto_resume_enabled():


### PR DESCRIPTION
## Summary

Omit `autoPause` from `POST /sandboxes` when callers leave the timeout lifecycle unspecified, while preserving explicit choices:

- unspecified lifecycle: omit `autoPause`
- explicit `kill`: send `autoPause: false`
- explicit `pause`: send `autoPause: true`

The change is applied consistently to the JavaScript SDK and both synchronous and asynchronous Python SDK paths.

## Why

The current SDK behavior eagerly converts its local default (`kill`) into `autoPause: false`. On the wire, that makes an omitted user preference indistinguishable from an explicit opt-out.

Preserving the distinction lets the API own its default behavior and evolve that default without SDK clients unintentionally overriding it. At the same time, users who explicitly select `kill` retain exactly the same request semantics as before.

This is intentionally a narrow serialization change: the SDK's local validation and explicit lifecycle behavior remain unchanged.

Closes #1669.

## Validation

- JS request-level tests for omitted, explicit `false`, and explicit `true` payloads
- Python sync and async request-construction tests for the same three states
- JS TypeScript typecheck
- JS Prettier check
- Python Ruff lint and format checks
- targeted Python test suite: 22 passed
