### PR TITLE
fix(build): move pnpm settings to workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,42 +34,5 @@
   },
   "engines": {
     "pnpm": ">=10.16.0 <11"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "workerd"
-    ],
-    "ignoredBuiltDependencies": [
-      "bufferutil",
-      "msw",
-      "utf-8-validate"
-    ],
-    "overrides": {
-      "rollup@>=4": ">=4.59.0",
-      "postcss@<8.5.10": "^8.5.10",
-      "vite@>=6.0.0 <6.4.3": "^6.4.3",
-      "lodash@<4.18.0": "^4.18.0",
-      "brace-expansion@<1.1.18": "^1.1.18",
-      "brace-expansion@>=2.0.0 <2.1.4": "^2.1.4",
-      "brace-expansion@>=3.0.0 <3.0.6": "^3.0.6",
-      "brace-expansion@>=4.0.0 <5.0.9": "^5.0.9",
-      "underscore@<1.13.8": "^1.13.8",
-      "js-yaml@<3.15.1": "^3.15.1",
-      "js-yaml@>=4.0.0 <4.3.1": "^4.3.1",
-      "@babel/core@<7.29.6": "^7.29.6",
-      "picomatch@<2.3.2": "^2.3.2",
-      "picomatch@>=4.0.0 <4.0.4": "^4.0.4",
-      "smol-toml@<1.6.1": "^1.6.1",
-      "minimatch@<3.1.3": "^3.1.3",
-      "minimatch@>=5.0.0 <5.1.8": "^5.1.8",
-      "minimatch@>=9.0.0 <9.0.7": "^9.0.7",
-      "minimatch@>=10.0.0 <10.2.3": "^10.2.3",
-      "undici@>=7.0.0 <7.29.0": "^7.29.0",
-      "ws@>=8.0.0 <8.20.1": "^8.20.1",
-      "shell-quote@<1.9.0": "^1.9.0",
-      "sharp@<0.35.0": "^0.35.0",
-      "tar@<7.5.19": "^7.5.19"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,41 @@
 packages:
   - packages/*
 
+onlyBuiltDependencies:
+  - esbuild
+  - workerd
+
+ignoredBuiltDependencies:
+  - bufferutil
+  - msw
+  - utf-8-validate
+
+overrides:
+  rollup@>=4: '>=4.59.0'
+  postcss@<8.5.10: ^8.5.10
+  vite@>=6.0.0 <6.4.3: ^6.4.3
+  lodash@<4.18.0: ^4.18.0
+  brace-expansion@<1.1.18: ^1.1.18
+  brace-expansion@>=2.0.0 <2.1.4: ^2.1.4
+  brace-expansion@>=3.0.0 <3.0.6: ^3.0.6
+  brace-expansion@>=4.0.0 <5.0.9: ^5.0.9
+  underscore@<1.13.8: ^1.13.8
+  js-yaml@<3.15.1: ^3.15.1
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
+  '@babel/core@<7.29.6': ^7.29.6
+  picomatch@<2.3.2: ^2.3.2
+  picomatch@>=4.0.0 <4.0.4: ^4.0.4
+  smol-toml@<1.6.1: ^1.6.1
+  minimatch@<3.1.3: ^3.1.3
+  minimatch@>=5.0.0 <5.1.8: ^5.1.8
+  minimatch@>=9.0.0 <9.0.7: ^9.0.7
+  minimatch@>=10.0.0 <10.2.3: ^10.2.3
+  undici@>=7.0.0 <7.29.0: ^7.29.0
+  ws@>=8.0.0 <8.20.1: ^8.20.1
+  shell-quote@<1.9.0: ^1.9.0
+  sharp@<0.35.0: ^0.35.0
+  tar@<7.5.19: ^7.5.19
+
 catalog:
   '@types/node': ^20.19.19
   '@typescript/native': npm:typescript@^7.0.2


### PR DESCRIPTION
## Summary

- move pnpm 10 workspace settings from the ignored `package.json#pnpm` field to `pnpm-workspace.yaml`
- restore the build-script allow/ignore policy and dependency security overrides
- preserve the existing lockfile resolution

Closes #1804

## Verification

- `pnpm config get onlyBuiltDependencies --json`
- `pnpm config get ignoredBuiltDependencies --json`
- `pnpm config get overrides --json`
- `pnpm install --lockfile-only --frozen-lockfile`
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check package.json pnpm-workspace.yaml`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:release` (10/10 passed)
- `pnpm --dir packages/js-sdk exec vitest run --project connectionConfig` (42/42 passed)

The full `pnpm test` suite was also run with a valid E2B API key and reached the online sandbox tests. It was not fully green because of remote integration failures unrelated to this configuration-only change: the `httpbin` template was unavailable for firewall-header cases, one sandbox request hit `ECONNRESET`, and one template upload hit `fetch failed`.