### PR TITLE
Revert "fix(release): bump Code Interpreter Python past PyPI collision"

### DIFF
--- a/.changeset/code-interpreter-python-pypi-clash.md
+++ b/.changeset/code-interpreter-python-pypi-clash.md
@@ -1,5 +1,0 @@
----
-'@e2b/code-interpreter-python': patch
----
-
-Bump past 2.9.2, which was already published to PyPI from the pre-migration e2b-dev/code-interpreter repository with different file contents, causing `uv publish --check-url` to fail during release.


### PR DESCRIPTION
Reverts e2b-dev/E2B#1785