### PR TITLE
fix(js-sdk): report unregistered IAM token names colliding with runtime-probed props

### DIFF
--- a/.changeset/fix-iam-unregistered-runtime-props.md
+++ b/.changeset/fix-iam-unregistered-runtime-props.md
@@ -1,0 +1,7 @@
+---
+"e2b": patch
+---
+
+Fix the network transform IAM guard so unregistered token names that collide with runtime-probed properties (`then`, `toJSON`, `toString`, `valueOf`) are reported as unknown instead of silently resolving to a built-in. Serializing and stringifying the registered tokens still works.
+
+Fixes #1673

--- a/packages/js-sdk/src/sandbox/iam.ts
+++ b/packages/js-sdk/src/sandbox/iam.ts
@@ -108,14 +108,15 @@ export function iamTokenPlaceholders(
   }
 
   // `then` is never needed for serialization and must behave like any other
-  // unregistered name on read; the rest are installed as non-enumerable own
-  // methods so the runtime path works.
-  const runtimeMethods: Record<string, () => unknown> = {
-    toJSON: guardedRuntimeMethod('toJSON'),
-    toString: guardedRuntimeMethod('toString'),
-    valueOf: guardedRuntimeMethod('valueOf'),
-  }
-  for (const [name, method] of Object.entries(runtimeMethods)) {
+  // unregistered name on read; `toJSON`/`toString`/`valueOf` are installed as
+  // non-enumerable own methods so the runtime path works. A registered token
+  // can legitimately be named after one of these props, and in that case the
+  // registered placeholder wins: skip the guard so `iam.tokens[name]` still
+  // resolves to the placeholder and stays enumerable for serialization.
+  for (const name of ['toJSON', 'toString', 'valueOf'] as const) {
+    if (Object.hasOwn(tokens, name)) continue
+
+    const method = guardedRuntimeMethod(name)
     Object.defineProperty(tokensWithRuntimeProps, name, {
       value: method,
       enumerable: false,

--- a/packages/js-sdk/src/sandbox/iam.ts
+++ b/packages/js-sdk/src/sandbox/iam.ts
@@ -10,17 +10,9 @@ import { InvalidArgumentError } from '../errors'
  * leaves `'b}'` as literal text, and `{` lets a name close its own placeholder
  * and open another one, minting a token the caller never referenced. Control
  * characters are rejected separately because they cannot appear in an HTTP
- * header value at all — the API would answer with an opaque 400.
+  * header value at all, so the API would answer with an opaque 400.
  */
 const INVALID_IAM_TOKEN_NAME_CHARS = /[{}\p{Cc}]/u
-
-/**
- * Properties the language and the runtime read off any object they serialize,
- * await, or coerce to a string. A token is never named after them, so they
- * resolve normally instead of counting as a token reference — otherwise
- * `JSON.stringify(iam.tokens)` inside a callback would throw.
- */
-const RUNTIME_PROBED_PROPS = new Set(['toJSON', 'then', 'toString', 'valueOf'])
 
 /**
  * Reject a token name that cannot survive the placeholder grammar.
@@ -58,7 +50,7 @@ export function iamTokenPlaceholder(name: string): string {
  * an error here.
  *
  * `validate: false` is for the update-network endpoint, whose payload carries no
- * `iam` config — the sandbox's registered token names are not known client-side
+  * `iam` config, since the sandbox's registered token names are not known client-side
  * there, so any name resolves to its placeholder.
  */
 export function iamTokenPlaceholders(
@@ -70,7 +62,69 @@ export function iamTokenPlaceholders(
     tokens[name] = iamTokenPlaceholder(name)
   }
 
-  return new Proxy(tokens, {
+  const tokensWithRuntimeProps = tokens as Record<string, string | (() => unknown)>
+
+  let proxy: Record<string, string | (() => unknown)>
+  const unregistered = (name: string): never => {
+    const hint =
+      tokenNames.length === 0
+        ? `Pass it to Sandbox.create as iam: { tokens: { '${name}': Secret.iamToken({ audience, tokenType }) } }.`
+        : `Registered tokens: ${tokenNames.map((n) => `'${n}'`).join(', ')}.`
+
+    throw new InvalidArgumentError(
+      `Network transform references iam token '${name}', which is not registered. ${hint}`
+    )
+  }
+
+  // The runtime reads `toJSON`, `toString` and `valueOf` off the object to
+  // serialize / coerce it (`JSON.stringify(iam.tokens)`, `String(iam.tokens)`).
+  // Those reads are indistinguishable from a user's name lookup, so the
+  // methods are guarded: calling them as methods of the proxy keeps the
+  // runtime path working, but coercing the read value itself, the typo
+  // `` `Bearer ${iam.tokens.toString}` ``, raises like any other
+  // unregistered name.
+  const guardedRuntimeMethod = (name: string) => {
+    const method = function (this: unknown) {
+      if (this === proxy) {
+        if (name === 'toJSON') {
+          const result: Record<string, string> = {}
+          for (const key of Object.keys(tokens)) {
+            result[key] = tokens[key]
+          }
+          return result
+        }
+        return 'iam.tokens'
+      }
+      unregistered(name)
+    }
+    // Coercing the method itself must raise instead of emitting source text.
+    Object.defineProperty(method, 'toString', {
+      value: () => unregistered(name),
+    })
+    Object.defineProperty(method, Symbol.toPrimitive, {
+      value: () => unregistered(name),
+    })
+    return method
+  }
+
+  // `then` is never needed for serialization and must behave like any other
+  // unregistered name on read; the rest are installed as non-enumerable own
+  // methods so the runtime path works.
+  const runtimeMethods: Record<string, () => unknown> = {
+    toJSON: guardedRuntimeMethod('toJSON'),
+    toString: guardedRuntimeMethod('toString'),
+    valueOf: guardedRuntimeMethod('valueOf'),
+  }
+  for (const [name, method] of Object.entries(runtimeMethods)) {
+    Object.defineProperty(tokensWithRuntimeProps, name, {
+      value: method,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    })
+  }
+
+  proxy = new Proxy(tokensWithRuntimeProps, {
     get(target, prop, receiver) {
       if (
         typeof prop === 'string' &&
@@ -78,21 +132,12 @@ export function iamTokenPlaceholders(
         // members, so an unregistered token named `constructor` or `__proto__`
         // would resolve to a built-in instead of being reported. Python's
         // mapping treats them as missing too.
-        !Object.hasOwn(target, prop) &&
-        !RUNTIME_PROBED_PROPS.has(prop)
+        !Object.hasOwn(target, prop)
       ) {
         if (!validate) {
           return iamTokenPlaceholder(prop)
         }
-
-        const hint =
-          tokenNames.length === 0
-            ? `Pass it to Sandbox.create as iam: { tokens: { '${prop}': Secret.iamToken({ audience, tokenType }) } }.`
-            : `Registered tokens: ${tokenNames.map((name) => `'${name}'`).join(', ')}.`
-
-        throw new InvalidArgumentError(
-          `Network transform references iam token '${prop}', which is not registered. ${hint}`
-        )
+        unregistered(prop)
       }
 
       return Reflect.get(target, prop, receiver)
@@ -106,4 +151,8 @@ export function iamTokenPlaceholders(
       return Object.hasOwn(target, prop)
     },
   })
+
+  // The runtime methods live on the proxy but are never exposed as token
+  // placeholders, so the public shape stays `Record<string, string>`.
+  return proxy as unknown as Record<string, string>
 }

--- a/packages/js-sdk/tests/sandbox/networkTransform.test.ts
+++ b/packages/js-sdk/tests/sandbox/networkTransform.test.ts
@@ -189,6 +189,58 @@ test.for(['constructor', '__proto__', 'hasOwnProperty'])(
   }
 )
 
+test.for(['then', 'toJSON', 'toString', 'valueOf'])(
+  'transform callback rejects runtime-probed iam token name %s',
+  async (name: string) => {
+    // `then`, `toJSON`, `toString` and `valueOf` are properties the language
+    // runtime probes when it serializes or coerces an object. A reference to an
+    // unregistered token by one of those names must still be reported like any
+    // other missing token instead of silently returning a built-in (issue #1673).
+    await expect(
+      Sandbox.create('base', {
+        apiKey: TEST_API_KEY,
+        iam: { tokens: { aws: awsToken } },
+        network: {
+          rules: {
+            'api.internal.example.com': [
+              {
+                transform: ({ iam }) => ({
+                  headers: { Authorization: `Bearer ${iam.tokens[name]}` },
+                }),
+              },
+            ],
+          },
+        },
+      })
+    ).rejects.toThrowError(`iam token '${name}', which is not registered`)
+
+    expect(lastCreateBody).toBeUndefined()
+  }
+)
+
+test('transform callback can still serialize and stringify registered iam tokens', async () => {
+  await expect(
+    Sandbox.create('base', {
+      apiKey: TEST_API_KEY,
+      iam: { tokens: { aws: awsToken } },
+      network: {
+        rules: {
+          'api.internal.example.com': [
+            {
+              transform: ({ iam }) => ({
+                'X-Json': JSON.stringify(iam.tokens),
+                'X-String': String(iam.tokens),
+              }),
+            },
+          ],
+        },
+      },
+    })
+  ).resolves.toBeDefined()
+
+  expect(lastCreateBody).toBeDefined()
+})
+
 test('transform callback rejects an iam token when no iam config is set', async () => {
   await expect(
     Sandbox.create('base', {

--- a/packages/js-sdk/tests/sandbox/networkTransform.test.ts
+++ b/packages/js-sdk/tests/sandbox/networkTransform.test.ts
@@ -241,6 +241,35 @@ test('transform callback can still serialize and stringify registered iam tokens
   expect(lastCreateBody).toBeDefined()
 })
 
+test('transform callback keeps a registered token named after a runtime prop', async () => {
+  // A workload can register a token literally named `toJSON`, `toString` or
+  // `valueOf`. The runtime-guard methods must not shadow such a registered
+  // token: it has to resolve to its placeholder and stay enumerable.
+  await expect(
+    Sandbox.create('base', {
+      apiKey: TEST_API_KEY,
+      iam: { tokens: { toString: awsToken } },
+      network: {
+        rules: {
+          'api.internal.example.com': [
+            {
+              transform: ({ iam }) => ({
+                'X-Placeholder': iam.tokens.toString,
+                'X-Keys': Object.keys(iam.tokens).join(','),
+              }),
+            },
+          ],
+        },
+      },
+    })
+  ).resolves.toBeDefined()
+
+  const transform =
+    lastCreateBody?.network?.rules?.['api.internal.example.com']?.[0]?.transform
+  expect(transform?.['X-Placeholder']).toBe('${e2b.identity.tokens.toString}')
+  expect(transform?.['X-Keys']).toBe('toString')
+})
+
 test('transform callback rejects an iam token when no iam config is set', async () => {
   await expect(
     Sandbox.create('base', {


### PR DESCRIPTION
## What

Fixes #1673. The network transform guard exempted `then`, `toJSON`, `toString` and `valueOf` from the unknown-token check so the runtime could serialize and coerce the tokens object. That exemption also let a callback reference an unregistered token by one of those names (for example `iam.tokens.toString`) and silently resolve it to a built-in instead of reporting it as unknown.

## How

Install `toJSON`/`toString`/`valueOf` as non-enumerable own methods on the tokens object. They behave normally when called on the proxy (so `JSON.stringify`, `String` and template coercion of the object itself still work) but throw the same `InvalidArgumentError` as any other unknown name when the value itself is coerced. `then` is no longer exempted, so it behaves like any other unknown name on read.

## Verification

- Added regression tests in `packages/js-sdk/tests/sandbox/networkTransform.test.ts` (the new `then`/`toJSON`/`toString`/`valueOf` rejection cases plus a serialization/stringify sanity case).
- `oxlint`, `tsc --noEmit` and `vitest run tests/sandbox/networkTransform.test.ts` all pass.
- Added a changeset (patch).

This is a behavior fix only; no public API types change for callers.