### PR TITLE
docs(js): fix copy-pasted JSDoc params and an ungrammatical error message

### DIFF
--- a/packages/code-interpreter-js/src/sandbox.ts
+++ b/packages/code-interpreter-js/src/sandbox.ts
@@ -255,7 +255,7 @@ export class Sandbox extends BaseSandbox {
 
       if (!res.body) {
         throw new Error(
-          `Not response body: ${res.statusText} ${await res?.text()}`
+          `No response body: ${res.statusText} ${await res?.text()}`
         )
       }
 

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -746,7 +746,7 @@ export class Sandbox extends SandboxApi {
    *
    * @param path path to the file in the sandbox.
    *
-   * @param opts download url options.
+   * @param opts upload url options.
    *
    * @returns URL for uploading file.
    */


### PR DESCRIPTION
Three small JS text fixes:

1. `packages/js-sdk/src/sandbox/index.ts` `uploadUrl`: JSDoc said `@param opts download url options.` — copy-paste from `downloadUrl`; now says upload.
2. `packages/code-interpreter-js/src/sandbox.ts`: the thrown error read "**Not** response body: …" → "**No** response body: …".
3. `packages/desktop-js/src/sandbox.ts` `drag`: documented `from`/`to` params while the signature destructures `[x1, y1]` / `[x2, y2]`.