### PR TITLE
refactor(cli): remove the E2B_ACCESS_TOKEN auth path

### DIFF
--- a/.changeset/lucky-doors-listen.md
+++ b/.changeset/lucky-doors-listen.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Remove the `E2B_ACCESS_TOKEN` auth path. Authentication moved to Hydra OAuth, so the CLI no longer reads an access token — from the environment or from `~/.e2b/config.json` — to authorize API requests. The API key alone scopes every endpoint the CLI calls, and `e2b auth login` / `e2b auth configure` build their own clients with Hydra JWTs.

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -13,23 +13,17 @@ export type Teams =
   e2b.paths['/teams']['get']['responses'][200]['content']['application/json']
 
 export let apiKey = process.env.E2B_API_KEY
-export let accessToken = process.env.E2B_ACCESS_TOKEN
 export const projectId = process.env.E2B_PROJECT_ID || process.env.E2B_TEAM_ID
 
-const authErrorBox = (keyName: 'E2B_API_KEY' | 'E2B_ACCESS_TOKEN') => {
-  const link =
-    keyName === 'E2B_API_KEY'
-      ? 'https://e2b.dev/dashboard?tab=keys'
-      : 'https://e2b.dev/dashboard?tab=personal'
-  const msg = keyName === 'E2B_API_KEY' ? 'API key' : 'access token'
+const authErrorBox = () => {
   const body = `You must be logged in to use this command. Run ${asBold(
     'e2b auth login'
   )}.
 
 If you are seeing this message in CI/CD you may need to set the ${asBold(
-    keyName
+    'E2B_API_KEY'
   )} environment variable.
-Visit ${asPrimary(link)} to get the ${msg}.`
+Visit ${asPrimary('https://e2b.dev/dashboard?tab=keys')} to get the API key.`
   return boxen.default(body, {
     width: 70,
     float: 'center',
@@ -48,7 +42,7 @@ export function ensureAPIKey() {
   }
 
   if (!apiKey) {
-    console.error(authErrorBox('E2B_API_KEY'))
+    console.error(authErrorBox())
     process.exit(1)
   } else {
     return apiKey
@@ -62,21 +56,6 @@ export function ensureUserConfig(): UserConfig {
     process.exit(1)
   }
   return userConfig
-}
-
-export function ensureAccessToken() {
-  // If accessToken is not already set (either from env var or from user config), try to get it from config file
-  if (!accessToken) {
-    const userConfig = getUserConfig()
-    accessToken = userConfig?.tokens.access_token
-  }
-
-  if (!accessToken) {
-    console.error(authErrorBox('E2B_ACCESS_TOKEN'))
-    process.exit(1)
-  } else {
-    return accessToken
-  }
 }
 
 /**
@@ -98,18 +77,12 @@ export function resolveProjectId(cliProjectId?: string): string | undefined {
 
 const userConfig = getUserConfig()
 
-const resolvedAccessToken =
-  process.env.E2B_ACCESS_TOKEN || userConfig?.tokens.access_token
-
 export const connectionConfig = new e2b.ConnectionConfig({
   apiKey: process.env.E2B_API_KEY || userConfig?.projectApiKey,
-  apiHeaders: resolvedAccessToken
-    ? { Authorization: `Bearer ${resolvedAccessToken}` }
-    : undefined,
 })
 
-// The CLI authenticates team-scoped endpoints (e.g. `/teams`) with the access
-// token instead of an API key, so don't require an API key here.
+// `e2b auth login` runs before any API key exists, and this client is built at
+// import time, so don't require an API key here.
 export const client = new e2b.ApiClient(connectionConfig, {
   requireApiKey: false,
 })

--- a/packages/cli/tests/attribution.test.ts
+++ b/packages/cli/tests/attribution.test.ts
@@ -33,7 +33,6 @@ async function captureUserAgent(args: string[]): Promise<string | undefined> {
     E2B_API_KEY: `e2b_${'0'.repeat(40)}`,
   }
   delete env.E2B_DEBUG
-  delete env.E2B_ACCESS_TOKEN
 
   userAgents.length = 0
   const result = await runCliWithPipedStdin(args, Buffer.alloc(0), {

--- a/packages/cli/tests/commands/template/create.test.ts
+++ b/packages/cli/tests/commands/template/create.test.ts
@@ -32,7 +32,7 @@ describe('template create cli backend integration', () => {
   })
 
   test(
-    'template create succeeds with E2B_API_KEY alone (no E2B_ACCESS_TOKEN)',
+    'template create succeeds with E2B_API_KEY alone',
     { timeout: 300_000 },
     () => {
       const result = runCli([
@@ -49,15 +49,15 @@ describe('template create cli backend integration', () => {
       // path prints "❌ Template build failed." instead.
       expect(output).toContain('✅ Building sandbox template')
       expect(output).not.toContain('❌ Template build failed')
-      // Auth never fell through to the access-token error box.
+      // Auth never fell through to the "log in first" error box.
       expect(output).not.toMatch(/You must be logged in/)
     }
   )
 })
 
 function runCli(args: string[]): ReturnType<typeof spawnSync> {
-  // Intentionally exclude E2B_ACCESS_TOKEN from the child env so this test
-  // verifies the API-key-only auth path end-to-end.
+  // A minimal child env (API key only) so this test verifies the API-key auth
+  // path end-to-end.
   return spawnSync('node', [cliPath, ...args], {
     env: {
       PATH: process.env.PATH,


### PR DESCRIPTION
Stacked on #1680.

Auth moved to Hydra OAuth in #1481, which left `ensureAccessToken()` with no callers and the module-level API client attaching a stale `Authorization: Bearer <access token>` header to every request. This drops `ensureAccessToken()`, the `accessToken` export, the `E2B_ACCESS_TOKEN` arm of the auth error box, and the `apiHeaders` wiring on `connectionConfig` — the only consumers of that header were `template list`/`create`, and `/templates` is scoped by the API key alone, while `auth login` / `auth configure` build their own clients with Hydra JWTs. `requireApiKey: false` stays on the shared client, but its justification is now that `e2b auth login` runs before any API key exists and the client is built at import time.

User-facing effect: combined with #1680, the CLI ignores `E2B_ACCESS_TOKEN` entirely, so CI setups can drop it and keep only the API key.

```bash
# Before: both were commonly set in CI
export E2B_ACCESS_TOKEN=sk_e2b_...
export E2B_API_KEY=e2b_...

# Now: the API key alone authorizes everything the CLI calls
export E2B_API_KEY=e2b_...
e2b template list
e2b template create my-template
```

Part of [SDK-6](https://linear.app/e2b/issue/SDK-6/mark-e2b-access-token-as-deprecated-inside-all-code-references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
