### PR TITLE
fix(release): isolate Python SDK-only publishes

### DIFF
--- a/.changeset/sunny-tigers-attend.md
+++ b/.changeset/sunny-tigers-attend.md
@@ -1,0 +1,5 @@
+---
+'@e2b/python-sdk': patch
+---
+
+Improve reliability for high-concurrency sandbox workloads by spreading envd traffic across four HTTP/2 connection pools. Set `E2B_ENVD_POOL_SHARDS` before importing the SDK to adjust the pool count.

--- a/.github/scripts/publish_command.cjs
+++ b/.github/scripts/publish_command.cjs
@@ -1,0 +1,12 @@
+const fs = require('node:fs')
+
+const { releases } = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
+if (!Array.isArray(releases) || releases.length === 0) {
+  throw new Error('Cannot publish without a release plan')
+}
+
+console.log(
+  releases.length === 1 && releases[0].name === '@e2b/python-sdk'
+    ? 'pnpm run publish:python-sdk'
+    : 'pnpm run publish'
+)

--- a/.github/scripts/publish_python_sdk.sh
+++ b/.github/scripts/publish_python_sdk.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+pnpm --filter @e2b/python-sdk run postPublish
+
+VERSION=$(node -p "require('./packages/python-sdk/package.json').version")
+TAG="@e2b/python-sdk@${VERSION}"
+git tag -a "$TAG" -m "$TAG"
+# changesets/action pushes this tag and creates the GitHub release.
+printf 'New tag: %s\n' "$TAG"

--- a/.github/scripts/release.test.cjs
+++ b/.github/scripts/release.test.cjs
@@ -6,8 +6,10 @@ const path = require('node:path')
 const { test } = require('node:test')
 
 const { scripts } = require('../../package.json')
+const root = path.resolve(__dirname, '../..')
+const { version } = require('../../packages/python-sdk/package.json')
 
-function publish(t, fail = '') {
+function publish(t, fail = '', script = scripts.publish) {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'e2b-release-'))
   t.after(() => fs.rmSync(cwd, { recursive: true, force: true }))
   const bin = path.join(cwd, 'bin')
@@ -18,9 +20,14 @@ function publish(t, fail = '') {
     '#!/bin/sh\nprintf "%s\\n" "$*" >> "$RELEASE_COMMANDS"\n[ "$*" != "$FAIL_COMMAND" ]\n',
     { mode: 0o755 }
   )
+  fs.writeFileSync(
+    path.join(bin, 'git'),
+    '#!/bin/sh\nprintf "git %s\\n" "$*" >> "$RELEASE_COMMANDS"\n[ "git $*" != "$FAIL_COMMAND" ]\n',
+    { mode: 0o755 }
+  )
   const log = path.join(cwd, 'commands')
