### PR TITLE
fix(js-sdk): release the inflight concurrency slot on body end, not h…

### DIFF
--- a/packages/js-sdk/src/api/inflight.ts
+++ b/packages/js-sdk/src/api/inflight.ts
@@ -45,17 +45,63 @@ function abortReason(signal: AbortSignal | undefined): unknown {
 }
 
 /**
+ * Wrap a response body so `release` fires exactly once: when the body is
+ * fully drained, when reading it errors, or when the consumer cancels it —
+ * never on response headers alone. Reconstructing the response this way
+ * loses `.url`, `.redirected`, and `.type` (the `Response` constructor has
+ * no way to set them, and `Body` methods like `.text()`/`.json()` read an
+ * internal body slot rather than the public `.body` getter, so patching
+ * just that getter would not intercept them). Nothing in this SDK reads
+ * those three properties off a dispatched response, and this wrapper is
+ * internal to the fetch pipeline, never part of the public API.
+ */
+function releaseOnBodyEnd(
+  body: ReadableStream<Uint8Array>,
+  release: () => void
+): ReadableStream<Uint8Array> {
+  const reader = body.getReader()
+  let released = false
+  const releaseOnce = () => {
+    if (!released) {
+      released = true
+      release()
+    }
+  }
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read()
+        if (done) {
+          releaseOnce()
+          controller.close()
+          return
+        }
+        controller.enqueue(value)
+      } catch (err) {
+        releaseOnce()
+        controller.error(err)
+      }
+    },
+    cancel(reason) {
+      releaseOnce()
+      return reader.cancel(reason)
+    },
+  })
+}
+
+/**
  * Wrap `fetcher` so at most `max` requests are in-flight at any time.
  * Subsequent requests are FIFO-queued inside the SDK process and dispatched
  * as earlier requests settle.
  *
- * NOTE: the slot is released as soon as `fetcher` resolves with the response
- * headers, not when the response body is fully consumed. This means the
- * effective concurrency can be higher than `max` while bodies are
- * still streaming.
- *
- * TODO: release on body end (consume/cancel/error) so the
- * SDK-level cap aligns with the dispatcher's connection accounting
+ * The slot stays held until the response body is fully consumed, errors, or
+ * is canceled — not just until headers arrive — so the SDK-level cap aligns
+ * with the dispatcher's actual connection accounting for streaming
+ * responses (logs, command output). A response with no body (e.g. 204/304,
+ * HEAD) releases immediately, there is nothing left to hold the slot open
+ * for. A caller that never reads the body at all (ignores it entirely)
+ * keeps the slot held forever, same as never closing a stream you opened.
  */
 export function limitConcurrency(
   fetcher: typeof fetch,
@@ -73,10 +119,24 @@ export function limitConcurrency(
     const signal =
       init?.signal ?? (isRequestLike(input) ? input.signal : undefined)
     const release = await sem.acquire(signal)
+
+    let response: Response
     try {
-      return await fetcher(input, init)
-    } finally {
+      response = await fetcher(input, init)
+    } catch (err) {
       release()
+      throw err
     }
+
+    if (response.body === null) {
+      release()
+      return response
+    }
+
+    return new Response(releaseOnBodyEnd(response.body, release), {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    })
   }) as typeof fetch
 }

--- a/packages/js-sdk/tests/api/inflight.test.ts
+++ b/packages/js-sdk/tests/api/inflight.test.ts
@@ -13,6 +13,40 @@ function deferred<T>() {
   return { promise, resolve, reject }
 }
 
