### PR TITLE
fix(sdk): parse detached upstream names correctly

### DIFF
--- a/.changeset/git-status-detached-name.md
+++ b/.changeset/git-status-detached-name.md
@@ -1,0 +1,6 @@
+---
+'@e2b/python-sdk': patch
+'e2b': patch
+---
+
+Fix Git status parsing when a tracked upstream branch name contains the word `detached`. Attached branches now keep their branch and upstream fields instead of being reported as detached HEADs.

--- a/packages/js-sdk/src/sandbox/git/utils.ts
+++ b/packages/js-sdk/src/sandbox/git/utils.ts
@@ -381,9 +381,7 @@ export function parseGitStatus(output: string): GitStatus {
       aheadStart === -1 ? undefined : branchInfo.slice(aheadStart + 2, -1)
     const normalizedBranch = normalizeBranchName(branchPart)
     const rawBranch = branchPart
-    const isDetached =
-      rawBranch.startsWith('HEAD (detached at ') ||
-      rawBranch.includes('detached')
+    const isDetached = rawBranch.startsWith('HEAD (detached at ')
 
     if (isDetached || normalizedBranch.startsWith('HEAD')) {
       detached = true

--- a/packages/js-sdk/src/sandbox/git/utils.ts
+++ b/packages/js-sdk/src/sandbox/git/utils.ts
@@ -72,7 +72,8 @@ export interface GitStatus {
    */
   behind: number
   /**
-   * Whether HEAD is detached.
+   * Whether HEAD is detached. When true, `currentBranch` and `upstream` are
+   * undefined.
    */
   detached: boolean
   /**
@@ -302,9 +303,11 @@ function parseAheadBehind(segment?: string): { ahead: number; behind: number } {
   return { ahead, behind }
 }
 
+const DETACHED_HEAD_PREFIX = 'HEAD (detached at '
+
 function normalizeBranchName(name: string): string {
-  if (name.startsWith('HEAD (detached at ')) {
-    return name.replace('HEAD (detached at ', '').replace(/\)$/, '')
+  if (name.startsWith(DETACHED_HEAD_PREFIX)) {
+    return name.replace(DETACHED_HEAD_PREFIX, '').replace(/\)$/, '')
   }
 
   return name
@@ -380,10 +383,9 @@ export function parseGitStatus(output: string): GitStatus {
     const aheadPart =
       aheadStart === -1 ? undefined : branchInfo.slice(aheadStart + 2, -1)
     const normalizedBranch = normalizeBranchName(branchPart)
-    const rawBranch = branchPart
-    const isDetached = rawBranch.startsWith('HEAD (detached at ')
+    const isDetached = branchPart.startsWith(DETACHED_HEAD_PREFIX)
 
-    if (isDetached || normalizedBranch.startsWith('HEAD')) {
+    if (isDetached || normalizedBranch === 'HEAD') {
       detached = true
     } else if (normalizedBranch.includes('...')) {
       const [branch, upstreamBranch] = normalizedBranch.split('...')

--- a/packages/js-sdk/tests/sandbox/git/parse.test.ts
+++ b/packages/js-sdk/tests/sandbox/git/parse.test.ts
@@ -10,8 +10,24 @@ test('does not treat detached in an upstream name as detached HEAD', () => {
   expect(status.detached).toBe(false)
 })
 
+test('does not treat a branch beginning with HEAD as detached HEAD', () => {
+  const status = parseGitStatus(
+    '## HEADless-refactor...origin/HEADless-refactor\n'
+  )
+
+  expect(status.currentBranch).toBe('HEADless-refactor')
+  expect(status.upstream).toBe('origin/HEADless-refactor')
+  expect(status.detached).toBe(false)
+})
+
 test('still detects a detached HEAD', () => {
   const status = parseGitStatus('## HEAD (detached at abc123)\n')
+
+  expect(status.detached).toBe(true)
+})
+
+test('detects a detached HEAD with no branch', () => {
+  const status = parseGitStatus('## HEAD (no branch)\n')
 
   expect(status.detached).toBe(true)
 })

--- a/packages/js-sdk/tests/sandbox/git/parse.test.ts
+++ b/packages/js-sdk/tests/sandbox/git/parse.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest'
+
+import { parseGitStatus } from '../../../src/sandbox/git/utils'
+
+test('does not treat detached in an upstream name as detached HEAD', () => {
+  const status = parseGitStatus('## main...origin/detached-work\n')
+
+  expect(status.currentBranch).toBe('main')
+  expect(status.upstream).toBe('origin/detached-work')
+  expect(status.detached).toBe(false)
+})
+
+test('still detects a detached HEAD', () => {
+  const status = parseGitStatus('## HEAD (detached at abc123)\n')
+
+  expect(status.detached).toBe(true)
+})

--- a/packages/python-sdk/e2b/sandbox/_git/parse.py
+++ b/packages/python-sdk/e2b/sandbox/_git/parse.py
@@ -125,9 +125,7 @@ def parse_git_status(output: str) -> GitStatus:
         ahead_part = None if ahead_start == -1 else branch_info[ahead_start + 2 : -1]
         normalized_branch = _normalize_branch_name(branch_part)
         raw_branch = branch_part
-        is_detached = raw_branch.startswith("HEAD (detached at ") or (
-            "detached" in raw_branch
-        )
+        is_detached = raw_branch.startswith("HEAD (detached at ")
 
         if is_detached or normalized_branch.startswith("HEAD"):
             detached = True

--- a/packages/python-sdk/e2b/sandbox/_git/parse.py
+++ b/packages/python-sdk/e2b/sandbox/_git/parse.py
@@ -4,6 +4,8 @@ from urllib.parse import urlparse
 from e2b.exceptions import InvalidArgumentException
 from e2b.sandbox._git.types import GitBranches, GitFileStatus, GitStatus
 
+_DETACHED_HEAD_PREFIX = "HEAD (detached at "
+
 
 def derive_repo_dir_from_url(url: str) -> Optional[str]:
     """
@@ -55,8 +57,8 @@ def _normalize_branch_name(name: str) -> str:
     :param name: Raw branch name section
     :return: Normalized branch name
     """
-    if name.startswith("HEAD (detached at "):
-        return name.replace("HEAD (detached at ", "").rstrip(")")
+    if name.startswith(_DETACHED_HEAD_PREFIX):
+        return name.replace(_DETACHED_HEAD_PREFIX, "").rstrip(")")
     return (
         name.replace("HEAD (no branch)", "HEAD")
         .replace("No commits yet on ", "")
@@ -124,10 +126,9 @@ def parse_git_status(output: str) -> GitStatus:
         branch_part = branch_info if ahead_start == -1 else branch_info[:ahead_start]
         ahead_part = None if ahead_start == -1 else branch_info[ahead_start + 2 : -1]
         normalized_branch = _normalize_branch_name(branch_part)
-        raw_branch = branch_part
-        is_detached = raw_branch.startswith("HEAD (detached at ")
+        is_detached = branch_part.startswith(_DETACHED_HEAD_PREFIX)
 
-        if is_detached or normalized_branch.startswith("HEAD"):
+        if is_detached or normalized_branch == "HEAD":
             detached = True
         elif "..." in normalized_branch:
             branch, upstream_branch = normalized_branch.split("...")

--- a/packages/python-sdk/e2b/sandbox/_git/types.py
+++ b/packages/python-sdk/e2b/sandbox/_git/types.py
@@ -37,7 +37,8 @@ class GitStatus:
     :param upstream: Upstream branch name, if available
     :param ahead: Number of commits the branch is ahead of upstream
     :param behind: Number of commits the branch is behind upstream
-    :param detached: Whether HEAD is detached
+    :param detached: Whether HEAD is detached; ``current_branch`` and
+        ``upstream`` are ``None`` when true
     :param file_status: List of file status entries
     """
 

--- a/packages/python-sdk/tests/shared/git/test_parse.py
+++ b/packages/python-sdk/tests/shared/git/test_parse.py
@@ -1,0 +1,15 @@
+from e2b.sandbox._git.parse import parse_git_status
+
+
+def test_status_does_not_treat_detached_in_upstream_name_as_detached():
+    status = parse_git_status("## main...origin/detached-work\n")
+
+    assert status.current_branch == "main"
+    assert status.upstream == "origin/detached-work"
+    assert status.detached is False
+
+
+def test_status_still_detects_detached_head():
+    status = parse_git_status("## HEAD (detached at abc123)\n")
+
+    assert status.detached is True

--- a/packages/python-sdk/tests/shared/git/test_parse.py
+++ b/packages/python-sdk/tests/shared/git/test_parse.py
@@ -9,7 +9,21 @@ def test_status_does_not_treat_detached_in_upstream_name_as_detached():
     assert status.detached is False
 
 
+def test_status_does_not_treat_head_prefix_in_branch_name_as_detached():
+    status = parse_git_status("## HEADless-refactor...origin/HEADless-refactor\n")
+
+    assert status.current_branch == "HEADless-refactor"
+    assert status.upstream == "origin/HEADless-refactor"
+    assert status.detached is False
+
+
 def test_status_still_detects_detached_head():
     status = parse_git_status("## HEAD (detached at abc123)\n")
+
+    assert status.detached is True
+
+
+def test_status_detects_detached_head_with_no_branch():
+    status = parse_git_status("## HEAD (no branch)\n")
 
     assert status.detached is True


### PR DESCRIPTION
## Summary

- Parse detached Git branches consistently in the JavaScript and Python SDKs.
- Preserve `currentBranch` / `upstream` for attached branches whose names contain `detached` or begin with `HEAD`.
- Keep the existing detached-HEAD forms (`HEAD (detached at <commit>)` and `HEAD (no branch)`) recognized.

## Why

`parseGitStatus` used substring and prefix heuristics that could classify an attached branch such as `main...origin/detached-work` or `HEADless-refactor...origin/HEADless-refactor` as detached. That incorrectly removed the branch and upstream values from the SDK result.

This change keeps the JavaScript and Python implementations in lockstep, centralizes the detached-HEAD marker, and narrows the normalized `HEAD` check to the exact value emitted for `(no branch)`.

Fixes #1373

## Validation

- JS Vitest detached-branch parser tests: 4 passed
- Python pytest detached-branch parser tests: 4 passed
- TypeScript type-check
- Prettier and Oxlint
- Ruff and Python compilation
- `git diff --check`

