### PR TITLE
chore: tag package homepage URLs with UTM parameters

### DIFF
--- a/.changeset/utm-tagged-package-homepages.md
+++ b/.changeset/utm-tagged-package-homepages.md
@@ -1,0 +1,7 @@
+---
+'e2b': patch
+'@e2b/cli': patch
+'@e2b/python-sdk': patch
+---
+
+Tag the package homepage and README links with UTM parameters (`utm_source=npm`/`pypi`) so registry traffic to e2b.dev is attributed correctly. No functional change.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@
 
 # E2B CLI
 
-This CLI tool allows you to build manager your running E2B sandbox and sandbox templates. Learn more in [our documentation](https://e2b.dev/docs).
+This CLI tool allows you to build manager your running E2B sandbox and sandbox templates. Learn more in [our documentation](https://e2b.dev/docs?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b-cli).
 
 ### 1. Install the CLI
 
@@ -33,9 +33,9 @@ e2b auth login
 > [!NOTE]
 > To authenticate without the ability to open the browser (e.g. in CI/CD),
 > provide `E2B_API_KEY` as an environment variable. You can find your API key
-> in the [API Keys](https://e2b.dev/dashboard?tab=keys) tab in the E2B dashboard.
+> in the [API Keys](https://e2b.dev/dashboard?tab=keys&utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b-cli) tab in the E2B dashboard.
 > Then use the CLI like this: `E2B_API_KEY=e2b_... e2b template create`.
 
 ### 3. Check out docs
 
-Visit our [CLI documentation](https://e2b.dev/docs) to learn more.
+Visit our [CLI documentation](https://e2b.dev/docs?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b-cli) to learn more.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@e2b/cli",
   "version": "2.16.2",
   "description": "CLI for managing e2b sandbox templates",
-  "homepage": "https://e2b.dev",
+  "homepage": "https://e2b.dev/?utm_source=npm&utm_medium=referral&utm_campaign=package_homepage&utm_content=e2b-cli",
   "license": "MIT",
   "author": {
     "name": "FoundryLabs, Inc.",

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -17,7 +17,7 @@
 <img width="100%" src="/readme-assets/preview.png" alt="Cover image">
 --->
 ## What is E2B?
-[E2B](https://www.e2b.dev/) is an open-source infrastructure that allows you to run AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/e2b) or [Python SDK](https://pypi.org/project/e2b).
+[E2B](https://e2b.dev/?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b) is an open-source infrastructure that allows you to run AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/e2b) or [Python SDK](https://pypi.org/project/e2b).
 
 ## Run your first Sandbox
 
@@ -28,8 +28,8 @@ npm i e2b
 ```
 
 ### 2. Get your E2B API key
-1. Sign up to E2B [here](https://e2b.dev).
-2. Get your API key [here](https://e2b.dev/dashboard?tab=keys).
+1. Sign up to E2B [here](https://e2b.dev/?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b).
+2. Get your API key [here](https://e2b.dev/dashboard?tab=keys&utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b).
 3. Set environment variable with your API key
 ```
 E2B_API_KEY=e2b_***
@@ -47,7 +47,7 @@ console.log(result.stdout) // Hello from E2B!
 
 ### 4. Code execution with Code Interpreter
 
-If you need [`runCode()`](https://e2b.dev/docs/code-interpreting), install the [Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter):
+If you need [`runCode()`](https://e2b.dev/docs/code-interpreting?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b), install the [Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter):
 
 ```bash
 npm i @e2b/code-interpreter
@@ -62,7 +62,7 @@ console.log(execution.text)  // outputs 2
 ```
 
 ### 5. Check docs
-Visit [E2B documentation](https://e2b.dev/docs).
+Visit [E2B documentation](https://e2b.dev/docs?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b).
 
 ### 6. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -2,7 +2,7 @@
   "name": "e2b",
   "version": "2.41.0",
   "description": "E2B SDK that give agents cloud environments",
-  "homepage": "https://e2b.dev",
+  "homepage": "https://e2b.dev/?utm_source=npm&utm_medium=referral&utm_campaign=package_homepage&utm_content=e2b",
   "license": "MIT",
   "author": {
     "name": "FoundryLabs, Inc.",

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -14,7 +14,7 @@
 
 
 ## What is E2B?
-[E2B](https://www.e2b.dev/) is an open-source infrastructure that allows you to run AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/e2b) or [Python SDK](https://pypi.org/project/e2b).
+[E2B](https://e2b.dev/?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=e2b) is an open-source infrastructure that allows you to run AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/e2b) or [Python SDK](https://pypi.org/project/e2b).
 
 ## Run your first Sandbox
 
@@ -25,8 +25,8 @@ pip install e2b
 ```
 
 ### 2. Get your E2B API key
-1. Sign up to E2B [here](https://e2b.dev).
-2. Get your API key [here](https://e2b.dev/dashboard?tab=keys).
+1. Sign up to E2B [here](https://e2b.dev/?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=e2b).
+2. Get your API key [here](https://e2b.dev/dashboard?tab=keys&utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=e2b).
 3. Set environment variable with your API key
 ```
 E2B_API_KEY=e2b_***
@@ -44,7 +44,7 @@ with Sandbox.create() as sandbox:
 
 ### 4. Code execution with Code Interpreter
 
-If you need [`run_code()`](https://e2b.dev/docs/code-interpreting), install the [Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter):
+If you need [`run_code()`](https://e2b.dev/docs/code-interpreting?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=e2b), install the [Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter):
 
 ```
 pip install e2b-code-interpreter
@@ -59,7 +59,7 @@ with Sandbox.create() as sandbox:
 ```
 
 ### 5. Check docs
-Visit [E2B documentation](https://e2b.dev/docs).
+Visit [E2B documentation](https://e2b.dev/docs?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=e2b).
 
 ### 6. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://e2b.dev/"
+Homepage = "https://e2b.dev/?utm_source=pypi&utm_medium=referral&utm_campaign=package_homepage&utm_content=e2b"
 Repository = "https://github.com/e2b-dev/e2b/tree/main/packages/python-sdk"
 "Bug Tracker" = "https://github.com/e2b-dev/e2b/issues"
 


### PR DESCRIPTION
The SDK and CLI homepage fields get utm_source=pypi/npm (utm_campaign=package_homepage) so traffic from the registry pages attributes to its real source instead of direct. Takes effect on the next publish of each package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)