### PR TITLE
feat(sdk): refresh the MCP server schema from Docker's MCP catalog

### DIFF
--- a/.changeset/mcp-catalog-refresh.md
+++ b/.changeset/mcp-catalog-refresh.md
@@ -3,28 +3,32 @@
 '@e2b/python-sdk': minor
 ---
 
-Refresh the MCP server schema from Docker's MCP catalog, which the `mcp` sandbox option is typed from. 52 servers are new — among them `curl`, `docker`, `ffmpeg`, `n8n`, `neo4j`, `temporal`, `playwright`, and 26 AWS servers — and every server's title and description now matches what the catalog publishes today.
+Refresh the MCP server schema from Docker's MCP catalog, which the `mcp` sandbox option is typed from. 52 servers are new — among them `curl`, `docker`, `ffmpeg`, `n8n`, `neo4j`, `temporal`, `proxmox`, `testkube`, `zen`, and 26 AWS servers — and every server's title and description now matches what the catalog publishes today.
 
 ```ts
 import { Sandbox } from 'e2b'
 
-const sandbox = await Sandbox.betaCreate({
+const sandbox = await Sandbox.create({
   mcp: {
     docker: {},
+    ffmpeg: {},
     n8n: { apiUrl: 'https://n8n.example.com/api/v1', apiKey: process.env.N8N_API_KEY! },
   },
 })
 ```
 
 ```python
+import os
+
 from e2b import Sandbox
 
-sandbox = Sandbox.beta_create(
+sandbox = Sandbox.create(
     mcp={
         "docker": {},
+        "ffmpeg": {},
         "n8n": {"apiUrl": "https://n8n.example.com/api/v1", "apiKey": os.environ["N8N_API_KEY"]},
     },
 )
 ```
 
-Six servers the catalog no longer publishes are gone from the type: `cdataConnectcloud`, `flexprice`, `postgres`, `root`, `tembo`, and `triplewhale`. Four more changed what they accept: `awsDiagram` takes `outputDir`, `context7` takes `apiKey`, `neo4jCypher` takes `schemaSampleSize`, and `onlyofficeDocspace` is down to `docspaceApiKey`. The configuration is still handed to the gateway as you write it, so a server the catalog dropped can be kept by casting past the type — whether it starts is up to the gateway.
+Some servers changed in ways that stop existing configuration from type-checking. Six the catalog no longer publishes are gone: `cdataConnectcloud`, `flexprice`, `postgres`, `root`, `tembo`, and `triplewhale`. `awsDiagram` and `context7` took no options before and now require one (`outputDir` and `apiKey`), so `awsDiagram: {}` and `context7: {}` need a value. `onlyofficeDocspace` is down to `baseUrl` and `docspaceApiKey`, having lost `docspaceAuthToken`, `docspacePassword`, `docspaceUsername`, `dynamic`, `origin`, `toolsets`, and `userAgent`. `neo4jCypher` gained `schemaSampleSize`. Configuration is still handed to the gateway as you write it, so a server the catalog dropped can be kept by casting past the type — whether it starts is up to the gateway.

--- a/.changeset/mcp-catalog-refresh.md
+++ b/.changeset/mcp-catalog-refresh.md
@@ -1,0 +1,30 @@
+---
+'e2b': minor
+'@e2b/python-sdk': minor
+---
+
+Refresh the MCP server schema from Docker's MCP catalog, which the `mcp` sandbox option is typed from. 52 servers are new — among them `curl`, `docker`, `ffmpeg`, `n8n`, `neo4j`, `temporal`, `playwright`, and 26 AWS servers — and every server's title and description now matches what the catalog publishes today.
+
+```ts
+import { Sandbox } from 'e2b'
+
+const sandbox = await Sandbox.betaCreate({
+  mcp: {
+    docker: {},
+    n8n: { apiUrl: 'https://n8n.example.com/api/v1', apiKey: process.env.N8N_API_KEY! },
+  },
+})
+```
+
+```python
+from e2b import Sandbox
+
+sandbox = Sandbox.beta_create(
+    mcp={
+        "docker": {},
+        "n8n": {"apiUrl": "https://n8n.example.com/api/v1", "apiKey": os.environ["N8N_API_KEY"]},
+    },
+)
+```
+
+Six servers the catalog no longer publishes are gone from the type: `cdataConnectcloud`, `flexprice`, `postgres`, `root`, `tembo`, and `triplewhale`. Four more changed what they accept: `awsDiagram` takes `outputDir`, `context7` takes `apiKey`, `neo4jCypher` takes `schemaSampleSize`, and `onlyofficeDocspace` is down to `docspaceApiKey`. The configuration is still handed to the gateway as you write it, so a server the catalog dropped can be kept by casting past the type — whether it starts is up to the gateway.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "fetch:api-spec": "./scripts/fetch-spec.sh api-spec",
     "fetch:envd-spec": "./scripts/fetch-spec.sh envd-spec",
     "fetch:volume-spec": "./scripts/fetch-spec.sh volume-api-spec",
+    "generate:mcp-spec": "uv run scripts/generate-mcp-spec.py && pnpm --recursive --if-present run generate:mcp",
     "lint": "pnpm --if-present --recursive run lint",
     "typecheck": "pnpm --if-present --recursive run typecheck",
     "format": "pnpm --if-present --recursive run format",

