### PR TITLE
docs: fix Dynatrace MCP server description

### DIFF
--- a/.changeset/fix-dynatrace-mcp-description.md
+++ b/.changeset/fix-dynatrace-mcp-description.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/python-sdk': patch
+---
+
+Fix the Dynatrace MCP server description in the generated SDK types.

--- a/packages/js-sdk/src/sandbox/mcp.d.ts
+++ b/packages/js-sdk/src/sandbox/mcp.d.ts
@@ -633,7 +633,7 @@ export interface DreamFactoryMCPServer {
  */
 export interface DuckDuckGo {}
 /**
- * This MCP Server allows interaction with the Dynatrace observability platform, brining real-time observability data directly into your development workflow.
+ * This MCP Server allows interaction with the Dynatrace observability platform, bringing real-time observability data directly into your development workflow.
  */
 export interface DynatraceMCPServer {
   oauthClientId: string

--- a/packages/python-sdk/e2b/sandbox/mcp.py
+++ b/packages/python-sdk/e2b/sandbox/mcp.py
@@ -1277,7 +1277,7 @@ class McpServer(TypedDict, closed=True):
     """
     dynatrace: NotRequired[Dynatrace]
     """
-    This MCP Server allows interaction with the Dynatrace observability platform, brining real-time observability data directly into your development workflow.
+    This MCP Server allows interaction with the Dynatrace observability platform, bringing real-time observability data directly into your development workflow.
     """
     e2b: NotRequired[E2b]
     """

--- a/spec/mcp-server.json
+++ b/spec/mcp-server.json
@@ -949,7 +949,7 @@
     },
     "dynatrace": {
       "title": "Dynatrace MCP Server",
-      "description": "This MCP Server allows interaction with the Dynatrace observability platform, brining real-time observability data directly into your development workflow.",
+      "description": "This MCP Server allows interaction with the Dynatrace observability platform, bringing real-time observability data directly into your development workflow.",
       "required": [
         "oauthClientId",
         "oauthClientSecret",


### PR DESCRIPTION
## Summary

- Fix `brining` to `bringing` in the Dynatrace MCP server schema.
- Sync the generated TypeScript and Python SDK types.
- Add patch changesets for both SDK packages.

## Testing

- `python -m json.tool spec/mcp-server.json`
- Regenerated the Python MCP types with `datamodel-code-generator==0.64.0`
- Verified that the source description matches the generated TypeScript and Python files
- `git diff --check`
