### PR TITLE
docs(desktop-python): fix docstring placement and stale parameter docs

### DIFF
--- a/packages/desktop-python/e2b_desktop/main.py
+++ b/packages/desktop-python/e2b_desktop/main.py
@@ -366,7 +366,7 @@ class Sandbox(SandboxBase):
         """
         Take a screenshot and return it in the specified format.
 
-        :param format: The format of the screenshot. Can be 'bytes', 'blob', or 'stream'.
+        :param format: The format of the screenshot. Can be 'bytes' or 'stream'.
         :returns: The screenshot in the specified format.
         """
         screenshot_path = f"/tmp/screenshot-{uuid4()}.png"
@@ -394,11 +394,11 @@ class Sandbox(SandboxBase):
         self.commands.run("xdotool click --repeat 2 1")
 
     def right_click(self, x: Optional[int] = None, y: Optional[int] = None):
-        if (x is None) != (y is None):
-            raise ValueError("Both x and y must be provided together")
         """
         Right click on the mouse position.
         """
+        if (x is None) != (y is None):
+            raise ValueError("Both x and y must be provided together")
         if x and y:
             self.move_mouse(x, y)
         self.commands.run("xdotool click 3")
@@ -519,7 +519,7 @@ class Sandbox(SandboxBase):
         """
         Drag the mouse from the given position to the given position.
 
-        :param from: The starting position.
+        :param fr: The starting position.
         :param to: The ending position.
         """
         self.move_mouse(fr[0], fr[1])

--- a/packages/desktop-python/e2b_desktop/main.py
+++ b/packages/desktop-python/e2b_desktop/main.py
@@ -396,6 +396,11 @@ class Sandbox(SandboxBase):
     def right_click(self, x: Optional[int] = None, y: Optional[int] = None):
         """
         Right click on the mouse position.
+
+        :param x: X coordinate to move the mouse to before clicking. Must be given together with ``y``.
+        :param y: Y coordinate to move the mouse to before clicking. Must be given together with ``x``.
+
+        :raises ValueError: If only one of ``x`` and ``y`` is provided.
         """
         if (x is None) != (y is None):
             raise ValueError("Both x and y must be provided together")


### PR DESCRIPTION
Three docstring fixes in `packages/desktop-python/e2b_desktop/main.py`, each verified against the signature:

1. `right_click`: the docstring sat **after** the validation `raise`, making it a dead no-op string (`right_click.__doc__ is None`) — moved to the top of the function, matching the sibling click methods.
2. `screenshot`: documented a `'blob'` format that neither it nor the underlying `files.read` accepts (copy-paste from the JS SDK, whose `screenshot` does take `'blob'`). Now documents `'bytes'` or `'stream'`.
3. `drag(fr, to)`: documented `:param from:` — the parameter is named `fr` (`from` is a Python keyword).