### PR TITLE
test(python-sdk): restore the stream-reader coverage dropped with the httpcore tests

### DIFF
--- a/packages/python-sdk/tests/test_file_stream_reader.py
+++ b/packages/python-sdk/tests/test_file_stream_reader.py
@@ -1,12 +1,15 @@
 """Unit tests for the streamed-read helpers.
 
 These exercise the readers' own lifecycle (consume / context manager /
-explicit close / idle timeout) against a local chunked HTTP server. They
-assert on the reader's contract — the underlying response is closed — rather
-than on connection-pool internals, which are private to the transport and
-absent on the pyqwest transports the SDK ships.
+explicit close / read error / abandonment / idle timeout) against a local
+chunked HTTP server. They assert on the reader's contract — the underlying
+response is closed, or deliberately left open — rather than on
+connection-pool internals, which are private to the transport and absent on
+the pyqwest transports the SDK ships.
 """
 
+import asyncio
+import gc
 import socket
 import threading
 import time
@@ -24,15 +27,32 @@ CHUNKS = [f"chunk{i}".encode() for i in range(5)]
 EXPECTED = b"".join(CHUNKS)
 
 
+def _read_request_head(conn) -> None:
+    """Read up to the end of the request head.
+
+    Accumulates across reads, since the head can arrive split across TCP
+    segments, and stops on a closed peer rather than spinning on empty reads.
+    """
+    buffered = b""
+    while b"\r\n\r\n" not in buffered:
+        received = conn.recv(65536)
+        if not received:
+            return
+        buffered += received
+
+
 def _start_chunked_server(
     stall_before: Optional[int] = None,
     stall_seconds: float = 0.0,
+    truncate_before: Optional[int] = None,
 ) -> int:
     """Start a one-shot HTTP server that replies with a chunked body.
 
     When ``stall_before`` is not None, the server sleeps ``stall_seconds``
     before sending that chunk index, so a reader with a shorter idle timeout
-    times out. Returns the server's port.
+    times out. When ``truncate_before`` is not None, the server drops the
+    connection at that chunk index without the terminating zero-length chunk,
+    so a mid-body read raises a protocol error. Returns the server's port.
     """
     sock = socket.socket()
     sock.bind(("127.0.0.1", 0))
