### PR TITLE
fix(sdk): git status parsing false-positives on detached HEAD and mis-splits repeated ellipsis

### DIFF
--- a/.changeset/fix-git-status-detached-ellipsis-parsing.md
+++ b/.changeset/fix-git-status-detached-ellipsis-parsing.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/python-sdk': patch
+---
+
+Fix `git.status()` reporting `detached: true` when an upstream branch name merely contains the substring "detached" (e.g. `origin/detached-work`), and fix incorrect branch/upstream parsing when the branch header contains more than one `...` separator

--- a/packages/js-sdk/src/sandbox/git/utils.ts
+++ b/packages/js-sdk/src/sandbox/git/utils.ts
@@ -381,14 +381,14 @@ export function parseGitStatus(output: string): GitStatus {
       aheadStart === -1 ? undefined : branchInfo.slice(aheadStart + 2, -1)
     const normalizedBranch = normalizeBranchName(branchPart)
     const rawBranch = branchPart
-    const isDetached =
-      rawBranch.startsWith('HEAD (detached at ') ||
-      rawBranch.includes('detached')
+    const isDetached = rawBranch.startsWith('HEAD (detached at ')
 
     if (isDetached || normalizedBranch.startsWith('HEAD')) {
       detached = true
     } else if (normalizedBranch.includes('...')) {
-      const [branch, upstreamBranch] = normalizedBranch.split('...')
+      const separatorIndex = normalizedBranch.indexOf('...')
+      const branch = normalizedBranch.slice(0, separatorIndex)
+      const upstreamBranch = normalizedBranch.slice(separatorIndex + 3)
       currentBranch = branch || undefined
       upstream = upstreamBranch || undefined
     } else {

--- a/packages/js-sdk/tests/sandbox/git/parse.test.ts
+++ b/packages/js-sdk/tests/sandbox/git/parse.test.ts
@@ -1,0 +1,49 @@
+import { test, expect } from 'vitest'
+
+import { parseGitStatus } from '../../../src/sandbox/git/utils'
+
+test('upstream branch containing the word "detached" is not reported as detached', () => {
+  // Regression test for e2b-dev/E2B#1373: a repository tracking an upstream
+  // branch whose name merely contains the substring "detached" (e.g.
+  // origin/detached-work) must not be reported as being in detached HEAD
+  // state.
+  const status = parseGitStatus('## main...origin/detached-work\n')
+
+  expect(status.detached).toBe(false)
+  expect(status.currentBranch).toBe('main')
+  expect(status.upstream).toBe('origin/detached-work')
+})
+
+test('real detached HEAD is still detected', () => {
+  const status = parseGitStatus('## HEAD (detached at abc1234)\n')
+
+  expect(status.detached).toBe(true)
+  expect(status.currentBranch).toBeUndefined()
+  expect(status.upstream).toBeUndefined()
+})
+
+test('HEAD (no branch) is still detected as detached', () => {
+  const status = parseGitStatus('## HEAD (no branch)\n')
+
+  expect(status.detached).toBe(true)
+})
+
+test('branch name containing an extra "..." does not get truncated', () => {
+  // Regression test for e2b-dev/E2B#1371: a normalized branch header
+  // containing more than one "..." separator must only split on the first
+  // occurrence, not silently drop the rest of the upstream name.
+  const status = parseGitStatus('## feat...v2...origin/feat...v2\n')
+
+  expect(status.currentBranch).toBe('feat')
+  expect(status.upstream).toBe('v2...origin/feat...v2')
+})
+
+test('ahead/behind counts are still parsed', () => {
+  const status = parseGitStatus('## main...origin/main [ahead 2, behind 1]\n')
+
+  expect(status.currentBranch).toBe('main')
+  expect(status.upstream).toBe('origin/main')
+  expect(status.ahead).toBe(2)
+  expect(status.behind).toBe(1)
+  expect(status.detached).toBe(false)
+})

--- a/packages/python-sdk/e2b/sandbox/_git/parse.py
+++ b/packages/python-sdk/e2b/sandbox/_git/parse.py
@@ -125,14 +125,12 @@ def parse_git_status(output: str) -> GitStatus:
         ahead_part = None if ahead_start == -1 else branch_info[ahead_start + 2 : -1]
         normalized_branch = _normalize_branch_name(branch_part)
         raw_branch = branch_part
-        is_detached = raw_branch.startswith("HEAD (detached at ") or (
-            "detached" in raw_branch
-        )
+        is_detached = raw_branch.startswith("HEAD (detached at ")
 
         if is_detached or normalized_branch.startswith("HEAD"):
             detached = True
         elif "..." in normalized_branch:
-            branch, upstream_branch = normalized_branch.split("...")
+            branch, upstream_branch = normalized_branch.split("...", 1)
             current_branch = branch or None
             upstream = upstream_branch or None
         else:

--- a/packages/python-sdk/tests/shared/git/test_parse.py
+++ b/packages/python-sdk/tests/shared/git/test_parse.py
@@ -1,0 +1,48 @@
+from e2b.sandbox._git import parse_git_status
+
+
+def test_status_upstream_branch_containing_word_detached_is_not_detached():
+    # Regression test for #1373: a repository tracking an upstream branch
+    # whose name merely contains the substring "detached" (e.g.
+    # origin/detached-work) must not be reported as being in detached HEAD
+    # state.
+    status = parse_git_status("## main...origin/detached-work\n")
+
+    assert status.detached is False
+    assert status.current_branch == "main"
+    assert status.upstream == "origin/detached-work"
+
+
+def test_status_real_detached_head_is_still_detected():
+    status = parse_git_status("## HEAD (detached at abc1234)\n")
+
+    assert status.detached is True
+    assert status.current_branch is None
+    assert status.upstream is None
+
+
+def test_status_head_no_branch_is_still_detected():
+    status = parse_git_status("## HEAD (no branch)\n")
+
+    assert status.detached is True
+
+
+def test_status_branch_containing_extra_ellipsis_does_not_raise():
+    # Regression test for #1371: a normalized branch header containing more
+    # than one "..." separator must not crash the two-value unpack. Only the
+    # first "..." separates branch from upstream; anything after it is part
+    # of the upstream name.
+    status = parse_git_status("## feat...v2...origin/feat...v2\n")
+
+    assert status.current_branch == "feat"
+    assert status.upstream == "v2...origin/feat...v2"
+
+
+def test_status_ahead_behind_still_parsed():
+    status = parse_git_status("## main...origin/main [ahead 2, behind 1]\n")
+
+    assert status.current_branch == "main"
+    assert status.upstream == "origin/main"
+    assert status.ahead == 2
+    assert status.behind == 1
+    assert status.detached is False


### PR DESCRIPTION
## Summary

`parse_git_status` (Python) / `parseGitStatus` (JS) share two bugs in the branch-header parsing at the top of `## <branch>...<upstream> [ahead N, behind N]`:

- **#1373** — `detached` was being detected with a bare substring check (`"detached" in raw_branch`), so any upstream branch name that merely *contains* the word "detached" (e.g. `origin/detached-work`) got misreported as a detached-HEAD state, with `current_branch`/`upstream` left empty. Fixed by relying only on the actual porcelain markers (`HEAD (detached at `, `HEAD (no branch)`) already checked a few lines down — same fix proposed in the issue.
- **#1371** — splitting on `"..."` with no limit breaks when the branch header itself contains more than one `...` separator: Python raises `ValueError: too many values to unpack`, and the JS SDK (same bug, not separately filed) silently truncates the upstream name via array destructuring instead of crashing. Fixed by splitting on only the first occurrence in both.

I independently verified the maintainer's comment on #1371 — `git check-ref-format` does reject branch names containing `..`/`...`, so the exact reproduction in the issue may not be reachable through normal git usage. I'm treating this as a defensive fix (it's a one-line change, and it converts undefined/incorrect behavior into correct behavior with no downside) rather than claiming it's a live crash for typical users.

Since the Python and JS SDKs implement this parser twice (checked for consistency by `test_parity.py`), I checked whether the same substring-based detection bug existed on the other side of the fence — it did, in `packages/js-sdk/src/sandbox/git/utils.ts`, so both are fixed together in one PR for parity rather than shipping two divergent behaviors.

## Test plan

- [x] Added `packages/python-sdk/tests/shared/git/test_parse.py` (no unit tests existed for this pure parser before) — 5 tests covering both fixes plus regression coverage for real detached HEAD, `HEAD (no branch)`, and ahead/behind parsing.
- [x] Added `packages/js-sdk/tests/sandbox/git/parse.test.ts` — same 5 cases, JS side.
- [x] `uv run pytest tests/shared/git/test_parse.py -v` — 5 passed.
- [x] `pnpm vitest run tests/sandbox/git/parse.test.ts` — 5 passed.
- [x] `uv run ruff check` / `uv run ruff format --check` on the changed Python files — clean.
- [x] `pnpm run typecheck` / `pnpm run lint` (oxlint) / `prettier --check` on the changed JS files — clean.
- [x] Added a changeset (`patch` bump on `e2b` and `@e2b/python-sdk`).

Fixes #1373, #1371