### PR TITLE
ci(js-sdk): install Playwright Chromium without `--with-deps`

### DIFF
--- a/.github/workflows/js_sdk_tests.yml
+++ b/.github/workflows/js_sdk_tests.yml
@@ -96,6 +96,17 @@ jobs:
           path: ${{ matrix.os == 'windows-latest' && '~/AppData/Local/ms-playwright' || '~/.cache/ms-playwright' }}
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
+      # `--with-deps` is deliberately omitted. It shells out to apt on Linux and
+      # to a DISM Media Foundation enable on Windows on every run, cache hit or
+      # not, which cost ~21m and ~4m30s respectively. The runner images already
+      # ship every shared library Chromium needs; the only packages
+      # `--with-deps` pulled in were CJK/Cyrillic fonts that the headless
+      # `browser` project never renders. Without it this step is a no-op once
+      # the cache above hits.
+      - name: Install Playwright Chromium
+        if: matrix.runtime == 'node'
+        run: pnpm run playwright:install
+
       # The unit bundle test and the Cloudflare deploy config fail in CI when
       # the build output is missing.
       - name: Test build

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -35,7 +35,7 @@
     "generate:volume-api": "openapi-typescript ../../spec/openapi-volumecontent.yml -x api_key --array-length --alphabetize --output src/volume/schema.gen.ts",
     "generate:mcp": "json2ts -i ./../../spec/mcp-server.json -o src/sandbox/mcp.d.ts --unreachableDefinitions --style.singleQuote --no-style.semi",
     "check-deps": "knip",
-    "pretest": "npx playwright install --with-deps chromium",
+    "playwright:install": "playwright install chromium",
     "test:bun": "bunx --bun vitest run --project unit --project connectionConfig --project template",
     "test:cf": "vitest run --config tests/runtimes/cloudflare/vitest.config.mts",
     "test:cf:deploy": "vitest run --config tests/runtimes/cloudflare-deploy/vitest.config.mts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes [SDK-339](https://linear.app/e2b/issue/SDK-339/js-sdk-node-ci-legs-spend-most-of-their-time-in-playwright-install). Related: [SDK-292](https://linear.app/e2b/issue/SDK-292/run-the-full-js-sdk-unit-test-suite-in-a-browser), which introduced the `browser` project this install serves.

## Problem

`packages/js-sdk/package.json` had a `pretest` hook running `npx playwright install --with-deps chromium`. `--with-deps` shells out to apt on Linux, and to a DISM Media Foundation enable on Windows, on **every** invocation — regardless of whether the workflow's Playwright browser cache hit. On one `Test JS SDK` run that hook was 90% of the Node leg:

| leg | step | time |
| --- | --- | --- |
| node / ubuntu-22.04 | `Run Node tests` total | 23m21s |
| | ↳ `pretest` (`--with-deps`) | **20m57s** |
| | ↳ `vitest run` (101 files, 100 passed) | 2m23s |
| node / windows-latest | `pretest` DISM Media Foundation enable | 4m31s |

The browser cache worked fine (`Cache hit for: playwright-Linux-1.55.1`, restored in 3s). The time went to apt: `apt-get update` 1m42s, then 18.4 MB fetched in 18m59s at 16.1 kB/s off a stalling Azure Ubuntu mirror (`fonts-wqy-zenhei` alone stalled 7m49s).

The mirror stall is transient; being on that path at all is the structural problem. Every shared library Chromium needs (`libnss3`, `libgbm1`, `libdrm2`, `libcairo2`, `xvfb`, …) was already `already the newest version` on the runner image — the only 9 new packages were CJK/Cyrillic fonts (`fonts-wqy-zenhei`, `fonts-ipafont-gothic`, `xfonts-*`) that the single headless `browser` test never renders. For comparison, in the same run the bun (2m44s), deno (2m41s) and cloudflare (2m1s) legs run the same test code with no Playwright `pretest`.

## Change

- `packages/js-sdk/package.json`: replace the `pretest` hook with an explicit `playwright:install` script (`playwright install chromium`, no `--with-deps`).
- `.github/workflows/js_sdk_tests.yml`: run it as its own step gated on `matrix.runtime == 'node'`, right after the existing browser-cache step, with a comment recording why `--with-deps` is omitted.

Moving it out of `pretest` also keeps it off every local `pnpm test`, including for contributors who never touch the browser project.

## Usage

CI installs the browser as a distinct, cache-backed step:

```yaml
      - name: Install Playwright Chromium
        if: matrix.runtime == 'node'
        run: pnpm run playwright:install
```

Locally, the `browser` project needs Chromium once per Playwright version:

```bash
cd packages/js-sdk
pnpm run playwright:install   # ~7s cold, ~0.8s once installed
pnpm test
```

Without it, the `browser` project fails with Playwright's own "Executable doesn't exist … run `playwright install`" message; the other projects (`unit`, `template`, `connectionConfig`) are unaffected.

## Verification

Run on this branch with no prior Playwright deps installed on the machine:

- `pnpm run playwright:install`: 6.5s cold (Chromium headless shell + ffmpeg, no apt), 0.78s as a no-op afterwards.
- `pnpm exec vitest run --project browser`: 1 passed. Chromium launches and drives a real sandbox without any `--with-deps` packages, confirming the fonts and libs weren't load-bearing.
- `pnpm build` + full `pnpm test`: 101 files, 99 passed / 1 skipped in 2m34s. The one failure is `tests/sandbox/network.test.ts > injected header is reflected by the httpbin sidecar`, which fails with `404: template 'httpbin' not found` — it needs a prebuilt `httpbin` template that this agent's API key doesn't have, unrelated to this change.
- `pnpm run format`, `pnpm run lint`, `pnpm run typecheck` clean for `packages/js-sdk` (the recursive root scripts fail only in `packages/python-sdk`, where `uv` isn't installed in this environment).
- `pnpm run check-deps` (knip) reports no new findings; `playwright` is still resolved as a used devDependency through the new script.

No changeset: this touches only dev tooling and CI, with no change to published behavior (the `pretest`/`playwright:install` scripts are inert for consumers of the package). The commit that originally added the hook, #977, likewise shipped without one.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2665a2d0-4269-4de2-9548-f82ff4ef69bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2665a2d0-4269-4de2-9548-f82ff4ef69bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

