### PR TITLE
docs(js-sdk): 3 docstrings name parameters the functions do not take

### DIFF
--- a/packages/js-sdk/src/template/index.ts
+++ b/packages/js-sdk/src/template/index.ts
@@ -1043,8 +1043,8 @@ export class TemplateBase
    * Internal implementation of the template build process.
    *
    * @param client API client for communicating with E2B backend
+   * @param config connection configuration for the API client
    * @param name Template name in 'name' or 'name:tag' format
-   * @param tags Additional tags to assign to the build
    * @param options Build configuration options
    * @throws BuildError if the build fails
    */

--- a/packages/js-sdk/src/volume/index.ts
+++ b/packages/js-sdk/src/volume/index.ts
@@ -329,8 +329,7 @@ export class Volume extends ClientFactory {
    * Create a directory.
    *
    * @param path path to the directory to create.
-   * @param options directory creation options.
-   * @param opts connection options.
+   * @param opts directory creation and connection options.
    */
   async makeDir(
     path: string,
@@ -663,8 +662,7 @@ export class Volume extends ClientFactory {
    *
    * @param path path to the file.
    * @param data data to write to the file. Data can be a string, `ArrayBuffer`, `Blob`, or `ReadableStream`. Outside the browser, `ReadableStream` data is streamed to the API instead of being buffered in memory.
-   * @param options file creation options.
-   * @param opts connection options.
+   * @param opts file creation and connection options.
    *
    * @returns information about the written file
    */

--- a/packages/js-sdk/src/volume/index.ts
+++ b/packages/js-sdk/src/volume/index.ts
@@ -329,7 +329,9 @@ export class Volume extends ClientFactory {
    * Create a directory.
    *
    * @param path path to the directory to create.
-   * @param opts directory creation and connection options.
+   * @param opts directory metadata (`uid`, `gid`, `mode`), `force` to create missing parent directories, and connection options such as `requestTimeoutMs` (60 seconds by default), `headers` and `proxy`.
+   *
+   * @returns stat of the created directory: `name`, `path`, `type`, `size`, `uid`, `gid`, `mode` and the access, modification and creation times.
    */
   async makeDir(
     path: string,
@@ -662,9 +664,9 @@ export class Volume extends ClientFactory {
    *
    * @param path path to the file.
    * @param data data to write to the file. Data can be a string, `ArrayBuffer`, `Blob`, or `ReadableStream`. Outside the browser, `ReadableStream` data is streamed to the API instead of being buffered in memory.
-   * @param opts file creation and connection options.
+   * @param opts file metadata (`uid`, `gid`, `mode`), `force` to overwrite an existing file, and connection options such as `requestTimeoutMs`, which defaults to 1 hour for file writes rather than the usual 60 seconds, `headers` and `proxy`.
    *
-   * @returns information about the written file
+   * @returns stat of the written file: `name`, `path`, `type`, `size`, `uid`, `gid`, `mode` and the access, modification and creation times.
    */
   async writeFile(
     path: string,


### PR DESCRIPTION
`Volume.makeDir` and `Volume.writeFile` each document `options` and `opts`, and the signature takes 1 merged parameter, `opts?: VolumeWriteOpts & VolumeApiOpts`. I merged the 2 doc lines instead of dropping one, since both halves are still true of the single argument.

`TemplateBase.build` documents `tags`, which is not in the signature, and says nothing about `config`, which is. I added a line for `config`; drop that hunk if you would rather leave the internal method as it was.

Comments only, no behaviour change. Found by a checker I wrote that compares every documented `@param` name against the signature under it. It read 183 of the 185 documented comments in this repository and these 3 were all it had to say.
