### PR TITLE
Preserve Retry-After on 429 RateLimit errors in Python and JS SDKs

### DIFF
--- a/.changeset/retry-after-preserved.md
+++ b/.changeset/retry-after-preserved.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/python-sdk': patch
+---
+
+Preserve the `Retry-After` header on 429 rate-limit errors so callers can wait for the server-specified cooldown instead of retrying immediately.

--- a/packages/js-sdk/src/api/index.ts
+++ b/packages/js-sdk/src/api/index.ts
@@ -19,7 +19,8 @@ export function apiErrorFromCode(
     message: string,
     stackTrace?: string
   ) => Error = SandboxError,
-  stackTrace?: string
+  stackTrace?: string,
+  retryAfterHeader?: string | null
 ): Error {
   if (code === 401) {
     const message = 'Unauthorized, please check your credentials.'
@@ -30,7 +31,9 @@ export function apiErrorFromCode(
 
   if (code === 429) {
     const message = 'Rate limit exceeded, please try again later'
-    return new RateLimitError(content ? `${message} - ${content}` : message)
+    return new RateLimitError(content ? `${message} - ${content}` : message, {
+      retryAfterHeader,
+    })
   }
 
   return new errorClass(`${code}: ${content}`, stackTrace)
@@ -51,12 +54,14 @@ export function handleApiError(
   }
 
   const status = response.response.status
+  const retryAfterHeader = response.response.headers?.get('Retry-After') ?? null
   if (status === 401 || status === 429) {
     return apiErrorFromCode(
       status,
       response.error?.message ?? response.error,
       errorClass,
-      stackTrace
+      stackTrace,
+      retryAfterHeader
     )
   }
 
@@ -64,7 +69,8 @@ export function handleApiError(
     status,
     response.error?.message || response.error || response.response.statusText,
     errorClass,
-    stackTrace
+    stackTrace,
+    retryAfterHeader
   )
 }
 

--- a/packages/js-sdk/src/envd/api.ts
+++ b/packages/js-sdk/src/envd/api.ts
@@ -25,8 +25,6 @@ const DEFAULT_ERROR_MAP: Record<number, (message: string) => Error> = {
   400: (message) => new InvalidArgumentError(message),
   401: (message) => new AuthenticationError(message),
   404: (message) => new NotFoundError(message),
-  429: (message) =>
-    new RateLimitError(`${message}: The requests are being rate limited.`),
   502: formatSandboxTimeoutError,
   507: (message) => new NotEnoughSpaceError(message),
 }
@@ -129,6 +127,14 @@ export async function handleEnvdApiError(
   // Check if a custom error mapping is provided for this error code
   if (errorMap && res.response.status in errorMap) {
     return errorMap[res.response.status]?.(message)
+  }
+
+  if (res.response.status === 429) {
+    const retryAfterHeader = res.response.headers?.get('Retry-After') ?? null
+    return new RateLimitError(
+      `${message}: The requests are being rate limited.`,
+      { retryAfterHeader }
+    )
   }
 
   // Check if there is a default error mapping for this error code

--- a/packages/js-sdk/src/errors.ts
+++ b/packages/js-sdk/src/errors.ts
@@ -139,12 +139,50 @@ export class TemplateError extends SandboxError {
 
 /**
  * Thrown when the API rate limit is exceeded.
+ *
+ * `retryAfter` is the parsed wait in seconds from the `Retry-After`
+ * response header when present. `retryAfterHeader` is the raw header
+ * value.
  */
 export class RateLimitError extends SandboxError {
-  constructor(message: string) {
-    super(message)
+  readonly retryAfter?: number
+  readonly retryAfterHeader?: string
+
+  constructor(
+    message: string,
+    opts: { retryAfter?: number; retryAfterHeader?: string | null } = {}
+  ) {
+    const retryAfter = opts.retryAfter ?? parseRetryAfter(opts.retryAfterHeader)
+    super(
+      retryAfter === undefined
+        ? message
+        : `${message} Retry after ${retryAfter} seconds.`
+    )
     this.name = 'RateLimitError'
+    this.retryAfter = retryAfter
+    this.retryAfterHeader = opts.retryAfterHeader ?? undefined
   }
+}
+
+/**
+ * Parses an HTTP `Retry-After` header value into a wait time in seconds.
+ *
+ * Returns `undefined` when the header is absent or not parseable. Numeric
+ * values (the common case) are used directly; HTTP-date values are converted
+ * to a relative delay against the current time.
+ */
+function parseRetryAfter(retryAfterHeader?: string | null): number | undefined {
+  if (!retryAfterHeader) return undefined
+
+  const trimmedRetryAfter = retryAfterHeader.trim()
+  if (/^-?\d+$/.test(trimmedRetryAfter)) {
+    return Math.max(Number.parseInt(trimmedRetryAfter, 10), 0)
+  }
+
+  const retryAt = Date.parse(trimmedRetryAfter)
+  if (Number.isNaN(retryAt)) return undefined
+
+  return Math.max(Math.floor((retryAt - Date.now()) / 1000), 0)
 }
 
 /**

--- a/packages/js-sdk/tests/api/handleApiError.test.ts
+++ b/packages/js-sdk/tests/api/handleApiError.test.ts
@@ -136,6 +136,29 @@ describe('handleApiError', () => {
       assert.instanceOf(err, RateLimitError)
       assert.include(err?.message, 'Rate limit')
     })
+
+    test('preserves Retry-After on 429', () => {
+      const res = createMockResponse(
+        429,
+        { message: 'Too many requests' },
+        undefined,
+        new Headers({ 'Retry-After': '60' })
+      )
+      const err = handleApiError(res as any)
+      assert.instanceOf(err, RateLimitError)
+      assert.equal((err as RateLimitError).retryAfter, 60)
+      assert.equal((err as RateLimitError).retryAfterHeader, '60')
+      assert.include(err?.message, 'Retry after 60 seconds')
+    })
+
+    test('429 without Retry-After has no wait', () => {
+      const res = createMockResponse(429, { message: 'Too many requests' })
+      const err = handleApiError(res as any)
+      assert.instanceOf(err, RateLimitError)
+      assert.isUndefined((err as RateLimitError).retryAfter)
+      assert.isUndefined((err as RateLimitError).retryAfterHeader)
+      assert.notInclude(err?.message, 'Retry after')
+    })
   })
 
   test('does not change failed response errors in CI', () => {

--- a/packages/js-sdk/tests/envd/handleEnvdApiError.test.ts
+++ b/packages/js-sdk/tests/envd/handleEnvdApiError.test.ts
@@ -12,7 +12,8 @@ import {
 
 function createMockResponse(
   status: number,
-  error?: { message?: string } | string
+  error?: { message?: string } | string,
+  headers: Headers = new Headers()
 ): {
   error?: { message?: string } | string
   response: Response
@@ -26,6 +27,7 @@ function createMockResponse(
       // openapi-fetch consumes the body whenever it produces an error value
       bodyUsed: error !== undefined,
       text: async () => (typeof error === 'string' ? error : ''),
+      headers,
     } as unknown as Response,
   }
 }
@@ -81,6 +83,28 @@ describe('handleEnvdApiError', () => {
     const err = await handleEnvdApiError(res)
     assert.instanceOf(err, RateLimitError)
     assert.include(err?.message, 'rate limited')
+  })
+
+  test('preserves Retry-After on 429', async () => {
+    const res = createMockResponse(
+      429,
+      { message: 'Too many requests' },
+      new Headers({ 'Retry-After': '45' })
+    )
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, RateLimitError)
+    assert.equal((err as RateLimitError).retryAfter, 45)
+    assert.equal((err as RateLimitError).retryAfterHeader, '45')
+    assert.include(err?.message, 'Retry after 45 seconds')
+  })
+
+  test('429 without Retry-After has no wait', async () => {
+    const res = createMockResponse(429, { message: 'Too many requests' })
+    const err = await handleEnvdApiError(res)
+    assert.instanceOf(err, RateLimitError)
+    assert.isUndefined((err as RateLimitError).retryAfter)
+    assert.isUndefined((err as RateLimitError).retryAfterHeader)
+    assert.notInclude(err?.message, 'Retry after')
   })
 
   test('returns TimeoutError for 502', async () => {

--- a/packages/python-sdk/e2b/api/__init__.py
+++ b/packages/python-sdk/e2b/api/__init__.py
@@ -183,10 +183,15 @@ def api_exception_from_code(
     message: Optional[str] = None,
     default_exception_class: type[Exception] = SandboxException,
     stack_trace: Optional[TracebackType] = None,
+    retry_after_header: Optional[str] = None,
 ) -> Exception:
     """Map an API error code and message to the matching exception class — the
     same mapping :func:`handle_api_exception` applies to HTTP responses, usable
-    for error objects embedded in response bodies (e.g. per-fork results)."""
+    for error objects embedded in response bodies (e.g. per-fork results).
+
+    :param retry_after_header: Value of the ``Retry-After`` response header,
+        used for 429 rate-limit errors.
+    """
     if status_code == 401:
         text = f"{status_code}: Unauthorized, please check your credentials."
         if message:
@@ -197,11 +202,24 @@ def api_exception_from_code(
         text = f"{status_code}: Rate limit exceeded, please try again later."
         if message:
             text += f" - {message}"
-        return RateLimitException(text)
+        return RateLimitException(text, retry_after_header=retry_after_header)
 
     return default_exception_class(f"{status_code}: {message}").with_traceback(
         stack_trace
     )
+
+
+def _retry_after_header(e: object) -> Optional[str]:
+    headers = getattr(e, "headers", None)
+    if headers is None:
+        return None
+    get = getattr(headers, "get", None)
+    if not callable(get):
+        return None
+    value = get("Retry-After")
+    if value is not None:
+        return value
+    return get("retry-after")
 
 
 def handle_api_exception(
@@ -225,6 +243,7 @@ def handle_api_exception(
         message,
         default_exception_class,
         stack_trace,
+        _retry_after_header(e),
     )
 
 

--- a/packages/python-sdk/e2b/envd/api.py
+++ b/packages/python-sdk/e2b/envd/api.py
@@ -22,9 +22,6 @@ _DEFAULT_API_ERROR_MAP: dict[int, Callable[[str], Exception]] = {
     400: InvalidArgumentException,
     401: AuthenticationException,
     404: NotFoundException,
-    429: lambda message: RateLimitException(
-        f"{message}: The requests are being rate limited."
-    ),
     502: format_sandbox_timeout_exception,
     507: NotEnoughSpaceException,
 }
@@ -133,7 +130,12 @@ def handle_envd_api_exception(
 
     res.read()
 
-    return format_envd_api_exception(res.status_code, get_message(res), error_map)
+    return format_envd_api_exception(
+        res.status_code,
+        get_message(res),
+        error_map,
+        retry_after_header=res.headers.get("Retry-After"),
+    )
 
 
 async def ahandle_envd_api_exception(
@@ -146,23 +148,36 @@ async def ahandle_envd_api_exception(
 
     await res.aread()
 
-    return format_envd_api_exception(res.status_code, get_message(res), error_map)
+    return format_envd_api_exception(
+        res.status_code,
+        get_message(res),
+        error_map,
+        retry_after_header=res.headers.get("Retry-After"),
+    )
 
 
 def format_envd_api_exception(
     status_code: int,
     message: str,
     error_map: Optional[dict[int, Callable[[str], Exception]]] = None,
+    retry_after_header: Optional[str] = None,
 ):
     """Map an HTTP status code and message to the appropriate exception.
 
     :param status_code: The HTTP status code.
     :param message: The error message from the response body.
     :param error_map: Optional map of HTTP status codes to exception factories that override the defaults.
+    :param retry_after_header: Value of the ``Retry-After`` response header, used for 429 rate-limit errors.
     :return: The corresponding exception.
     """
     if error_map and status_code in error_map:
         return error_map[status_code](message)
+
+    if status_code == 429:
+        return RateLimitException(
+            f"{message}: The requests are being rate limited.",
+            retry_after_header=retry_after_header,
+        )
 
     if status_code in _DEFAULT_API_ERROR_MAP:
         return _DEFAULT_API_ERROR_MAP[status_code](message)

--- a/packages/python-sdk/e2b/exceptions.py
+++ b/packages/python-sdk/e2b/exceptions.py
@@ -1,3 +1,35 @@
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Optional
+
+
+def parse_retry_after(retry_after_header: Optional[str]) -> Optional[int]:
+    """Parse an HTTP ``Retry-After`` header into a wait time in seconds.
+
+    Returns ``None`` when the header is absent or not parseable. Numeric
+    values (delta-seconds) are used directly; HTTP-date values are converted
+    to a relative delay against the current time.
+    """
+    if not retry_after_header:
+        return None
+
+    trimmed = retry_after_header.strip()
+    try:
+        return max(int(trimmed), 0)
+    except ValueError:
+        pass
+
+    try:
+        retry_at = parsedate_to_datetime(trimmed)
+    except (TypeError, ValueError, IndexError, OverflowError):
+        return None
+
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=timezone.utc)
+
+    return max(int((retry_at - datetime.now(timezone.utc)).total_seconds()), 0)
+
+
 def format_sandbox_timeout_exception(message: str):
     return TimeoutException(
         f"{message}: This error is likely due to sandbox timeout. You can modify the sandbox timeout by passing 'timeout' when starting the sandbox or calling '.set_timeout' on the sandbox with the desired timeout."
@@ -114,7 +146,28 @@ class TemplateException(SandboxException):
 class RateLimitException(SandboxException):
     """
     Raised when the API rate limit is exceeded.
+
+    ``retry_after`` is the parsed wait in seconds from the ``Retry-After``
+    response header when present. ``retry_after_header`` is the raw header
+    value.
     """
+
+    retry_after: Optional[int]
+    retry_after_header: Optional[str]
+
+    def __init__(
+        self,
+        message: str,
+        retry_after: Optional[int] = None,
+        retry_after_header: Optional[str] = None,
+    ):
+        if retry_after is None:
+            retry_after = parse_retry_after(retry_after_header)
+        if retry_after is not None:
+            message = f"{message} Retry after {retry_after} seconds."
+        super().__init__(message)
+        self.retry_after = retry_after
+        self.retry_after_header = retry_after_header
 
 
 class BuildException(Exception):

--- a/packages/python-sdk/tests/test_retry_after_rate_limit.py
+++ b/packages/python-sdk/tests/test_retry_after_rate_limit.py
@@ -1,0 +1,56 @@
+import httpx
+
+from e2b.api import handle_api_exception
+from e2b.envd.api import handle_envd_api_exception
+from e2b.exceptions import RateLimitException
+
+
+class _ApiError:
+    def __init__(self, headers=None):
+        self.status_code = 429
+        self.content = b'{"message":"too many requests"}'
+        self.headers = headers or {}
+
+
+def test_api_rate_limit_preserves_retry_after_header():
+    err = handle_api_exception(_ApiError({"Retry-After": "60"}))
+
+    assert isinstance(err, RateLimitException)
+    assert err.retry_after == 60
+    assert err.retry_after_header == "60"
+    assert "Retry after 60 seconds" in str(err)
+
+
+def test_envd_rate_limit_preserves_retry_after_header():
+    res = httpx.Response(
+        429,
+        json={"message": "too many requests"},
+        headers={"Retry-After": "45"},
+    )
+
+    err = handle_envd_api_exception(res)
+
+    assert isinstance(err, RateLimitException)
+    assert err.retry_after == 45
+    assert err.retry_after_header == "45"
+    assert "Retry after 45 seconds" in str(err)
+
+
+def test_api_rate_limit_without_retry_after_has_no_wait():
+    err = handle_api_exception(_ApiError())
+
+    assert isinstance(err, RateLimitException)
+    assert err.retry_after is None
+    assert err.retry_after_header is None
+    assert "Retry after" not in str(err)
+
+
+def test_parse_retry_after_delta_seconds_and_http_date():
+    from e2b.exceptions import parse_retry_after
+
+    assert parse_retry_after("60") == 60
+    assert parse_retry_after(None) is None
+    assert parse_retry_after("not-a-retry-after") is None
+
+    wait = parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT")
+    assert wait == 0


### PR DESCRIPTION
RateLimit errors were dropping the `Retry-After` header, so clients could not back off. Preserve it on 429 in the Python and JS SDKs.

Fixes #1325