+/** A ReadableStream<Uint8Array> a test can push/close/error on demand. */
+function controllableStream() {
+  let controller!: ReadableStreamDefaultController<Uint8Array>
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c
+    },
+  })
+  return {
+    stream,
+    push: (chunk: string) => controller.enqueue(new TextEncoder().encode(chunk)),
+    close: () => controller.close(),
+    error: (reason: unknown) => controller.error(reason),
+  }
+}
+
+async function readAll(body: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = body.getReader()
+  const chunks: Uint8Array[] = []
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  return new TextDecoder().decode(
+    chunks.reduce((acc, chunk) => {
+      const merged = new Uint8Array(acc.length + chunk.length)
+      merged.set(acc)
+      merged.set(chunk, acc.length)
+      return merged
+    }, new Uint8Array())
+  )
+}
+
 test('limitConcurrency queues requests over the cap and releases on response', async () => {
   const gate = deferred<Response>()
   let secondStarted = false
@@ -98,4 +132,114 @@ test('limitConcurrency honors the signal of a Request the global class disowns',
   }
 
   expect(inner).not.toHaveBeenCalled()
+})
+
+test('limitConcurrency holds the slot while a streaming body is still being read', async () => {
+  const first = controllableStream()
+  let secondStarted = false
+  const inner = vi.fn(async (input: RequestInfo | URL) => {
+    if (String(input).endsWith('/first')) return new Response(first.stream)
+    secondStarted = true
+    return new Response('second')
+  }) as unknown as typeof fetch
+
+  const limited = limitConcurrency(inner, 1)
+  const firstResponse = await limited('https://example.com/first')
+  const secondPromise = limited('https://example.com/second')
+
+  // Headers are back and the body hasn't been touched — the slot must still
+  // be held (this is exactly what the un-fixed version got wrong: it
+  // released here, as soon as `fetcher` resolved).
+  await Promise.resolve()
+  await Promise.resolve()
+  expect(secondStarted).toBe(false)
+
+  first.push('chunk')
+  first.close()
+  expect(await readAll(firstResponse.body!)).toBe('chunk')
+
+  // Draining the body released the slot; the queued request can now start.
+  await secondPromise
+  expect(secondStarted).toBe(true)
+})
+
+test('limitConcurrency releases the slot when the body errors mid-stream', async () => {
+  const first = controllableStream()
+  let secondStarted = false
+  const inner = vi.fn(async (input: RequestInfo | URL) => {
+    if (String(input).endsWith('/first')) return new Response(first.stream)
+    secondStarted = true
+    return new Response('second')
+  }) as unknown as typeof fetch
+
+  const limited = limitConcurrency(inner, 1)
+  const firstResponse = await limited('https://example.com/first')
+  const secondPromise = limited('https://example.com/second')
+
+  first.push('partial')
+  first.error(new Error('connection reset'))
+  await expect(readAll(firstResponse.body!)).rejects.toThrow(
+    'connection reset'
+  )
+
+  await secondPromise
+  expect(secondStarted).toBe(true)
+})
+
+test('limitConcurrency releases the slot when the consumer cancels the body', async () => {
+  const first = controllableStream()
+  let secondStarted = false
+  const inner = vi.fn(async (input: RequestInfo | URL) => {
+    if (String(input).endsWith('/first')) return new Response(first.stream)
+    secondStarted = true
+    return new Response('second')
+  }) as unknown as typeof fetch
+
+  const limited = limitConcurrency(inner, 1)
+  const firstResponse = await limited('https://example.com/first')
+  const secondPromise = limited('https://example.com/second')
+
+  await firstResponse.body!.cancel('no longer needed')
+
+  await secondPromise
+  expect(secondStarted).toBe(true)
+})
+
+test('limitConcurrency releases immediately for a response with no body', async () => {
+  let secondStarted = false
+  const inner = vi.fn(async (input: RequestInfo | URL) => {
+    if (String(input).endsWith('/first')) {
+      return new Response(null, { status: 204 })
+    }
+    secondStarted = true
+    return new Response('second')
+  }) as unknown as typeof fetch
+
+  const limited = limitConcurrency(inner, 1)
+  await limited('https://example.com/first')
+  await limited('https://example.com/second')
+
+  expect(secondStarted).toBe(true)
+})
+
+test('limitConcurrency preserves status, statusText, and headers on the wrapped response', async () => {
+  const first = controllableStream()
+  const inner = vi.fn(
+    async () =>
+      new Response(first.stream, {
+        status: 201,
+        statusText: 'Created',
+        headers: { 'x-request-id': 'abc123' },
+      })
+  ) as unknown as typeof fetch
+
+  const limited = limitConcurrency(inner, 1)
+  const response = await limited('https://example.com/first')
+
+  expect(response.status).toBe(201)
+  expect(response.statusText).toBe('Created')
+  expect(response.headers.get('x-request-id')).toBe('abc123')
+
+  first.close()
+  await readAll(response.body!)
 })


### PR DESCRIPTION
## Problem

Fixes #1666.

`limitConcurrency` (`js-sdk/src/api/inflight.ts`) releases its semaphore slot as soon as `fetcher` resolves with the response headers, not once the body is fully consumed:

```ts
const release = await sem.acquire(signal)
try {
  return await fetcher(input, init)
} finally {
  release()
}
```

For streaming responses (logs, command output, file/volume transfers) this lets real concurrency exceed `inflightLimit` while bodies are still in flight, risking `ERR_HTTP2_TOO_MANY_CONCURRENT_STREAMS` under load. There was already a `TODO` for this.

## Changes

- Slot now releases on body end, error, or cancel, not on headers, via a passthrough `ReadableStream` (`releaseOnBodyEnd`).
- No-body responses (204/304, HEAD) release immediately.
- Reconstructing the response loses `.url`/`.redirected`/`.type` (no way to set them via the constructor). Confirmed nothing in this SDK reads them, and this wrapper is internal only.
- 5 new tests covering hold-during-stream, release on end/error/cancel, and the no-body path.

## Verified

- New "holds slot while streaming" test fails on old code, passes on the fix, confirmed by reverting and re-running.
- Real consumption paths, not just the test helper: 500KB chunked binary round-trips byte-exact via `.arrayBuffer()`, `.blob()`/`.json()` both work, 3 concurrent streams against a cap of 2 never exceed 2 mid-stream.
- Also used by `envd/http2.ts` (file read/write) and `volume/client.ts`, not just the main API client.
- Full JS unit project: same pre-existing failure count before/after.
- `oxlint` + `tsc --noEmit` clean.
