### PR TITLE
test: cover the implicit file context, isolate temp fixtures per test

### DIFF
--- a/packages/js-sdk/tests/template/fileContext.test.ts
+++ b/packages/js-sdk/tests/template/fileContext.test.ts
@@ -1,0 +1,41 @@
+import os from 'node:os'
+import { describe, expect, test } from 'vitest'
+import { Template } from '../../src'
+
+// Path to a committed, read-only fixture, relative to this file's directory.
+// The implicit file context is the directory of the file that calls Template(),
+// so it is always inside the repository — which is why the fixture is committed
+// and never written to, rather than generated into a temp directory.
+const fixturePath = 'fixtures/hello.txt'
+
+describe('file context', () => {
+  test('defaults to the directory of the caller of Template()', async () => {
+    const implicit = Template().fromBaseImage().copy(fixturePath, 'hello.txt')
+    const explicit = Template({ fileContextPath: __dirname })
+      .fromBaseImage()
+      .copy(fixturePath, 'hello.txt')
+
+    // toJSON hashes each COPY's files, so the two serializations only match if
+    // the implicit context resolved to this file's directory, the glob found
+    // the fixture there, and its contents were read. This is the only test that
+    // exercises the implicit default end to end — every other template test
+    // passes fileContextPath explicitly, and the unit test for
+    // getCallerDirectory covers the helper in isolation, not its use here.
+    expect(await Template.toJSON(implicit)).toBe(
+      await Template.toJSON(explicit)
+    )
+  })
+
+  test('fails to resolve a source that is not in the context', async () => {
+    // Keeps the assertion above from passing vacuously: the hashes match
+    // because the fixture was found, not because a missing file hashes the
+    // same either way.
+    const wrongContext = Template({ fileContextPath: os.tmpdir() })
+      .fromBaseImage()
+      .copy(fixturePath, 'hello.txt')
+
+    await expect(Template.toJSON(wrongContext)).rejects.toThrow(
+      /No files found/
+    )
+  })
+})

--- a/packages/js-sdk/tests/template/fixtures/hello.txt
+++ b/packages/js-sdk/tests/template/fixtures/hello.txt
@@ -1,0 +1,3 @@
+This file is the fixture for the implicit file-context test. It is read-only:
+the implicit context is the directory of the file that calls Template(), which
+is inside the repository, so nothing may be written here at test time.

--- a/packages/js-sdk/tests/template/utils/getAllFilesInPath.test.ts
+++ b/packages/js-sdk/tests/template/utils/getAllFilesInPath.test.ts
@@ -1,24 +1,20 @@
-import { expect, test, describe, beforeAll, afterAll, beforeEach } from 'vitest'
+import { expect, test, describe, afterEach, beforeEach } from 'vitest'
 import { writeFile, mkdir, mkdtemp, rm } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join, basename } from 'path'
 import { getAllFilesInPath } from '../../../src/template/utils'
 
 describe('getAllFilesInPath', () => {
-  // A temp directory, so a test run never writes into the repository tree.
+  // A fresh temp directory per test, so a run never writes into the repository
+  // tree and no fixture leaks from one test into the next.
   let testDir: string
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     testDir = await mkdtemp(join(tmpdir(), 'getAllFilesInPath-test-'))
   })
 
