### PR TITLE
fix(python-sdk): raise SandboxException instead of bare Exception when command stream ends without exit event

### DIFF
--- a/.changeset/fix-command-handle-sandbox-exception.md
+++ b/.changeset/fix-command-handle-sandbox-exception.md
@@ -1,0 +1,5 @@
+---
+"e2b": patch
+---
+
+Raise `SandboxException` instead of bare `Exception` in `CommandHandle.wait()` when the command stream ends without an exit event, giving a clearer error message when the sandbox was killed, paused, or timed out mid-stream.

--- a/packages/js-sdk/src/sandbox/commands/commandHandle.ts
+++ b/packages/js-sdk/src/sandbox/commands/commandHandle.ts
@@ -162,6 +162,8 @@ export class CommandHandle
    * If the command exits with a non-zero exit code, it throws a `CommandExitError`.
    *
    * @returns `CommandResult` result of command execution.
+   * @throws {CommandExitError} the command exited with a non-zero exit code
+   * @throws {SandboxError} the command stream ended before an exit event was received, e.g. the sandbox was killed or timed out
    */
   async wait() {
     await this._wait
@@ -171,7 +173,7 @@ export class CommandHandle
     }
 
     if (!this.result) {
-      throw new SandboxError('Process exited without a result')
+      throw new SandboxError('Command stream ended without an exit event. The sandbox is no longer running — it may have been killed, paused, or timed out.')
     }
 
     if (this.result.exitCode !== 0) {

--- a/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
+++ b/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
@@ -250,7 +250,9 @@ class AsyncCommandHandle:
             raise self._iteration_exception
 
         if self._result is None:
-            raise Exception("Command ended without an end event")
+            raise SandboxException(
+                "Command stream ended without an exit event. The sandbox may have been killed, paused, or timed out."
+            )
 
         if self._result.exit_code != 0:
             raise CommandExitException(

--- a/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
+++ b/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
@@ -244,6 +244,8 @@ class AsyncCommandHandle:
         If the command exits with a non-zero exit code, it throws a `CommandExitException`.
 
         :return: `CommandResult` result of command execution
+        :raises CommandExitException: the command exited with a non-zero exit code
+        :raises SandboxException: the command stream ended before an exit event was received, e.g. the sandbox was killed or timed out
         """
         await self._wait
         if self._iteration_exception:

--- a/packages/python-sdk/e2b/sandbox_sync/commands/command_handle.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/command_handle.py
@@ -172,6 +172,8 @@ class CommandHandle:
         :param on_stderr: Callback for stderr output
 
         :return: `CommandResult` result of command execution
+        :raises CommandExitException: the command exited with a non-zero exit code
+        :raises SandboxException: the command stream ended before an exit event was received, e.g. the sandbox was killed or timed out
         """
         try:
             for stdout, stderr, pty in self:

--- a/packages/python-sdk/e2b/sandbox_sync/commands/command_handle.py
+++ b/packages/python-sdk/e2b/sandbox_sync/commands/command_handle.py
@@ -193,7 +193,9 @@ class CommandHandle:
             raise self._iteration_exception
 
         if self._result is None:
-            raise Exception("Command ended without an end event")
+            raise SandboxException(
+                "Command stream ended without an exit event. The sandbox may have been killed, paused, or timed out."
+            )
 
         if self._result.exit_code != 0:
             raise CommandExitException(


### PR DESCRIPTION
## Summary

- `CommandHandle.wait()` (sync) and `AsyncCommandHandle.wait()` (async) raised a bare `Exception("Command ended without an end event")` when the command stream closed without a ConnectRPC end event.
- This surfaces as an opaque `Exception` instead of a `SandboxException`, breaking `except SandboxException` handlers and giving no indication that the sandbox lifecycle is the cause.

## Change

Replace the bare `Exception` with `SandboxException` in both `sandbox_sync` and `sandbox_async`:

```python
# before
raise Exception("Command ended without an end event")

# after
raise SandboxException(
    "Command stream ended without an exit event. "
    "The sandbox may have been killed, paused, or timed out."
)
```

## Context

This path is reached when the transport closes the stream before a ConnectRPC end envelope arrives — e.g. when a sandbox is killed or times out mid-command and the connection is dropped at the TCP level. The transport failure itself is already caught and mapped by `handle_rpc_exception_with_health` (which raises `TimeoutException` when the sandbox health probe confirms it is gone). This `result is None` branch is the fallback for cases where the stream closed cleanly but no end event was received.

Closes #1726 (Problem 3).