### PR TITLE
feat(sdk): remove the deprecated accessToken option

### DIFF
--- a/.changeset/remove-access-token-option.md
+++ b/.changeset/remove-access-token-option.md
@@ -1,0 +1,28 @@
+---
+'e2b': minor
+'@e2b/python-sdk': minor
+---
+
+Remove the deprecated `accessToken` / `access_token` option and its `E2B_ACCESS_TOKEN` environment fallback. E2B access tokens are no longer accepted for API authentication, so the SDKs no longer resolve one or send it as an `Authorization: Bearer` header — requests authenticate with the API key alone.
+
+If you were relying on the option to send a bearer token to a custom deployment, pass the header directly, which is what the deprecation notice already pointed to:
+
+```ts
+// Before
+const sandbox = await Sandbox.create({ accessToken: token })
+
+// After
+const sandbox = await Sandbox.create({
+  apiHeaders: { Authorization: `Bearer ${token}` },
+})
+```
+
+```python
+# Before
+config = ConnectionConfig(access_token=token)
+
+# After
+config = ConnectionConfig(api_headers={"Authorization": f"Bearer {token}"})
+```
+
+Note that `Sandbox.envd_access_token` / `traffic_access_token` are unrelated per-sandbox tokens and are unaffected.

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -116,9 +116,6 @@ class ApiClient {
       headers: {
         ...defaultHeaders,
         ...(config.apiKey && { 'X-API-KEY': config.apiKey }),
-        ...(config.accessToken && {
-          Authorization: `Bearer ${config.accessToken}`,
-        }),
         ...config.headers,
       },
       querySerializer: {

--- a/packages/js-sdk/src/connectionConfig.ts
+++ b/packages/js-sdk/src/connectionConfig.ts
@@ -30,15 +30,6 @@ export interface ConnectionOpts {
    */
   validateApiKey?: boolean
   /**
-   * E2B access token to use for authentication.
-   *
-   * @deprecated Pass the token through `apiHeaders` instead, e.g.
-   * `apiHeaders: { Authorization: \`Bearer ${token}\` }`.
-   *
-   * @default E2B_ACCESS_TOKEN // environment variable
-   */
-  accessToken?: string
-  /**
    * Domain to use for the API.
    *
    * @default E2B_DOMAIN // environment variable or `e2b.app`
@@ -407,10 +398,6 @@ export class ConnectionConfig {
 
   readonly apiKey?: string
   readonly validateApiKey: boolean
-  /**
-   * @deprecated Pass the token through `apiHeaders` instead.
-   */
-  readonly accessToken?: string
 
   readonly headers?: Record<string, string>
 
@@ -422,7 +409,6 @@ export class ConnectionConfig {
       opts?.validateApiKey ?? ConnectionConfig.validateApiKey
     this.debug = opts?.debug ?? ConnectionConfig.debug
     this.domain = opts?.domain || ConnectionConfig.domain
-    this.accessToken = opts?.accessToken || ConnectionConfig.accessToken
     this.requestTimeoutMs = opts?.requestTimeoutMs ?? REQUEST_TIMEOUT_MS
     this.logger = opts?.logger
     this.headers = { ...(opts?.headers ?? {}), ...(opts?.apiHeaders ?? {}) }
@@ -461,10 +447,6 @@ export class ConnectionConfig {
     return (
       (getEnvVar('E2B_VALIDATE_API_KEY') || 'true').toLowerCase() !== 'false'
     )
-  }
-
-  private static get accessToken() {
-    return getEnvVar('E2B_ACCESS_TOKEN')
   }
 
   getSignal(requestTimeoutMs?: number, signal?: AbortSignal) {

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -235,15 +235,6 @@ class ApiClient(AuthenticatedClient):
 
         headers = {
             **default_headers,
-            # Deprecated: send the access token alongside the API key when one
-            # is available, mirroring the JS SDK. Prefer `api_headers` instead.
-            # Spread before `config.headers` so a custom `Authorization` in
-            # `api_headers` wins over the deprecated access token, matching JS.
-            **(
-                {"Authorization": f"Bearer {config.access_token}"}
-                if config.access_token is not None
-                else {}
-            ),
             **(config.headers or {}),
         }
 

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -135,10 +135,6 @@ class ConnectionConfig:
         return os.getenv("E2B_SANDBOX_URL")
 
     @staticmethod
-    def _access_token():
-        return os.getenv("E2B_ACCESS_TOKEN")
-
-    @staticmethod
     def _build_user_agent() -> str:
         user_agent_parts = [f"e2b-python-sdk/{package_version}"]
 
@@ -175,7 +171,6 @@ class ConnectionConfig:
         validate_api_key: Optional[bool] = None,
         api_url: Optional[str] = None,
         sandbox_url: Optional[str] = None,
-        access_token: Optional[str] = None,
         request_timeout: Optional[float] = None,
         headers: Optional[Dict[str, str]] = None,
         api_headers: Optional[Dict[str, str]] = None,
@@ -192,9 +187,6 @@ class ConnectionConfig:
             if validate_api_key is not None
             else ConnectionConfig._validate_api_key()
         )
-        # Deprecated: pass the token through `api_headers` instead, e.g.
-        # api_headers={"Authorization": f"Bearer {token}"}.
-        self.access_token = access_token or ConnectionConfig._access_token()
         self.headers = {**(headers or {}), **(api_headers or {})}
         self._user_agent_is_sdk_built = self._apply_user_agent(
             self.headers,
@@ -280,7 +272,6 @@ class ConnectionConfig:
         Get the parameters for the API call.
 
         This is used to avoid passing the following attributes to the API call:
-        - access_token
         - api_url
 
         It also returns a copy, so the original object is not modified.

--- a/packages/python-sdk/tests/test_api_client_transport.py
+++ b/packages/python-sdk/tests/test_api_client_transport.py
@@ -202,7 +202,7 @@ def test_sync_envd_transports_keyed_by_streaming(test_api_key):
 
 def test_sync_envd_api_client_wiring(test_api_key):
     reset_sync_api_transports()
-    config = ConnectionConfig(api_key=test_api_key, access_token="tok")
+    config = ConnectionConfig(api_key=test_api_key)
 
     client = get_sync_envd_api(config, "https://sandbox.e2b.app")
     streaming = get_sync_envd_api(config, "https://sandbox.e2b.app", for_streaming=True)
@@ -381,7 +381,7 @@ async def test_async_envd_transports_keyed_by_streaming(test_api_key):
 @pytest.mark.asyncio
 async def test_async_envd_api_client_wiring(test_api_key):
     reset_async_api_transports()
-    config = ConnectionConfig(api_key=test_api_key, access_token="tok")
+    config = ConnectionConfig(api_key=test_api_key)
 
     client = get_async_envd_api(config, "https://sandbox.e2b.app")
 


### PR DESCRIPTION
Removes the deprecated `accessToken` / `access_token` option from both SDKs, along with its `E2B_ACCESS_TOKEN` environment fallback and the `Authorization: Bearer` header it produced. The option was already deprecated in both SDKs — `connectionConfig.ts` and `connection_config.py` both pointed at `apiHeaders` / `api_headers` as the replacement — and E2B access tokens are no longer accepted for API authentication, so resolving one and putting it on the wire was dead weight. Requests now authenticate with the API key alone.

Callers who need a bearer token for a custom deployment pass it explicitly, which is what the deprecation notice already told them to do:

```ts
// Before
const sandbox = await Sandbox.create({ accessToken: token })

// After
const sandbox = await Sandbox.create({
  apiHeaders: { Authorization: `Bearer ${token}` },
})
```

```python
# Before
config = ConnectionConfig(access_token=token)

# After
config = ConnectionConfig(api_headers={"Authorization": f"Bearer {token}"})
```

`Sandbox.envd_access_token` / `traffic_access_token` are unrelated per-sandbox tokens and are unaffected, as is the volume client's `token` (which never read the env var — there's a test asserting exactly that).

Part of [SDK-6](https://linear.app/e2b/issue/SDK-6/mark-e2b-access-token-as-deprecated-inside-all-code-references). The CLI half is stacked on top in #1679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