@@ -42,49 +62,20 @@ def _start_chunked_server(
     def serve():
         try:
             conn, _ = sock.accept()
-            while b"\r\n\r\n" not in conn.recv(65536):
-                pass
+            _read_request_head(conn)
             conn.sendall(
                 b"HTTP/1.1 200 OK\r\n"
                 b"Content-Type: application/octet-stream\r\n"
                 b"Transfer-Encoding: chunked\r\n\r\n"
             )
             for idx, chunk in enumerate(CHUNKS):
+                if idx == truncate_before:
+                    break
                 if idx == stall_before:
                     time.sleep(stall_seconds)
                 conn.sendall(f"{len(chunk):x}\r\n".encode() + chunk + b"\r\n")
-            conn.sendall(b"0\r\n\r\n")
-            conn.close()
-        except OSError:
-            pass
-        finally:
-            sock.close()
-
-    threading.Thread(target=serve, daemon=True).start()
-    return port
-
-
-def _start_truncating_server() -> int:
-    """One-shot server that sends the head and one chunk, then drops the
-    connection without the terminating zero-length chunk, so a mid-body read
-    raises a protocol error."""
-    sock = socket.socket()
-    sock.bind(("127.0.0.1", 0))
-    sock.listen(1)
-    port = sock.getsockname()[1]
-
-    def serve():
-        try:
-            conn, _ = sock.accept()
-            while b"\r\n\r\n" not in conn.recv(65536):
-                pass
-            conn.sendall(
-                b"HTTP/1.1 200 OK\r\n"
-                b"Content-Type: application/octet-stream\r\n"
-                b"Transfer-Encoding: chunked\r\n\r\n"
-            )
-            chunk = CHUNKS[0]
-            conn.sendall(f"{len(chunk):x}\r\n".encode() + chunk + b"\r\n")
+            else:
+                conn.sendall(b"0\r\n\r\n")
             conn.close()
         except OSError:
             pass
@@ -102,7 +93,7 @@ def _open_stream(client, port):
     return client.send(request, stream=True)
 
 
-def test_sync_full_consume_releases_connection():
+def test_sync_full_consume_releases_response():
     with httpx.Client() as client:
         port = _start_chunked_server()
         response = _open_stream(client, port)
@@ -135,18 +126,37 @@ def test_sync_close_is_idempotent():
 
 def test_sync_read_error_releases_response():
     with httpx.Client() as client:
-        port = _start_truncating_server()
+        port = _start_chunked_server(truncate_before=1)
         response = _open_stream(client, port)
         reader = FileStreamReader(response)
         it = iter(reader)
         assert next(it) == CHUNKS[0]
         # A mid-body error propagates and the reader releases the response.
-        with pytest.raises(httpx.RemoteProtocolError):
+        # Asserted on the `httpx.HTTPError` base rather than the concrete
+        # class, because which error a truncated body surfaces as is the
+        # transport's business, not part of the reader's contract.
+        with pytest.raises(httpx.HTTPError):
             next(it)
         assert response.is_closed
 
 
-async def test_async_full_consume_releases_connection():
+def test_sync_abandoned_reader_leaves_the_response_open():
+    with httpx.Client() as client:
+        port = _start_chunked_server()
+        response = _open_stream(client, port)
+        reader = FileStreamReader(response)
+        assert next(iter(reader)) == CHUNKS[0]
+
+        # The reader documents that it has no garbage-collection safety net,
+        # so dropping it half-consumed must leave the response — and the
+        # pooled connection behind it — open. Callers have to consume it
+        # fully, use the context manager, or call `close()`.
+        del reader
+        gc.collect()
+        assert not response.is_closed
+
+
+async def test_async_full_consume_releases_response():
     async with httpx.AsyncClient() as client:
         port = _start_chunked_server()
         request = client.build_request("GET", f"http://127.0.0.1:{port}/files")
@@ -177,6 +187,25 @@ async def test_async_aclose_is_idempotent():
         await reader.aclose()
         await reader.aclose()
         assert response.is_closed
+
+
+async def test_async_abandoned_reader_leaves_the_response_open():
+    async with httpx.AsyncClient() as client:
+        port = _start_chunked_server()
+        request = client.build_request("GET", f"http://127.0.0.1:{port}/files")
+        response = await client.send(request, stream=True)
+        reader = AsyncFileStreamReader(response)
+        assert await reader.__anext__() == CHUNKS[0]
+
+        # Same contract as the sync reader, and for a stronger reason:
+        # releasing an async response requires awaiting `aclose()`, which a
+        # finalizer cannot do. Sleeping gives the event loop a chance to run
+        # async-generator finalization, so this asserts the response really
+        # stays open rather than just outracing the loop.
+        del reader
+        gc.collect()
+        await asyncio.sleep(0.05)
+        assert not response.is_closed
 
 
 async def test_async_reader_explicit_idle_timeout_bounds_each_read():

--- a/packages/python-sdk/tests/test_volume_client.py
+++ b/packages/python-sdk/tests/test_volume_client.py
@@ -169,6 +169,20 @@ def test_async_transport_is_shared_across_loops():
 CHUNK = b"x" * 1024
 
 
+def _read_request_head(conn) -> None:
+    """Read up to the end of the request head.
+
+    Accumulates across reads, since the head can arrive split across TCP
+    segments, and stops on a closed peer rather than spinning on empty reads.
+    """
+    buffered = b""
+    while b"\r\n\r\n" not in buffered:
+        received = conn.recv(65536)
+        if not received:
+            return
+        buffered += received
+
+
 def _start_volume_file_server(
     chunk_delays: List[float], ttfb_delay: float = 0.0
 ) -> str:
@@ -183,8 +197,7 @@ def _start_volume_file_server(
     def serve():
         try:
             conn, _ = sock.accept()
-            while b"\r\n\r\n" not in conn.recv(65536):
-                pass
+            _read_request_head(conn)
             time.sleep(ttfb_delay)
             conn.sendall(
                 b"HTTP/1.1 200 OK\r\n"
@@ -244,6 +257,38 @@ def test_sync_stream_stall_raises_read_timeout(short_read_timeout):
     assert received == [CHUNK]
 
 
+# A body far past the ~500 KiB the socket and reqwest buffers hold between
+# them, so a stall a quarter of the way in provably lands mid-transfer with the
+# server still pushing, rather than after the whole body was read ahead.
+SLOW_CONSUMER_CHUNKS = 2048
+SLOW_CONSUMER_STALL_AT = SLOW_CONSUMER_CHUNKS // 4
+
+
+def test_sync_stream_survives_a_consumer_slower_than_read_timeout(short_read_timeout):
+    # The idle read timeout is wire-only: the server sends every chunk
+    # promptly and the consumer then pauses for far longer than the bound,
+    # which must not abort the stream (parity with the JS SDK's
+    # "wrapStreamWithConnectionCleanup does not abort a slow consumer").
+    # This guards the bound staying an idle one — putting a wall-clock deadline
+    # back on the streaming path would fail here while every stall test above
+    # kept passing.
+    api_url = _start_volume_file_server([0.0] * SLOW_CONSUMER_CHUNKS)
+    volume = Volume(volume_id="v1", name="test", token="vol-token")
+
+    stream = volume.read_file("file.bin", format="stream", api_url=api_url)
+    received = 0
+    stalled = False
+    for chunk in stream:
+        received += len(chunk)
+        # A threshold rather than an exact count: the transport is free to
+        # coalesce or split the chunks it hands back.
+        if not stalled and received >= len(CHUNK) * SLOW_CONSUMER_STALL_AT:
+            stalled = True
+            time.sleep(short_read_timeout * 3)
+    assert stalled
+    assert received == len(CHUNK) * SLOW_CONSUMER_CHUNKS
+
+
 def test_async_stream_survives_transfers_longer_than_read_timeout(short_read_timeout):
     api_url = _start_volume_file_server([0.15] * 4)
     volume = AsyncVolume(volume_id="v1", name="test", token="vol-token")
@@ -253,6 +298,54 @@ def test_async_stream_survives_transfers_longer_than_read_timeout(short_read_tim
         return b"".join([chunk async for chunk in stream])
 
     assert asyncio.run(run()) == CHUNK * 4
+
+
+def test_async_stream_survives_a_consumer_slower_than_read_timeout(short_read_timeout):
+    # Async counterpart of the sync slow-consumer case above, against the
+    # async streaming transport.
+    api_url = _start_volume_file_server([0.0] * SLOW_CONSUMER_CHUNKS)
+    volume = AsyncVolume(volume_id="v1", name="test", token="vol-token")
+
+    async def run():
+        stream = await volume.read_file("file.bin", format="stream", api_url=api_url)
+        received = 0
+        stalled = False
+        async for chunk in stream:
+            received += len(chunk)
+            if not stalled and received >= len(CHUNK) * SLOW_CONSUMER_STALL_AT:
+                stalled = True
+                await asyncio.sleep(short_read_timeout * 3)
+        return stalled, received
+
+    assert asyncio.run(run()) == (True, len(CHUNK) * SLOW_CONSUMER_CHUNKS)
+
+
+def test_sync_stream_explicit_request_timeout_is_a_total_transfer_deadline(
+    short_read_timeout,
+):
+    # The counterpart that makes the two tests above meaningful: same fixture,
+    # same body, same stall — the only difference is the explicit
+    # `request_timeout`, which is documented as a whole-transfer deadline and
+    # so *does* cut off a slow consumer. Without this A/B, a regression that
+    # turned the default idle bound into a wall-clock one would look
+    # indistinguishable from correct behavior. The stall is longer than the
+    # total deadline, and the tests above establish that a slow consumer never
+    # trips the idle bound, so the timeout here can only be the deadline.
+    api_url = _start_volume_file_server([0.0] * SLOW_CONSUMER_CHUNKS)
+    volume = Volume(volume_id="v1", name="test", token="vol-token")
+
+    stream = volume.read_file(
+        "file.bin", format="stream", request_timeout=1.0, api_url=api_url
+    )
+    received = 0
+    stalled = False
+    with pytest.raises(httpx.TimeoutException):
+        for chunk in stream:
+            received += len(chunk)
+            if not stalled and received >= len(CHUNK) * SLOW_CONSUMER_STALL_AT:
+                stalled = True
+                time.sleep(2.0)
+    assert stalled
 
 
 def test_async_stream_stall_raises_read_timeout(short_read_timeout):


### PR DESCRIPTION
Follow-up to #1690 (review findings). That PR deleted five httpcore-era tests from `test_file_stream_reader.py`; three of them only ever asserted httpcore internals and are correctly gone, but two covered behavior that is still true — and still worth guarding — once re-anchored the way the surviving tests were.

## Restores the abandoned-reader contract

`FileStreamReader` and `AsyncFileStreamReader` both document in their **public** docstrings (`e2b/sandbox/filesystem/filesystem.py:166` and `:213`) that they have no garbage-collection safety net. The deleted tests were that contract's only executable proof. They re-anchor on `response.is_closed` as cleanly as everything else in #1690 did — drop the reader half-consumed, collect, assert the response stayed open.

The async variant sleeps before asserting so async-generator finalization gets a chance to run, which is what makes it a real assertion rather than a race the test happens to win.

## Restores the slow-consumer guard, on the real pyqwest transports

The idle read timeout is wire-only, so a consumer that stalls far longer than the bound must not abort the stream. The JS SDK asserts this (`packages/js-sdk/tests/connectionConfig.test.ts:561`, "does not abort a slow consumer"); Python had no equivalent left after #1690. It now lives in `test_volume_client.py` against actual streaming transports rather than a bare `httpx.Client()`, for both sync and async.

Two details make it non-vacuous:

- **The body is 2 MiB.** I measured how far the server gets before backpressure blocks it — ~526 KiB across the socket and reqwest buffers — so a stall at the quarter mark provably lands mid-transfer, rather than after the whole body was already read ahead. The original 3 KiB shape would have passed no matter what the timeout did.
- **A third test supplies the A/B.** Identical fixture, body, and stall, plus an explicit `request_timeout` — a documented whole-transfer deadline — and the same slow consumer *does* get cut off. Without that pairing, a regression that turned the default idle bound into a wall-clock one would be indistinguishable from correct behavior.

## Cleanups from the same review

- Folds `_start_truncating_server` back into `_start_chunked_server` as a `truncate_before` chunk index, dropping ~25 duplicated lines.
- Relaxes the truncated-body assertion from `httpx.RemoteProtocolError` to the `httpx.HTTPError` base. Which concrete error a truncated body surfaces as is the transport's business; the reader's contract is only that it closes the response. Pinning the concrete class re-introduced exactly the transport coupling #1690 set out to remove.
- Renames the three surviving `..._releases_connection` tests to `..._releases_response`, matching their assertions, the module docstring, and #1690's own new `test_sync_read_error_releases_response`.
- Fixes the request-head read loop both files share: `while b"\r\n\r\n" not in conn.recv(65536)` inspected only the latest `recv` instead of accumulated bytes, and spun forever on a closed peer. Near-unreachable on loopback, but #1690 copied it into a second helper, so it's fixed in both.

## Usage examples

None — this PR touches only `packages/python-sdk/tests/`. No public API changes, so nothing user-facing differs.

## Verification

```
$ uv run pytest tests/test_file_stream_reader.py tests/test_volume_client.py -q
32 passed in 9.86s        # stable across 6 consecutive runs

$ uv run pytest tests/*.py -q
267 passed in 20.69s      # full python-sdk unit suite (262 before, +5 here)

$ uv run ruff format .    # 414 files left unchanged
$ uv run ruff check .     # All checks passed!
$ uv run ty check         # All checks passed!
```

Both restored contracts were verified to actually hold before being committed as assertions, and the slow-consumer guard was mutation-tested (a wall-clock deadline on the same path does fail it) so it isn't a test that can only pass.

Test-only, so no changeset — matching the convention #1690 followed.

Follow-up to SDK-324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)