### PR TITLE
chore: link the resolved code-interpreting page

### DIFF
--- a/.changeset/code-interpreting-resolved-path.md
+++ b/.changeset/code-interpreting-resolved-path.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/python-sdk': patch
+---
+
+Point the two Code Interpreter README links at `code-interpreting/analyze-data-with-ai` instead of the `code-interpreting` section index. The index has no landing page and 307s to that article, dropping the query string on the way, so the UTM parameters were lost before the reader arrived. Linking at the resolved path keeps them.

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -68,7 +68,7 @@ Per-call options still take precedence over the client's options, and clients ar
 
 ### 5. Code execution with Code Interpreter
 
-If you need [`runCode()`](https://docs.e2b.dev/code-interpreting?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b), install the [Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter):
+If you need [`runCode()`](https://docs.e2b.dev/code-interpreting/analyze-data-with-ai?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b), install the [Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter):
 
 ```bash
 npm i @e2b/code-interpreter

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -68,7 +68,7 @@ Per-call params still take precedence over the client's params, and clients are 
 
 ### 5. Code execution with Code Interpreter
 
-If you need [`run_code()`](https://docs.e2b.dev/code-interpreting?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=e2b), install the [Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter):
+If you need [`run_code()`](https://docs.e2b.dev/code-interpreting/analyze-data-with-ai?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=e2b), install the [Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter):
 
 ```
 pip install e2b-code-interpreter


### PR DESCRIPTION
Follow-up to #1754. That PR moved these links to `docs.e2b.dev` but left an attribution bug in place.

`docs.e2b.dev/code-interpreting` is a section index with no landing page. It returns a 307 to `docs.e2b.dev/code-interpreting/analyze-data-with-ai` and drops the query string on the way, so the UTM parameters never reach the destination. The old domain behaved the same way, so this predates the migration and #1754 did not fix it.

To reproduce:

```
curl -sSL -o /dev/null -w "final=%{url_effective}\n" -A "Mozilla/5.0" -H "Accept: text/html" \
  "https://docs.e2b.dev/code-interpreting?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=e2b"
```

The final URL has no `utm_` parameters. Requesting `code-interpreting/analyze-data-with-ai` directly returns 200 with them intact.

Two links. Worth a look from whoever owns this section: the resolved article is narrower than the section index the text implies, so if there is a better target for "if you need `runCode()`", that is the one to use.

Changeset covers `e2b` and `@e2b/python-sdk` only, since `packages/cli` is not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)