### PR TITLE
chore: point README docs links at docs.e2b.dev

### DIFF
--- a/.changeset/docs-subdomain-links.md
+++ b/.changeset/docs-subdomain-links.md
@@ -1,0 +1,7 @@
+---
+'e2b': patch
+'@e2b/cli': patch
+'@e2b/python-sdk': patch
+---
+
+Point the README documentation links at `docs.e2b.dev` instead of `e2b.dev/docs`. The docs site moved to its own subdomain and has no `/docs` path prefix there, so `e2b.dev/docs` serves a 308 to `docs.e2b.dev/` and `e2b.dev/docs/code-interpreting` maps to `docs.e2b.dev/code-interpreting`. The UTM parameters are unchanged and survived the redirect, so this removes a redirect hop rather than fixing broken attribution.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@
 
 # E2B CLI
 
-This CLI tool allows you to build manager your running E2B sandbox and sandbox templates. Learn more in [our documentation](https://e2b.dev/docs?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b-cli).
+This CLI tool allows you to build manager your running E2B sandbox and sandbox templates. Learn more in [our documentation](https://docs.e2b.dev/?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b-cli).
 
 ### 1. Install the CLI
 
@@ -38,4 +38,4 @@ e2b auth login
 
 ### 3. Check out docs
 
-Visit our [CLI documentation](https://e2b.dev/docs?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b-cli) to learn more.
+Visit our [CLI documentation](https://docs.e2b.dev/?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b-cli) to learn more.

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -68,7 +68,7 @@ Per-call options still take precedence over the client's options, and clients ar
 
 ### 5. Code execution with Code Interpreter
 
-If you need [`runCode()`](https://e2b.dev/docs/code-interpreting?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b), install the [Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter):
+If you need [`runCode()`](https://docs.e2b.dev/code-interpreting?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b), install the [Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter):
 
 ```bash
 npm i @e2b/code-interpreter
@@ -83,7 +83,7 @@ console.log(execution.text)  // outputs 2
 ```
 
 ### 6. Check docs
-Visit [E2B documentation](https://e2b.dev/docs?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b).
+Visit [E2B documentation](https://docs.e2b.dev/?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b).
 
 ### 7. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -68,7 +68,7 @@ Per-call params still take precedence over the client's params, and clients are 
 
 ### 5. Code execution with Code Interpreter
 
-If you need [`run_code()`](https://e2b.dev/docs/code-interpreting?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=e2b), install the [Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter):
+If you need [`run_code()`](https://docs.e2b.dev/code-interpreting?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=e2b), install the [Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter):
 
 ```
 pip install e2b-code-interpreter
@@ -83,7 +83,7 @@ with Sandbox.create() as sandbox:
 ```
 
 ### 6. Check docs
-Visit [E2B documentation](https://e2b.dev/docs?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=e2b).
+Visit [E2B documentation](https://docs.e2b.dev/?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=e2b).
 
 ### 7. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.


### PR DESCRIPTION
Follow-up to #1724. The docs site moved to its own subdomain, so the links that PR tagged point at the pre-migration domain.

`e2b.dev/docs` returns a 308 to `docs.e2b.dev/`, and the subdomain has no `/docs` path prefix, so `e2b.dev/docs/code-interpreting` maps to `docs.e2b.dev/code-interpreting`.

The UTM query string is preserved across the redirect, so attribution was not broken. This removes the redirect hop.

Six links across the three packaged READMEs. Changeset covers the same three packages as #1724.

This does not touch the root `README.md`, which has its own docs links on the old domain. That is queued separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)