### PR TITLE
fix(sdk): omit autoResume when unset

### DIFF
--- a/.changeset/omit-default-auto-resume.md
+++ b/.changeset/omit-default-auto-resume.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/python-sdk': patch
+---
+
+Omit `autoResume` from sandbox creation requests when callers do not configure it, while preserving explicit `false` and `true` values. This lets the API distinguish an unset preference from an explicit opt-out and apply its own default.

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -1457,7 +1457,10 @@ export class SandboxApi {
       iam,
       autoPause: action === 'pause',
       autoPauseMemory: action === 'pause' ? keepMemory : undefined,
-      autoResume: { enabled: autoResume },
+      autoResume:
+        opts?.lifecycle?.autoResume === undefined
+          ? undefined
+          : { enabled: autoResume },
     }
 
     if (opts?.volumeMounts) {

--- a/packages/js-sdk/tests/sandbox/autoResumePayload.test.ts
+++ b/packages/js-sdk/tests/sandbox/autoResumePayload.test.ts
@@ -1,0 +1,52 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { Sandbox } from '../../src'
+import { TEST_API_KEY, apiUrl } from '../setup'
+
+let lastCreateBody: Record<string, unknown> | undefined
+
+const server = setupServer(
+  http.post(apiUrl('/sandboxes'), async ({ request }) => {
+    lastCreateBody = (await request.json()) as Record<string, unknown>
+    return HttpResponse.json({
+      sandboxID: 'test-sandbox-id',
+      templateID: 'base',
+      envdVersion: '0.2.4',
+    })
+  })
+)
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterAll(() => server.close())
+
+afterEach(() => {
+  lastCreateBody = undefined
+  server.resetHandlers()
+})
+
+test('Sandbox.create omits autoResume when lifecycle.autoResume is not provided', async () => {
+  await Sandbox.create('base', { apiKey: TEST_API_KEY })
+
+  expect(lastCreateBody).toBeDefined()
+  expect(lastCreateBody).not.toHaveProperty('autoResume')
+})
+
+test('Sandbox.create sends autoResume false when explicitly disabled', async () => {
+  await Sandbox.create('base', {
+    apiKey: TEST_API_KEY,
+    lifecycle: { autoResume: false },
+  })
+
+  expect(lastCreateBody?.autoResume).toEqual({ enabled: false })
+})
+
+test('Sandbox.create sends autoResume true when explicitly enabled', async () => {
+  await Sandbox.create('base', {
+    apiKey: TEST_API_KEY,
+    lifecycle: { onTimeout: 'pause', autoResume: true },
+  })
+
+  expect(lastCreateBody?.autoResume).toEqual({ enabled: true })
+})

--- a/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_async/sandbox_api.py
@@ -265,7 +265,11 @@ class SandboxApi(SandboxBase):
             template_id=template,
             auto_pause=on_timeout == "pause",
             auto_pause_memory=keep_memory if on_timeout == "pause" else UNSET,
-            auto_resume=SandboxAutoResumeConfig(enabled=auto_resume),
+            auto_resume=(
+                SandboxAutoResumeConfig(enabled=auto_resume)
+                if lifecycle is not None and "auto_resume" in lifecycle
+                else UNSET
+            ),
             metadata=metadata or {},
             timeout=timeout,
             env_vars=env_vars or {},

--- a/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
+++ b/packages/python-sdk/e2b/sandbox_sync/sandbox_api.py
@@ -264,7 +264,11 @@ class SandboxApi(SandboxBase):
             template_id=template,
             auto_pause=on_timeout == "pause",
             auto_pause_memory=keep_memory if on_timeout == "pause" else UNSET,
-            auto_resume=SandboxAutoResumeConfig(enabled=auto_resume),
+            auto_resume=(
+                SandboxAutoResumeConfig(enabled=auto_resume)
+                if lifecycle is not None and "auto_resume" in lifecycle
+                else UNSET
+            ),
             metadata=metadata or {},
             timeout=timeout,
             env_vars=env_vars or {},

--- a/packages/python-sdk/tests/async/sandbox_async/test_create.py
+++ b/packages/python-sdk/tests/async/sandbox_async/test_create.py
@@ -1,4 +1,5 @@
 import asyncio
+from http import HTTPStatus
 from typing import Any, cast
 from uuid import uuid4
 
@@ -10,7 +11,8 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
-from e2b.api.client.types import UNSET
+from e2b.api.client.models.sandbox import Sandbox as ApiSandbox
+from e2b.api.client.types import UNSET, Response
 from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.sandbox_api import build_iam_config
 
@@ -89,6 +91,58 @@ def test_create_payload_deserializes_auto_resume_enabled():
 
     assert isinstance(body.auto_resume, SandboxAutoResumeConfig)
     assert body.auto_resume.to_dict() == {"enabled": False}
+
+
+@pytest.mark.parametrize(
+    ("lifecycle", "expected_auto_resume"),
+    [
+        (None, UNSET),
+        ({"auto_resume": False}, False),
+        ({"on_timeout": "pause", "auto_resume": True}, True),
+    ],
+)
+async def test_create_sends_auto_resume_only_when_configured(
+    monkeypatch, test_api_key, lifecycle, expected_auto_resume
+):
+    captured_body = None
+
+    async def mock_create(*, body, client):
+        nonlocal captured_body
+        captured_body = body
+        return Response(
+            status_code=HTTPStatus.CREATED,
+            content=b"",
+            headers={},
+            parsed=ApiSandbox(
+                template_id="base",
+                sandbox_id="test-sandbox-id",
+                client_id="test-client-id",
+                envd_version="0.2.4",
+            ),
+        )
+
+    monkeypatch.setattr(
+        "e2b.sandbox_async.sandbox_api.post_sandboxes.asyncio_detailed", mock_create
+    )
+
+    await AsyncSandbox._create_sandbox(
+        template="base",
+        timeout=15,
+        allow_internet_access=True,
+        metadata=None,
+        env_vars=None,
+        secure=True,
+        lifecycle=lifecycle,
+        api_key=test_api_key,
+    )
+
+    assert captured_body is not None
+    if expected_auto_resume is UNSET:
+        assert "autoResume" not in captured_body.to_dict()
+    else:
+        assert captured_body.to_dict()["autoResume"] == {
+            "enabled": expected_auto_resume
+        }
 
 
 def test_create_payload_serializes_iam_tokens():

--- a/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
+++ b/packages/python-sdk/tests/sync/sandbox_sync/test_create.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from time import sleep
 from typing import Any, cast
 from uuid import uuid4
@@ -10,7 +11,8 @@ from e2b.api.client.models import (
     NewSandbox,
     SandboxAutoResumeConfig,
 )
-from e2b.api.client.types import UNSET
+from e2b.api.client.models.sandbox import Sandbox as ApiSandbox
+from e2b.api.client.types import UNSET, Response
 from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox.sandbox_api import SandboxQuery, build_iam_config
 
@@ -89,6 +91,58 @@ def test_create_payload_deserializes_auto_resume_enabled():
 
     assert isinstance(body.auto_resume, SandboxAutoResumeConfig)
     assert body.auto_resume.to_dict() == {"enabled": False}
+
+
+@pytest.mark.parametrize(
+    ("lifecycle", "expected_auto_resume"),
+    [
+        (None, UNSET),
+        ({"auto_resume": False}, False),
+        ({"on_timeout": "pause", "auto_resume": True}, True),
+    ],
+)
+def test_create_sends_auto_resume_only_when_configured(
+    monkeypatch, test_api_key, lifecycle, expected_auto_resume
+):
+    captured_body = None
+
+    def mock_create(*, body, client):
+        nonlocal captured_body
+        captured_body = body
+        return Response(
+            status_code=HTTPStatus.CREATED,
+            content=b"",
+            headers={},
+            parsed=ApiSandbox(
+                template_id="base",
+                sandbox_id="test-sandbox-id",
+                client_id="test-client-id",
+                envd_version="0.2.4",
+            ),
+        )
+
+    monkeypatch.setattr(
+        "e2b.sandbox_sync.sandbox_api.post_sandboxes.sync_detailed", mock_create
+    )
+
+    Sandbox._create_sandbox(
+        template="base",
+        timeout=15,
+        allow_internet_access=True,
+        metadata=None,
+        env_vars=None,
+        secure=True,
+        lifecycle=lifecycle,
+        api_key=test_api_key,
+    )
+
+    assert captured_body is not None
+    if expected_auto_resume is UNSET:
+        assert "autoResume" not in captured_body.to_dict()
+    else:
+        assert captured_body.to_dict()["autoResume"] == {
+            "enabled": expected_auto_resume
+        }
 
 
 def test_create_payload_serializes_iam_tokens():


### PR DESCRIPTION
## Summary

Omit `autoResume` from `POST /sandboxes` when callers leave it unspecified, while preserving both explicit choices:

- unspecified: omit `autoResume`
- explicit `false`: send `{"autoResume":{"enabled":false}}`
- explicit `true`: send `{"autoResume":{"enabled":true}}`

The change is applied consistently to the JavaScript SDK and the synchronous and asynchronous Python SDK paths.

## Why

The SDKs currently default the local value to `false` and always serialize it. On the wire, that makes an omitted user preference indistinguishable from an explicit opt-out.

Preserving the distinction allows the API to own and safely evolve its default without SDK clients unintentionally overriding it. Explicit `false` and `true` configurations retain their existing request semantics and validation.

This is analogous to #1669, but applies to the optional nested `autoResume` configuration.

Closes #1677.

## Usage

No application changes are required. Existing explicit configurations continue to work:

```ts
await Sandbox.create({
  lifecycle: { onTimeout: 'pause', autoResume: true },
})
```

```python
Sandbox.create(
    lifecycle={"on_timeout": "pause", "auto_resume": True},
)
```

Callers that omit `autoResume` now leave the preference unset at the API boundary.

## Validation

- JavaScript request-level tests for omitted, explicit `false`, and explicit `true`
- Python sync and async request-construction tests for the same three states
- JavaScript TypeScript typecheck, Oxlint, and targeted Prettier check
- Python Ruff lint/format and `ty` typecheck
- 3 JavaScript tests passed
- 8 targeted Python tests passed

The repository-wide JavaScript Prettier check reports existing Windows line-ending differences across 157 untouched files; all files changed by this PR pass the targeted Prettier check.