-  afterAll(async () => {
+  afterEach(async () => {
     await rm(testDir, { recursive: true, force: true })
-  })
-
-  beforeEach(async () => {
-    await rm(testDir, { recursive: true, force: true })
-    await mkdir(testDir, { recursive: true })
   })
 
   test('should return files matching a simple pattern', async () => {

--- a/packages/js-sdk/tests/template/utils/spoolTarArchive.test.ts
+++ b/packages/js-sdk/tests/template/utils/spoolTarArchive.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe, beforeAll, afterAll, beforeEach } from 'vitest'
+import { expect, test, describe, afterEach, beforeEach } from 'vitest'
 import {
   writeFile,
   mkdir,
@@ -15,20 +15,16 @@ import * as tar from 'tar'
 import { ReadEntry } from 'tar'
 
 describe('spoolTarArchive', () => {
-  // A temp directory, so a test run never writes into the repository tree.
+  // A fresh temp directory per test, so a run never writes into the repository
+  // tree and no fixture leaks from one test into the next.
   let testDir: string
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     testDir = await mkdtemp(join(tmpdir(), 'spoolTarArchive-test-'))
   })
 
-  afterAll(async () => {
+  afterEach(async () => {
     await rm(testDir, { recursive: true, force: true })
-  })
-
-  beforeEach(async () => {
-    await rm(testDir, { recursive: true, force: true })
-    await mkdir(testDir, { recursive: true })
   })
 
   /**

--- a/packages/python-sdk/tests/shared/template/fixtures/hello.txt
+++ b/packages/python-sdk/tests/shared/template/fixtures/hello.txt
@@ -1,0 +1,3 @@
+This file is the fixture for the implicit file-context test. It is read-only:
+the implicit context is the directory of the file that calls Template(), which
+is inside the repository, so nothing may be written here at test time.

--- a/packages/python-sdk/tests/shared/template/test_file_context.py
+++ b/packages/python-sdk/tests/shared/template/test_file_context.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+
+import pytest
+
+from e2b import Template
+
+# Path to a committed, read-only fixture, relative to this file's directory.
+# The implicit file context is the directory of the file that calls Template(),
+# so it is always inside the repository — which is why the fixture is committed
+# and never written to, rather than generated into a temp directory.
+FIXTURE_PATH = "fixtures/hello.txt"
+
+
+def test_file_context_defaults_to_caller_directory():
+    implicit = Template().from_base_image().copy(FIXTURE_PATH, "hello.txt")
+    explicit = (
+        Template(file_context_path=os.path.dirname(__file__))
+        .from_base_image()
+        .copy(FIXTURE_PATH, "hello.txt")
+    )
+
+    # to_json hashes each COPY's files, so the two serializations only match if
+    # the implicit context resolved to this file's directory, the glob found the
+    # fixture there, and its contents were read. This is the only test that
+    # exercises the implicit default end to end — every other template test
+    # passes file_context_path explicitly, and the unit test for
+    # get_caller_directory covers the helper in isolation, not its use here.
+    assert Template.to_json(implicit) == Template.to_json(explicit)
+
+
+def test_file_context_without_the_source_fails_to_resolve_it():
+    # Keeps the assertion above from passing vacuously: the hashes match because
+    # the fixture was found, not because a missing file hashes the same either
+    # way.
+    with tempfile.TemporaryDirectory() as empty_context:
+        wrong_context = (
+            Template(file_context_path=empty_context)
+            .from_base_image()
+            .copy(FIXTURE_PATH, "hello.txt")
+        )
+
+        with pytest.raises(ValueError, match="No files found"):
+            Template.to_json(wrong_context)


### PR DESCRIPTION
Follow-up to #1689, which moved test fixtures out of the repository tree. Two loose ends from reviewing it.

## `mkdtemp` per test instead of per file

`getAllFilesInPath.test.ts` and `spoolTarArchive.test.ts` create the fixture root with `mkdtemp` in `beforeAll`, but kept the pre-existing `beforeEach` that deletes and recreates it:

```ts
beforeAll(async () => { testDir = await mkdtemp(join(tmpdir(), 'x-test-')) })
beforeEach(async () => {
  await rm(testDir, { recursive: true, force: true })
  await mkdir(testDir, { recursive: true })   // plain mkdir: 0777 & umask
})
```

Every test therefore ran against a fixed path recreated with default permissions — `mkdtemp`'s 0700 mode and its uniqueness were both discarded, and the only thing it still contributed was the location. Not a bug today (vitest runs tests within a file sequentially), but the hook says one thing and the code does another.

Both now `mkdtemp` in `beforeEach` and `rm` in `afterEach`, which is also what the Python mirrors already do with a `tempfile.TemporaryDirectory()` fixture.

## A test for the implicit file context

`Template()` with no options resolves relative `copy()` sources against the directory of the file that called it. #1689 switched `build.test.ts` to an explicit `fileContextPath`, which was the right call — but it left that default with no end-to-end coverage: `getCallerDirectory.test.ts` tests the helper in isolation, and the one remaining bare `Template()` (`build template from base template`) never copies. The default has broken before under a change in TypeScript emit, when a native class-field initializer inserted a stack frame the resolution didn't expect, so it is worth a test.

The fixture is committed and read-only rather than generated: the implicit context is a directory inside the repository by definition, so a temp directory cannot stand in for it — which is exactly why #1689 had to remove the previous coverage.

`toJSON` / `to_json` hash each COPY's files offline, so comparing an implicit serialization against an explicit one asserts that the context resolved, the glob found the fixture, and its contents were read — no network, no build:

```ts
const implicit = Template().fromBaseImage().copy('fixtures/hello.txt', 'hello.txt')
const explicit = Template({ fileContextPath: __dirname })
  .fromBaseImage()
  .copy('fixtures/hello.txt', 'hello.txt')

expect(await Template.toJSON(implicit)).toBe(await Template.toJSON(explicit))
```

A second test points a context at an empty temp directory and expects the copy to fail, so the equality above cannot pass vacuously on two identically-missing files.

Added to both SDKs (`packages/js-sdk/tests/template/fileContext.test.ts` and `packages/python-sdk/tests/shared/template/test_file_context.py`); the builder-level behaviour is shared between sync and async Python, so the Python test lives under `tests/shared/`.

## Verification

- `packages/js-sdk`, `--project template` over `fileContext.test.ts` and `tests/template/utils/`: 63 passed, 3 skipped.
- `packages/python-sdk`, `pytest tests/shared/template`: 90 passed, 1 skipped.
- Mutation-checked both new tests — stubbing the caller-directory lookup out of the constructor (JS `getCallerDirectory()` → `'.'`, Python `get_caller_directory()` → `"."`) fails each one. Both SDK files restored afterwards; the diff is test-only.
- `pnpm run format`, `pnpm run lint`, `pnpm run typecheck` all clean.
- `git status` clean after every run, no leftover fixture directories — the property #1689 established.

No usage examples apply and no changeset: test-only, nothing ships in either published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)