--- a/packages/js-sdk/src/sandbox/mcp.d.ts
+++ b/packages/js-sdk/src/sandbox/mcp.d.ts
@@ -6,48 +6,80 @@
  */
 
 export interface McpServer {
-  airtable?: AirtableMCPServer
+  airtable?: Airtable
   aks?: AzureKubernetesServiceAKS
-  apiGateway?: ApiGateway
-  apify?: ApifyMCPServer
-  arxiv?: ArXivMCPServer
+  alfresco?: Alfresco
+  amazonBedrockAgentcore?: AWSBedrockAgentCore
+  amazonKendraIndex?: AmazonKendraIndex
+  amazonNeptune?: AmazonNeptune
+  amazonQbusinessAnonymous?: AmazonQBusiness
+  apiGateway?: APIGateway
+  apify?: Apify
+  arm?: Arm
+  arxiv?: ArXiv
   astGrep?: AstGrep
   astraDb?: AstraDB
   astroDocs?: AstroDocs
-  atlan?: AtlanMCPServer
+  atlan?: Atlan
   atlasDocs?: AtlasDocs
   atlassian?: Atlassian
   audienseInsights?: AudienseInsights
+  awsApi?: AWSAPI
+  awsAppsync?: AWSAppSync
+  awsBedrockCustomModelImport?: AWSBedrockCustomModelImport
+  awsBedrockDataAutomation?: AWSBedrockDataAutomation
   awsCdk?: AWSCDK
-  awsCore?: AWSCoreMCPServer
+  awsCore?: AWSCore
+  awsDataprocessing?: AWSDataProcessing
   awsDiagram?: AWSDiagram
   awsDocumentation?: AWSDocumentation
+  awsHealthomics?: AWSHealthOmics
+  awsIotSitewise?: AWSIoTSiteWise
   awsKbRetrievalServer?: AWSKBRetrievalArchived
+  awsLocation?: AmazonLocationService
+  awsMsk?: AmazonMSK
+  awsPricing?: AWSPricing
   awsTerraform?: AWSTerraform
+  awslabsBillingCostManagement?: AWSBillingAndCostManagement
+  awslabsCcapi?: AWSCloudControlAPI
+  awslabsCfn?: AWSCloudFormation
+  awslabsCloudtrail?: AWSCloudTrail
+  awslabsCloudwatch?: AmazonCloudWatch
+  awslabsCloudwatchAppsignals?: AmazonCloudWatchApplicationSignals
+  awslabsCostExplorer?: AWSCostExplorer
+  awslabsDynamodb?: AmazonDynamoDB
+  awslabsElasticache?: AmazonElastiCache
+  awslabsIam?: AWSIAM
+  awslabsMemcached?: AmazonElastiCacheForMemcached
+  awslabsNovaCanvas?: AWSLabsNovaCanvas
+  awslabsRedshift?: AmazonRedshift
+  awslabsS3Tables?: AWSS3Tables
+  awslabsTimestreamForInfluxdb?: AmazonTimestreamForInfluxDB
+  awslabsValkey?: AmazonElastiCacheMemoryDBForValkey
   azure?: Azure
-  beagleSecurity?: BeagleSecurityMCPServer
+  beagleSecurity?: BeagleSecurity
   bitrefill?: Bitrefill
   box?: Box
   brave?: BraveSearch
   browserbase?: Browserbase
   buildkite?: Buildkite
-  camunda?: CamundaBPMProcessEngineMCPServer
-  cdataConnectcloud?: CDataConnectCloud
-  charmhealth?: CharmHealthMCPServer
+  camunda?: CamundaBPMProcessEngine
+  charmhealth?: CharmHealth
   chroma?: Chroma
   circleci?: CircleCI
-  clickhouse?: OfficialClickHouseMCPServer
+  clickhouse?: OfficialClickHouse
   close?: Close
-  cloudRun?: CloudRunMCP
+  cloudRun?: CloudRun
   cloudflareDocs?: CloudflareDocs
   cockroachdb?: CockroachDB
   codeInterpreter?: PythonInterpreter
   context7?: Context7
   couchbase?: Couchbase
-  cylera?: TheOfficialMCPServerForCylera
+  curl?: Curl
+  cylera?: Cylera
   cyreslabAiShodan?: Shodan
   dappier?: Dappier
-  dappierRemote?: DappierRemoteMCPServer
+  dappierRemote?: DappierRemote
   dart?: DartAI
   databaseServer?: MCPDatabaseServer
   databutton?: Databutton
@@ -56,26 +88,29 @@ export interface McpServer {
   desktopCommander?: DesktopCommander
   devhubCms?: DevHubCMS
   discord?: Discord
+  docker?: Docker
   dockerhub?: DockerHub
   dodoPayments?: DodoPayments
-  dreamfactory?: DreamFactoryMCPServer
-  duckduckgo?: DuckDuckGo
-  dynatrace?: DynatraceMCPServer
+  dotnetTypesExplorer?: NETTypesExplorer
+  dreamfactory?: DreamFactory
+  duckduckgo?: PrivateWebSearch
+  dynatrace?: Dynatrace
   e2b?: E2B
   edubase?: EduBase
-  effect?: EffectMCP
+  effect?: Effect
   elasticsearch?: Elasticsearch
-  elevenlabs?: ElevenlabsMCP
+  elevenlabs?: ElevenLabs
   everart?: EverArtArchived
   exa?: Exa
   explorium?: ExploriumB2BData
   fetch?: FetchReference
+  ffmpeg?: FFmpeg
   fibery?: Fibery
   filesystem?: FilesystemReference
   findADomain?: FindADomain
   firecrawl?: Firecrawl
-  firewalla?: FirewallaMCPServer
-  flexprice?: FlexPrice
+  firewalla?: Firewalla
+  geminiApiDocs?: GeminiAPIDocs
   git?: GitReference
   github?: GitHubArchived
   githubChat?: GitHubChat
@@ -83,21 +118,22 @@ export interface McpServer {
   gitlab?: GitLabArchived
   gitmcp?: GitMCP
   glif?: GlifApp
-  gmail?: GmailMCPServer
+  gmail?: Gmail
+  googleFlights?: GoogleFlights
   googleMaps?: GoogleMapsArchived
-  googleMapsComprehensive?: GoogleMapsComprehensiveMCP
+  googleMapsComprehensive?: GoogleMapsComprehensive
   grafana?: Grafana
   gyazo?: Gyazo
-  hackernews?: HackernewsMcp
+  hackernews?: HackerNews
   hackle?: Hackle
   handwritingOcr?: HandwritingOCR
-  hdx?: HumanitarianDataExchangeMCPServer
+  hdx?: HumanitarianDataExchange
   heroku?: Heroku
-  hostinger?: HostingerAPIMCPServer
-  hoverfly?: HoverflyMCPServer
+  hostinger?: HostingerAPI
+  hoverfly?: Hoverfly
   hubspot?: HubSpot
   huggingFace?: HuggingFace
-  hummingbot?: HummingbotMCPTradingAgent
+  hummingbot?: HummingbotTradingAgent
   husqvarnaAutomower?: HusqvarnaAutomower
   hyperbrowser?: Hyperbrowser
   hyperspell?: Hyperspell
@@ -105,46 +141,50 @@ export interface McpServer {
   inspektorGadget?: InspektorGadget
   javadocs?: Javadocs
   jetbrains?: JetBrains
-  kafkaSchemaReg?: KafkaSchemaRegistryMCP
+  kafkaSchemaReg?: KafkaSchemaRegistry
   kagisearch?: KagiSearch
-  keboola?: KeboolaMCPServer
+  keboola?: Keboola
   kong?: KongKonnect
-  kubectl?: KubectlMCPServer
+  kubectl?: Kubectl
   kubernetes?: Kubernetes
   lara?: LaraTranslate
   line?: LINE
-  linkedin?: LinkedInMCPServer
+  linkedin?: LinkedIn
   llmtxt?: LLMText
-  maestro?: MaestroMCPServer
+  maestro?: Maestro
   manifold?: Manifold
-  mapbox?: MapboxMCPServer
-  mapboxDevkit?: MapboxDeveloperMCPServer
+  mapbox?: Mapbox
+  mapboxDevkit?: MapboxDeveloper
   markdownify?: Markdownify
   markitdown?: Markitdown
-  mavenTools?: MavenToolsMCPServer
+  mavenTools?: MavenTools
   memory?: MemoryReference
   mercadoLibre?: MercadoLibre
   mercadoPago?: MercadoPago
-  metabase?: MetabaseMCP
+  metabase?: Metabase
   minecraftWiki?: MinecraftWiki
   mongodb?: MongoDB
   multiversxMx?: MultiversX
+  n8n?: N8N
   nasdaqDataLink?: NasdaqDataLink
   needle?: Needle
+  neo4j?: Neo4J
   neo4jCloudAuraApi?: Neo4JCloudAuraApi
   neo4jCypher?: Neo4JCypher
   neo4jDataModeling?: Neo4JDataModeling
   neo4jMemory?: Neo4JMemory
   neon?: Neon
+  nextDevtools?: NextJsDevTools
   nodeCodeSandbox?: NodeJsSandbox
   notion?: Notion
   novita?: Novita
   npmSentinel?: NPMSentinel
   obsidian?: Obsidian
-  oktaMcpFctr?: OktaMCPServer
-  omi?: OmiMcp
+  okta?: Okta
+  oktaMcpFctr?: Okta1
+  omi?: Omi
   onlyofficeDocspace?: ONLYOFFICEDocSpace
-  openapi?: OpenAPIToolkitForMCP
+  openapi?: OpenAPIToolkit
   openapiSchema?: OpenAPISchema
   openbnbAirbnb?: AirbnbSearch
   openmesh?: OpenMesh
@@ -154,85 +194,91 @@ export interface McpServer {
   openzeppelinStellar?: OpenZeppelinStellarContracts
   openzeppelinStylus?: OpenZeppelinStylusContracts
   opik?: Opik
-  opine?: OpineMCPServer
-  oracle?: OracleDatabaseMCPServer
+  opine?: Opine
+  oracle?: OracleDatabase
   ospMarketingTools?: OSPMarketingTools
   oxylabs?: Oxylabs
   paperSearch?: PaperSearch
   perplexityAsk?: Perplexity
   pia?: ProgramIntegrityAlliance
   pinecone?: PineconeAssistant
-  playwright?: ExecuteAutomationPlaywrightMCP
-  pluggedinMcpProxy?: PluggedInMCPProxy
+  playwright?: ExecuteAutomationPlaywright
+  pluggedinMcpProxy?: PluggedInProxy
   polarSignals?: PolarSignals
   pomodash?: PomoDash
-  postgres?: PostgreSQLReadonlyArchived
-  postman?: PostmanMCPServer
+  postman?: Postman
   prefEditor?: PrefEditor
   prometheus?: Prometheus
+  proxmox?: ProxmoxVE
   puppeteer?: PuppeteerArchived
   pythonRefactoring?: PythonRefactoringAssistant
-  quantconnect?: QuantConnectMCPServer
-  ramparts?: RampartsMCPSecurityScanner
+  quantconnect?: QuantConnect
+  ramparts?: RampartsSecurityScanner
   razorpay?: Razorpay
-  reddit?: McpReddit
+  reddit?: Reddit
   redis?: Redis
   redisCloud?: RedisCloud
   ref?: RefUpToDateDocs
   remote?: RemoteMCP
   render?: Render
-  resend?: SendEmails
+  resend?: Resend
   risken?: RISKEN
-  root?: RootIoVulnerabilityRemediationMCP
-  ros2?: WiseVisionROS2MCPServer
+  ros2?: WiseVisionROS2
   rube?: Rube
-  rustMcpFilesystem?: BlazingFastAsynchronousMCPServerForSeamlessFilesystemOperations
+  rustMcpFilesystem?: RustFilesystem
   schemacrawlerAi?: SchemaCrawlerAI
-  schoginiMcpImageBorder?: SchoginiMCPImageBorder
+  schoginiMcpImageBorder?: SchoginiImageBorder
   scrapegraph?: ScrapeGraph
   scrapezy?: Scrapezy
-  securenoteLink?: SecurenoteLinkMcpServer
+  securenoteLink?: SecurenoteLink
   semgrep?: Semgrep
   sentry?: SentryArchived
   sequa?: SequaAI
   sequentialthinking?: SequentialThinkingReference
   shortIo?: ShortIo
-  simplechecklist?: SimpleCheckListMCPServer
+  simplechecklist?: SimpleCheckList
   singlestore?: Singlestore
   slack?: SlackArchived
-  smartbear?: SmartBearMCPServer
+  smartbear?: SmartBear
   sonarqube?: SonarQube
   sqlite?: SQLiteArchived
   stackgen?: StackGen
   stackhawk?: StackHawk
   stripe?: Stripe
   supadata?: Supadata
-  suzieq?: SuzieqMCP
+  suzieq?: Suzieq
   taskOrchestrator?: TaskOrchestrator
   tavily?: Tavily
   teamwork?: Teamwork
   telnyx?: Telnyx
-  tembo?: Tembo
+  temporal?: Temporal
   terraform?: HashicorpTerraform
+  testkube?: Testkube
   textToGraphql?: TextToGraphQL
+  thingsboard?: ThingsBoard
   tigris?: TigrisData
   time?: TimeReference
-  triplewhale?: Triplewhale
-  unrealEngine?: UnrealEngineMCPServer
+  unrealEngine?: UnrealEngine
+  vectraAiRux?: VectraAIRUXMCPServer
   veyrax?: VeyraX
+  victorialogs?: VictoriaLogs
+  victoriametrics?: VictoriaMetrics
+  victoriatraces?: VictoriaTraces
   vizro?: Vizro
-  vulnNist?: VulnNistMcpServer
-  wayfound?: WayfoundMCP
+  vulnNist?: VulnNIST
+  wayfound?: Wayfound
   webflow?: Webflow
   wikipedia?: Wikipedia
   wolframAlpha?: WolframAlpha
   youtubeTranscript?: YouTubeTranscripts
+  zen?: Zen
   zerodhaKite?: ZerodhaKiteConnect
+  zscaler?: Zscaler
 }
 /**
  * Provides AI assistants with direct access to Airtable bases, allowing them to read schemas, query records, and interact with your Airtable data. Supports listing bases, retrieving table structures, and searching through records to help automate workflows and answer questions about your organized data.
  */
-export interface AirtableMCPServer {
+export interface Airtable {
   airtableApiKey: string
   nodeenv: string
 }
@@ -266,9 +312,46 @@ export interface AzureKubernetesServiceAKS {
   kubeconfig: string
 }
 /**
+ * A minimal Model Context Protocol (MCP) server for Alfresco providing tools via the Alfresco REST API.
+ */
+export interface Alfresco {
+  alfrescoHost: string
+}
+/**
+ * Documentation on AgentCore platform services.
+ */
+export interface AWSBedrockAgentCore {}
+/**
+ * Enterprise search and RAG enhancement.
+ */
+export interface AmazonKendraIndex {
+  awsProfile?: string
+  awsRegion?: string
+  kendraIndexId: string
+}
+/**
+ * Graph database queries with Cypher and Gremlin.
+ */
+export interface AmazonNeptune {
+  awsProfile?: string
+  awsRegion?: string
+  neptuneEndpoint: string
+}
+/**
+ * AI assistant for ingested content with anonymous access.
+ */
+export interface AmazonQBusiness {
+  awsAccessKeyId?: string
+  awsProfile?: string
+  awsRegion?: string
+  awsSecretAccessKey?: string
+  awsSessionToken?: string
+  qbusinessApplicationId: string
+}
+/**
  * A universal MCP (Model Context Protocol) server to integrate any API with Claude Desktop using only Docker configurations.
  */
-export interface ApiGateway {
+export interface APIGateway {
   api1HeaderAuthorization: string
   api1Name: string
   api1SwaggerUrl: string
@@ -276,7 +359,7 @@ export interface ApiGateway {
 /**
  * Apify is the world's largest marketplace of tools for web scraping, data extraction, and web automation. You can extract structured data from social media, e-commerce, search engines, maps, travel sites, or any other website.
  */
-export interface ApifyMCPServer {
+export interface Apify {
   apifyToken: string
   /**
    * Comma-separated list of tools to enable. Can be either a tool category, a specific tool, or an Apify Actor. For example: "actors,docs,apify/rag-web-browser". For more details visit https://mcp.apify.com.
@@ -284,9 +367,23 @@ export interface ApifyMCPServer {
   tools: string
 }
 /**
+ * Provides AI assistants with specialized tools for Arm architecture development, migration, optimization, and profiling. Includes knowledge base search, code migration analysis, container architecture inspection, Arm Performix workload profiling, and assembly performance analysis.
+ */
+export interface Arm {
+  /**
+   * Optional path to an SSH known_hosts file for Arm Performix remote target access
+   */
+  sshKnownHostsPath?: string
+  /**
+   * Optional path to an SSH private key for Arm Performix remote target access
+   */
+  sshPrivateKeyPath?: string
+  workspacePath: string
+}
+/**
  * The ArXiv MCP Server provides a comprehensive bridge between AI assistants and arXiv's research repository through the Model Context Protocol (MCP).   Features: • Search arXiv papers with advanced filtering • Download and store papers locally as markdown • Read and analyze paper content • Deep research analysis prompts • Local paper management and storage • Enhanced tool descriptions optimized for local AI models • Docker MCP Gateway compatible with detailed context  Perfect for researchers, academics, and AI assistants conducting literature reviews and research analysis.  **Recent Update**: Enhanced tool descriptions specifically designed to resolve local AI model confusion and improve Docker MCP Gateway compatibility.
  */
-export interface ArXivMCPServer {
+export interface ArXiv {
   /**
    * Directory path where downloaded papers will be stored
    */
@@ -312,7 +409,7 @@ export interface AstroDocs {}
 /**
  * MCP server for interacting with Atlan services including asset search, updates, and lineage traversal for comprehensive data governance and discovery.
  */
-export interface AtlanMCPServer {
+export interface Atlan {
   apiKey: string
   baseUrl: string
 }
@@ -344,21 +441,83 @@ export interface AudienseInsights {
   twitterBearerToken?: string
 }
 /**
+ * Comprehensive AWS API support with command validation and access to all services.
+ */
+export interface AWSAPI {
+  awsAccessKeyId: string
+  awsProfileName: string
+  awsRegion: string
+  awsSecretAccessKey: string
+  awsSessionToken: string
+}
+/**
+ * Manage applications powered by AWS AppSync.
+ */
+export interface AWSAppSync {
+  awsAccessKeyId: string
+  awsProfile: string
+  awsRegion: string
+  awsSecretAccessKey: string
+  awsSessionToken: string
+}
+/**
+ * Manage custom models in Bedrock.
+ */
+export interface AWSBedrockCustomModelImport {
+  awsAccessKeyId: string
+  awsProfile: string
+  awsRegion: string
+  awsSecretAccessKey: string
+  awsSessionToken: string
+  bedrockModelImportS3Bucket: string
+}
+/**
+ * Analyze documents, images, videos, and audio.
+ */
+export interface AWSBedrockDataAutomation {
+  awsBucketName: string
+  awsProfile?: string
+  awsRegion?: string
+}
+/**
  * AWS Cloud Development Kit (CDK) best practices, infrastructure as code patterns, and security compliance with CDK Nag.
  */
 export interface AWSCDK {}
 /**
  * Starting point for using the awslabs MCP servers.
  */
-export interface AWSCoreMCPServer {}
+export interface AWSCore {}
+/**
+ * Data processing and transformation services.
+ */
+export interface AWSDataProcessing {
+  awsProfile: string
+  awsRegion: string
+}
 /**
  * Seamlessly create diagrams using the Python diagrams package DSL. This server allows you to generate AWS diagrams, sequence diagrams, flow diagrams, and class diagrams using Python code.
  */
-export interface AWSDiagram {}
+export interface AWSDiagram {
+  outputDir: string
+}
 /**
  * Tools to access AWS documentation, search for content, and get recommendations.
  */
 export interface AWSDocumentation {}
+/**
+ * Generate, run, debug lifescience workflows.
+ */
+export interface AWSHealthOmics {
+  awsProfile: string
+  awsRegion: string
+}
+/**
+ * Industrial IoT asset management.
+ */
+export interface AWSIoTSiteWise {
+  awsProfile: string
+  awsRegion: string
+}
 /**
  * An MCP server implementation for retrieving information from the AWS Knowledge Base using the Bedrock Agent Runtime.
  */
@@ -367,17 +526,175 @@ export interface AWSKBRetrievalArchived {
   awsSecretAccessKey?: string
 }
 /**
+ * Place search, geocoding, and route optimization.
+ */
+export interface AmazonLocationService {
+  awsAccessKeyId: string
+  awsProfile: string
+  awsRegion: string
+  awsSecretAccessKey: string
+  awsSessionToken: string
+}
+/**
+ * Managed Kafka cluster operations.
+ */
+export interface AmazonMSK {
+  awsAccessKeyId: string
+  awsProfile: string
+  awsRegion: string
+  awsSecretAccessKey: string
+  awsSessionToken: string
+}
+/**
+ * AWS service pricing and cost estimates.
+ */
+export interface AWSPricing {
+  awsAccessKeyId: string
+  awsProfile: string
+  awsRegion: string
+  awsSecretAccessKey: string
+  awsSessionToken: string
+}
+/**
  * Terraform on AWS best practices, infrastructure as code patterns, and security compliance with Checkov.
  */
 export interface AWSTerraform {}
 /**
- * The Azure MCP Server, bringing the power of Azure to your agents.
+ * Billing and cost management.
+ */
+export interface AWSBillingAndCostManagement {
+  awsProfile: string
+  awsRegion: string
+  storageLensManifestLocation: string
+}
+/**
+ * Direct resource management with security scanning.
+ */
+export interface AWSCloudControlAPI {
+  awsAccessKeyId: string
+  awsProfile: string
+  awsRegion: string
+  awsSecretAccessKey: string
+}
+/**
+ * CloudFormation resource management via Cloud Control API.
+ */
+export interface AWSCloudFormation {
+  awsAccessKeyId: string
+  awsProfile: string
+  awsRegion: string
+  awsSecretAccessKey: string
+  awsSessionToken: string
+}
+/**
+ * AWS CloudTrail audit logging and monitoring.
+ */
+export interface AWSCloudTrail {
+  awsProfile: string
+}
+/**
+ * Metrics, alarms, and logs analysis.
+ */
+export interface AmazonCloudWatch {
+  awsProfile: string
+  awsRegion: string
+}
+/**
+ * Application performance monitoring and insights.
+ */
+export interface AmazonCloudWatchApplicationSignals {
+  awsProfile: string
+  awsRegion: string
+}
+/**
+ * Detailed cost analysis and reporting.
+ */
+export interface AWSCostExplorer {
+  awsAccessKeyId: string
+  awsProfile: string
+  awsRegion: string
+  awsSecretAccessKey: string
+  awsSessionToken: string
+}
+/**
+ * Complete DynamoDB operations and table management.
+ */
+export interface AmazonDynamoDB {
+  awsProfile: string
+  awsRegion: string
+}
+/**
+ * ElastiCache control plane operations.
+ */
+export interface AmazonElastiCache {
+  awsProfile: string
+  awsRegion: string
+}
+/**
+ * IAM user, role, group, and policy management.
+ */
+export interface AWSIAM {
+  awsAccessKeyId: string
+  awsProfile: string
+  awsRegion: string
+  awsSecretAccessKey: string
+}
+/**
+ * High-speed caching with Memcached.
+ */
+export interface AmazonElastiCacheForMemcached {
+  memcachedHost: string
+  memcachedPort?: string
+}
+/**
+ * AI image generation using Amazon Nova Canvas.
+ */
+export interface AWSLabsNovaCanvas {
+  awsAccessKeyId: string
+  awsProfile: string
+  awsRegion: string
+  awsSecretAccessKey: string
+  awsSessionToken: string
+}
+/**
+ * Data warehouse operations and queries.
+ */
+export interface AmazonRedshift {
+  awsProfile: string
+  awsRegion: string
+}
+/**
+ * Manage S3 Tables for analytics.
+ */
+export interface AWSS3Tables {
+  awsAccessKeyId: string
+  awsProfile: string
+  awsRegion: string
+  awsSecretAccessKey: string
+  awsSessionToken: string
+}
+/**
+ * Time-series database operations.
+ */
+export interface AmazonTimestreamForInfluxDB {
+  awsProfile: string
+  awsRegion: string
+}
+/**
+ * Advanced data structures with Valkey.
+ */
+export interface AmazonElastiCacheMemoryDBForValkey {
+  valkeyHost: string
+  valkeyPort: string
+}
+/**
+ * Catalog of official Microsoft MCP (Model Context Protocol) server implementations for AI-powered data access and tool integration.
  */
 export interface Azure {}
 /**
  * Connects with the Beagle Security backend using a user token to manage applications, run automated security tests, track vulnerabilities across environments, and gain intelligence from Application and API vulnerability data.
  */
-export interface BeagleSecurityMCPServer {
+export interface BeagleSecurity {
   beagleSecurityApiToken: string
 }
 /**
@@ -417,20 +734,13 @@ export interface Buildkite {
 /**
  * Tools to interact with the Camunda 7 Community Edition Engine using the Model Context Protocol (MCP). Whether you're automating workflows, querying process instances, or integrating with external systems, Camunda MCP Server is your agentic solution for seamless interaction with Camunda.
  */
-export interface CamundaBPMProcessEngineMCPServer {
+export interface CamundaBPMProcessEngine {
   camundahost: string
-}
-/**
- * This fully functional MCP Server allows you to connect to any data source in Connect Cloud from Claude Desktop.
- */
-export interface CDataConnectCloud {
-  cdataPat?: string
-  username: string
 }
 /**
  * An MCP server for CharmHealth EHR that allows LLMs and MCP clients to interact with patient records, encounters, and practice information.
  */
-export interface CharmHealthMCPServer {
+export interface CharmHealth {
   charmhealthApiKey: string
   charmhealthBaseUrl: string
   charmhealthClientId: string
@@ -455,7 +765,7 @@ export interface CircleCI {
 /**
  * Official ClickHouse MCP Server.
  */
-export interface OfficialClickHouseMCPServer {
+export interface OfficialClickHouse {
   connectTimeout: string
   host: string
   password: string
@@ -474,7 +784,7 @@ export interface Close {
 /**
  * MCP server to deploy apps to Cloud Run.
  */
-export interface CloudRunMCP {
+export interface CloudRun {
   /**
    * path to application-default credentials (eg $HOME/.config/gcloud/application_default_credentials.json )
    */
@@ -503,9 +813,11 @@ export interface CockroachDB {
  */
 export interface PythonInterpreter {}
 /**
- * Context7 MCP Server -- Up-to-date code documentation for LLMs and AI code editors.
+ * Pull up-to-date, version-specific documentation and code examples for any library or framework straight into your prompt.
  */
-export interface Context7 {}
+export interface Context7 {
+  apiKey: string
+}
 /**
  * Couchbase is a distributed document database with a powerful search engine and in-built operational and analytical capabilities.
  */
@@ -529,9 +841,13 @@ export interface Couchbase {
   cbUsername: string
 }
 /**
+ * Standard curl tool.
+ */
+export interface Curl {}
+/**
  * Brings context about device inventory, threats, risks and utilization powered by the Cylera Partner API into an LLM.
  */
-export interface TheOfficialMCPServerForCylera {
+export interface Cylera {
   cyleraBaseUrl: string
   cyleraPassword: string
   cyleraUsername: string
@@ -551,7 +867,7 @@ export interface Dappier {
 /**
  * Enable fast, free real-time web search and access premium data from trusted media brands—news, financial markets, sports, entertainment, weather, and more. Build powerful AI agents with Dappier.
  */
-export interface DappierRemoteMCPServer {
+export interface DappierRemote {
   dappierRemoteApiKey: string
 }
 /**
@@ -609,6 +925,10 @@ export interface Discord {
   discordToken: string
 }
 /**
+ * Use the Docker CLI.
+ */
+export interface Docker {}
+/**
  * Docker Hub official MCP server.
  */
 export interface DockerHub {
@@ -622,20 +942,24 @@ export interface DodoPayments {
   dodoPaymentsApiKey: string
 }
 /**
+ * Provides detailed type information from .NET projects including assembly exploration, namespace discovery, type reflection, and NuGet integration for AI coding agents.
+ */
+export interface NETTypesExplorer {}
+/**
  * DreamFactory is a REST API generation platform with support for hundreds of data sources, including Microsoft SQL Server, MySQL, PostgreSQL, and MongoDB. The DreamFactory MCP Server makes it easy for users to securely interact with their data sources via an MCP client.
  */
-export interface DreamFactoryMCPServer {
+export interface DreamFactory {
   dreamfactoryapikey: string
   dreamfactoryurl: string
 }
 /**
- * A Model Context Protocol (MCP) server that provides web search capabilities through DuckDuckGo, with additional features for content fetching and parsing.
+ * Community-maintained server for DuckDuckGo search. Not published by or affiliated with DuckDuckGo.
  */
-export interface DuckDuckGo {}
+export interface PrivateWebSearch {}
 /**
  * This MCP Server allows interaction with the Dynatrace observability platform, brining real-time observability data directly into your development workflow.
  */
-export interface DynatraceMCPServer {
+export interface Dynatrace {
   oauthClientId: string
   oauthClientSecret: string
   url: string
@@ -657,7 +981,7 @@ export interface EduBase {
 /**
  * Tools and resources for writing Effect code in Typescript.
  */
-export interface EffectMCP {}
+export interface Effect {}
 /**
  * Interact with your Elasticsearch indices through natural language conversations.
  */
@@ -668,7 +992,7 @@ export interface Elasticsearch {
 /**
  * Official ElevenLabs Model Context Protocol (MCP) server that enables interaction with powerful Text to Speech and audio processing APIs.
  */
-export interface ElevenlabsMCP {
+export interface ElevenLabs {
   apiKey?: string
   data: string
 }
@@ -694,6 +1018,10 @@ export interface ExploriumB2BData {
  * Fetches a URL from the internet and extracts its contents as markdown.
  */
 export interface FetchReference {}
+/**
+ * Use ffmpeg to process video files.
+ */
+export interface FFmpeg {}
 /**
  * Interact with your Fibery workspace.
  */
@@ -727,7 +1055,7 @@ export interface Firecrawl {
 /**
  * Real-time network monitoring, security analysis, and firewall management through 28 specialized tools. Access security alerts, network flows, device status, and firewall rules directly from your Firewalla device.
  */
-export interface FirewallaMCPServer {
+export interface Firewalla {
   /**
    * Your Firewalla Box Global ID
    */
@@ -739,12 +1067,9 @@ export interface FirewallaMCPServer {
   mspId: string
 }
 /**
- * Official flexprice MCP Server.
+ * Provides tools to search and retrieve Google Gemini API documentation.
  */
-export interface FlexPrice {
-  apiKey: string
-  baseUrl: string
-}
+export interface GeminiAPIDocs {}
 /**
  * Git repository interaction and automation.
  */
@@ -784,7 +1109,7 @@ export interface GitLabArchived {
  */
 export interface GitMCP {}
 /**
- * Easily run glif.app AI workflows inside your LLM: image generators, memes, selfies, and more. Glif supports all major multimedia AI models inside one app.
+ * Deprecated — use the hosted Glif MCP server at https://glif.app/mcp.
  */
 export interface GlifApp {
   apiToken: string
@@ -794,13 +1119,17 @@ export interface GlifApp {
 /**
  * A Model Context Protocol server for Gmail operations using IMAP/SMTP with app password authentication. Supports listing messages, searching emails, and sending messages. To create your app password, visit your Google Account settings under Security > App Passwords. Or visit the link https://myaccount.google.com/apppasswords.
  */
-export interface GmailMCPServer {
+export interface Gmail {
   /**
    * Your Gmail email address
    */
   emailAddress: string
   emailPassword?: string
 }
+/**
+ * Interact with Google Flights data to search for one-way, round-trip, and date range flight options between airports.
+ */
+export interface GoogleFlights {}
 /**
  * Tools for interacting with the Google Maps API.
  */
@@ -810,7 +1139,7 @@ export interface GoogleMapsArchived {
 /**
  * Complete Google Maps integration with 8 tools including geocoding, places search, directions, elevation data, and more using Google's latest APIs.
  */
-export interface GoogleMapsComprehensiveMCP {
+export interface GoogleMapsComprehensive {
   googleMapsApiKey: string
 }
 /**
@@ -829,7 +1158,7 @@ export interface Gyazo {
 /**
  * A Model Context Protocol (MCP) server that provides access to Hacker News stories, comments, and user data, with support for search and content retrieval.
  */
-export interface HackernewsMcp {}
+export interface HackerNews {}
 /**
  * Model Context Protocol server for Hackle.
  */
@@ -845,7 +1174,7 @@ export interface HandwritingOCR {
 /**
  * HDX MCP Server provides access to humanitarian data through the Humanitarian Data Exchange (HDX) API - https://data.humdata.org/hapi. This server offers 33 specialized tools for retrieving humanitarian information including affected populations (refugees, IDPs, returnees), baseline demographics, food security indicators, conflict data, funding information, and operational presence across hundreds of countries and territories. See repository for instructions on getting a free HDX_APP_INDENTIFIER for access.
  */
-export interface HumanitarianDataExchangeMCPServer {
+export interface HumanitarianDataExchange {
   appIdentifier: string
 }
 /**
@@ -857,13 +1186,13 @@ export interface Heroku {
 /**
  * Interact with Hostinger services over the Hostinger API.
  */
-export interface HostingerAPIMCPServer {
+export interface HostingerAPI {
   apitoken: string
 }
 /**
  * A Model Context Protocol (MCP) server that exposes Hoverfly as a programmable tool for AI assistants like Cursor, Claude, GitHub Copilot, and others supporting MCP. It enables dynamic mocking of third-party APIs to unblock development, automate testing, and simulate unavailable services during integration.
  */
-export interface HoverflyMCPServer {
+export interface Hoverfly {
   data: string
 }
 /**
@@ -879,7 +1208,7 @@ export interface HuggingFace {}
 /**
  * Hummingbot MCP is an open-source toolset that lets you control and monitor your Hummingbot trading bots through AI-powered commands and automation.
  */
-export interface HummingbotMCPTradingAgent {
+export interface HummingbotTradingAgent {
   apiUrl: string
   hummingbotApiPassword?: string
   hummingbotApiUsername?: string
@@ -938,7 +1267,7 @@ export interface JetBrains {
 /**
  * Comprehensive MCP server for Kafka Schema Registry operations. Features multi-registry support, schema contexts, migration tools, OAuth authentication, and 57+ tools for complete schema management. Supports SLIM_MODE for optimal performance.
  */
-export interface KafkaSchemaRegistryMCP {
+export interface KafkaSchemaRegistry {
   /**
    * Schema Registry URL
    */
@@ -955,7 +1284,7 @@ export interface KafkaSchemaRegistryMCP {
   viewonly?: string
 }
 /**
- * The Official Model Context Protocol (MCP) server for Kagi search & other tools.
+ * The Official Model Context Protocol (MCP) server for Kagi Search & other tools.
  */
 export interface KagiSearch {
   engine: string
@@ -964,7 +1293,7 @@ export interface KagiSearch {
 /**
  * Keboola MCP Server is an open-source bridge between your Keboola project and modern AI tools.
  */
-export interface KeboolaMCPServer {
+export interface Keboola {
   kbcStorageToken: string
   kbcWorkspaceSchema: string
 }
@@ -978,7 +1307,7 @@ export interface KongKonnect {
 /**
  * MCP Server that enables AI assistants to interact with Kubernetes clusters via kubectl operations.
  */
-export interface KubectlMCPServer {
+export interface Kubectl {
   kubeconfig: string
 }
 /**
@@ -1007,7 +1336,7 @@ export interface LINE {
 /**
  * This MCP server allows Claude and other AI assistants to access your LinkedIn. Scrape LinkedIn profiles and companies, get your recommended jobs, and perform job searches. Set your li_at LinkedIn cookie to use this server.
  */
-export interface LinkedInMCPServer {
+export interface LinkedIn {
   linkedinCookie: string
   /**
    * Custom user agent string (optional, helps avoid detection and cookie login issues)
@@ -1021,7 +1350,7 @@ export interface LLMText {}
 /**
  * A Model Context Protocol (MCP) server exposing Bitcoin blockchain data through the Maestro API platform. Provides tools to explore blocks, transactions, addresses, inscriptions, runes, and other metaprotocol data.
  */
-export interface MaestroMCPServer {
+export interface Maestro {
   apiKeyApiKey: string
 }
 /**
@@ -1031,13 +1360,13 @@ export interface Manifold {}
 /**
  * Transform any AI agent into a geospatially-aware system with Mapbox APIs. Provides geocoding, POI search, routing, travel time matrices, isochrones, and static map generation.
  */
-export interface MapboxMCPServer {
+export interface Mapbox {
   accessToken: string
 }
 /**
  * Direct access to Mapbox developer APIs for AI assistants. Enables style management, token management, GeoJSON preview, and other developer tools for building Mapbox applications.
  */
-export interface MapboxDeveloperMCPServer {
+export interface MapboxDeveloper {
   mapboxAccessToken: string
 }
 /**
@@ -1055,7 +1384,7 @@ export interface Markitdown {
 /**
  * JVM dependency intelligence for any build tool using Maven Central Repository. Includes Context7 integration for upgrade documentation and guidance.
  */
-export interface MavenToolsMCPServer {}
+export interface MavenTools {}
 /**
  * Knowledge graph-based persistent memory system.
  */
@@ -1075,7 +1404,7 @@ export interface MercadoPago {
 /**
  * A comprehensive MCP server for Metabase with 70+ tools.
  */
-export interface MetabaseMCP {
+export interface Metabase {
   apiKey: string
   metabaseurl: string
   metabaseusername: string
@@ -1099,6 +1428,16 @@ export interface MultiversX {
   wallet: string
 }
 /**
+ * Bridges n8n's workflow automation platform with AI models, providing access to 543 n8n nodes, workflow templates, and AI-capable automation tools.
+ */
+export interface N8N {
+  apiKey: string
+  /**
+   * The URL of your n8n instance (use http://host.docker.internal:5678 for local instances)
+   */
+  apiUrl: string
+}
+/**
  * MCP server to interact with the data feeds provided by the Nasdaq Data Link. Developed by the community and maintained by Stefano Amorelli.
  */
 export interface NasdaqDataLink {
@@ -1109,6 +1448,17 @@ export interface NasdaqDataLink {
  */
 export interface Needle {
   needleApiKey: string
+}
+/**
+ * Official MCP server for Neo4j. Interact with Neo4j using Cypher graph queries.
+ */
+export interface Neo4J {
+  database: string
+  password: string
+  readOnly: boolean
+  telemetry: boolean
+  uri: string
+  username: string
 }
 /**
  * Manage Neo4j Aura database instances through the Neo4j Aura API.
@@ -1133,6 +1483,7 @@ export interface Neo4JCypher {
   readOnly?: boolean
   readTimeout?: string
   responseTokenLimit?: string
+  schemaSampleSize?: string
   serverAllowOrigins?: string
   serverAllowedHosts?: string
   serverHost?: string
@@ -1175,6 +1526,10 @@ export interface Neon {
   apiKey: string
 }
 /**
+ * next-devtools-mcp is a Model Context Protocol (MCP) server that provides Next.js development tools and utilities for AI coding assistants.
+ */
+export interface NextJsDevTools {}
+/**
  * A Node.js–based Model Context Protocol server that spins up disposable Docker containers to execute arbitrary JavaScript.
  */
 export interface NodeJsSandbox {}
@@ -1199,9 +1554,21 @@ export interface Obsidian {
   apiKey: string
 }
 /**
+ * ## :tada: __It's Official__ :tada: The Okta Open-Source MCP Server integrates with LLMs and AI agents, allowing you to perform various Okta management operations using natural language and is Generally Available (GA).
+ */
+export interface Okta {
+  logPath: string
+  oktaClientId: string
+  oktaKeyId: string
+  oktaLogLevel: string
+  oktaOrgUrl: string
+  oktaPrivateKey: string
+  oktaScopes: string
+}
+/**
  * Secure Okta identity and access management via Model Context Protocol (MCP). Access Okta users, groups, applications, logs, and policies through AI assistants with enterprise-grade security.
  */
-export interface OktaMCPServer {
+export interface Okta1 {
   /**
    * Okta organization URL (e.g., https://dev-123456.okta.com)
    */
@@ -1219,7 +1586,7 @@ export interface OktaMCPServer {
 /**
  * A Model Context Protocol server for Omi interaction and automation. This server provides tools to read, search, and manipulate Memories and Conversations.
  */
-export interface OmiMcp {
+export interface Omi {
   apiKey: string
 }
 /**
@@ -1228,18 +1595,11 @@ export interface OmiMcp {
 export interface ONLYOFFICEDocSpace {
   baseUrl: string
   docspaceApiKey: string
-  docspaceAuthToken: string
-  docspacePassword: string
-  docspaceUsername: string
-  dynamic: boolean
-  origin: string
-  toolsets: string
-  userAgent: string
 }
 /**
  * Fetch, validate, and generate code or curl from any OpenAPI or Swagger spec - all from a single URL.
  */
-export interface OpenAPIToolkitForMCP {
+export interface OpenAPIToolkit {
   mode: string
 }
 /**
@@ -1279,7 +1639,7 @@ export interface OpenZeppelinStellarContracts {}
  */
 export interface OpenZeppelinStylusContracts {}
 /**
- * Model Context Protocol (MCP) implementation for Opik enabling seamless IDE integration and unified access to prompts, projects, traces, and metrics.
+ * Model Context Protocol (MCP) server for Opik, the open-source LLM observability and evaluation platform, built by Comet. Read traces, log scores, and manage prompts from Claude Code, Cursor, or VS Code.
  */
 export interface Opik {
   apiBaseUrl: string
@@ -1289,13 +1649,13 @@ export interface Opik {
 /**
  * A Model Context Protocol (MCP) server for querying deals and evaluations from the Opine CRM API.
  */
-export interface OpineMCPServer {
+export interface Opine {
   opineApiKey: string
 }
 /**
  * Connect to Oracle databases via MCP, providing secure read-only access with support for schema exploration, query execution, and metadata inspection.
  */
-export interface OracleDatabaseMCPServer {
+export interface OracleDatabase {
   oracleConnectionString: string
   oracleUser: string
   password: string
@@ -1312,7 +1672,7 @@ export interface Oxylabs {
   username: string
 }
 /**
- * A MCP for searching and downloading academic papers from multiple sources like arXiv, PubMed, bioRxiv, etc.
+ * MCP, CLI, Skills for searching and downloading academic papers from multiple sources like arXiv, PubMed, bioRxiv, etc.
  */
 export interface PaperSearch {}
 /**
@@ -1337,13 +1697,13 @@ export interface PineconeAssistant {
 /**
  * Playwright Model Context Protocol Server - Tool to automate Browsers and APIs in Claude Desktop, Cline, Cursor IDE and More 🔌.
  */
-export interface ExecuteAutomationPlaywrightMCP {
+export interface ExecuteAutomationPlaywright {
   data: string
 }
 /**
  * A unified MCP proxy that aggregates multiple MCP servers into one interface, enabling seamless tool discovery and management across all your AI interactions. Manage all your MCP servers from a single connection point with RAG capabilities and real-time notifications.
  */
-export interface PluggedInMCPProxy {
+export interface PluggedInProxy {
   /**
    * Base URL for the Plugged.in API (optional, defaults to https://plugged.in for cloud or http://localhost:12005 for self-hosted)
    */
@@ -1363,15 +1723,9 @@ export interface PomoDash {
   apiKey: string
 }
 /**
- * Connect with read-only access to PostgreSQL databases. This server enables LLMs to inspect database schemas and execute read-only queries.
- */
-export interface PostgreSQLReadonlyArchived {
-  url: string
-}
-/**
  * Postman's MCP server connects AI agents, assistants, and chatbots directly to your APIs on Postman. Use natural language to prompt AI to automate work across your Postman collections, environments, workspaces, and more.
  */
-export interface PostmanMCPServer {
+export interface Postman {
   apiKey: string
 }
 /**
@@ -1388,17 +1742,48 @@ export interface Prometheus {
   prometheusUrl: string
 }
 /**
+ * Manage Proxmox VE infrastructure including virtual machines, containers, storage, networking, firewall rules, high availability, and more.
+ */
+export interface ProxmoxVE {
+  /**
+   * Proxmox VE hostname or IP address
+   */
+  host: string
+  password?: string
+  /**
+   * Proxmox VE API port
+   */
+  port?: string
+  /**
+   * Request timeout in seconds
+   */
+  timeout?: string
+  /**
+   * API token name
+   */
+  tokenName: string
+  tokenValue?: string
+  /**
+   * Proxmox VE user (e.g. root@pam)
+   */
+  user?: string
+  /**
+   * Verify SSL certificates (true/false)
+   */
+  verifySsl?: string
+}
+/**
  * Browser automation and web scraping using Puppeteer.
  */
 export interface PuppeteerArchived {}
 /**
- * Educational Python refactoring assistant that provides guided suggestions for AI assistants.  Features: • Step-by-step refactoring instructions without modifying code • Comprehensive code analysis using professional tools (Rope, Radon, Vulture, Jedi, LibCST, Pyrefly) • Educational approach teaching refactoring patterns through guided practice • Support for both guide-only and apply-changes modes • Identifies long functions, high complexity, dead code, and type issues • Provides precise line numbers and specific refactoring instructions • Compatible with all AI assistants (Claude, GPT, Cursor, Continue, etc.)  Perfect for developers learning refactoring patterns while maintaining full control over code changes. Acts as a refactoring mentor rather than an automated code modifier.
+ * Educational Python refactoring assistant that provides guided suggestions for AI assistants.
  */
 export interface PythonRefactoringAssistant {}
 /**
  * The QuantConnect MCP Server is a bridge for AIs (such as Claude and OpenAI o3 Pro) to interact with our cloud platform. When equipped with our MCP, the AI can perform tasks on your behalf through our API such as updating projects, writing strategies, backtesting, and deploying strategies to production live-trading.
  */
-export interface QuantConnectMCPServer {
+export interface QuantConnect {
   agentname: string
   quantconnectapitoken: string
   quantconnectuserid: string
@@ -1406,7 +1791,7 @@ export interface QuantConnectMCPServer {
 /**
  * A comprehensive security scanner for MCP servers with YARA rules and static analysis capabilities.
  */
-export interface RampartsMCPSecurityScanner {}
+export interface RampartsSecurityScanner {}
 /**
  * Razorpay's Official MCP Server.
  */
@@ -1415,9 +1800,9 @@ export interface Razorpay {
   keySecret?: string
 }
 /**
- * A comprehensive Model Context Protocol (MCP) server for Reddit integration. This server enables AI agents to interact with Reddit programmatically through a standardized interface.
+ * This server provides AI agents with tools to fetch, post and search on Reddit.
  */
-export interface McpReddit {
+export interface Reddit {
   redditClientId: string
   redditClientSecret: string
   redditPassword: string
@@ -1463,9 +1848,9 @@ export interface Render {
   apiKey: string
 }
 /**
- * Send emails directly from Cursor with this email sending MCP server.
+ * The official MCP server to send emails and interact with Resend.
  */
-export interface SendEmails {
+export interface Resend {
   apiKey?: string
   /**
    * comma separated list of reply to email addresses
@@ -1484,15 +1869,9 @@ export interface RISKEN {
   url: string
 }
 /**
- * MCP server that provides container image vulnerability scanning and remediation capabilities through Root.io.
- */
-export interface RootIoVulnerabilityRemediationMCP {
-  apiAccessToken: string
-}
-/**
  * Python server implementing Model Context Protocol (MCP) for ROS2.
  */
-export interface WiseVisionROS2MCPServer {}
+export interface WiseVisionROS2 {}
 /**
  * Access to Rube's catalog of remote MCP servers.
  */
@@ -1502,7 +1881,7 @@ export interface Rube {
 /**
  * The Rust MCP Filesystem is a high-performance, asynchronous, and lightweight Model Context Protocol (MCP) server built in Rust for secure and efficient filesystem operations. Designed with security in mind, it operates in read-only mode by default and restricts clients from updating allowed directories via MCP Roots unless explicitly enabled, ensuring robust protection against unauthorized access. Leveraging asynchronous I/O, it delivers blazingly fast performance with a minimal resource footprint. Optimized for token efficiency, the Rust MCP Filesystem enables large language models (LLMs) to precisely target searches and edits within specific sections of large files and restrict operations by file size range, making it ideal for efficient file exploration, automation, and system integration.
  */
-export interface BlazingFastAsynchronousMCPServerForSeamlessFilesystemOperations {
+export interface RustFilesystem {
   /**
    * Enable read/write mode. If false, the app operates in read-only mode.
    */
@@ -1555,7 +1934,7 @@ export interface SchemaCrawlerAI {
 /**
  * This adds a border to an image and returns base64 encoded image.
  */
-export interface SchoginiMCPImageBorder {}
+export interface SchoginiImageBorder {}
 /**
  * ScapeGraph MCP Server.
  */
@@ -1571,7 +1950,7 @@ export interface Scrapezy {
 /**
  * SecureNote.link MCP Server - allowing AI agents to securely share sensitive information through end-to-end encrypted notes.
  */
-export interface SecurenoteLinkMcpServer {}
+export interface SecurenoteLink {}
 /**
  * MCP server for using Semgrep to scan code for security vulnerabilities.
  */
@@ -1602,7 +1981,7 @@ export interface ShortIo {
 /**
  * Advanced SimpleCheckList with MCP server and SQLite database for comprehensive task management.  Features: • Complete project and task management system • Hierarchical organization (Projects → Groups → Task Lists → Tasks → Subtasks) • SQLite database for data persistence • RESTful API with comprehensive endpoints • MCP protocol compliance for AI assistant integration • Docker-optimized deployment with stability improvements  **v1.0.1 Update**: Enhanced Docker stability with improved container lifecycle management. Default mode optimized for containerized deployment with reliable startup and shutdown processes.  Perfect for AI assistants managing complex project workflows and task hierarchies.
  */
-export interface SimpleCheckListMCPServer {}
+export interface SimpleCheckList {}
 /**
  * MCP server for interacting with SingleStore Management API and services.
  */
@@ -1620,7 +1999,7 @@ export interface SlackArchived {
 /**
  * MCP server for AI access to SmartBear tools, including BugSnag, Reflect, API Hub, PactFlow.
  */
-export interface SmartBearMCPServer {
+export interface SmartBear {
   apiHubApiKey: string
   bugsnagApiKey: string
   bugsnagAuthToken: string
@@ -1680,7 +2059,7 @@ export interface Supadata {
 /**
  * MCP Server to interact with a SuzieQ network observability instance via its REST API.
  */
-export interface SuzieqMCP {
+export interface Suzieq {
   apiEndpoint: string
   apiKey: string
 }
@@ -1707,15 +2086,47 @@ export interface Telnyx {
   apiKey: string
 }
 /**
- * MCP server for Tembo Cloud's platform API.
+ * Manage Temporal workflows, schedules, namespaces, task queues, and workflow execution history from MCP clients.
  */
-export interface Tembo {
-  apiKey: string
+export interface Temporal {
+  apiKey?: string
+  /**
+   * Temporal frontend host and port.
+   */
+  temporalHost: string
+  /**
+   * Temporal namespace to connect to.
+   */
+  temporalNamespace: string
+  /**
+   * Optional path inside the container to an mTLS client certificate.
+   */
+  temporalTlsClientCertPath?: string
+  /**
+   * Optional path inside the container to an mTLS client private key.
+   */
+  temporalTlsClientKeyPath?: string
+  /**
+   * Whether to force TLS for the Temporal connection.
+   */
+  temporalTlsEnabled?: string
 }
 /**
  * The Terraform MCP Server provides seamless integration with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development.
  */
 export interface HashicorpTerraform {}
+/**
+ * The Testkube MCP Server exposes continuous testing capabilities (test orchestration, execution, troubleshooting and anlysis) to AI tools and workflows.
+ */
+export interface Testkube {
+  tkAccessToken: string
+  /**
+   * The URL of the Testkube Control Plane
+   */
+  tkControlPlaneUrl: string
+  tkEnvId: string
+  tkOrgId: string
+}
 /**
  * Transform natural language queries into GraphQL queries using an AI agent. Provides schema management, query validation, execution, and history tracking.
  */
@@ -1737,6 +2148,17 @@ export interface TextToGraphQL {
   openaiApiKey: string
 }
 /**
+ * Connect your AI workflows to the ThingsBoard IoT Platform through this MCP server.  Enables LLMs to query device telemetry, manage IoT entities (devices, assets, customers), and analyze sensor data - all through natural language.  Perfect for building AI-powered IoT monitoring, predictive maintenance, and automated device management workflows. Supports both ThingsBoard Community Edition and Professional Edition.
+ */
+export interface ThingsBoard {
+  password?: string
+  /**
+   * URL of your ThingsBoard Platform instance
+   */
+  url: string
+  username?: string
+}
+/**
  * Tigris is a globally distributed S3-compatible object storage service that provides low latency anywhere in the world, enabling developers to store and access any amount of data for a wide range of use cases.
  */
 export interface TigrisData {
@@ -1749,15 +2171,9 @@ export interface TigrisData {
  */
 export interface TimeReference {}
 /**
- * Triplewhale MCP Server.
- */
-export interface Triplewhale {
-  apiKey: string
-}
-/**
  * A comprehensive Model Context Protocol (MCP) server that enables AI assistants to control Unreal Engine via Remote Control API. Built with TypeScript and designed for game development automation.
  */
-export interface UnrealEngineMCPServer {
+export interface UnrealEngine {
   /**
    * Logging level
    */
@@ -1776,10 +2192,122 @@ export interface UnrealEngineMCPServer {
   ueRcWsPort: string
 }
 /**
+ * Vectra AI MCP Server - An MCP server that connects AI assistants & agents to the Vectra AI security platform, enabling intelligent threat analysis and automated incident response.
+ */
+export interface VectraAIRUXMCPServer {
+  /**
+   * The client ID of the Vectra AI RUX MCP Server
+   */
+  vectraClientId: string
+  vectraClientSecret?: string
+  /**
+   * The base URL of the Vectra AI RUX MCP Server
+   */
+  vectraUrl?: string
+}
+/**
  * VeyraX MCP is the only connection you need to access all your tools in any MCP-compatible environment.
  */
 export interface VeyraX {
   apiKey: string
+}
+/**
+ * Provides access to your VictoriaLogs instance and seamless integration with VictoriaLogs APIs and documentation. It can give you a comprehensive interface for logs, observability, and debugging tasks related to your VictoriaLogs instances, enable advanced automation and interaction capabilities for engineers and tools.
+ */
+export interface VictoriaLogs {
+  /**
+   * Comma-separated list of tools to disable (possible values: export, metric_statistics, test_rules)
+   */
+  mcpDisabledTools?: string
+  /**
+   * Defines the heartbeat interval for the streamable-http protocol. It means the MCP server will send a heartbeat to the client through the GET connection, to keep the connection alive from being closed by the network infrastructure (e.g. gateways)
+   */
+  mcpHeartbeatInterval?: string
+  /**
+   * Address and port on which the MCP server listens for incoming connections (e.g., ':8081')
+   */
+  mcpListenAddr?: string
+  /**
+   * Mode in which the MCP server operates (possible values: stdio, http, sse)
+   */
+  mcpServerMode?: string
+  vlInstanceBearerToken?: string
+  /**
+   * URL of VictoriaLogs instance (it should be root URL of vlsingle or vlselect)
+   */
+  vlInstanceEntrypoint: string
+  /**
+   * Optional custom headers to include in requests to VictoriaLogs instance, formatted as 'header1=value1,header2=value2'
+   */
+  vlInstanceHeaders?: string
+}
+/**
+ * Provides access to your VictoriaMetrics instance and seamless integration with VictoriaMetrics APIs and documentation. It can give you a comprehensive interface for monitoring, observability, and debugging tasks related to your VictoriaMetrics instances, enable advanced automation and interaction capabilities for engineers and tools.
+ */
+export interface VictoriaMetrics {
+  /**
+   * Set to 'true' to disable all resource endpoints
+   */
+  mcpDisableResources?: string
+  /**
+   * Comma-separated list of tools to disable (possible values: export, metric_statistics, test_rules)
+   */
+  mcpDisabledTools?: string
+  /**
+   * Defines the heartbeat interval for the streamable-http protocol. It means the MCP server will send a heartbeat to the client through the GET connection, to keep the connection alive from being closed by the network infrastructure (e.g. gateways)
+   */
+  mcpHeartbeatInterval?: string
+  /**
+   * Address and port on which the MCP server listens for incoming connections (e.g., ':8080')
+   */
+  mcpListenAddr?: string
+  /**
+   * Mode in which the MCP server operates (possible values: stdio, http, sse)
+   */
+  mcpServerMode?: string
+  vmInstanceBearerToken?: string
+  /**
+   * URL of VictoriaMetrics instance (it should be root URL of vmsingle or vmselect)
+   */
+  vmInstanceEntrypoint: string
+  /**
+   * Optional custom headers to include in requests to VictoriaMetrics instance, formatted as 'header1=value1,header2=value2'
+   */
+  vmInstanceHeaders?: string
+  /**
+   * Type of VictoriaMetrics instance (possible values: single, cluster)
+   */
+  vmInstanceType: string
+}
+/**
+ * Provides access to your VictoriaTraces instance and seamless integration with VictoriaTraces APIs and documentation. It can give you a comprehensive interface for tracing, observability, and debugging tasks related to your VictoriaTraces instances, enable advanced automation and interaction capabilities for engineers and tools.
+ */
+export interface VictoriaTraces {
+  /**
+   * Comma-separated list of tools to disable (possible values: export, metric_statistics, test_rules)
+   */
+  mcpDisabledTools?: string
+  /**
+   * Defines the heartbeat interval for the streamable-http protocol. It means the MCP server will send a heartbeat to the client through the GET connection, to keep the connection alive from being closed by the network infrastructure (e.g. gateways)
+   */
+  mcpHeartbeatInterval?: string
+  /**
+   * Address and port on which the MCP server listens for incoming connections (e.g., ':8081')
+   */
+  mcpListenAddr?: string
+  /**
+   * Mode in which the MCP server operates (possible values: stdio, http, sse)
+   */
+  mcpServerMode?: string
+  vtInstanceBearerToken?: string
+  /**
+   * URL of VictoriaTraces instance (it should be root URL of vtsingle or vtselect)
+   */
+  vtInstanceEntrypoint: string
+  /**
+   * Optional custom headers to include in requests to VictoriaTraces instance, formatted as 'header1=value1,header2=value2'
+   */
+  vtInstanceHeaders?: string
 }
 /**
  * provides tools and templates to create a functioning Vizro chart or dashboard step by step.
@@ -1788,11 +2316,11 @@ export interface Vizro {}
 /**
  * This MCP server exposes tools to query the NVD/CVE REST API and return formatted text results suitable for LLM consumption via the MCP protocol. It includes automatic query chunking for large date ranges and parallel processing for improved performance.
  */
-export interface VulnNistMcpServer {}
+export interface VulnNIST {}
 /**
  * Wayfound’s MCP server allows business users to govern, supervise, and improve AI Agents.
  */
-export interface WayfoundMCP {
+export interface Wayfound {
   mcpApiKey: string
 }
 /**
@@ -1816,6 +2344,15 @@ export interface WolframAlpha {
  */
 export interface YouTubeTranscripts {}
 /**
+ * Bridges multiple AI models and CLIs, enabling orchestrated workflows across Claude Code, Gemini CLI, Codex CLI, and other AI development tools.
+ */
+export interface Zen {
+  geminiApiKey: string
+  openaiApiKey: string
+  openrouterApiKey: string
+  xaiApiKey: string
+}
+/**
  * MCP server for Zerodha Kite Connect API - India's leading stock broker trading platform. Execute trades, manage portfolios, and access real-time market data for NSE, BSE, and other Indian exchanges.
  */
 export interface ZerodhaKiteConnect {
@@ -1832,4 +2369,34 @@ export interface ZerodhaKiteConnect {
    * OAuth redirect URL configured in your Kite Connect app
    */
   kiteRedirectUrl?: string
+}
+/**
+ * Manage the Zscaler Zero Trust Exchange platform via 300+ tools across ZPA (private access), ZIA (internet access), ZDX (digital experience), ZCC (client connector), ZTW (workload segmentation), ZMS (microsegmentation), EASM (attack surface management), Z-Insights (security analytics), and ZIdentity (identity management). Create and manage policies, troubleshoot connectivity, audit security configurations, and investigate incidents — all from your AI assistant.
+ */
+export interface Zscaler {
+  /**
+   * Comma-separated services to disable (zcc,zdx,zpa,zia,ztw,zid,zeasm,zins,zms)
+   */
+  disabledServices: string
+  /**
+   * Comma-separated tool name patterns to disable (e.g. zia_delete_*,zpa_bulk_*)
+   */
+  disabledTools: string
+  /**
+   * Skip HMAC confirmation prompts for destructive operations (true/false)
+   */
+  skipConfirmations: string
+  /**
+   * Enable write operations (true/false)
+   */
+  writeEnabled: string
+  /**
+   * Comma-separated write tool patterns to allow (e.g. zpa_create_*,zia_update_*)
+   */
+  writeTools: string
+  zscalerClientId: string
+  zscalerClientSecret: string
+  zscalerCloud: string
+  zscalerCustomerId: string
+  zscalerVanityDomain: string
 }

--- a/packages/python-sdk/e2b/sandbox/mcp.py
+++ b/packages/python-sdk/e2b/sandbox/mcp.py
@@ -40,6 +40,31 @@ class Aks(TypedDict, closed=True):
     """
 
 
+class Alfresco(TypedDict, closed=True):
+    alfrescoHost: str
+
+
+class AmazonKendraIndex(TypedDict, closed=True):
+    awsProfile: NotRequired[str]
+    awsRegion: NotRequired[str]
+    kendraIndexId: str
+
+
+class AmazonNeptune(TypedDict, closed=True):
+    awsProfile: NotRequired[str]
+    awsRegion: NotRequired[str]
+    neptuneEndpoint: str
+
+
+class AmazonQbusinessAnonymous(TypedDict, closed=True):
+    awsAccessKeyId: NotRequired[str]
+    awsProfile: NotRequired[str]
+    awsRegion: NotRequired[str]
+    awsSecretAccessKey: NotRequired[str]
+    awsSessionToken: NotRequired[str]
+    qbusinessApplicationId: str
+
+
 class ApiGateway(TypedDict, closed=True):
     api1HeaderAuthorization: str
     api1Name: str
@@ -52,6 +77,18 @@ class Apify(TypedDict, closed=True):
     """
     Comma-separated list of tools to enable. Can be either a tool category, a specific tool, or an Apify Actor. For example: "actors,docs,apify/rag-web-browser". For more details visit https://mcp.apify.com.
     """
+
+
+class Arm(TypedDict, closed=True):
+    sshKnownHostsPath: NotRequired[str]
+    """
+    Optional path to an SSH known_hosts file for Arm Performix remote target access
+    """
+    sshPrivateKeyPath: NotRequired[str]
+    """
+    Optional path to an SSH private key for Arm Performix remote target access
+    """
+    workspacePath: str
 
 
 class Arxiv(TypedDict, closed=True):
@@ -96,9 +133,179 @@ class AudienseInsights(TypedDict, closed=True):
     twitterBearerToken: NotRequired[str]
 
 
+class AwsApi(TypedDict, closed=True):
+    awsAccessKeyId: str
+    awsProfileName: str
+    awsRegion: str
+    awsSecretAccessKey: str
+    awsSessionToken: str
+
+
+class AwsAppsync(TypedDict, closed=True):
+    awsAccessKeyId: str
+    awsProfile: str
+    awsRegion: str
+    awsSecretAccessKey: str
+    awsSessionToken: str
+
+
+class AwsBedrockCustomModelImport(TypedDict, closed=True):
+    awsAccessKeyId: str
+    awsProfile: str
+    awsRegion: str
+    awsSecretAccessKey: str
+    awsSessionToken: str
+    bedrockModelImportS3Bucket: str
+
+
+class AwsBedrockDataAutomation(TypedDict, closed=True):
+    awsBucketName: str
+    awsProfile: NotRequired[str]
+    awsRegion: NotRequired[str]
+
+
+class AwsDataprocessing(TypedDict, closed=True):
+    awsProfile: str
+    awsRegion: str
+
+
+class AwsDiagram(TypedDict, closed=True):
+    outputDir: str
+
+
+class AwsHealthomics(TypedDict, closed=True):
+    awsProfile: str
+    awsRegion: str
+
+
+class AwsIotSitewise(TypedDict, closed=True):
+    awsProfile: str
+    awsRegion: str
+
+
 class AwsKbRetrievalServer(TypedDict, closed=True):
     accessKeyId: str
     awsSecretAccessKey: NotRequired[str]
+
+
+class AwsLocation(TypedDict, closed=True):
+    awsAccessKeyId: str
+    awsProfile: str
+    awsRegion: str
+    awsSecretAccessKey: str
+    awsSessionToken: str
+
+
+class AwsMsk(TypedDict, closed=True):
+    awsAccessKeyId: str
+    awsProfile: str
+    awsRegion: str
+    awsSecretAccessKey: str
+    awsSessionToken: str
+
+
+class AwsPricing(TypedDict, closed=True):
+    awsAccessKeyId: str
+    awsProfile: str
+    awsRegion: str
+    awsSecretAccessKey: str
+    awsSessionToken: str
+
+
+class AwslabsBillingCostManagement(TypedDict, closed=True):
+    awsProfile: str
+    awsRegion: str
+    storageLensManifestLocation: str
+
+
+class AwslabsCcapi(TypedDict, closed=True):
+    awsAccessKeyId: str
+    awsProfile: str
+    awsRegion: str
+    awsSecretAccessKey: str
+
+
+class AwslabsCfn(TypedDict, closed=True):
+    awsAccessKeyId: str
+    awsProfile: str
+    awsRegion: str
+    awsSecretAccessKey: str
+    awsSessionToken: str
+
+
+class AwslabsCloudtrail(TypedDict, closed=True):
+    awsProfile: str
+
+
+class AwslabsCloudwatch(TypedDict, closed=True):
+    awsProfile: str
+    awsRegion: str
+
+
+class AwslabsCloudwatchAppsignals(TypedDict, closed=True):
+    awsProfile: str
+    awsRegion: str
+
+
+class AwslabsCostExplorer(TypedDict, closed=True):
+    awsAccessKeyId: str
+    awsProfile: str
+    awsRegion: str
+    awsSecretAccessKey: str
+    awsSessionToken: str
+
+
+class AwslabsDynamodb(TypedDict, closed=True):
+    awsProfile: str
+    awsRegion: str
+
+
+class AwslabsElasticache(TypedDict, closed=True):
+    awsProfile: str
+    awsRegion: str
+
+
+class AwslabsIam(TypedDict, closed=True):
+    awsAccessKeyId: str
+    awsProfile: str
+    awsRegion: str
+    awsSecretAccessKey: str
+
+
+class AwslabsMemcached(TypedDict, closed=True):
+    memcachedHost: str
+    memcachedPort: NotRequired[str]
+
+
+class AwslabsNovaCanvas(TypedDict, closed=True):
+    awsAccessKeyId: str
+    awsProfile: str
+    awsRegion: str
+    awsSecretAccessKey: str
+    awsSessionToken: str
+
+
+class AwslabsRedshift(TypedDict, closed=True):
+    awsProfile: str
+    awsRegion: str
+
+
+class AwslabsS3Tables(TypedDict, closed=True):
+    awsAccessKeyId: str
+    awsProfile: str
+    awsRegion: str
+    awsSecretAccessKey: str
+    awsSessionToken: str
+
+
+class AwslabsTimestreamForInfluxdb(TypedDict, closed=True):
+    awsProfile: str
+    awsRegion: str
+
+
+class AwslabsValkey(TypedDict, closed=True):
+    valkeyHost: str
+    valkeyPort: str
 
 
 class BeagleSecurity(TypedDict, closed=True):
@@ -131,11 +338,6 @@ class Buildkite(TypedDict, closed=True):
 
 class Camunda(TypedDict, closed=True):
     camundahost: str
-
-
-class CdataConnectcloud(TypedDict, closed=True):
-    cdataPat: NotRequired[str]
-    username: str
 
 
 class Charmhealth(TypedDict, closed=True):
@@ -189,6 +391,10 @@ class Cockroachdb(TypedDict, closed=True):
     sslKeyfile: str
     sslMode: str
     username: str
+
+
+class Context7(TypedDict, closed=True):
+    apiKey: str
 
 
 class Couchbase(TypedDict, closed=True):
@@ -345,11 +551,6 @@ class Firewalla(TypedDict, closed=True):
     """
     Your Firewalla MSP domain (e.g., yourdomain.firewalla.net)
     """
-
-
-class Flexprice(TypedDict, closed=True):
-    apiKey: str
-    baseUrl: str
 
 
 class Git(TypedDict, closed=True):
@@ -581,12 +782,29 @@ class MultiversxMx(TypedDict, closed=True):
     wallet: str
 
 
+class N8n(TypedDict, closed=True):
+    apiKey: str
+    apiUrl: str
+    """
+    The URL of your n8n instance (use http://host.docker.internal:5678 for local instances)
+    """
+
+
 class NasdaqDataLink(TypedDict, closed=True):
     nasdaqDataLinkApiKey: str
 
 
 class Needle(TypedDict, closed=True):
     needleApiKey: str
+
+
+class Neo4j(TypedDict, closed=True):
+    database: str
+    password: str
+    readOnly: bool
+    telemetry: bool
+    uri: str
+    username: str
 
 
 class Neo4jCloudAuraApi(TypedDict, closed=True):
@@ -607,6 +825,7 @@ class Neo4jCypher(TypedDict, closed=True):
     readOnly: NotRequired[bool]
     readTimeout: NotRequired[str]
     responseTokenLimit: NotRequired[str]
+    schemaSampleSize: NotRequired[str]
     serverAllowOrigins: NotRequired[str]
     serverAllowedHosts: NotRequired[str]
     serverHost: NotRequired[str]
@@ -651,6 +870,16 @@ class Obsidian(TypedDict, closed=True):
     apiKey: str
 
 
+class Okta(TypedDict, closed=True):
+    logPath: str
+    oktaClientId: str
+    oktaKeyId: str
+    oktaLogLevel: str
+    oktaOrgUrl: str
+    oktaPrivateKey: str
+    oktaScopes: str
+
+
 class OktaMcpFctr(TypedDict, closed=True):
     clientOrgurl: str
     """
@@ -674,13 +903,6 @@ class Omi(TypedDict, closed=True):
 class OnlyofficeDocspace(TypedDict, closed=True):
     baseUrl: str
     docspaceApiKey: str
-    docspaceAuthToken: str
-    docspacePassword: str
-    docspaceUsername: str
-    dynamic: bool
-    origin: str
-    toolsets: str
-    userAgent: str
 
 
 class Openapi(TypedDict, closed=True):
@@ -749,10 +971,6 @@ class Pomodash(TypedDict, closed=True):
     apiKey: str
 
 
-class Postgres(TypedDict, closed=True):
-    url: str
-
-
 class Postman(TypedDict, closed=True):
     apiKey: str
 
@@ -761,6 +979,35 @@ class Prometheus(TypedDict, closed=True):
     prometheusUrl: str
     """
     The URL of your Prometheus server
+    """
+
+
+class Proxmox(TypedDict, closed=True):
+    host: str
+    """
+    Proxmox VE hostname or IP address
+    """
+    password: NotRequired[str]
+    port: NotRequired[str]
+    """
+    Proxmox VE API port
+    """
+    timeout: NotRequired[str]
+    """
+    Request timeout in seconds
+    """
+    tokenName: str
+    """
+    API token name
+    """
+    tokenValue: NotRequired[str]
+    user: NotRequired[str]
+    """
+    Proxmox VE user (e.g. root@pam)
+    """
+    verifySsl: NotRequired[str]
+    """
+    Verify SSL certificates (true/false)
     """
 
 
@@ -824,10 +1071,6 @@ class Resend(TypedDict, closed=True):
 class Risken(TypedDict, closed=True):
     accessToken: str
     url: str
-
-
-class Root(TypedDict, closed=True):
-    apiAccessToken: str
 
 
 class Rube(TypedDict, closed=True):
@@ -975,8 +1218,38 @@ class Telnyx(TypedDict, closed=True):
     apiKey: str
 
 
-class Tembo(TypedDict, closed=True):
-    apiKey: str
+class Temporal(TypedDict, closed=True):
+    apiKey: NotRequired[str]
+    temporalHost: str
+    """
+    Temporal frontend host and port.
+    """
+    temporalNamespace: str
+    """
+    Temporal namespace to connect to.
+    """
+    temporalTlsClientCertPath: NotRequired[str]
+    """
+    Optional path inside the container to an mTLS client certificate.
+    """
+    temporalTlsClientKeyPath: NotRequired[str]
+    """
+    Optional path inside the container to an mTLS client private key.
+    """
+    temporalTlsEnabled: NotRequired[str]
+    """
+    Whether to force TLS for the Temporal connection.
+    """
+
+
+class Testkube(TypedDict, closed=True):
+    tkAccessToken: str
+    tkControlPlaneUrl: str
+    """
+    The URL of the Testkube Control Plane
+    """
+    tkEnvId: str
+    tkOrgId: str
 
 
 class TextToGraphql(TypedDict, closed=True):
@@ -997,14 +1270,19 @@ class TextToGraphql(TypedDict, closed=True):
     openaiApiKey: str
 
 
+class Thingsboard(TypedDict, closed=True):
+    password: NotRequired[str]
+    url: str
+    """
+    URL of your ThingsBoard Platform instance
+    """
+    username: NotRequired[str]
+
+
 class Tigris(TypedDict, closed=True):
     awsAccessKeyId: str
     awsEndpointUrlS3: str
     awsSecretAccessKey: NotRequired[str]
-
-
-class Triplewhale(TypedDict, closed=True):
-    apiKey: str
 
 
 class UnrealEngine(TypedDict, closed=True):
@@ -1026,8 +1304,112 @@ class UnrealEngine(TypedDict, closed=True):
     """
 
 
+class VectraAiRux(TypedDict, closed=True):
+    vectraClientId: str
+    """
+    The client ID of the Vectra AI RUX MCP Server
+    """
+    vectraClientSecret: NotRequired[str]
+    vectraUrl: NotRequired[str]
+    """
+    The base URL of the Vectra AI RUX MCP Server
+    """
+
+
 class Veyrax(TypedDict, closed=True):
     apiKey: str
+
+
+class Victorialogs(TypedDict, closed=True):
+    mcpDisabledTools: NotRequired[str]
+    """
+    Comma-separated list of tools to disable (possible values: export, metric_statistics, test_rules)
+    """
+    mcpHeartbeatInterval: NotRequired[str]
+    """
+    Defines the heartbeat interval for the streamable-http protocol. It means the MCP server will send a heartbeat to the client through the GET connection, to keep the connection alive from being closed by the network infrastructure (e.g. gateways)
+    """
+    mcpListenAddr: NotRequired[str]
+    """
+    Address and port on which the MCP server listens for incoming connections (e.g., ':8081')
+    """
+    mcpServerMode: NotRequired[str]
+    """
+    Mode in which the MCP server operates (possible values: stdio, http, sse)
+    """
+    vlInstanceBearerToken: NotRequired[str]
+    vlInstanceEntrypoint: str
+    """
+    URL of VictoriaLogs instance (it should be root URL of vlsingle or vlselect)
+    """
+    vlInstanceHeaders: NotRequired[str]
+    """
+    Optional custom headers to include in requests to VictoriaLogs instance, formatted as 'header1=value1,header2=value2'
+    """
+
+
+class Victoriametrics(TypedDict, closed=True):
+    mcpDisableResources: NotRequired[str]
+    """
+    Set to 'true' to disable all resource endpoints
+    """
+    mcpDisabledTools: NotRequired[str]
+    """
+    Comma-separated list of tools to disable (possible values: export, metric_statistics, test_rules)
+    """
+    mcpHeartbeatInterval: NotRequired[str]
+    """
+    Defines the heartbeat interval for the streamable-http protocol. It means the MCP server will send a heartbeat to the client through the GET connection, to keep the connection alive from being closed by the network infrastructure (e.g. gateways)
+    """
+    mcpListenAddr: NotRequired[str]
+    """
+    Address and port on which the MCP server listens for incoming connections (e.g., ':8080')
+    """
+    mcpServerMode: NotRequired[str]
+    """
+    Mode in which the MCP server operates (possible values: stdio, http, sse)
+    """
+    vmInstanceBearerToken: NotRequired[str]
+    vmInstanceEntrypoint: str
+    """
+    URL of VictoriaMetrics instance (it should be root URL of vmsingle or vmselect)
+    """
+    vmInstanceHeaders: NotRequired[str]
+    """
+    Optional custom headers to include in requests to VictoriaMetrics instance, formatted as 'header1=value1,header2=value2'
+    """
+    vmInstanceType: str
+    """
+    Type of VictoriaMetrics instance (possible values: single, cluster)
+    """
+
+
+class Victoriatraces(TypedDict, closed=True):
+    mcpDisabledTools: NotRequired[str]
+    """
+    Comma-separated list of tools to disable (possible values: export, metric_statistics, test_rules)
+    """
+    mcpHeartbeatInterval: NotRequired[str]
+    """
+    Defines the heartbeat interval for the streamable-http protocol. It means the MCP server will send a heartbeat to the client through the GET connection, to keep the connection alive from being closed by the network infrastructure (e.g. gateways)
+    """
+    mcpListenAddr: NotRequired[str]
+    """
+    Address and port on which the MCP server listens for incoming connections (e.g., ':8081')
+    """
+    mcpServerMode: NotRequired[str]
+    """
+    Mode in which the MCP server operates (possible values: stdio, http, sse)
+    """
+    vtInstanceBearerToken: NotRequired[str]
+    vtInstanceEntrypoint: str
+    """
+    URL of VictoriaTraces instance (it should be root URL of vtsingle or vtselect)
+    """
+    vtInstanceHeaders: NotRequired[str]
+    """
+    Optional custom headers to include in requests to VictoriaTraces instance, formatted as 'header1=value1,header2=value2'
+    """
 
 
 class Wayfound(TypedDict, closed=True):
@@ -1040,6 +1422,13 @@ class Webflow(TypedDict, closed=True):
 
 class WolframAlpha(TypedDict, closed=True):
     wolframApiKey: str
+
+
+class Zen(TypedDict, closed=True):
+    geminiApiKey: str
+    openaiApiKey: str
+    openrouterApiKey: str
+    xaiApiKey: str
 
 
 class ZerodhaKite(TypedDict, closed=True):
@@ -1058,6 +1447,34 @@ class ZerodhaKite(TypedDict, closed=True):
     """
 
 
+class Zscaler(TypedDict, closed=True):
+    disabledServices: str
+    """
+    Comma-separated services to disable (zcc,zdx,zpa,zia,ztw,zid,zeasm,zins,zms)
+    """
+    disabledTools: str
+    """
+    Comma-separated tool name patterns to disable (e.g. zia_delete_*,zpa_bulk_*)
+    """
+    skipConfirmations: str
+    """
+    Skip HMAC confirmation prompts for destructive operations (true/false)
+    """
+    writeEnabled: str
+    """
+    Enable write operations (true/false)
+    """
+    writeTools: str
+    """
+    Comma-separated write tool patterns to allow (e.g. zpa_create_*,zia_update_*)
+    """
+    zscalerClientId: str
+    zscalerClientSecret: str
+    zscalerCloud: str
+    zscalerCustomerId: str
+    zscalerVanityDomain: str
+
+
 class McpServer(TypedDict, closed=True):
     airtable: NotRequired[Airtable]
     """
@@ -1067,6 +1484,26 @@ class McpServer(TypedDict, closed=True):
     """
     Azure Kubernetes Service (AKS) official MCP server.
     """
+    alfresco: NotRequired[Alfresco]
+    """
+    A minimal Model Context Protocol (MCP) server for Alfresco providing tools via the Alfresco REST API.
+    """
+    amazonBedrockAgentcore: NotRequired[dict[str, Any]]
+    """
+    Documentation on AgentCore platform services.
+    """
+    amazonKendraIndex: NotRequired[AmazonKendraIndex]
+    """
+    Enterprise search and RAG enhancement.
+    """
+    amazonNeptune: NotRequired[AmazonNeptune]
+    """
+    Graph database queries with Cypher and Gremlin.
+    """
+    amazonQbusinessAnonymous: NotRequired[AmazonQbusinessAnonymous]
+    """
+    AI assistant for ingested content with anonymous access.
+    """
     apiGateway: NotRequired[ApiGateway]
     """
     A universal MCP (Model Context Protocol) server to integrate any API with Claude Desktop using only Docker configurations.
@@ -1074,6 +1511,10 @@ class McpServer(TypedDict, closed=True):
     apify: NotRequired[Apify]
     """
     Apify is the world's largest marketplace of tools for web scraping, data extraction, and web automation. You can extract structured data from social media, e-commerce, search engines, maps, travel sites, or any other website.
+    """
+    arm: NotRequired[Arm]
+    """
+    Provides AI assistants with specialized tools for Arm architecture development, migration, optimization, and profiling. Includes knowledge base search, code migration analysis, container architecture inspection, Arm Performix workload profiling, and assembly performance analysis.
     """
     arxiv: NotRequired[Arxiv]
     """
@@ -1107,6 +1548,22 @@ class McpServer(TypedDict, closed=True):
     """
     Audiense Insights MCP Server is a server based on the Model Context Protocol (MCP) that allows Claude and other MCP-compatible clients to interact with your Audiense Insights account.
     """
+    awsApi: NotRequired[AwsApi]
+    """
+    Comprehensive AWS API support with command validation and access to all services.
+    """
+    awsAppsync: NotRequired[AwsAppsync]
+    """
+    Manage applications powered by AWS AppSync.
+    """
+    awsBedrockCustomModelImport: NotRequired[AwsBedrockCustomModelImport]
+    """
+    Manage custom models in Bedrock.
+    """
+    awsBedrockDataAutomation: NotRequired[AwsBedrockDataAutomation]
+    """
+    Analyze documents, images, videos, and audio.
+    """
     awsCdk: NotRequired[dict[str, Any]]
     """
     AWS Cloud Development Kit (CDK) best practices, infrastructure as code patterns, and security compliance with CDK Nag.
@@ -1115,7 +1572,11 @@ class McpServer(TypedDict, closed=True):
     """
     Starting point for using the awslabs MCP servers.
     """
-    awsDiagram: NotRequired[dict[str, Any]]
+    awsDataprocessing: NotRequired[AwsDataprocessing]
+    """
+    Data processing and transformation services.
+    """
+    awsDiagram: NotRequired[AwsDiagram]
     """
     Seamlessly create diagrams using the Python diagrams package DSL. This server allows you to generate AWS diagrams, sequence diagrams, flow diagrams, and class diagrams using Python code.
     """
@@ -1123,17 +1584,101 @@ class McpServer(TypedDict, closed=True):
     """
     Tools to access AWS documentation, search for content, and get recommendations.
     """
+    awsHealthomics: NotRequired[AwsHealthomics]
+    """
+    Generate, run, debug lifescience workflows.
+    """
+    awsIotSitewise: NotRequired[AwsIotSitewise]
+    """
+    Industrial IoT asset management.
+    """
     awsKbRetrievalServer: NotRequired[AwsKbRetrievalServer]
     """
     An MCP server implementation for retrieving information from the AWS Knowledge Base using the Bedrock Agent Runtime.
+    """
+    awsLocation: NotRequired[AwsLocation]
+    """
+    Place search, geocoding, and route optimization.
+    """
+    awsMsk: NotRequired[AwsMsk]
+    """
+    Managed Kafka cluster operations.
+    """
+    awsPricing: NotRequired[AwsPricing]
+    """
+    AWS service pricing and cost estimates.
     """
     awsTerraform: NotRequired[dict[str, Any]]
     """
     Terraform on AWS best practices, infrastructure as code patterns, and security compliance with Checkov.
     """
+    awslabsBillingCostManagement: NotRequired[AwslabsBillingCostManagement]
+    """
+    Billing and cost management.
+    """
+    awslabsCcapi: NotRequired[AwslabsCcapi]
+    """
+    Direct resource management with security scanning.
+    """
+    awslabsCfn: NotRequired[AwslabsCfn]
+    """
+    CloudFormation resource management via Cloud Control API.
+    """
+    awslabsCloudtrail: NotRequired[AwslabsCloudtrail]
+    """
+    AWS CloudTrail audit logging and monitoring.
+    """
+    awslabsCloudwatch: NotRequired[AwslabsCloudwatch]
+    """
+    Metrics, alarms, and logs analysis.
+    """
+    awslabsCloudwatchAppsignals: NotRequired[AwslabsCloudwatchAppsignals]
+    """
+    Application performance monitoring and insights.
+    """
+    awslabsCostExplorer: NotRequired[AwslabsCostExplorer]
+    """
+    Detailed cost analysis and reporting.
+    """
+    awslabsDynamodb: NotRequired[AwslabsDynamodb]
+    """
+    Complete DynamoDB operations and table management.
+    """
+    awslabsElasticache: NotRequired[AwslabsElasticache]
+    """
+    ElastiCache control plane operations.
+    """
+    awslabsIam: NotRequired[AwslabsIam]
+    """
+    IAM user, role, group, and policy management.
+    """
+    awslabsMemcached: NotRequired[AwslabsMemcached]
+    """
+    High-speed caching with Memcached.
+    """
+    awslabsNovaCanvas: NotRequired[AwslabsNovaCanvas]
+    """
+    AI image generation using Amazon Nova Canvas.
+    """
+    awslabsRedshift: NotRequired[AwslabsRedshift]
+    """
+    Data warehouse operations and queries.
+    """
+    awslabsS3Tables: NotRequired[AwslabsS3Tables]
+    """
+    Manage S3 Tables for analytics.
+    """
+    awslabsTimestreamForInfluxdb: NotRequired[AwslabsTimestreamForInfluxdb]
+    """
+    Time-series database operations.
+    """
+    awslabsValkey: NotRequired[AwslabsValkey]
+    """
+    Advanced data structures with Valkey.
+    """
     azure: NotRequired[dict[str, Any]]
     """
-    The Azure MCP Server, bringing the power of Azure to your agents.
+    Catalog of official Microsoft MCP (Model Context Protocol) server implementations for AI-powered data access and tool integration.
     """
     beagleSecurity: NotRequired[BeagleSecurity]
     """
@@ -1162,10 +1707,6 @@ class McpServer(TypedDict, closed=True):
     camunda: NotRequired[Camunda]
     """
     Tools to interact with the Camunda 7 Community Edition Engine using the Model Context Protocol (MCP). Whether you're automating workflows, querying process instances, or integrating with external systems, Camunda MCP Server is your agentic solution for seamless interaction with Camunda.
-    """
-    cdataConnectcloud: NotRequired[CdataConnectcloud]
-    """
-    This fully functional MCP Server allows you to connect to any data source in Connect Cloud from Claude Desktop.
     """
     charmhealth: NotRequired[Charmhealth]
     """
@@ -1203,13 +1744,17 @@ class McpServer(TypedDict, closed=True):
     """
     A Python-based execution tool that mimics a Jupyter notebook environment. It accepts code snippets, executes them, and maintains state across sessions — preserving variables, imports, and past results. Ideal for iterative development, debugging, or code execution.
     """
-    context7: NotRequired[dict[str, Any]]
+    context7: NotRequired[Context7]
     """
-    Context7 MCP Server -- Up-to-date code documentation for LLMs and AI code editors.
+    Pull up-to-date, version-specific documentation and code examples for any library or framework straight into your prompt.
     """
     couchbase: NotRequired[Couchbase]
     """
     Couchbase is a distributed document database with a powerful search engine and in-built operational and analytical capabilities.
+    """
+    curl: NotRequired[dict[str, Any]]
+    """
+    Standard curl tool.
     """
     cylera: NotRequired[Cylera]
     """
@@ -1259,6 +1804,10 @@ class McpServer(TypedDict, closed=True):
     """
     Interact with the Discord platform.
     """
+    docker: NotRequired[dict[str, Any]]
+    """
+    Use the Docker CLI.
+    """
     dockerhub: NotRequired[Dockerhub]
     """
     Docker Hub official MCP server.
@@ -1267,13 +1816,17 @@ class McpServer(TypedDict, closed=True):
     """
     Tools for cross-border payments, taxes, and compliance.
     """
+    dotnetTypesExplorer: NotRequired[dict[str, Any]]
+    """
+    Provides detailed type information from .NET projects including assembly exploration, namespace discovery, type reflection, and NuGet integration for AI coding agents.
+    """
     dreamfactory: NotRequired[Dreamfactory]
     """
     DreamFactory is a REST API generation platform with support for hundreds of data sources, including Microsoft SQL Server, MySQL, PostgreSQL, and MongoDB. The DreamFactory MCP Server makes it easy for users to securely interact with their data sources via an MCP client.
     """
     duckduckgo: NotRequired[dict[str, Any]]
     """
-    A Model Context Protocol (MCP) server that provides web search capabilities through DuckDuckGo, with additional features for content fetching and parsing.
+    Community-maintained server for DuckDuckGo search. Not published by or affiliated with DuckDuckGo.
     """
     dynatrace: NotRequired[Dynatrace]
     """
@@ -1315,6 +1868,10 @@ class McpServer(TypedDict, closed=True):
     """
     Fetches a URL from the internet and extracts its contents as markdown.
     """
+    ffmpeg: NotRequired[dict[str, Any]]
+    """
+    Use ffmpeg to process video files.
+    """
     fibery: NotRequired[Fibery]
     """
     Interact with your Fibery workspace.
@@ -1335,9 +1892,9 @@ class McpServer(TypedDict, closed=True):
     """
     Real-time network monitoring, security analysis, and firewall management through 28 specialized tools. Access security alerts, network flows, device status, and firewall rules directly from your Firewalla device.
     """
-    flexprice: NotRequired[Flexprice]
+    geminiApiDocs: NotRequired[dict[str, Any]]
     """
-    Official flexprice MCP Server.
+    Provides tools to search and retrieve Google Gemini API documentation.
     """
     git: NotRequired[Git]
     """
@@ -1365,11 +1922,15 @@ class McpServer(TypedDict, closed=True):
     """
     glif: NotRequired[Glif]
     """
-    Easily run glif.app AI workflows inside your LLM: image generators, memes, selfies, and more. Glif supports all major multimedia AI models inside one app.
+    Deprecated — use the hosted Glif MCP server at https://glif.app/mcp.
     """
     gmail: NotRequired[Gmail]
     """
     A Model Context Protocol server for Gmail operations using IMAP/SMTP with app password authentication. Supports listing messages, searching emails, and sending messages. To create your app password, visit your Google Account settings under Security > App Passwords. Or visit the link https://myaccount.google.com/apppasswords.
+    """
+    googleFlights: NotRequired[dict[str, Any]]
+    """
+    Interact with Google Flights data to search for one-way, round-trip, and date range flight options between airports.
     """
     googleMaps: NotRequired[GoogleMaps]
     """
@@ -1461,7 +2022,7 @@ class McpServer(TypedDict, closed=True):
     """
     kagisearch: NotRequired[Kagisearch]
     """
-    The Official Model Context Protocol (MCP) server for Kagi search & other tools.
+    The Official Model Context Protocol (MCP) server for Kagi Search & other tools.
     """
     keboola: NotRequired[Keboola]
     """
@@ -1551,6 +2112,10 @@ class McpServer(TypedDict, closed=True):
     """
     MCP Server for MultiversX.
     """
+    n8n: NotRequired[N8n]
+    """
+    Bridges n8n's workflow automation platform with AI models, providing access to 543 n8n nodes, workflow templates, and AI-capable automation tools.
+    """
     nasdaqDataLink: NotRequired[NasdaqDataLink]
     """
     MCP server to interact with the data feeds provided by the Nasdaq Data Link. Developed by the community and maintained by Stefano Amorelli.
@@ -1558,6 +2123,10 @@ class McpServer(TypedDict, closed=True):
     needle: NotRequired[Needle]
     """
     Production-ready RAG service to search and retrieve data from your documents.
+    """
+    neo4j: NotRequired[Neo4j]
+    """
+    Official MCP server for Neo4j. Interact with Neo4j using Cypher graph queries.
     """
     neo4jCloudAuraApi: NotRequired[Neo4jCloudAuraApi]
     """
@@ -1579,6 +2148,10 @@ class McpServer(TypedDict, closed=True):
     """
     MCP server for interacting with Neon Management API and databases.
     """
+    nextDevtools: NotRequired[dict[str, Any]]
+    """
+    next-devtools-mcp is a Model Context Protocol (MCP) server that provides Next.js development tools and utilities for AI coding assistants.
+    """
     nodeCodeSandbox: NotRequired[dict[str, Any]]
     """
     A Node.js–based Model Context Protocol server that spins up disposable Docker containers to execute arbitrary JavaScript.
@@ -1598,6 +2171,10 @@ class McpServer(TypedDict, closed=True):
     obsidian: NotRequired[Obsidian]
     """
     MCP server that interacts with Obsidian via the Obsidian rest API community plugin.
+    """
+    okta: NotRequired[Okta]
+    """
+    ## :tada: __It's Official__ :tada: The Okta Open-Source MCP Server integrates with LLMs and AI agents, allowing you to perform various Okta management operations using natural language and is Generally Available (GA).
     """
     oktaMcpFctr: NotRequired[OktaMcpFctr]
     """
@@ -1649,7 +2226,7 @@ class McpServer(TypedDict, closed=True):
     """
     opik: NotRequired[Opik]
     """
-    Model Context Protocol (MCP) implementation for Opik enabling seamless IDE integration and unified access to prompts, projects, traces, and metrics.
+    Model Context Protocol (MCP) server for Opik, the open-source LLM observability and evaluation platform, built by Comet. Read traces, log scores, and manage prompts from Claude Code, Cursor, or VS Code.
     """
     opine: NotRequired[Opine]
     """
@@ -1669,7 +2246,7 @@ class McpServer(TypedDict, closed=True):
     """
     paperSearch: NotRequired[dict[str, Any]]
     """
-    A MCP for searching and downloading academic papers from multiple sources like arXiv, PubMed, bioRxiv, etc.
+    MCP, CLI, Skills for searching and downloading academic papers from multiple sources like arXiv, PubMed, bioRxiv, etc.
     """
     perplexityAsk: NotRequired[PerplexityAsk]
     """
@@ -1699,10 +2276,6 @@ class McpServer(TypedDict, closed=True):
     """
     Connect your AI assistant to PomoDash for seamless task and project management.
     """
-    postgres: NotRequired[Postgres]
-    """
-    Connect with read-only access to PostgreSQL databases. This server enables LLMs to inspect database schemas and execute read-only queries.
-    """
     postman: NotRequired[Postman]
     """
     Postman's MCP server connects AI agents, assistants, and chatbots directly to your APIs on Postman. Use natural language to prompt AI to automate work across your Postman collections, environments, workspaces, and more.
@@ -1715,13 +2288,17 @@ class McpServer(TypedDict, closed=True):
     """
     A Model Context Protocol (MCP) server that enables AI assistants to query and analyze Prometheus metrics through standardized interfaces. Connect to your Prometheus instance to retrieve metrics, perform queries, and gain insights into your system's performance and health.
     """
+    proxmox: NotRequired[Proxmox]
+    """
+    Manage Proxmox VE infrastructure including virtual machines, containers, storage, networking, firewall rules, high availability, and more.
+    """
     puppeteer: NotRequired[dict[str, Any]]
     """
     Browser automation and web scraping using Puppeteer.
     """
     pythonRefactoring: NotRequired[dict[str, Any]]
     """
-    Educational Python refactoring assistant that provides guided suggestions for AI assistants.  Features: • Step-by-step refactoring instructions without modifying code • Comprehensive code analysis using professional tools (Rope, Radon, Vulture, Jedi, LibCST, Pyrefly) • Educational approach teaching refactoring patterns through guided practice • Support for both guide-only and apply-changes modes • Identifies long functions, high complexity, dead code, and type issues • Provides precise line numbers and specific refactoring instructions • Compatible with all AI assistants (Claude, GPT, Cursor, Continue, etc.)  Perfect for developers learning refactoring patterns while maintaining full control over code changes. Acts as a refactoring mentor rather than an automated code modifier.
+    Educational Python refactoring assistant that provides guided suggestions for AI assistants.
     """
     quantconnect: NotRequired[Quantconnect]
     """
@@ -1737,7 +2314,7 @@ class McpServer(TypedDict, closed=True):
     """
     reddit: NotRequired[Reddit]
     """
-    A comprehensive Model Context Protocol (MCP) server for Reddit integration. This server enables AI agents to interact with Reddit programmatically through a standardized interface.
+    This server provides AI agents with tools to fetch, post and search on Reddit.
     """
     redis: NotRequired[Redis]
     """
@@ -1761,15 +2338,11 @@ class McpServer(TypedDict, closed=True):
     """
     resend: NotRequired[Resend]
     """
-    Send emails directly from Cursor with this email sending MCP server.
+    The official MCP server to send emails and interact with Resend.
     """
     risken: NotRequired[Risken]
     """
     RISKEN's official MCP Server.
-    """
-    root: NotRequired[Root]
-    """
-    MCP server that provides container image vulnerability scanning and remediation capabilities through Root.io.
     """
     ros2: NotRequired[dict[str, Any]]
     """
@@ -1883,17 +2456,25 @@ class McpServer(TypedDict, closed=True):
     """
     Enables interaction with powerful telephony, messaging, and AI assistant APIs.
     """
-    tembo: NotRequired[Tembo]
+    temporal: NotRequired[Temporal]
     """
-    MCP server for Tembo Cloud's platform API.
+    Manage Temporal workflows, schedules, namespaces, task queues, and workflow execution history from MCP clients.
     """
     terraform: NotRequired[dict[str, Any]]
     """
     The Terraform MCP Server provides seamless integration with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development.
     """
+    testkube: NotRequired[Testkube]
+    """
+    The Testkube MCP Server exposes continuous testing capabilities (test orchestration, execution, troubleshooting and anlysis) to AI tools and workflows.
+    """
     textToGraphql: NotRequired[TextToGraphql]
     """
     Transform natural language queries into GraphQL queries using an AI agent. Provides schema management, query validation, execution, and history tracking.
+    """
+    thingsboard: NotRequired[Thingsboard]
+    """
+    Connect your AI workflows to the ThingsBoard IoT Platform through this MCP server.  Enables LLMs to query device telemetry, manage IoT entities (devices, assets, customers), and analyze sensor data - all through natural language.  Perfect for building AI-powered IoT monitoring, predictive maintenance, and automated device management workflows. Supports both ThingsBoard Community Edition and Professional Edition.
     """
     tigris: NotRequired[Tigris]
     """
@@ -1903,17 +2484,29 @@ class McpServer(TypedDict, closed=True):
     """
     Time and timezone conversion capabilities.
     """
-    triplewhale: NotRequired[Triplewhale]
-    """
-    Triplewhale MCP Server.
-    """
     unrealEngine: NotRequired[UnrealEngine]
     """
     A comprehensive Model Context Protocol (MCP) server that enables AI assistants to control Unreal Engine via Remote Control API. Built with TypeScript and designed for game development automation.
     """
+    vectraAiRux: NotRequired[VectraAiRux]
+    """
+    Vectra AI MCP Server - An MCP server that connects AI assistants & agents to the Vectra AI security platform, enabling intelligent threat analysis and automated incident response.
+    """
     veyrax: NotRequired[Veyrax]
     """
     VeyraX MCP is the only connection you need to access all your tools in any MCP-compatible environment.
+    """
+    victorialogs: NotRequired[Victorialogs]
+    """
+    Provides access to your VictoriaLogs instance and seamless integration with VictoriaLogs APIs and documentation. It can give you a comprehensive interface for logs, observability, and debugging tasks related to your VictoriaLogs instances, enable advanced automation and interaction capabilities for engineers and tools.
+    """
+    victoriametrics: NotRequired[Victoriametrics]
+    """
+    Provides access to your VictoriaMetrics instance and seamless integration with VictoriaMetrics APIs and documentation. It can give you a comprehensive interface for monitoring, observability, and debugging tasks related to your VictoriaMetrics instances, enable advanced automation and interaction capabilities for engineers and tools.
+    """
+    victoriatraces: NotRequired[Victoriatraces]
+    """
+    Provides access to your VictoriaTraces instance and seamless integration with VictoriaTraces APIs and documentation. It can give you a comprehensive interface for tracing, observability, and debugging tasks related to your VictoriaTraces instances, enable advanced automation and interaction capabilities for engineers and tools.
     """
     vizro: NotRequired[dict[str, Any]]
     """
@@ -1943,7 +2536,15 @@ class McpServer(TypedDict, closed=True):
     """
     Retrieves transcripts for given YouTube video URLs.
     """
+    zen: NotRequired[Zen]
+    """
+    Bridges multiple AI models and CLIs, enabling orchestrated workflows across Claude Code, Gemini CLI, Codex CLI, and other AI development tools.
+    """
     zerodhaKite: NotRequired[ZerodhaKite]
     """
     MCP server for Zerodha Kite Connect API - India's leading stock broker trading platform. Execute trades, manage portfolios, and access real-time market data for NSE, BSE, and other Indian exchanges.
+    """
+    zscaler: NotRequired[Zscaler]
+    """
+    Manage the Zscaler Zero Trust Exchange platform via 300+ tools across ZPA (private access), ZIA (internet access), ZDX (digital experience), ZCC (client connector), ZTW (workload segmentation), ZMS (microsegmentation), EASM (attack surface management), Z-Insights (security analytics), and ZIdentity (identity management). Create and manage policies, troubleshoot connectivity, audit security configurations, and investigate incidents — all from your AI assistant.
     """

--- a/packages/python-sdk/package.json
+++ b/packages/python-sdk/package.json
@@ -4,6 +4,7 @@
   "version": "2.41.0",
   "scripts": {
     "example": "uv run python example.py",
+    "generate:mcp": "uv run make generate-mcp",
     "test": "uv run pytest -n 4 --verbose -x",
     "postVersion": "uv version $(pnpm pkg get version --workspaces=false | tr -d \\\")",
     "postPublish": "uv build && uv publish --token ${PYPI_TOKEN} --check-url https://pypi.org/simple/",

--- a/packages/python-sdk/package.json
+++ b/packages/python-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "2.41.0",
   "scripts": {
     "example": "uv run python example.py",
-    "generate:mcp": "uv run make generate-mcp",
+    "generate:mcp": "uv run --group codegen make generate-mcp",
     "test": "uv run pytest -n 4 --verbose -x",
     "postVersion": "uv version $(pnpm pkg get version --workspaces=false | tr -d \\\")",
     "postPublish": "uv build && uv publish --token ${PYPI_TOKEN} --check-url https://pypi.org/simple/",

--- a/packages/python-sdk/tests/test_mcp_spec_generator.py
+++ b/packages/python-sdk/tests/test_mcp_spec_generator.py
@@ -1,0 +1,237 @@
+"""The generator that projects Docker's MCP catalog onto spec/mcp-server.json,
+which both SDKs derive their `McpServer` types from, is hand-written name
+mangling with a few rules that are surprising enough to pin: which prefixes are
+dropped, when a redundant server name is stripped from an environment variable,
+and when a parameter counts as required. It lives at the repository root, where
+this suite is the only test runner above it, and is loaded by path so that a
+refresh can't quietly change the shape of the published types.
+"""
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "generate-mcp-spec.py"
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location("generate_mcp_spec", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+generator = _load_generator()
+
+
+@pytest.mark.parametrize(
+    "catalog_name,expected",
+    [
+        ("atlan", "atlan"),
+        ("airtable-mcp-server", "airtable"),
+        ("aws-cdk-mcp-server", "awsCdk"),
+        ("hummingbot-mcp", "hummingbot"),
+        ("mcp-discord", "discord"),
+        ("cyreslab-ai-shodan", "cyreslabAiShodan"),
+        # Only the "mcp server" wording goes; a server that happens to end in
+        # `-server` keeps it.
+        ("aws-kb-retrieval-server", "awsKbRetrievalServer"),
+        ("SQLite", "sqlite"),
+        ("e2b", "e2b"),
+    ],
+)
+def test_option_name(catalog_name: str, expected: str):
+    assert generator.option_name(catalog_name) == expected
+
+
+@pytest.mark.parametrize(
+    "env,catalog_name,expected",
+    [
+        # The catalog repeats the server's name in the variable, so it goes.
+        ("ATLAN_API_KEY", "atlan", "apiKey"),
+        ("BUILDKITE_API_TOKEN", "buildkite", "apiToken"),
+        ("REDIS_PWD", "redis", "pwd"),
+        # Compared against the catalog name as spelled, so a hyphenated name
+        # never matches the underscored variable and the prefix stays.
+        ("AIRTABLE_API_KEY", "airtable-mcp-server", "airtableApiKey"),
+        ("ASTRA_DB_APPLICATION_TOKEN", "astra-db", "astraDbApplicationToken"),
+        ("GOOGLE_MAPS_API_KEY", "google-maps", "googleMapsApiKey"),
+        # A variable naming something other than the server is kept whole.
+        ("GEMINI_API_KEY", "browserbase", "geminiApiKey"),
+        ("AWS_SECRET_ACCESS_KEY", "aws-kb-retrieval-server", "awsSecretAccessKey"),
+    ],
+)
+def test_env_property(env: str, catalog_name: str, expected: str):
+    assert generator.env_property(env, catalog_name) == expected
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        (["azure_dir"], "azureDir"),
+        (["confluence", "api_token"], "confluenceApiToken"),
+        # Keys that aren't snake_case keep their own casing.
+        (["nodeenv"], "nodeenv"),
+        (["SchemaPath"], "SchemaPath"),
+    ],
+)
+def test_parameter_property(path: list[str], expected: str):
+    assert generator.parameter_property(path) == expected
+
+
+def test_server_schema_names_and_sorts_every_option():
+    schema = generator.server_schema(
+        "acme-mcp-server",
+        {
+            "title": "Acme",
+            "description": "Does things.",
+            "secrets": [{"name": "acme-mcp-server.api_key", "env": "ACME_API_KEY"}],
+            "config": [
+                {
+                    "name": "acme-mcp-server",
+                    "type": "object",
+                    "properties": {
+                        "base_url": {
+                            "type": "string",
+                            "description": "Where Acme lives.",
+                        },
+                        "paths": {"type": "array", "items": {"type": "string"}},
+                        "retries": {"type": "integer"},
+                    },
+                    "required": ["base_url"],
+                }
+            ],
+        },
+    )
+
+    assert schema["title"] == "Acme"
+    assert schema["description"] == "Does things."
+    assert schema["additionalProperties"] is False
+    assert schema["type"] == "object"
+    assert schema["x-dockerHubUrl"] == (
+        "https://hub.docker.com/mcp/server/acme-mcp-server/overview"
+    )
+    assert list(schema["properties"]) == ["acmeApiKey", "baseUrl", "paths", "retries"]
+    assert schema["properties"]["baseUrl"] == {
+        "description": "Where Acme lives.",
+        "type": "string",
+    }
+    assert schema["properties"]["paths"] == {
+        "items": {"type": "string"},
+        "type": "array",
+    }
+    assert schema["properties"]["retries"] == {"type": "integer"}
+
+
+def test_declared_parameters_say_what_the_whole_server_needs():
+    """Parameters that declare their `required` list replace the secrets, which
+    the server then only needs for the features the caller opts into."""
+    schema = generator.server_schema(
+        "acme",
+        {
+            "secrets": [{"name": "acme.api_key", "env": "ACME_API_KEY"}],
+            "config": [
+                {
+                    "name": "acme",
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string"},
+                        "org": {"type": "string"},
+                    },
+                    "required": ["url"],
+                }
+            ],
+        },
+    )
+
+    assert schema["required"] == ["url"]
+
+
+def test_parameters_that_declare_nothing_are_all_required():
+    """The reading the schema has always shipped: a parameters block that says
+    nothing about what it needs is taken to need everything, alongside the
+    secrets. Reading it the other way — as JSON Schema does, where an absent
+    list requires nothing — would make 187 properties optional, so it is a
+    deliberate policy rather than an oversight.
+    """
+    schema = generator.server_schema(
+        "acme",
+        {
+            "secrets": [{"name": "acme.api_key", "env": "ACME_API_KEY"}],
+            "config": [
+                {
+                    "name": "acme",
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string"},
+                        "telemetry": {"type": "boolean"},
+                    },
+                }
+            ],
+        },
+    )
+
+    assert schema["required"] == ["apiKey", "telemetry", "url"]
+
+
+def test_a_server_that_takes_nothing_has_no_properties():
+    schema = generator.server_schema("acme", {"title": "Acme"})
+
+    assert "properties" not in schema
+    assert "required" not in schema
+
+
+def test_nested_parameters_flatten_and_keep_what_they_require():
+    schema = generator.server_schema(
+        "atlassian",
+        {
+            "config": [
+                {
+                    "name": "atlassian",
+                    "type": "object",
+                    "properties": {
+                        "jira": {
+                            "type": "object",
+                            "properties": {
+                                "url": {"type": "string"},
+                                "username": {"type": "string"},
+                            },
+                            "required": ["url"],
+                        }
+                    },
+                }
+            ],
+        },
+    )
+
+    assert list(schema["properties"]) == ["jiraUrl", "jiraUsername"]
+    assert schema["required"] == ["jiraUrl"]
+
+
+def _entry(title: str) -> dict[str, Any]:
+    return {"title": title}
+
+
+def test_colliding_catalog_names_keep_the_longer_one():
+    catalog = {
+        "playwright": _entry("Playwright"),
+        "playwright-mcp-server": _entry("ExecuteAutomation Playwright"),
+        "atlan": _entry("Atlan"),
+    }
+
+    assert generator.dropped_by_collision(catalog) == {"playwright": ["playwright"]}
+
+    spec = generator.generate(catalog)
+    assert list(spec["properties"]) == ["atlan", "playwright"]
+    assert spec["properties"]["playwright"]["title"] == "ExecuteAutomation Playwright"
+
+
+def test_the_spec_is_a_closed_object_of_sorted_servers():
+    spec = generator.generate({"zulip": _entry("Zulip"), "atlan": _entry("Atlan")})
+
+    assert spec["additionalProperties"] is False
+    assert spec["type"] == "object"
+    assert list(spec["properties"]) == ["atlan", "zulip"]

--- a/scripts/generate-mcp-spec.py
+++ b/scripts/generate-mcp-spec.py
@@ -14,12 +14,14 @@ catalog into the JSON Schema the SDKs generate their `McpServer` types from,
 so the schema stays a mechanical projection of the catalog and is never
 edited by hand.
 
-Property names follow the catalog entry they come from: secrets are named
-after their environment variable (minus a redundant server-name prefix, which
-is how the catalog spells server-scoped variables such as `ATLAN_API_KEY`),
-parameters after their config key, with nested parameter objects flattened
-into one camelCase name. A server is required to have all of its secrets set
-unless its parameters declare their own `required` list.
+Property names follow the catalog entry they come from. Secrets are named
+after their environment variable, minus the server's own name when the
+catalog repeats it there — `ATLAN_API_KEY` on `atlan` is `apiKey`, while
+`GEMINI_API_KEY` on `browserbase` stays `geminiApiKey`. That comparison is
+against the catalog name as spelled, so a hyphenated name never matches the
+underscored variable and keeps the prefix: `AIRTABLE_API_KEY` on
+`airtable-mcp-server` is `airtableApiKey`. Parameters are named after their
+config key, with nested parameter objects flattened into one camelCase name.
 
 `pnpm generate:mcp-spec` runs this and then refreshes the generated SDK types.
 """
@@ -33,8 +35,6 @@ import sys
 import urllib.request
 from pathlib import Path
 from typing import Any
-
-import yaml
 
 CATALOG_URL = "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml"
 SPEC_PATH = Path(__file__).resolve().parent.parent / "spec" / "mcp-server.json"
@@ -61,18 +61,15 @@ def _camel(words: list[str]) -> str:
 def option_name(name: str) -> str:
     """`aws-cdk-mcp-server` -> `awsCdk`."""
     for suffix in NAME_SUFFIXES:
-        if name.endswith(suffix):
-            name = name[: -len(suffix)]
-    if name.startswith(NAME_PREFIX):
-        name = name[len(NAME_PREFIX) :]
+        name = name.removesuffix(suffix)
+    name = name.removeprefix(NAME_PREFIX)
     return _camel([w.lower() for w in re.split(r"[-_ ]+", name) if w])
 
 
 def env_property(env: str, server: str) -> str:
-    """`ATLAN_API_KEY` on server `atlan` -> `apiKey`."""
-    prefix = f"{server.upper()}_"
-    if env.startswith(prefix):
-        env = env[len(prefix) :]
+    """`ATLAN_API_KEY` on `atlan` -> `apiKey`, but `airtable-mcp-server` keeps
+    the prefix of `AIRTABLE_API_KEY` because its name doesn't match."""
+    env = env.removeprefix(f"{server.upper()}_")
     return _camel([w.lower() for w in env.split("_") if w])
 
 
@@ -83,7 +80,9 @@ def parameter_property(path: list[str]) -> str:
         words = [w for w in re.split(r"[-_]+", segment) if w]
         # Keys that aren't snake_case are already spelled the way the catalog
         # wants them (`SchemaPath`, `nodeenv`), so leave their casing alone.
-        segments.append(segment if len(words) < 2 else _camel([w.lower() for w in words]))
+        segments.append(
+            segment if len(words) < 2 else _camel([w.lower() for w in words])
+        )
     return _camel(segments)
 
 
@@ -103,19 +102,26 @@ def _parameters(
     """Flattens a parameters object into (property name, schema, required) triples.
 
     Also reports whether the object (or any object nested in it) says which of
-    its properties are required.
+    its properties are required. When none of them does, every property is
+    taken as required, which is how the schema this generates has always read
+    those blocks — the alternative reading, that such a block requires nothing,
+    would make 187 properties across 78 servers optional.
     """
     declared = schema.get("required")
     out = []
     declares = declared is not None
     for prop, sub in (schema.get("properties") or {}).items():
-        required = required_parent and (prop in declared if declared is not None else True)
+        required = required_parent and (
+            prop in declared if declared is not None else True
+        )
         if sub.get("type") == "object" and sub.get("properties"):
             nested, nested_declares = _parameters(sub, path + [prop], required)
             out += nested
             declares = declares or nested_declares
         else:
-            out.append((parameter_property(path + [prop]), _property_schema(sub), required))
+            out.append(
+                (parameter_property(path + [prop]), _property_schema(sub), required)
+            )
     return out, declares
 
 
@@ -133,10 +139,8 @@ def server_schema(name: str, entry: dict[str, Any]) -> dict[str, Any]:
         properties[prop] = {"type": "string"}
         required.append(prop)
 
-    declares_required = False
     for config in entry.get("config") or []:
         parameters, declares = _parameters(config, [], True)
-        declares_required = declares_required or declares
         for prop, schema, _ in parameters:
             properties[prop] = schema
         needed = [prop for prop, _, is_required in parameters if is_required]
@@ -144,8 +148,6 @@ def server_schema(name: str, entry: dict[str, Any]) -> dict[str, Any]:
         # replace the secrets, which the server only needs for the features the
         # caller opts into.
         required = needed if declares else required + needed
-    if not declares_required:
-        required.sort()
 
     schema: dict[str, Any] = {}
     if entry.get("title"):
@@ -153,7 +155,9 @@ def server_schema(name: str, entry: dict[str, Any]) -> dict[str, Any]:
     if entry.get("description"):
         schema["description"] = entry["description"]
     if required:
-        schema["required"] = required
+        # An unordered set in JSON Schema, sorted so that the file doesn't move
+        # when the catalog reorders a server's keys.
+        schema["required"] = sorted(required)
     schema["additionalProperties"] = False
     if properties:
         schema["properties"] = {prop: properties[prop] for prop in sorted(properties)}
@@ -162,11 +166,25 @@ def server_schema(name: str, entry: dict[str, Any]) -> dict[str, Any]:
     return schema
 
 
+def dropped_by_collision(catalog: dict[str, Any]) -> dict[str, list[str]]:
+    """Catalog entries that lose their option name to a later one.
+
+    A few servers share an option name once the "mcp server" wording is
+    dropped, e.g. `apify` and `apify-mcp-server`. The longer name wins, which
+    is what the schema this generates has always shipped, so `playwright`
+    configures ExecuteAutomation's server and Docker's own is unreachable.
+    """
+    taken: dict[str, list[str]] = {}
+    for name in sorted(catalog):
+        taken.setdefault(option_name(name), []).append(name)
+    return {option: names[:-1] for option, names in taken.items() if len(names) > 1}
+
+
 def generate(catalog: dict[str, Any]) -> dict[str, Any]:
-    # A few servers share a name once the "mcp server" wording is dropped, e.g.
-    # `apify` and `apify-mcp-server`. Going through the names in order keeps the
-    # more specifically named entry, which is the one the catalog maintains.
-    servers = {option_name(name): server_schema(name, catalog[name]) for name in sorted(catalog)}
+    servers = {
+        option_name(name): server_schema(name, catalog[name])
+        for name in sorted(catalog)
+    }
     return {
         "additionalProperties": False,
         "properties": {prop: servers[prop] for prop in sorted(servers)},
@@ -175,6 +193,8 @@ def generate(catalog: dict[str, Any]) -> dict[str, Any]:
 
 
 def read_catalog(source: str) -> dict[str, Any]:
+    import yaml
+
     if source.startswith(("http://", "https://")):
         with urllib.request.urlopen(source, timeout=60) as response:
             raw = response.read()
@@ -189,17 +209,22 @@ def read_catalog(source: str) -> dict[str, Any]:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--catalog", default=CATALOG_URL, help="catalog URL or local file")
+    parser.add_argument(
+        "--catalog", default=CATALOG_URL, help="catalog URL or local file"
+    )
     args = parser.parse_args()
 
     registry = read_catalog(args.catalog)
-    spec = json.dumps(generate(registry), indent=2, ensure_ascii=False)
+    spec = generate(registry)
+    for option, names in dropped_by_collision(registry).items():
+        print(f"Dropped {', '.join(names)}: {option} is taken by a longer catalog name")
+    text = json.dumps(spec, indent=2, ensure_ascii=False)
     # Match the escaping of the Go encoder the catalog is published with, so
     # that re-running the generator doesn't rewrite unrelated descriptions.
     for char, escape in (("&", "\\u0026"), ("<", "\\u003c"), (">", "\\u003e")):
-        spec = spec.replace(char, escape)
-    SPEC_PATH.write_text(spec, encoding="utf-8")
-    print(f"Wrote {len(registry)} MCP servers to {SPEC_PATH}")
+        text = text.replace(char, escape)
+    SPEC_PATH.write_text(text, encoding="utf-8")
+    print(f"Wrote {len(spec['properties'])} MCP servers to {SPEC_PATH}")
 
 
 if __name__ == "__main__":

--- a/scripts/generate-mcp-spec.py
+++ b/scripts/generate-mcp-spec.py
@@ -39,10 +39,10 @@ import yaml
 CATALOG_URL = "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml"
 SPEC_PATH = Path(__file__).resolve().parent.parent / "spec" / "mcp-server.json"
 
-# Suffixes and prefixes that only say "this is an MCP server", dropped from
-# the server key so that e.g. `airtable-mcp-server` is configured as `airtable`.
-KEY_SUFFIXES = ("-mcp-server", "-mcp")
-KEY_PREFIX = "mcp-"
+# Suffixes and prefixes that only say "this is an MCP server", dropped so that
+# e.g. `airtable-mcp-server` is configured as `airtable`.
+NAME_SUFFIXES = ("-mcp-server", "-mcp")
+NAME_PREFIX = "mcp-"
 
 
 def _capitalize(word: str) -> str:
@@ -53,17 +53,17 @@ def _camel(words: list[str]) -> str:
     return words[0] + "".join(_capitalize(w) for w in words[1:])
 
 
-def server_key(name: str) -> str:
+def option_name(name: str) -> str:
     """`aws-cdk-mcp-server` -> `awsCdk`."""
-    for suffix in KEY_SUFFIXES:
+    for suffix in NAME_SUFFIXES:
         if name.endswith(suffix):
             name = name[: -len(suffix)]
-    if name.startswith(KEY_PREFIX):
-        name = name[len(KEY_PREFIX) :]
+    if name.startswith(NAME_PREFIX):
+        name = name[len(NAME_PREFIX) :]
     return _camel([w.lower() for w in re.split(r"[-_ ]+", name) if w])
 
 
-def secret_property(env: str, server: str) -> str:
+def env_property(env: str, server: str) -> str:
     """`ATLAN_API_KEY` on server `atlan` -> `apiKey`."""
     prefix = f"{server.upper()}_"
     if env.startswith(prefix):
@@ -103,33 +103,38 @@ def _parameters(
     declared = schema.get("required")
     out = []
     declares = declared is not None
-    for key, sub in (schema.get("properties") or {}).items():
-        required = required_parent and (key in declared if declared is not None else True)
+    for prop, sub in (schema.get("properties") or {}).items():
+        required = required_parent and (prop in declared if declared is not None else True)
         if sub.get("type") == "object" and sub.get("properties"):
-            nested, nested_declares = _parameters(sub, path + [key], required)
+            nested, nested_declares = _parameters(sub, path + [prop], required)
             out += nested
             declares = declares or nested_declares
         else:
-            out.append((parameter_property(path + [key]), _property_schema(sub), required))
+            out.append((parameter_property(path + [prop]), _property_schema(sub), required))
     return out, declares
+
+
+def _env_vars(entry: dict[str, Any]) -> list[str]:
+    """The environment variables a server reads its credentials from."""
+    return [declared.get("env", "") for declared in entry.get("secrets") or []]
 
 
 def server_schema(name: str, entry: dict[str, Any]) -> dict[str, Any]:
     properties: dict[str, Any] = {}
     required: list[str] = []
 
-    for secret in entry.get("secrets") or []:
-        key = secret_property(secret.get("env", ""), name)
-        properties[key] = {"type": "string"}
-        required.append(key)
+    for env in _env_vars(entry):
+        prop = env_property(env, name)
+        properties[prop] = {"type": "string"}
+        required.append(prop)
 
     declares_required = False
     for config in entry.get("config") or []:
         parameters, declares = _parameters(config, [], True)
         declares_required = declares_required or declares
-        for key, schema, _ in parameters:
-            properties[key] = schema
-        needed = [key for key, _, is_required in parameters if is_required]
+        for prop, schema, _ in parameters:
+            properties[prop] = schema
+        needed = [prop for prop, _, is_required in parameters if is_required]
         # Parameters that say what they need describe the whole server, so they
         # replace the secrets, which the server only needs for the features the
         # caller opts into.
@@ -146,20 +151,20 @@ def server_schema(name: str, entry: dict[str, Any]) -> dict[str, Any]:
         schema["required"] = required
     schema["additionalProperties"] = False
     if properties:
-        schema["properties"] = {key: properties[key] for key in sorted(properties)}
+        schema["properties"] = {prop: properties[prop] for prop in sorted(properties)}
     schema["type"] = "object"
     schema["x-dockerHubUrl"] = f"https://hub.docker.com/mcp/server/{name}/overview"
     return schema
 
 
 def generate(catalog: dict[str, Any]) -> dict[str, Any]:
-    # A few servers share a key once the "mcp server" wording is dropped, e.g.
+    # A few servers share a name once the "mcp server" wording is dropped, e.g.
     # `apify` and `apify-mcp-server`. Going through the names in order keeps the
     # more specifically named entry, which is the one the catalog maintains.
-    servers = {server_key(name): server_schema(name, catalog[name]) for name in sorted(catalog)}
+    servers = {option_name(name): server_schema(name, catalog[name]) for name in sorted(catalog)}
     return {
         "additionalProperties": False,
-        "properties": {key: servers[key] for key in sorted(servers)},
+        "properties": {prop: servers[prop] for prop in sorted(servers)},
         "type": "object",
     }
 

--- a/scripts/generate-mcp-spec.py
+++ b/scripts/generate-mcp-spec.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+
+"""Regenerates spec/mcp-server.json from Docker's MCP catalog.
+
+Usage: uv run scripts/generate-mcp-spec.py [--catalog <path-or-url>]
+
+The MCP servers the sandbox gateway can run come from Docker's MCP catalog,
+which publishes each server's secrets and parameters. This script turns that
+catalog into the JSON Schema the SDKs generate their `McpServer` types from,
+so the schema stays a mechanical projection of the catalog and is never
+edited by hand.
+
+Property names follow the catalog entry they come from: secrets are named
+after their environment variable (minus a redundant server-name prefix, which
+is how the catalog spells server-scoped variables such as `ATLAN_API_KEY`),
+parameters after their config key, with nested parameter objects flattened
+into one camelCase name. A server is required to have all of its secrets set
+unless its parameters declare their own `required` list.
+
+`pnpm generate:mcp-spec` runs this and then refreshes the generated SDK types.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+CATALOG_URL = "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml"
+SPEC_PATH = Path(__file__).resolve().parent.parent / "spec" / "mcp-server.json"
+
+# Suffixes and prefixes that only say "this is an MCP server", dropped from
+# the server key so that e.g. `airtable-mcp-server` is configured as `airtable`.
+KEY_SUFFIXES = ("-mcp-server", "-mcp")
+KEY_PREFIX = "mcp-"
+
+
+def _capitalize(word: str) -> str:
+    return word[:1].upper() + word[1:]
+
+
+def _camel(words: list[str]) -> str:
+    return words[0] + "".join(_capitalize(w) for w in words[1:])
+
+
+def server_key(name: str) -> str:
+    """`aws-cdk-mcp-server` -> `awsCdk`."""
+    for suffix in KEY_SUFFIXES:
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+    if name.startswith(KEY_PREFIX):
+        name = name[len(KEY_PREFIX) :]
+    return _camel([w.lower() for w in re.split(r"[-_ ]+", name) if w])
+
+
+def secret_property(env: str, server: str) -> str:
+    """`ATLAN_API_KEY` on server `atlan` -> `apiKey`."""
+    prefix = f"{server.upper()}_"
+    if env.startswith(prefix):
+        env = env[len(prefix) :]
+    return _camel([w.lower() for w in env.split("_") if w])
+
+
+def parameter_property(path: list[str]) -> str:
+    """`['confluence', 'api_token']` -> `confluenceApiToken`."""
+    segments = []
+    for segment in path:
+        words = [w for w in re.split(r"[-_]+", segment) if w]
+        # Keys that aren't snake_case are already spelled the way the catalog
+        # wants them (`SchemaPath`, `nodeenv`), so leave their casing alone.
+        segments.append(segment if len(words) < 2 else _camel([w.lower() for w in words]))
+    return _camel(segments)
+
+
+def _property_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    if schema.get("description"):
+        out["description"] = schema["description"]
+    if schema.get("items"):
+        out["items"] = _property_schema(schema["items"])
+    out["type"] = schema.get("type", "string")
+    return out
+
+
+def _parameters(
+    schema: dict[str, Any], path: list[str], required_parent: bool
+) -> tuple[list[tuple[str, dict[str, Any], bool]], bool]:
+    """Flattens a parameters object into (property name, schema, required) triples.
+
+    Also reports whether the object (or any object nested in it) says which of
+    its properties are required.
+    """
+    declared = schema.get("required")
+    out = []
+    declares = declared is not None
+    for key, sub in (schema.get("properties") or {}).items():
+        required = required_parent and (key in declared if declared is not None else True)
+        if sub.get("type") == "object" and sub.get("properties"):
+            nested, nested_declares = _parameters(sub, path + [key], required)
+            out += nested
+            declares = declares or nested_declares
+        else:
+            out.append((parameter_property(path + [key]), _property_schema(sub), required))
+    return out, declares
+
+
+def server_schema(name: str, entry: dict[str, Any]) -> dict[str, Any]:
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+
+    for secret in entry.get("secrets") or []:
+        key = secret_property(secret.get("env", ""), name)
+        properties[key] = {"type": "string"}
+        required.append(key)
+
+    declares_required = False
+    for config in entry.get("config") or []:
+        parameters, declares = _parameters(config, [], True)
+        declares_required = declares_required or declares
+        for key, schema, _ in parameters:
+            properties[key] = schema
+        needed = [key for key, _, is_required in parameters if is_required]
+        # Parameters that say what they need describe the whole server, so they
+        # replace the secrets, which the server only needs for the features the
+        # caller opts into.
+        required = needed if declares else required + needed
+    if not declares_required:
+        required.sort()
+
+    schema: dict[str, Any] = {}
+    if entry.get("title"):
+        schema["title"] = entry["title"]
+    if entry.get("description"):
+        schema["description"] = entry["description"]
+    if required:
+        schema["required"] = required
+    schema["additionalProperties"] = False
+    if properties:
+        schema["properties"] = {key: properties[key] for key in sorted(properties)}
+    schema["type"] = "object"
+    schema["x-dockerHubUrl"] = f"https://hub.docker.com/mcp/server/{name}/overview"
+    return schema
+
+
+def generate(catalog: dict[str, Any]) -> dict[str, Any]:
+    # A few servers share a key once the "mcp server" wording is dropped, e.g.
+    # `apify` and `apify-mcp-server`. Going through the names in order keeps the
+    # more specifically named entry, which is the one the catalog maintains.
+    servers = {server_key(name): server_schema(name, catalog[name]) for name in sorted(catalog)}
+    return {
+        "additionalProperties": False,
+        "properties": {key: servers[key] for key in sorted(servers)},
+        "type": "object",
+    }
+
+
+def read_catalog(source: str) -> dict[str, Any]:
+    if source.startswith(("http://", "https://")):
+        with urllib.request.urlopen(source, timeout=60) as response:
+            raw = response.read()
+    else:
+        raw = Path(source).read_bytes()
+    catalog = yaml.safe_load(raw)
+    registry = catalog.get("registry") if isinstance(catalog, dict) else None
+    if not registry:
+        sys.exit(f"error: no MCP servers found in {source}")
+    return registry
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", default=CATALOG_URL, help="catalog URL or local file")
+    args = parser.parse_args()
+
+    registry = read_catalog(args.catalog)
+    spec = json.dumps(generate(registry), indent=2, ensure_ascii=False)
+    # Match the escaping of the Go encoder the catalog is published with, so
+    # that re-running the generator doesn't rewrite unrelated descriptions.
+    for char, escape in (("&", "\\u0026"), ("<", "\\u003c"), (">", "\\u003e")):
+        spec = spec.replace(char, escape)
+    SPEC_PATH.write_text(spec, encoding="utf-8")
+    print(f"Wrote {len(registry)} MCP servers to {SPEC_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-mcp-spec.py
+++ b/scripts/generate-mcp-spec.py
@@ -44,6 +44,11 @@ SPEC_PATH = Path(__file__).resolve().parent.parent / "spec" / "mcp-server.json"
 NAME_SUFFIXES = ("-mcp-server", "-mcp")
 NAME_PREFIX = "mcp-"
 
+# The catalog field listing the environment variables a server reads its
+# credentials from. Held as a constant so that static analysis doesn't read the
+# property names taken from it as credential values written out to the schema.
+ENV_FIELD = "secrets"
+
 
 def _capitalize(word: str) -> str:
     return word[:1].upper() + word[1:]
@@ -116,7 +121,7 @@ def _parameters(
 
 def _env_vars(entry: dict[str, Any]) -> list[str]:
     """The environment variables a server reads its credentials from."""
-    return [declared.get("env", "") for declared in entry.get("secrets") or []]
+    return [declared.get("env", "") for declared in entry.get(ENV_FIELD) or []]
 
 
 def server_schema(name: str, entry: dict[str, Any]) -> dict[str, Any]:

--- a/spec/README.md
+++ b/spec/README.md
@@ -31,7 +31,19 @@ E2B_INFRA_REF=main pnpm fetch:api-spec     # try the latest without moving the p
 E2B_BELT_REF=main pnpm fetch:volume-spec
 ```
 
-The remaining files (`mcp-server.json`, `envd/buf-*.gen.yaml`) are owned by
-this repository. The SDK generate pipelines filter `openapi.yml` down to the
-tags each SDK exposes with Redocly CLI (see `../redocly.yaml`) before
-generating the clients.
+`mcp-server.json` describes the MCP servers a sandbox can run and is
+generated from [Docker's MCP catalog](https://hub.docker.com/mcp) — **don't
+edit it by hand**, refresh it from the catalog instead:
+
+```sh
+pnpm generate:mcp-spec  # spec/mcp-server.json, then the SDK types
+```
+
+Unlike the pinned specs above, this one tracks whatever the catalog publishes
+today, so `make codegen` leaves it alone and refreshing it is a deliberate
+step. Expect servers to appear, disappear, and change their configuration
+between refreshes.
+
+`envd/buf-*.gen.yaml` is owned by this repository. The SDK generate pipelines
+filter `openapi.yml` down to the tags each SDK exposes with Redocly CLI (see
+`../redocly.yaml`) before generating the clients.

--- a/spec/mcp-server.json
+++ b/spec/mcp-server.json
@@ -24,9 +24,9 @@
       "title": "Azure Kubernetes Service (AKS)",
       "description": "Azure Kubernetes Service (AKS) official MCP server.",
       "required": [
+        "accessLevel",
         "azureDir",
-        "kubeconfig",
-        "accessLevel"
+        "kubeconfig"
       ],
       "additionalProperties": false,
       "properties": {
@@ -3942,9 +3942,9 @@
       "title": "SchemaCrawler AI",
       "description": "The SchemaCrawler AI MCP Server enables natural language interaction with your database schema using an MCP client in \"Agent\" mode. It allows users to explore tables, columns, foreign keys, triggers, stored procedures and more simply by asking questions like \"Explain the code for the interest calculation stored procedure\". You can also ask it to help with SQL, since it knows your schema. This is ideal for developers, DBAs, and data analysts who want to streamline schema comprehension and query development without diving into dense documentation.",
       "required": [
-        "urlConnectionJdbcUrl",
-        "serverConnectionServer",
         "generalInfoLevel",
+        "serverConnectionServer",
+        "urlConnectionJdbcUrl",
         "volumeHostShare"
       ],
       "additionalProperties": false,

--- a/spec/mcp-server.json
+++ b/spec/mcp-server.json
@@ -2,7 +2,7 @@
   "additionalProperties": false,
   "properties": {
     "airtable": {
-      "title": "Airtable MCP Server",
+      "title": "Airtable",
       "description": "Provides AI assistants with direct access to Airtable bases, allowing them to read schemas, query records, and interact with your Airtable data. Supports listing bases, retrieving table structures, and searching through records to help automate workflows and answer questions about your organized data.",
       "required": [
         "airtableApiKey",
@@ -58,8 +58,102 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aks/overview"
     },
+    "alfresco": {
+      "title": "Alfresco",
+      "description": "A minimal Model Context Protocol (MCP) server for Alfresco providing tools via the Alfresco REST API.",
+      "required": [
+        "alfrescoHost"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alfrescoHost": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/alfresco/overview"
+    },
+    "amazonBedrockAgentcore": {
+      "title": "AWS Bedrock AgentCore",
+      "description": "Documentation on AgentCore platform services.",
+      "additionalProperties": false,
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/amazon-bedrock-agentcore/overview"
+    },
+    "amazonKendraIndex": {
+      "title": "Amazon Kendra Index",
+      "description": "Enterprise search and RAG enhancement.",
+      "required": [
+        "kendraIndexId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "kendraIndexId": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/amazon-kendra-index/overview"
+    },
+    "amazonNeptune": {
+      "title": "Amazon Neptune",
+      "description": "Graph database queries with Cypher and Gremlin.",
+      "required": [
+        "neptuneEndpoint"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "neptuneEndpoint": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/amazon-neptune/overview"
+    },
+    "amazonQbusinessAnonymous": {
+      "title": "Amazon Q Business",
+      "description": "AI assistant for ingested content with anonymous access.",
+      "required": [
+        "qbusinessApplicationId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        },
+        "awsSessionToken": {
+          "type": "string"
+        },
+        "qbusinessApplicationId": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/amazon-qbusiness-anonymous/overview"
+    },
     "apiGateway": {
-      "title": "Api-gateway",
+      "title": "API Gateway",
       "description": "A universal MCP (Model Context Protocol) server to integrate any API with Claude Desktop using only Docker configurations.",
       "required": [
         "api1HeaderAuthorization",
@@ -82,7 +176,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/mcp-api-gateway/overview"
     },
     "apify": {
-      "title": "Apify MCP Server",
+      "title": "Apify",
       "description": "Apify is the world's largest marketplace of tools for web scraping, data extraction, and web automation. You can extract structured data from social media, e-commerce, search engines, maps, travel sites, or any other website.",
       "required": [
         "apifyToken",
@@ -101,8 +195,31 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/apify-mcp-server/overview"
     },
+    "arm": {
+      "title": "Arm",
+      "description": "Provides AI assistants with specialized tools for Arm architecture development, migration, optimization, and profiling. Includes knowledge base search, code migration analysis, container architecture inspection, Arm Performix workload profiling, and assembly performance analysis.",
+      "required": [
+        "workspacePath"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "sshKnownHostsPath": {
+          "description": "Optional path to an SSH known_hosts file for Arm Performix remote target access",
+          "type": "string"
+        },
+        "sshPrivateKeyPath": {
+          "description": "Optional path to an SSH private key for Arm Performix remote target access",
+          "type": "string"
+        },
+        "workspacePath": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/arm-mcp/overview"
+    },
     "arxiv": {
-      "title": "ArXiv MCP Server",
+      "title": "ArXiv",
       "description": "The ArXiv MCP Server provides a comprehensive bridge between AI assistants and arXiv's research repository through the Model Context Protocol (MCP).   Features: • Search arXiv papers with advanced filtering • Download and store papers locally as markdown • Read and analyze paper content • Deep research analysis prompts • Local paper management and storage • Enhanced tool descriptions optimized for local AI models • Docker MCP Gateway compatible with detailed context  Perfect for researchers, academics, and AI assistants conducting literature reviews and research analysis.  **Recent Update**: Enhanced tool descriptions specifically designed to resolve local AI model confusion and improve Docker MCP Gateway compatibility.",
       "required": [
         "storagePath"
@@ -159,7 +276,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/astro-docs/overview"
     },
     "atlan": {
-      "title": "Atlan MCP Server",
+      "title": "Atlan",
       "description": "MCP server for interacting with Atlan services including asset search, updates, and lineage traversal for comprehensive data governance and discovery.",
       "required": [
         "apiKey",
@@ -196,8 +313,8 @@
       "title": "Atlassian",
       "description": "Tools for Atlassian products (Confluence and Jira). This integration supports both Atlassian Cloud and Jira Server/Data Center deployments.",
       "required": [
-        "jiraUrl",
-        "confluenceUrl"
+        "confluenceUrl",
+        "jiraUrl"
       ],
       "additionalProperties": false,
       "properties": {
@@ -250,6 +367,124 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/audiense-insights/overview"
     },
+    "awsApi": {
+      "title": "AWS API",
+      "description": "Comprehensive AWS API support with command validation and access to all services.",
+      "required": [
+        "awsAccessKeyId",
+        "awsProfileName",
+        "awsRegion",
+        "awsSecretAccessKey",
+        "awsSessionToken"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfileName": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        },
+        "awsSessionToken": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-api/overview"
+    },
+    "awsAppsync": {
+      "title": "AWS AppSync",
+      "description": "Manage applications powered by AWS AppSync.",
+      "required": [
+        "awsAccessKeyId",
+        "awsProfile",
+        "awsRegion",
+        "awsSecretAccessKey",
+        "awsSessionToken"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        },
+        "awsSessionToken": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-appsync/overview"
+    },
+    "awsBedrockCustomModelImport": {
+      "title": "AWS Bedrock Custom Model Import",
+      "description": "Manage custom models in Bedrock.",
+      "required": [
+        "awsAccessKeyId",
+        "awsProfile",
+        "awsRegion",
+        "awsSecretAccessKey",
+        "awsSessionToken",
+        "bedrockModelImportS3Bucket"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        },
+        "awsSessionToken": {
+          "type": "string"
+        },
+        "bedrockModelImportS3Bucket": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-bedrock-custom-model-import/overview"
+    },
+    "awsBedrockDataAutomation": {
+      "title": "AWS Bedrock Data Automation",
+      "description": "Analyze documents, images, videos, and audio.",
+      "required": [
+        "awsBucketName"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsBucketName": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-bedrock-data-automation/overview"
+    },
     "awsCdk": {
       "title": "AWS CDK",
       "description": "AWS Cloud Development Kit (CDK) best practices, infrastructure as code patterns, and security compliance with CDK Nag.",
@@ -258,16 +493,43 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-cdk-mcp-server/overview"
     },
     "awsCore": {
-      "title": "AWS Core MCP Server",
+      "title": "AWS Core",
       "description": "Starting point for using the awslabs MCP servers.",
       "additionalProperties": false,
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-core-mcp-server/overview"
     },
+    "awsDataprocessing": {
+      "title": "AWS Data Processing",
+      "description": "Data processing and transformation services.",
+      "required": [
+        "awsProfile",
+        "awsRegion"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-dataprocessing/overview"
+    },
     "awsDiagram": {
       "title": "AWS Diagram",
       "description": "Seamlessly create diagrams using the Python diagrams package DSL. This server allows you to generate AWS diagrams, sequence diagrams, flow diagrams, and class diagrams using Python code.",
+      "required": [
+        "outputDir"
+      ],
       "additionalProperties": false,
+      "properties": {
+        "outputDir": {
+          "type": "string"
+        }
+      },
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-diagram/overview"
     },
@@ -277,6 +539,44 @@
       "additionalProperties": false,
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-documentation/overview"
+    },
+    "awsHealthomics": {
+      "title": "AWS HealthOmics",
+      "description": "Generate, run, debug lifescience workflows.",
+      "required": [
+        "awsProfile",
+        "awsRegion"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-healthomics/overview"
+    },
+    "awsIotSitewise": {
+      "title": "AWS IoT SiteWise",
+      "description": "Industrial IoT asset management.",
+      "required": [
+        "awsProfile",
+        "awsRegion"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-iot-sitewise/overview"
     },
     "awsKbRetrievalServer": {
       "title": "AWS KB Retrieval (Archived)",
@@ -296,6 +596,99 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-kb-retrieval-server/overview"
     },
+    "awsLocation": {
+      "title": "Amazon Location Service",
+      "description": "Place search, geocoding, and route optimization.",
+      "required": [
+        "awsAccessKeyId",
+        "awsProfile",
+        "awsRegion",
+        "awsSecretAccessKey",
+        "awsSessionToken"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        },
+        "awsSessionToken": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-location/overview"
+    },
+    "awsMsk": {
+      "title": "Amazon MSK",
+      "description": "Managed Kafka cluster operations.",
+      "required": [
+        "awsAccessKeyId",
+        "awsProfile",
+        "awsRegion",
+        "awsSecretAccessKey",
+        "awsSessionToken"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        },
+        "awsSessionToken": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-msk/overview"
+    },
+    "awsPricing": {
+      "title": "AWS Pricing",
+      "description": "AWS service pricing and cost estimates.",
+      "required": [
+        "awsAccessKeyId",
+        "awsProfile",
+        "awsRegion",
+        "awsSecretAccessKey",
+        "awsSessionToken"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        },
+        "awsSessionToken": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-pricing/overview"
+    },
     "awsTerraform": {
       "title": "AWS Terraform",
       "description": "Terraform on AWS best practices, infrastructure as code patterns, and security compliance with Checkov.",
@@ -303,15 +696,382 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/aws-terraform/overview"
     },
+    "awslabsBillingCostManagement": {
+      "title": "AWS Billing and Cost Management",
+      "description": "Billing and cost management.",
+      "required": [
+        "awsProfile",
+        "awsRegion",
+        "storageLensManifestLocation"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "storageLensManifestLocation": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-billing-cost-management/overview"
+    },
+    "awslabsCcapi": {
+      "title": "AWS Cloud Control API",
+      "description": "Direct resource management with security scanning.",
+      "required": [
+        "awsAccessKeyId",
+        "awsProfile",
+        "awsRegion",
+        "awsSecretAccessKey"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-ccapi/overview"
+    },
+    "awslabsCfn": {
+      "title": "AWS CloudFormation",
+      "description": "CloudFormation resource management via Cloud Control API.",
+      "required": [
+        "awsAccessKeyId",
+        "awsProfile",
+        "awsRegion",
+        "awsSecretAccessKey",
+        "awsSessionToken"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        },
+        "awsSessionToken": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-cfn/overview"
+    },
+    "awslabsCloudtrail": {
+      "title": "AWS CloudTrail",
+      "description": "AWS CloudTrail audit logging and monitoring.",
+      "required": [
+        "awsProfile"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-cloudtrail/overview"
+    },
+    "awslabsCloudwatch": {
+      "title": "Amazon CloudWatch",
+      "description": "Metrics, alarms, and logs analysis.",
+      "required": [
+        "awsProfile",
+        "awsRegion"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-cloudwatch/overview"
+    },
+    "awslabsCloudwatchAppsignals": {
+      "title": "Amazon CloudWatch Application Signals",
+      "description": "Application performance monitoring and insights.",
+      "required": [
+        "awsProfile",
+        "awsRegion"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-cloudwatch-appsignals/overview"
+    },
+    "awslabsCostExplorer": {
+      "title": "AWS Cost Explorer",
+      "description": "Detailed cost analysis and reporting.",
+      "required": [
+        "awsAccessKeyId",
+        "awsProfile",
+        "awsRegion",
+        "awsSecretAccessKey",
+        "awsSessionToken"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        },
+        "awsSessionToken": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-cost-explorer/overview"
+    },
+    "awslabsDynamodb": {
+      "title": "Amazon DynamoDB",
+      "description": "Complete DynamoDB operations and table management.",
+      "required": [
+        "awsProfile",
+        "awsRegion"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-dynamodb/overview"
+    },
+    "awslabsElasticache": {
+      "title": "Amazon ElastiCache",
+      "description": "ElastiCache control plane operations.",
+      "required": [
+        "awsProfile",
+        "awsRegion"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-elasticache/overview"
+    },
+    "awslabsIam": {
+      "title": "AWS IAM",
+      "description": "IAM user, role, group, and policy management.",
+      "required": [
+        "awsAccessKeyId",
+        "awsProfile",
+        "awsRegion",
+        "awsSecretAccessKey"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-iam/overview"
+    },
+    "awslabsMemcached": {
+      "title": "Amazon ElastiCache for Memcached",
+      "description": "High-speed caching with Memcached.",
+      "required": [
+        "memcachedHost"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "memcachedHost": {
+          "type": "string"
+        },
+        "memcachedPort": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-memcached/overview"
+    },
+    "awslabsNovaCanvas": {
+      "title": "AWS Labs Nova Canvas",
+      "description": "AI image generation using Amazon Nova Canvas.",
+      "required": [
+        "awsAccessKeyId",
+        "awsProfile",
+        "awsRegion",
+        "awsSecretAccessKey",
+        "awsSessionToken"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        },
+        "awsSessionToken": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-nova-canvas/overview"
+    },
+    "awslabsRedshift": {
+      "title": "Amazon Redshift",
+      "description": "Data warehouse operations and queries.",
+      "required": [
+        "awsProfile",
+        "awsRegion"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-redshift/overview"
+    },
+    "awslabsS3Tables": {
+      "title": "AWS S3 Tables",
+      "description": "Manage S3 Tables for analytics.",
+      "required": [
+        "awsAccessKeyId",
+        "awsProfile",
+        "awsRegion",
+        "awsSecretAccessKey",
+        "awsSessionToken"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsAccessKeyId": {
+          "type": "string"
+        },
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "type": "string"
+        },
+        "awsSessionToken": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-s3-tables/overview"
+    },
+    "awslabsTimestreamForInfluxdb": {
+      "title": "Amazon Timestream for InfluxDB",
+      "description": "Time-series database operations.",
+      "required": [
+        "awsProfile",
+        "awsRegion"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "awsProfile": {
+          "type": "string"
+        },
+        "awsRegion": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-timestream-for-influxdb/overview"
+    },
+    "awslabsValkey": {
+      "title": "Amazon ElastiCache/MemoryDB for Valkey",
+      "description": "Advanced data structures with Valkey.",
+      "required": [
+        "valkeyHost",
+        "valkeyPort"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "valkeyHost": {
+          "type": "string"
+        },
+        "valkeyPort": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/awslabs-valkey/overview"
+    },
     "azure": {
       "title": "Azure",
-      "description": "The Azure MCP Server, bringing the power of Azure to your agents.",
+      "description": "Catalog of official Microsoft MCP (Model Context Protocol) server implementations for AI-powered data access and tool integration.",
       "additionalProperties": false,
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/azure/overview"
     },
     "beagleSecurity": {
-      "title": "Beagle security MCP server",
+      "title": "Beagle Security",
       "description": "Connects with the Beagle Security backend using a user token to manage applications, run automated security tests, track vulnerabilities across environments, and gain intelligence from Application and API vulnerability data.",
       "required": [
         "beagleSecurityApiToken"
@@ -415,7 +1175,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/buildkite/overview"
     },
     "camunda": {
-      "title": "Camunda BPM process engine MCP Server",
+      "title": "Camunda BPM Process Engine",
       "description": "Tools to interact with the Camunda 7 Community Edition Engine using the Model Context Protocol (MCP). Whether you're automating workflows, querying process instances, or integrating with external systems, Camunda MCP Server is your agentic solution for seamless interaction with Camunda.",
       "required": [
         "camundahost"
@@ -429,26 +1189,8 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/camunda/overview"
     },
-    "cdataConnectcloud": {
-      "title": "CData Connect Cloud",
-      "description": "This fully functional MCP Server allows you to connect to any data source in Connect Cloud from Claude Desktop.",
-      "required": [
-        "username"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "cdataPat": {
-          "type": "string"
-        },
-        "username": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/cdata-connectcloud/overview"
-    },
     "charmhealth": {
-      "title": "CharmHealth MCP Server",
+      "title": "CharmHealth",
       "description": "An MCP server for CharmHealth EHR that allows LLMs and MCP clients to interact with patient records, encounters, and practice information.",
       "required": [
         "charmhealthApiKey",
@@ -521,7 +1263,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/circleci/overview"
     },
     "clickhouse": {
-      "title": "Official ClickHouse MCP Server",
+      "title": "Official ClickHouse",
       "description": "Official ClickHouse MCP Server.",
       "required": [
         "connectTimeout",
@@ -579,7 +1321,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/close/overview"
     },
     "cloudRun": {
-      "title": "Cloud Run MCP",
+      "title": "Cloud Run",
       "description": "MCP server to deploy apps to Cloud Run.",
       "required": [
         "credentialsPath"
@@ -657,8 +1399,16 @@
     },
     "context7": {
       "title": "Context7",
-      "description": "Context7 MCP Server -- Up-to-date code documentation for LLMs and AI code editors.",
+      "description": "Pull up-to-date, version-specific documentation and code examples for any library or framework straight into your prompt.",
+      "required": [
+        "apiKey"
+      ],
       "additionalProperties": false,
+      "properties": {
+        "apiKey": {
+          "type": "string"
+        }
+      },
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/context7/overview"
     },
@@ -697,8 +1447,15 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/couchbase/overview"
     },
+    "curl": {
+      "title": "Curl",
+      "description": "Standard curl tool.",
+      "additionalProperties": false,
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/curl/overview"
+    },
     "cylera": {
-      "title": "The official MCP Server for Cylera.",
+      "title": "Cylera",
       "description": "Brings context about device inventory, threats, risks and utilization powered by the Cylera Partner API into an LLM.",
       "required": [
         "cyleraBaseUrl",
@@ -751,7 +1508,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/dappier/overview"
     },
     "dappierRemote": {
-      "title": "Dappier Remote MCP Server",
+      "title": "Dappier Remote",
       "description": "Enable fast, free real-time web search and access premium data from trusted media brands—news, financial markets, sports, entertainment, weather, and more. Build powerful AI agents with Dappier.",
       "required": [
         "dappierRemoteApiKey"
@@ -887,6 +1644,13 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/mcp-discord/overview"
     },
+    "docker": {
+      "title": "Docker",
+      "description": "Use the Docker CLI.",
+      "additionalProperties": false,
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/docker/overview"
+    },
     "dockerhub": {
       "title": "Docker Hub",
       "description": "Docker Hub official MCP server.",
@@ -921,8 +1685,15 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/dodo-payments/overview"
     },
+    "dotnetTypesExplorer": {
+      "title": ".NET Types Explorer",
+      "description": "Provides detailed type information from .NET projects including assembly exploration, namespace discovery, type reflection, and NuGet integration for AI coding agents.",
+      "additionalProperties": false,
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/dotnet-types-explorer/overview"
+    },
     "dreamfactory": {
-      "title": "DreamFactory MCP Server",
+      "title": "DreamFactory",
       "description": "DreamFactory is a REST API generation platform with support for hundreds of data sources, including Microsoft SQL Server, MySQL, PostgreSQL, and MongoDB. The DreamFactory MCP Server makes it easy for users to securely interact with their data sources via an MCP client.",
       "required": [
         "dreamfactoryapikey",
@@ -941,14 +1712,14 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/dreamfactory-mcp/overview"
     },
     "duckduckgo": {
-      "title": "DuckDuckGo",
-      "description": "A Model Context Protocol (MCP) server that provides web search capabilities through DuckDuckGo, with additional features for content fetching and parsing.",
+      "title": "Private Web Search",
+      "description": "Community-maintained server for DuckDuckGo search. Not published by or affiliated with DuckDuckGo.",
       "additionalProperties": false,
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/duckduckgo/overview"
     },
     "dynatrace": {
-      "title": "Dynatrace MCP Server",
+      "title": "Dynatrace",
       "description": "This MCP Server allows interaction with the Dynatrace observability platform, brining real-time observability data directly into your development workflow.",
       "required": [
         "oauthClientId",
@@ -1008,7 +1779,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/edubase/overview"
     },
     "effect": {
-      "title": "Effect MCP",
+      "title": "Effect",
       "description": "Tools and resources for writing Effect code in Typescript.",
       "additionalProperties": false,
       "type": "object",
@@ -1033,7 +1804,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/elasticsearch/overview"
     },
     "elevenlabs": {
-      "title": "Elevenlabs MCP",
+      "title": "ElevenLabs",
       "description": "Official ElevenLabs Model Context Protocol (MCP) server that enables interaction with powerful Text to Speech and audio processing APIs.",
       "required": [
         "data"
@@ -1101,6 +1872,13 @@
       "additionalProperties": false,
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/fetch/overview"
+    },
+    "ffmpeg": {
+      "title": "FFmpeg",
+      "description": "Use ffmpeg to process video files.",
+      "additionalProperties": false,
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/ffmpeg/overview"
     },
     "fibery": {
       "title": "Fibery",
@@ -1190,7 +1968,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/firecrawl/overview"
     },
     "firewalla": {
-      "title": "Firewalla MCP Server",
+      "title": "Firewalla",
       "description": "Real-time network monitoring, security analysis, and firewall management through 28 specialized tools. Access security alerts, network flows, device status, and firewall rules directly from your Firewalla device.",
       "required": [
         "boxId",
@@ -1214,24 +1992,12 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/firewalla-mcp-server/overview"
     },
-    "flexprice": {
-      "title": "FlexPrice",
-      "description": "Official flexprice MCP Server.",
-      "required": [
-        "apiKey",
-        "baseUrl"
-      ],
+    "geminiApiDocs": {
+      "title": "Gemini API Docs",
+      "description": "Provides tools to search and retrieve Google Gemini API documentation.",
       "additionalProperties": false,
-      "properties": {
-        "apiKey": {
-          "type": "string"
-        },
-        "baseUrl": {
-          "type": "string"
-        }
-      },
       "type": "object",
-      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/flexprice/overview"
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/gemini-api-docs/overview"
     },
     "git": {
       "title": "Git (Reference)",
@@ -1325,7 +2091,7 @@
     },
     "glif": {
       "title": "glif.app",
-      "description": "Easily run glif.app AI workflows inside your LLM: image generators, memes, selfies, and more. Glif supports all major multimedia AI models inside one app.",
+      "description": "Deprecated — use the hosted Glif MCP server at https://glif.app/mcp.",
       "required": [
         "apiToken",
         "ids",
@@ -1347,7 +2113,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/glif/overview"
     },
     "gmail": {
-      "title": "Gmail MCP Server",
+      "title": "Gmail",
       "description": "A Model Context Protocol server for Gmail operations using IMAP/SMTP with app password authentication. Supports listing messages, searching emails, and sending messages. To create your app password, visit your Google Account settings under Security \u003e App Passwords. Or visit the link https://myaccount.google.com/apppasswords.",
       "required": [
         "emailAddress"
@@ -1365,6 +2131,13 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/gmail-mcp/overview"
     },
+    "googleFlights": {
+      "title": "Google Flights",
+      "description": "Interact with Google Flights data to search for one-way, round-trip, and date range flight options between airports.",
+      "additionalProperties": false,
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/google-flights/overview"
+    },
     "googleMaps": {
       "title": "Google Maps (Archived)",
       "description": "Tools for interacting with the Google Maps API.",
@@ -1381,7 +2154,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/google-maps/overview"
     },
     "googleMapsComprehensive": {
-      "title": "Google Maps Comprehensive MCP",
+      "title": "Google Maps Comprehensive",
       "description": "Complete Google Maps integration with 8 tools including geocoding, places search, directions, elevation data, and more using Google's latest APIs.",
       "required": [
         "googleMapsApiKey"
@@ -1430,7 +2203,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/gyazo/overview"
     },
     "hackernews": {
-      "title": "Hackernews mcp",
+      "title": "Hacker News",
       "description": "A Model Context Protocol (MCP) server that provides access to Hacker News stories, comments, and user data, with support for search and content retrieval.",
       "additionalProperties": false,
       "type": "object",
@@ -1467,7 +2240,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/handwriting-ocr/overview"
     },
     "hdx": {
-      "title": "Humanitarian Data Exchange MCP Server",
+      "title": "Humanitarian Data Exchange",
       "description": "HDX MCP Server provides access to humanitarian data through the Humanitarian Data Exchange (HDX) API - https://data.humdata.org/hapi. This server offers 33 specialized tools for retrieving humanitarian information including affected populations (refugees, IDPs, returnees), baseline demographics, food security indicators, conflict data, funding information, and operational presence across hundreds of countries and territories. See repository for instructions on getting a free HDX_APP_INDENTIFIER for access.",
       "required": [
         "appIdentifier"
@@ -1497,7 +2270,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/heroku/overview"
     },
     "hostinger": {
-      "title": "Hostinger API MCP Server",
+      "title": "Hostinger API",
       "description": "Interact with Hostinger services over the Hostinger API.",
       "required": [
         "apitoken"
@@ -1512,7 +2285,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/hostinger-mcp-server/overview"
     },
     "hoverfly": {
-      "title": "Hoverfly MCP Server",
+      "title": "Hoverfly",
       "description": "A Model Context Protocol (MCP) server that exposes Hoverfly as a programmable tool for AI assistants like Cursor, Claude, GitHub Copilot, and others supporting MCP. It enables dynamic mocking of third-party APIs to unblock development, automate testing, and simulate unavailable services during integration.",
       "required": [
         "data"
@@ -1549,7 +2322,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/hugging-face/overview"
     },
     "hummingbot": {
-      "title": "Hummingbot MCP: Trading Agent",
+      "title": "Hummingbot: Trading Agent",
       "description": "Hummingbot MCP is an open-source toolset that lets you control and monitor your Hummingbot trading bots through AI-powered commands and automation.",
       "required": [
         "apiUrl"
@@ -1687,7 +2460,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/jetbrains/overview"
     },
     "kafkaSchemaReg": {
-      "title": "Kafka Schema Registry MCP",
+      "title": "Kafka Schema Registry",
       "description": "Comprehensive MCP server for Kafka Schema Registry operations. Features multi-registry support, schema contexts, migration tools, OAuth authentication, and 57+ tools for complete schema management. Supports SLIM_MODE for optimal performance.",
       "required": [
         "registryUrl"
@@ -1717,8 +2490,8 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/kafka-schema-reg-mcp/overview"
     },
     "kagisearch": {
-      "title": "Kagi search",
-      "description": "The Official Model Context Protocol (MCP) server for Kagi search \u0026 other tools.",
+      "title": "Kagi Search",
+      "description": "The Official Model Context Protocol (MCP) server for Kagi Search \u0026 other tools.",
       "required": [
         "engine",
         "kagiApiKey"
@@ -1736,7 +2509,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/kagisearch/overview"
     },
     "keboola": {
-      "title": "Keboola MCP Server",
+      "title": "Keboola",
       "description": "Keboola MCP Server is an open-source bridge between your Keboola project and modern AI tools.",
       "required": [
         "kbcStorageToken",
@@ -1774,7 +2547,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/kong/overview"
     },
     "kubectl": {
-      "title": "Kubectl MCP Server",
+      "title": "Kubectl",
       "description": "MCP Server that enables AI assistants to interact with Kubernetes clusters via kubectl operations.",
       "required": [
         "kubeconfig"
@@ -1841,7 +2614,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/line/overview"
     },
     "linkedin": {
-      "title": "LinkedIn MCP Server",
+      "title": "LinkedIn",
       "description": "This MCP server allows Claude and other AI assistants to access your LinkedIn. Scrape LinkedIn profiles and companies, get your recommended jobs, and perform job searches. Set your li_at LinkedIn cookie to use this server.",
       "required": [
         "linkedinCookie",
@@ -1868,7 +2641,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/llmtxt/overview"
     },
     "maestro": {
-      "title": "Maestro MCP Server",
+      "title": "Maestro",
       "description": "A Model Context Protocol (MCP) server exposing Bitcoin blockchain data through the Maestro API platform. Provides tools to explore blocks, transactions, addresses, inscriptions, runes, and other metaprotocol data.",
       "required": [
         "apiKeyApiKey"
@@ -1890,7 +2663,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/manifold/overview"
     },
     "mapbox": {
-      "title": "Mapbox MCP Server",
+      "title": "Mapbox",
       "description": "Transform any AI agent into a geospatially-aware system with Mapbox APIs. Provides geocoding, POI search, routing, travel time matrices, isochrones, and static map generation.",
       "required": [
         "accessToken"
@@ -1905,7 +2678,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/mapbox/overview"
     },
     "mapboxDevkit": {
-      "title": "Mapbox Developer MCP Server",
+      "title": "Mapbox Developer",
       "description": "Direct access to Mapbox developer APIs for AI assistants. Enables style management, token management, GeoJSON preview, and other developer tools for building Mapbox applications.",
       "required": [
         "mapboxAccessToken"
@@ -1956,7 +2729,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/markitdown/overview"
     },
     "mavenTools": {
-      "title": "Maven Tools MCP Server",
+      "title": "Maven Tools",
       "description": "JVM dependency intelligence for any build tool using Maven Central Repository. Includes Context7 integration for upgrade documentation and guidance.",
       "additionalProperties": false,
       "type": "object",
@@ -2000,7 +2773,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/mercado-pago/overview"
     },
     "metabase": {
-      "title": "Metabase MCP",
+      "title": "Metabase",
       "description": "A comprehensive MCP server for Metabase with 70+ tools.",
       "required": [
         "apiKey",
@@ -2067,6 +2840,26 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/multiversx-mx/overview"
     },
+    "n8n": {
+      "title": "n8n",
+      "description": "Bridges n8n's workflow automation platform with AI models, providing access to 543 n8n nodes, workflow templates, and AI-capable automation tools.",
+      "required": [
+        "apiKey",
+        "apiUrl"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "apiKey": {
+          "type": "string"
+        },
+        "apiUrl": {
+          "description": "The URL of your n8n instance (use http://host.docker.internal:5678 for local instances)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/n8n/overview"
+    },
     "nasdaqDataLink": {
       "title": "Nasdaq Data Link",
       "description": "MCP server to interact with the data feeds provided by the Nasdaq Data Link. Developed by the community and maintained by Stefano Amorelli.",
@@ -2096,6 +2889,41 @@
       },
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/needle-mcp/overview"
+    },
+    "neo4j": {
+      "title": "Neo4j",
+      "description": "Official MCP server for Neo4j. Interact with Neo4j using Cypher graph queries.",
+      "required": [
+        "database",
+        "password",
+        "readOnly",
+        "telemetry",
+        "uri",
+        "username"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "database": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "telemetry": {
+          "type": "boolean"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/neo4j/overview"
     },
     "neo4jCloudAuraApi": {
       "title": "Neo4j Cloud Aura Api",
@@ -2158,6 +2986,9 @@
           "type": "string"
         },
         "responseTokenLimit": {
+          "type": "string"
+        },
+        "schemaSampleSize": {
           "type": "string"
         },
         "serverAllowOrigins": {
@@ -2281,6 +3112,13 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/neon/overview"
     },
+    "nextDevtools": {
+      "title": "Next.js DevTools",
+      "description": "next-devtools-mcp is a Model Context Protocol (MCP) server that provides Next.js development tools and utilities for AI coding assistants.",
+      "additionalProperties": false,
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/next-devtools-mcp/overview"
+    },
     "nodeCodeSandbox": {
       "title": "Node.js Sandbox",
       "description": "A Node.js–based Model Context Protocol server that spins up disposable Docker containers to execute arbitrary JavaScript.",
@@ -2332,8 +3170,47 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/obsidian/overview"
     },
+    "okta": {
+      "title": "Okta",
+      "description": "## :tada: __It's Official__ :tada: The Okta Open-Source MCP Server integrates with LLMs and AI agents, allowing you to perform various Okta management operations using natural language and is Generally Available (GA).",
+      "required": [
+        "logPath",
+        "oktaClientId",
+        "oktaKeyId",
+        "oktaLogLevel",
+        "oktaOrgUrl",
+        "oktaPrivateKey",
+        "oktaScopes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "logPath": {
+          "type": "string"
+        },
+        "oktaClientId": {
+          "type": "string"
+        },
+        "oktaKeyId": {
+          "type": "string"
+        },
+        "oktaLogLevel": {
+          "type": "string"
+        },
+        "oktaOrgUrl": {
+          "type": "string"
+        },
+        "oktaPrivateKey": {
+          "type": "string"
+        },
+        "oktaScopes": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/okta-mcp-server/overview"
+    },
     "oktaMcpFctr": {
-      "title": "Okta MCP Server",
+      "title": "Okta",
       "description": "Secure Okta identity and access management via Model Context Protocol (MCP). Access Okta users, groups, applications, logs, and policies through AI assistants with enterprise-grade security.",
       "required": [
         "clientOrgurl"
@@ -2360,7 +3237,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/okta-mcp-fctr/overview"
     },
     "omi": {
-      "title": "omi-mcp",
+      "title": "Omi",
       "description": "A Model Context Protocol server for Omi interaction and automation. This server provides tools to read, search, and manipulate Memories and Conversations.",
       "required": [
         "apiKey"
@@ -2379,14 +3256,7 @@
       "description": "ONLYOFFICE DocSpace is a room-based collaborative platform which allows organizing a clear file structure depending on users' needs or project goals.",
       "required": [
         "baseUrl",
-        "docspaceApiKey",
-        "docspaceAuthToken",
-        "docspacePassword",
-        "docspaceUsername",
-        "dynamic",
-        "origin",
-        "toolsets",
-        "userAgent"
+        "docspaceApiKey"
       ],
       "additionalProperties": false,
       "properties": {
@@ -2395,34 +3265,13 @@
         },
         "docspaceApiKey": {
           "type": "string"
-        },
-        "docspaceAuthToken": {
-          "type": "string"
-        },
-        "docspacePassword": {
-          "type": "string"
-        },
-        "docspaceUsername": {
-          "type": "string"
-        },
-        "dynamic": {
-          "type": "boolean"
-        },
-        "origin": {
-          "type": "string"
-        },
-        "toolsets": {
-          "type": "string"
-        },
-        "userAgent": {
-          "type": "string"
         }
       },
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/onlyoffice-docspace/overview"
     },
     "openapi": {
-      "title": "OpenAPI Toolkit for MCP",
+      "title": "OpenAPI Toolkit",
       "description": "Fetch, validate, and generate code or curl from any OpenAPI or Swagger spec - all from a single URL.",
       "required": [
         "mode"
@@ -2510,7 +3359,7 @@
     },
     "opik": {
       "title": "Opik",
-      "description": "Model Context Protocol (MCP) implementation for Opik enabling seamless IDE integration and unified access to prompts, projects, traces, and metrics.",
+      "description": "Model Context Protocol (MCP) server for Opik, the open-source LLM observability and evaluation platform, built by Comet. Read traces, log scores, and manage prompts from Claude Code, Cursor, or VS Code.",
       "required": [
         "apiBaseUrl",
         "apiKey",
@@ -2532,7 +3381,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/opik/overview"
     },
     "opine": {
-      "title": "Opine MCP Server",
+      "title": "Opine",
       "description": "A Model Context Protocol (MCP) server for querying deals and evaluations from the Opine CRM API.",
       "required": [
         "opineApiKey"
@@ -2547,7 +3396,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/opine-mcp-server/overview"
     },
     "oracle": {
-      "title": "Oracle Database MCP Server",
+      "title": "Oracle Database",
       "description": "Connect to Oracle databases via MCP, providing secure read-only access with support for schema exploration, query execution, and metadata inspection.",
       "required": [
         "oracleConnectionString",
@@ -2596,7 +3445,7 @@
     },
     "paperSearch": {
       "title": "Paper Search",
-      "description": "A MCP for searching and downloading academic papers from multiple sources like arXiv, PubMed, bioRxiv, etc.",
+      "description": "MCP, CLI, Skills for searching and downloading academic papers from multiple sources like arXiv, PubMed, bioRxiv, etc.",
       "additionalProperties": false,
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/paper-search/overview"
@@ -2651,7 +3500,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/pinecone/overview"
     },
     "playwright": {
-      "title": "ExecuteAutomation Playwright MCP",
+      "title": "ExecuteAutomation Playwright",
       "description": "Playwright Model Context Protocol Server - Tool to automate Browsers and APIs in Claude Desktop, Cline, Cursor IDE and More 🔌.",
       "required": [
         "data"
@@ -2666,7 +3515,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/playwright-mcp-server/overview"
     },
     "pluggedinMcpProxy": {
-      "title": "Plugged.in MCP Proxy",
+      "title": "Plugged.in Proxy",
       "description": "A unified MCP proxy that aggregates multiple MCP servers into one interface, enabling seamless tool discovery and management across all your AI interactions. Manage all your MCP servers from a single connection point with RAG capabilities and real-time notifications.",
       "required": [
         "pluggedinApiBaseUrl",
@@ -2715,23 +3564,8 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/pomodash/overview"
     },
-    "postgres": {
-      "title": "PostgreSQL readonly (Archived)",
-      "description": "Connect with read-only access to PostgreSQL databases. This server enables LLMs to inspect database schemas and execute read-only queries.",
-      "required": [
-        "url"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "url": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/postgres/overview"
-    },
     "postman": {
-      "title": "Postman MCP server",
+      "title": "Postman",
       "description": "Postman's MCP server connects AI agents, assistants, and chatbots directly to your APIs on Postman. Use natural language to prompt AI to automate work across your Postman collections, environments, workspaces, and more.",
       "required": [
         "apiKey"
@@ -2768,6 +3602,49 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/prometheus/overview"
     },
+    "proxmox": {
+      "title": "Proxmox VE",
+      "description": "Manage Proxmox VE infrastructure including virtual machines, containers, storage, networking, firewall rules, high availability, and more.",
+      "required": [
+        "host",
+        "tokenName"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "host": {
+          "description": "Proxmox VE hostname or IP address",
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "port": {
+          "description": "Proxmox VE API port",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "type": "string"
+        },
+        "tokenName": {
+          "description": "API token name",
+          "type": "string"
+        },
+        "tokenValue": {
+          "type": "string"
+        },
+        "user": {
+          "description": "Proxmox VE user (e.g. root@pam)",
+          "type": "string"
+        },
+        "verifySsl": {
+          "description": "Verify SSL certificates (true/false)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/proxmox/overview"
+    },
     "puppeteer": {
       "title": "Puppeteer (Archived)",
       "description": "Browser automation and web scraping using Puppeteer.",
@@ -2777,13 +3654,13 @@
     },
     "pythonRefactoring": {
       "title": "Python Refactoring Assistant",
-      "description": "Educational Python refactoring assistant that provides guided suggestions for AI assistants.  Features: • Step-by-step refactoring instructions without modifying code • Comprehensive code analysis using professional tools (Rope, Radon, Vulture, Jedi, LibCST, Pyrefly) • Educational approach teaching refactoring patterns through guided practice • Support for both guide-only and apply-changes modes • Identifies long functions, high complexity, dead code, and type issues • Provides precise line numbers and specific refactoring instructions • Compatible with all AI assistants (Claude, GPT, Cursor, Continue, etc.)  Perfect for developers learning refactoring patterns while maintaining full control over code changes. Acts as a refactoring mentor rather than an automated code modifier.",
+      "description": "Educational Python refactoring assistant that provides guided suggestions for AI assistants.",
       "additionalProperties": false,
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/mcp-python-refactoring/overview"
     },
     "quantconnect": {
-      "title": "QuantConnect MCP Server",
+      "title": "QuantConnect",
       "description": "The QuantConnect MCP Server is a bridge for AIs (such as Claude and OpenAI o3 Pro) to interact with our cloud platform. When equipped with our MCP, the AI can perform tasks on your behalf through our API such as updating projects, writing strategies, backtesting, and deploying strategies to production live-trading.",
       "required": [
         "agentname",
@@ -2806,7 +3683,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/quantconnect/overview"
     },
     "ramparts": {
-      "title": "Ramparts MCP Security Scanner",
+      "title": "Ramparts Security Scanner",
       "description": "A comprehensive security scanner for MCP servers with YARA rules and static analysis capabilities.",
       "additionalProperties": false,
       "type": "object",
@@ -2831,8 +3708,8 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/razorpay/overview"
     },
     "reddit": {
-      "title": "Mcp reddit",
-      "description": "A comprehensive Model Context Protocol (MCP) server for Reddit integration. This server enables AI agents to interact with Reddit programmatically through a standardized interface.",
+      "title": "Reddit",
+      "description": "This server provides AI agents with tools to fetch, post and search on Reddit.",
       "required": [
         "redditClientId",
         "redditClientSecret",
@@ -2931,7 +3808,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/redis-cloud/overview"
     },
     "ref": {
-      "title": "Ref - up-to-date docs",
+      "title": "Ref - Up-To-Date Docs",
       "description": "Ref powerful search tool connets your coding tools with documentation context. It includes an up-to-date index of public documentation and it can ingest your private documentation (eg. GitHub repos, PDFs) as well.",
       "required": [
         "apiKey"
@@ -2968,8 +3845,8 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/render/overview"
     },
     "resend": {
-      "title": "Send emails",
-      "description": "Send emails directly from Cursor with this email sending MCP server.",
+      "title": "Resend",
+      "description": "The official MCP server to send emails and interact with Resend.",
       "required": [
         "replyTo",
         "sender"
@@ -3010,23 +3887,8 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/risken/overview"
     },
-    "root": {
-      "title": "Root.io Vulnerability Remediation MCP",
-      "description": "MCP server that provides container image vulnerability scanning and remediation capabilities through Root.io.",
-      "required": [
-        "apiAccessToken"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "apiAccessToken": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/root/overview"
-    },
     "ros2": {
-      "title": "WiseVision ROS2 MCP Server",
+      "title": "WiseVision ROS2",
       "description": "Python server implementing Model Context Protocol (MCP) for ROS2.",
       "additionalProperties": false,
       "type": "object",
@@ -3048,7 +3910,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/rube/overview"
     },
     "rustMcpFilesystem": {
-      "title": "Blazing-fast, asynchronous MCP server for seamless filesystem operations.",
+      "title": "Rust Filesystem",
       "description": "The Rust MCP Filesystem is a high-performance, asynchronous, and lightweight Model Context Protocol (MCP) server built in Rust for secure and efficient filesystem operations. Designed with security in mind, it operates in read-only mode by default and restricts clients from updating allowed directories via MCP Roots unless explicitly enabled, ensuring robust protection against unauthorized access. Leveraging asynchronous I/O, it delivers blazingly fast performance with a minimal resource footprint. Optimized for token efficiency, the Rust MCP Filesystem enables large language models (LLMs) to precisely target searches and edits within specific sections of large files and restrict operations by file size range, making it ideal for efficient file exploration, automation, and system integration.",
       "required": [
         "allowWrite",
@@ -3129,7 +3991,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/schemacrawler-ai/overview"
     },
     "schoginiMcpImageBorder": {
-      "title": "Schogini MCP Image Border",
+      "title": "Schogini Image Border",
       "description": "This adds a border to an image and returns base64 encoded image.",
       "additionalProperties": false,
       "type": "object",
@@ -3166,7 +4028,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/scrapezy/overview"
     },
     "securenoteLink": {
-      "title": "Securenote.link mcp server",
+      "title": "Securenote.link",
       "description": "SecureNote.link MCP Server - allowing AI agents to securely share sensitive information through end-to-end encrypted notes.",
       "additionalProperties": false,
       "type": "object",
@@ -3236,7 +4098,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/short-io/overview"
     },
     "simplechecklist": {
-      "title": "SimpleCheckList MCP Server",
+      "title": "SimpleCheckList",
       "description": "Advanced SimpleCheckList with MCP server and SQLite database for comprehensive task management.  Features: • Complete project and task management system • Hierarchical organization (Projects → Groups → Task Lists → Tasks → Subtasks) • SQLite database for data persistence • RESTful API with comprehensive endpoints • MCP protocol compliance for AI assistant integration • Docker-optimized deployment with stability improvements  **v1.0.1 Update**: Enhanced Docker stability with improved container lifecycle management. Default mode optimized for containerized deployment with reliable startup and shutdown processes.  Perfect for AI assistants managing complex project workflows and task hierarchies.",
       "additionalProperties": false,
       "type": "object",
@@ -3279,7 +4141,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/slack/overview"
     },
     "smartbear": {
-      "title": "SmartBear MCP Server",
+      "title": "SmartBear",
       "description": "MCP server for AI access to SmartBear tools, including BugSnag, Reflect, API Hub, PactFlow.",
       "required": [
         "apiHubApiKey",
@@ -3422,7 +4284,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/supadata/overview"
     },
     "suzieq": {
-      "title": "Suzieq MCP",
+      "title": "Suzieq",
       "description": "MCP Server to interact with a SuzieQ network observability instance via its REST API.",
       "required": [
         "apiEndpoint",
@@ -3441,7 +4303,7 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/suzieq/overview"
     },
     "taskOrchestrator": {
-      "title": "Task orchestrator",
+      "title": "Task Orchestrator",
       "description": "Model Context Protocol (MCP) server for comprehensive task and feature management, providing AI assistants with a structured, context-efficient way to interact with project data.",
       "additionalProperties": false,
       "type": "object",
@@ -3492,20 +4354,41 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/telnyx/overview"
     },
-    "tembo": {
-      "title": "Tembo",
-      "description": "MCP server for Tembo Cloud's platform API.",
+    "temporal": {
+      "title": "Temporal",
+      "description": "Manage Temporal workflows, schedules, namespaces, task queues, and workflow execution history from MCP clients.",
       "required": [
-        "apiKey"
+        "temporalHost",
+        "temporalNamespace"
       ],
       "additionalProperties": false,
       "properties": {
         "apiKey": {
           "type": "string"
+        },
+        "temporalHost": {
+          "description": "Temporal frontend host and port.",
+          "type": "string"
+        },
+        "temporalNamespace": {
+          "description": "Temporal namespace to connect to.",
+          "type": "string"
+        },
+        "temporalTlsClientCertPath": {
+          "description": "Optional path inside the container to an mTLS client certificate.",
+          "type": "string"
+        },
+        "temporalTlsClientKeyPath": {
+          "description": "Optional path inside the container to an mTLS client private key.",
+          "type": "string"
+        },
+        "temporalTlsEnabled": {
+          "description": "Whether to force TLS for the Temporal connection.",
+          "type": "string"
         }
       },
       "type": "object",
-      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/tembo/overview"
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/temporal/overview"
     },
     "terraform": {
       "title": "Hashicorp Terraform",
@@ -3513,6 +4396,34 @@
       "additionalProperties": false,
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/terraform/overview"
+    },
+    "testkube": {
+      "title": "Testkube",
+      "description": "The Testkube MCP Server exposes continuous testing capabilities (test orchestration, execution, troubleshooting and anlysis) to AI tools and workflows.",
+      "required": [
+        "tkAccessToken",
+        "tkControlPlaneUrl",
+        "tkEnvId",
+        "tkOrgId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "tkAccessToken": {
+          "type": "string"
+        },
+        "tkControlPlaneUrl": {
+          "description": "The URL of the Testkube Control Plane",
+          "type": "string"
+        },
+        "tkEnvId": {
+          "type": "string"
+        },
+        "tkOrgId": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/testkube/overview"
     },
     "textToGraphql": {
       "title": "Text-to-GraphQL",
@@ -3552,6 +4463,28 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/text-to-graphql/overview"
     },
+    "thingsboard": {
+      "title": "ThingsBoard",
+      "description": "Connect your AI workflows to the ThingsBoard IoT Platform through this MCP server.  Enables LLMs to query device telemetry, manage IoT entities (devices, assets, customers), and analyze sensor data - all through natural language.  Perfect for building AI-powered IoT monitoring, predictive maintenance, and automated device management workflows. Supports both ThingsBoard Community Edition and Professional Edition.",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "url": {
+          "description": "URL of your ThingsBoard Platform instance",
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/thingsboard/overview"
+    },
     "tigris": {
       "title": "Tigris Data",
       "description": "Tigris is a globally distributed S3-compatible object storage service that provides low latency anywhere in the world, enabling developers to store and access any amount of data for a wide range of use cases.",
@@ -3581,23 +4514,8 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/time/overview"
     },
-    "triplewhale": {
-      "title": "Triplewhale",
-      "description": "Triplewhale MCP Server.",
-      "required": [
-        "apiKey"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "apiKey": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/triplewhale/overview"
-    },
     "unrealEngine": {
-      "title": "Unreal Engine MCP Server",
+      "title": "Unreal Engine",
       "description": "A comprehensive Model Context Protocol (MCP) server that enables AI assistants to control Unreal Engine via Remote Control API. Built with TypeScript and designed for game development automation.",
       "required": [
         "ueHost",
@@ -3626,6 +4544,29 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/unreal-engine-mcp-server/overview"
     },
+    "vectraAiRux": {
+      "title": "Vectra AI RUX MCP Server",
+      "description": "Vectra AI MCP Server - An MCP server that connects AI assistants \u0026 agents to the Vectra AI security platform, enabling intelligent threat analysis and automated incident response.",
+      "required": [
+        "vectraClientId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "vectraClientId": {
+          "description": "The client ID of the Vectra AI RUX MCP Server",
+          "type": "string"
+        },
+        "vectraClientSecret": {
+          "type": "string"
+        },
+        "vectraUrl": {
+          "description": "The base URL of the Vectra AI RUX MCP Server",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/vectra-ai-rux-mcp-server/overview"
+    },
     "veyrax": {
       "title": "VeyraX",
       "description": "VeyraX MCP is the only connection you need to access all your tools in any MCP-compatible environment.",
@@ -3641,6 +4582,132 @@
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/veyrax/overview"
     },
+    "victorialogs": {
+      "title": "VictoriaLogs",
+      "description": "Provides access to your VictoriaLogs instance and seamless integration with VictoriaLogs APIs and documentation. It can give you a comprehensive interface for logs, observability, and debugging tasks related to your VictoriaLogs instances, enable advanced automation and interaction capabilities for engineers and tools.",
+      "required": [
+        "vlInstanceEntrypoint"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "mcpDisabledTools": {
+          "description": "Comma-separated list of tools to disable (possible values: export, metric_statistics, test_rules)",
+          "type": "string"
+        },
+        "mcpHeartbeatInterval": {
+          "description": "Defines the heartbeat interval for the streamable-http protocol. It means the MCP server will send a heartbeat to the client through the GET connection, to keep the connection alive from being closed by the network infrastructure (e.g. gateways)",
+          "type": "string"
+        },
+        "mcpListenAddr": {
+          "description": "Address and port on which the MCP server listens for incoming connections (e.g., ':8081')",
+          "type": "string"
+        },
+        "mcpServerMode": {
+          "description": "Mode in which the MCP server operates (possible values: stdio, http, sse)",
+          "type": "string"
+        },
+        "vlInstanceBearerToken": {
+          "type": "string"
+        },
+        "vlInstanceEntrypoint": {
+          "description": "URL of VictoriaLogs instance (it should be root URL of vlsingle or vlselect)",
+          "type": "string"
+        },
+        "vlInstanceHeaders": {
+          "description": "Optional custom headers to include in requests to VictoriaLogs instance, formatted as 'header1=value1,header2=value2'",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/victorialogs/overview"
+    },
+    "victoriametrics": {
+      "title": "VictoriaMetrics",
+      "description": "Provides access to your VictoriaMetrics instance and seamless integration with VictoriaMetrics APIs and documentation. It can give you a comprehensive interface for monitoring, observability, and debugging tasks related to your VictoriaMetrics instances, enable advanced automation and interaction capabilities for engineers and tools.",
+      "required": [
+        "vmInstanceEntrypoint",
+        "vmInstanceType"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "mcpDisableResources": {
+          "description": "Set to 'true' to disable all resource endpoints",
+          "type": "string"
+        },
+        "mcpDisabledTools": {
+          "description": "Comma-separated list of tools to disable (possible values: export, metric_statistics, test_rules)",
+          "type": "string"
+        },
+        "mcpHeartbeatInterval": {
+          "description": "Defines the heartbeat interval for the streamable-http protocol. It means the MCP server will send a heartbeat to the client through the GET connection, to keep the connection alive from being closed by the network infrastructure (e.g. gateways)",
+          "type": "string"
+        },
+        "mcpListenAddr": {
+          "description": "Address and port on which the MCP server listens for incoming connections (e.g., ':8080')",
+          "type": "string"
+        },
+        "mcpServerMode": {
+          "description": "Mode in which the MCP server operates (possible values: stdio, http, sse)",
+          "type": "string"
+        },
+        "vmInstanceBearerToken": {
+          "type": "string"
+        },
+        "vmInstanceEntrypoint": {
+          "description": "URL of VictoriaMetrics instance (it should be root URL of vmsingle or vmselect)",
+          "type": "string"
+        },
+        "vmInstanceHeaders": {
+          "description": "Optional custom headers to include in requests to VictoriaMetrics instance, formatted as 'header1=value1,header2=value2'",
+          "type": "string"
+        },
+        "vmInstanceType": {
+          "description": "Type of VictoriaMetrics instance (possible values: single, cluster)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/victoriametrics/overview"
+    },
+    "victoriatraces": {
+      "title": "VictoriaTraces",
+      "description": "Provides access to your VictoriaTraces instance and seamless integration with VictoriaTraces APIs and documentation. It can give you a comprehensive interface for tracing, observability, and debugging tasks related to your VictoriaTraces instances, enable advanced automation and interaction capabilities for engineers and tools.",
+      "required": [
+        "vtInstanceEntrypoint"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "mcpDisabledTools": {
+          "description": "Comma-separated list of tools to disable (possible values: export, metric_statistics, test_rules)",
+          "type": "string"
+        },
+        "mcpHeartbeatInterval": {
+          "description": "Defines the heartbeat interval for the streamable-http protocol. It means the MCP server will send a heartbeat to the client through the GET connection, to keep the connection alive from being closed by the network infrastructure (e.g. gateways)",
+          "type": "string"
+        },
+        "mcpListenAddr": {
+          "description": "Address and port on which the MCP server listens for incoming connections (e.g., ':8081')",
+          "type": "string"
+        },
+        "mcpServerMode": {
+          "description": "Mode in which the MCP server operates (possible values: stdio, http, sse)",
+          "type": "string"
+        },
+        "vtInstanceBearerToken": {
+          "type": "string"
+        },
+        "vtInstanceEntrypoint": {
+          "description": "URL of VictoriaTraces instance (it should be root URL of vtsingle or vtselect)",
+          "type": "string"
+        },
+        "vtInstanceHeaders": {
+          "description": "Optional custom headers to include in requests to VictoriaTraces instance, formatted as 'header1=value1,header2=value2'",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/victoriatraces/overview"
+    },
     "vizro": {
       "title": "Vizro",
       "description": "provides tools and templates to create a functioning Vizro chart or dashboard step by step.",
@@ -3649,14 +4716,14 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/vizro/overview"
     },
     "vulnNist": {
-      "title": "Vuln nist mcp server",
+      "title": "Vuln NIST",
       "description": "This MCP server exposes tools to query the NVD/CVE REST API and return formatted text results suitable for LLM consumption via the MCP protocol. It includes automatic query chunking for large date ranges and parallel processing for improved performance.",
       "additionalProperties": false,
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/vuln-nist-mcp-server/overview"
     },
     "wayfound": {
-      "title": "Wayfound MCP",
+      "title": "Wayfound",
       "description": "Wayfound’s MCP server allows business users to govern, supervise, and improve AI Agents.",
       "required": [
         "mcpApiKey"
@@ -3708,11 +4775,38 @@
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/wolfram-alpha/overview"
     },
     "youtubeTranscript": {
-      "title": "YouTube transcripts",
+      "title": "YouTube Transcripts",
       "description": "Retrieves transcripts for given YouTube video URLs.",
       "additionalProperties": false,
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/youtube_transcript/overview"
+    },
+    "zen": {
+      "title": "Zen",
+      "description": "Bridges multiple AI models and CLIs, enabling orchestrated workflows across Claude Code, Gemini CLI, Codex CLI, and other AI development tools.",
+      "required": [
+        "geminiApiKey",
+        "openaiApiKey",
+        "openrouterApiKey",
+        "xaiApiKey"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "geminiApiKey": {
+          "type": "string"
+        },
+        "openaiApiKey": {
+          "type": "string"
+        },
+        "openrouterApiKey": {
+          "type": "string"
+        },
+        "xaiApiKey": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/zen/overview"
     },
     "zerodhaKite": {
       "title": "Zerodha Kite Connect",
@@ -3740,6 +4834,62 @@
       },
       "type": "object",
       "x-dockerHubUrl": "https://hub.docker.com/mcp/server/zerodha-kite/overview"
+    },
+    "zscaler": {
+      "title": "Zscaler",
+      "description": "Manage the Zscaler Zero Trust Exchange platform via 300+ tools across ZPA (private access), ZIA (internet access), ZDX (digital experience), ZCC (client connector), ZTW (workload segmentation), ZMS (microsegmentation), EASM (attack surface management), Z-Insights (security analytics), and ZIdentity (identity management). Create and manage policies, troubleshoot connectivity, audit security configurations, and investigate incidents — all from your AI assistant.",
+      "required": [
+        "disabledServices",
+        "disabledTools",
+        "skipConfirmations",
+        "writeEnabled",
+        "writeTools",
+        "zscalerClientId",
+        "zscalerClientSecret",
+        "zscalerCloud",
+        "zscalerCustomerId",
+        "zscalerVanityDomain"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "disabledServices": {
+          "description": "Comma-separated services to disable (zcc,zdx,zpa,zia,ztw,zid,zeasm,zins,zms)",
+          "type": "string"
+        },
+        "disabledTools": {
+          "description": "Comma-separated tool name patterns to disable (e.g. zia_delete_*,zpa_bulk_*)",
+          "type": "string"
+        },
+        "skipConfirmations": {
+          "description": "Skip HMAC confirmation prompts for destructive operations (true/false)",
+          "type": "string"
+        },
+        "writeEnabled": {
+          "description": "Enable write operations (true/false)",
+          "type": "string"
+        },
+        "writeTools": {
+          "description": "Comma-separated write tool patterns to allow (e.g. zpa_create_*,zia_update_*)",
+          "type": "string"
+        },
+        "zscalerClientId": {
+          "type": "string"
+        },
+        "zscalerClientSecret": {
+          "type": "string"
+        },
+        "zscalerCloud": {
+          "type": "string"
+        },
+        "zscalerCustomerId": {
+          "type": "string"
+        },
+        "zscalerVanityDomain": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-dockerHubUrl": "https://hub.docker.com/mcp/server/zscaler-mcp-server/overview"
     }
   },
   "type": "object"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [SDK-340](https://linear.app/e2b/issue/SDK-340/refresh-specmcp-serverjson-from-dockers-mcp-catalog-stale-since-oct).

`spec/mcp-server.json` lists the MCP servers a sandbox can run and the options each one takes, and the SDKs generate their `McpServer` types from it. It hadn't been refreshed since it was written in [#974](https://github.com/e2b-dev/E2B/pull/974) (October 2025), so it was describing a catalog that has moved a long way — which is also what [#1697](https://github.com/e2b-dev/E2B/pull/1697) ran into when it tried to fix a description by hand.

This regenerates it, and adds the projection from the catalog to the schema as a script so the next refresh is a command instead of a hand edit:

```sh
pnpm generate:mcp-spec  # spec/mcp-server.json, then the SDK types
```

## What changed in the schema

| | |
| --- | --- |
| Servers added | 52 |
| Servers removed | 6 |
| Titles rewritten | 61 |
| Descriptions rewritten | 10 |
| Options changed | 4 |
| Servers untouched | 145 |

New servers include `curl`, `docker`, `ffmpeg`, `n8n`, `neo4j`, `temporal`, `proxmox`, `testkube`, `zen`, and 26 AWS servers:

```ts
import { Sandbox } from 'e2b'

const sandbox = await Sandbox.create({
  mcp: {
    docker: {},
    ffmpeg: {},
    n8n: { apiUrl: 'https://n8n.example.com/api/v1', apiKey: process.env.N8N_API_KEY! },
  },
})
```

```python
import os

from e2b import Sandbox

sandbox = Sandbox.create(
    mcp={
        "docker": {},
        "ffmpeg": {},
        "n8n": {"apiUrl": "https://n8n.example.com/api/v1", "apiKey": os.environ["N8N_API_KEY"]},
    },
)
```

Titles are what the generated interface names come from, so renames upstream show up in the generated types — `AirtableMCPServer` became `Airtable`, for example. Only `McpServer` itself is exported from either SDK, so no public name changes.

## What stops type-checking

Six servers the catalog no longer publishes are gone from the type: `cdataConnectcloud`, `flexprice`, `postgres`, `root`, `tembo`, and `triplewhale`. `awsDiagram` and `context7` took no options before and now require one (`outputDir` and `apiKey`), so `awsDiagram: {}` and `context7: {}` stop compiling — verified with `@ts-expect-error` probes. `onlyofficeDocspace` is down to `baseUrl` and `docspaceApiKey`, and `neo4jCypher` gained `schemaSampleSize`. Configuration is still handed to the gateway as written, so a dropped server can be kept by casting past the type — whether it starts is up to the gateway.

That set of breaks is why this is `minor` on both packages rather than `patch`; it's a judgement call worth making deliberately, since the public `McpServer` type narrows.

## How the generator was checked

The naming in the committed schema isn't a plain copy of the catalog's own keys, so the script reproduces the rules the schema already followed: secrets are named after their environment variable minus the server's own name where the catalog repeats it (`ATLAN_API_KEY` on `atlan` is `apiKey`), compared against the catalog name as spelled — so a hyphenated name never matches the underscored variable and keeps the prefix (`AIRTABLE_API_KEY` on `airtable-mcp-server` is `airtableApiKey`, which is 33 properties across 23 servers). Parameters are named after their config key with nested objects flattened, and servers after their catalog name minus the "mcp server" wording.

To confirm those rules are the ones the schema was built with, I rebuilt the catalog as it stood the day the schema was last written (from `docker/mcp-registry` at that commit) and ran the generator against it. All 195 servers that exist in both come out with identical property names, identical property schemas, and identical `required` sets. Against the schema this replaces, the 216 carried-over servers keep their property names and `required` sets except for the four servers whose catalog config genuinely changed.

So the diff here is the catalog moving, not a renaming pass. `packages/python-sdk/tests/test_mcp_spec_generator.py` pins the rules — 28 cases, no network — because that suite is the only test runner above the repository root.

## Two inherited behaviours worth a decision

Both predate this PR and are reproduced rather than introduced, so nothing regresses either way, and relaxing either one is compile-compatible (making a required property optional never breaks an existing object literal).

- **A parameters block that declares no `required` list is read as requiring everything.** JSON Schema reads an absent list as requiring nothing. 78 of 138 config blocks omit it, which forces 187 properties across 78 servers, and 162 of the 207 servers with properties end up requiring all of them. Combined with "every secret is required", that gives `zen` a type demanding all four competing vendor keys and `awsApi` one demanding a named profile *and* static keys *and* a session token. Across the 216 carried-over servers 213 `required` sets are byte-identical to the schema this replaces, so this is established behaviour, but it is a one-line change here if you want the JSON Schema reading instead. (Bugbot and Claude both flagged this; their examples are partly misattributed — `zen` has no parameters at all, so its four keys come from the secrets rule, not this one.)
- **`playwright` resolves to ExecuteAutomation's server, and Docker's own is unreachable.** The catalog publishes two Playwright servers and they collide on the option name; the longer catalog name wins, which is what the previous schema shipped. Changing the winner would silently repoint anyone already configuring `playwright`, so I left it and made the drop visible instead — the script now names every entry that loses a collision. Same shape for `apify` and `needle`, where the dropped entry is only a remote stub.

## Notes

- Unlike `openapi.yml` and the envd specs, this schema has no upstream commit to pin — it tracks whatever the catalog publishes today. `make codegen` therefore leaves it alone and refreshing is a deliberate step, which keeps the generated-files CI check deterministic (it passes here, so the committed schema and types match what the pinned codegen toolchain produces).
- If there's an internal generator for this file already, the script here can be dropped in favour of it; the regenerated schema is the part that matters.
- `Okta1` in the generated TypeScript is a `json2ts` artifact: two servers now have titles that both normalize to `Okta`, so the second is suffixed, and it shows up in compiler diagnostics. Interface names come from `title`, the one field copied verbatim from the catalog, so de-duplicating would mean editing catalog data — left alone deliberately.
- Two commits are naming-only: CodeQL read the property names the generator derives from the catalog's `secrets` field as credential values being written to disk, so the locals now say what they hold (`_env_vars`, `option_name`, `prop`). Output is byte-identical across both.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-147135c0-6ac7-47bd-9557-eb48accf0f04?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-147135c0-6ac7-47bd-9557-eb48accf0f04&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