-  const result = spawnSync('sh', ['-c', scripts.publish], {
-    cwd,
+  const result = spawnSync('sh', ['-c', script], {
+    cwd: root,
     env: {
       ...process.env,
       PATH: `${bin}${path.delimiter}${process.env.PATH}`,
@@ -31,7 +38,9 @@ function publish(t, fail = '') {
   })
   return {
     ...result,
-    commands: fs.readFileSync(log, 'utf8').trim().split('\n'),
+    commands: fs.existsSync(log)
+      ? fs.readFileSync(log, 'utf8').trim().split('\n')
+      : [],
   }
 }
 
@@ -61,4 +70,74 @@ test('an npm failure remains a failed release after Python succeeds', (t) => {
   const result = publish(t, npm)
   assert.notEqual(result.status, 0)
   assert.deepEqual(result.commands, [build, python, npm])
+})
+
+function publishCommand(t, releases) {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'e2b-release-plan-'))
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true }))
+  const plan = path.join(cwd, 'plan.json')
+  fs.writeFileSync(plan, JSON.stringify({ releases }))
+  return spawnSync(
+    process.execPath,
+    [path.join(__dirname, 'publish_command.cjs'), plan],
+    {
+      encoding: 'utf8',
+    }
+  )
+}
+
+test('a Python SDK-only release plan selects the isolated publisher', (t) => {
+  const result = publishCommand(t, [
+    {
+      name: '@e2b/python-sdk',
+      type: 'patch',
+      oldVersion: '2.46.3',
+      newVersion: '2.46.4',
+    },
+  ])
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(result.stdout.trim(), 'pnpm run publish:python-sdk')
+})
+
+test('other release plans retain the workspace publisher', (t) => {
+  for (const releases of [
+    [{ name: 'e2b' }],
+    [{ name: '@e2b/python-sdk' }, { name: '@e2b/desktop' }],
+  ]) {
+    const result = publishCommand(t, releases)
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.stdout.trim(), 'pnpm run publish')
+  }
+})
+
+test('an empty release plan cannot default to publishing everything', (t) => {
+  const result = publishCommand(t, [])
+  assert.notEqual(result.status, 0)
+  assert.equal(result.stdout, '')
+})
+
+const sdkPython = '--filter @e2b/python-sdk run postPublish'
+const sdkTag = `@e2b/python-sdk@${version}`
+const tagCommand = `git tag -a ${sdkTag} -m ${sdkTag}`
+const sdkScript = scripts['publish:python-sdk']
+
+test('the isolated publisher uploads and tags only the base Python SDK', (t) => {
+  const result = publish(t, '', sdkScript)
+  assert.equal(result.status, 0, result.stderr)
+  assert.deepEqual(result.commands, [sdkPython, tagCommand])
+  assert.equal(result.stdout.trim(), `New tag: ${sdkTag}`)
+})
+
+test('a failed SDK upload creates no tag or release marker', (t) => {
+  const result = publish(t, sdkPython, sdkScript)
+  assert.notEqual(result.status, 0)
+  assert.deepEqual(result.commands, [sdkPython])
+  assert.equal(result.stdout, '')
+})
+
+test('a failed tag command emits no release marker', (t) => {
+  const result = publish(t, tagCommand, sdkScript)
+  assert.notEqual(result.status, 0)
+  assert.deepEqual(result.commands, [sdkPython, tagCommand])
+  assert.equal(result.stdout, '')
 })

--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -68,6 +68,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Select publisher
+        id: publisher
+        run: |
+          pnpm changeset status --output="$RUNNER_TEMP/release-plan.json"
+          COMMAND=$(node .github/scripts/publish_command.cjs "$RUNNER_TEMP/release-plan.json")
+          echo "command=$COMMAND" >> "$GITHUB_OUTPUT"
+
       - name: Create new versions
         run: pnpm run version
         env:
@@ -95,7 +102,7 @@ jobs:
         id: release
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          publish: pnpm run publish
+          publish: ${{ steps.publisher.outputs.command }}
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "version": "pnpm changeset version && pnpm run -r postVersion",
     "publish": "pnpm --dir packages/js-sdk build && pnpm run -r postPublish && pnpm changeset publish",
+    "publish:python-sdk": "sh .github/scripts/publish_python_sdk.sh",
     "test:release": "node --test .github/scripts/release.test.cjs",
     "test": "pnpm --dir packages/js-sdk build && pnpm --recursive --if-present run test",
     "rm-node-modules": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +",


### PR DESCRIPTION
## Summary

- Select an isolated publisher when the Changesets release plan contains only `@e2b/python-sdk`.
- Upload only the base Python SDK, then create only its tag. The existing Changesets action pushes that tag and creates the GitHub release. No npm, Desktop, or Code Interpreter uploads run on this path.
- Add a Python patch changeset for a fresh `e2b 2.46.4` release. No recovery switch or credential changes.

[Release 33677741645](https://github.com/e2b-dev/E2B/actions/runs/33677741645/job/100408304950) selected only Python SDK tests but ran every Python publish hook. Desktop rejected the shared project-scoped token with a 403, which stopped the overall publish. The release plan is now captured before versioning consumes the changesets, so a Python-only release stays Python-only through uploading and tagging.

## Verification

- Ten release-tooling tests pass, including isolated selection, unchanged multi-package selection, empty-plan rejection, SDK-only upload/tag commands, and upload/tag failures. Five new tests failed before implementation. Registry and tag commands are stubbed; nothing was uploaded locally.
- The actual Changesets plan selects `pnpm run publish:python-sdk` and bumps only `@e2b/python-sdk` from 2.46.3 to 2.46.4.
- Repository format, lint, and typecheck pass; Actionlint and ShellCheck pass for the workflow and new shell script.

## Release

After merging, run the normal Release workflow on main. With only this Python changeset pending, it publishes only `e2b` to PyPI. Mixed-package releases retain the existing publisher and still need appropriate credentials for those projects; this does not widen the shared token's scope.
