### PR TITLE
fix(python-sdk): strip uppercase/mixed-case AS stage alias in from_dockerfile

### DIFF
--- a/packages/python-sdk/e2b/template/dockerfile_parser.py
+++ b/packages/python-sdk/e2b/template/dockerfile_parser.py
@@ -98,9 +98,14 @@ def parse_dockerfile(
 
         # Set the base image from the first FROM instruction
         base_image = from_instructions[0]["value"]
-        # Remove AS alias if present (e.g., "node:18 AS builder" -> "node:18")
-        if " as " in base_image.lower():
-            base_image = base_image.split(" as ")[0].strip()
+        # Remove a stage alias if present (e.g., "node:18 AS builder" -> "node:18").
+        # AS is case-insensitive in Dockerfiles, so it must be matched that way:
+        # splitting on a lowercase " as " left the canonical uppercase form
+        # ("FROM node:18 AS builder") unstripped, leaking " AS builder" into the
+        # base image name.
+        base_image = re.split(
+            r"\s+as\s+", base_image, maxsplit=1, flags=re.IGNORECASE
+        )[0].strip()
 
         user_changed = False
         workdir_changed = False

--- a/packages/python-sdk/tests/async/template_async/methods/test_from_dockerfile.py
+++ b/packages/python-sdk/tests/async/template_async/methods/test_from_dockerfile.py
@@ -43,6 +43,20 @@ ENTRYPOINT ["sleep", "20"]"""
 
 
 @pytest.mark.skip_debug()
+async def test_from_dockerfile_strips_stage_alias_case_insensitively():
+    # AS is case-insensitive in Dockerfiles, so the canonical uppercase form
+    # (and mixed case) must also have its stage alias stripped from the base
+    # image. Previously only a lowercase " as " was stripped.
+    for dockerfile in [
+        "FROM node:24 AS builder",
+        "FROM node:24 as builder",
+        "FROM node:24 As Build",
+    ]:
+        template = AsyncTemplate().from_dockerfile(dockerfile)
+        assert template._template._base_image == "node:24"
+
+
+@pytest.mark.skip_debug()
 async def test_from_dockerfile_with_default_user_and_workdir():
     dockerfile = "FROM node:24"
 

--- a/packages/python-sdk/tests/sync/template_sync/methods/test_from_dockerfile.py
+++ b/packages/python-sdk/tests/sync/template_sync/methods/test_from_dockerfile.py
@@ -43,6 +43,20 @@ ENTRYPOINT ["sleep", "20"]"""
 
 
 @pytest.mark.skip_debug()
+def test_from_dockerfile_strips_stage_alias_case_insensitively():
+    # AS is case-insensitive in Dockerfiles, so the canonical uppercase form
+    # (and mixed case) must also have its stage alias stripped from the base
+    # image. Previously only a lowercase " as " was stripped.
+    for dockerfile in [
+        "FROM node:24 AS builder",
+        "FROM node:24 as builder",
+        "FROM node:24 As Build",
+    ]:
+        template = Template().from_dockerfile(dockerfile)
+        assert template._template._base_image == "node:24"
+
+
+@pytest.mark.skip_debug()
 def test_from_dockerfile_with_default_user_and_workdir():
     dockerfile = "FROM node:24"
 


### PR DESCRIPTION
## What

`parse_dockerfile` (used by `Template.from_dockerfile`) strips a stage alias from the base image, but only when it is written as lowercase ` as `:

```python
if " as " in base_image.lower():
    base_image = base_image.split(" as ")[0].strip()
```

The guard lowercases the string, but the `split` runs on the original-case value with a **lowercase** delimiter. So the canonical, uppercase Docker form is not stripped:

```
FROM node:24 AS builder   -> base_image = "node:24 AS builder"   (broken image ref)
FROM node:24 As Build     -> base_image = "node:24 As Build"
FROM node:24 as builder   -> base_image = "node:24"              (only this worked)
```

`AS` is case-insensitive in Dockerfiles (and the docs use uppercase), so this is the common case.

## Fix

Match `AS` case-insensitively:

```python
base_image = re.split(r"\s+as\s+", base_image, maxsplit=1, flags=re.IGNORECASE)[0].strip()
```

Verified against the real `parse_dockerfile`: `FROM node:24 AS builder`, `as builder`, `As Build`, and `FROM node:24` all resolve to `node:24`. Added sync + async regression tests.

## How the code was written

Authored with the help of a coding agent; I verified the fix by running the actual `parse_dockerfile` and can explain the change.
