### PR TITLE
fix(code-interpreter): serialize SuperChart for pydantic JSON dump

### DIFF
--- a/.changeset/soft-charts-serialize.md
+++ b/.changeset/soft-charts-serialize.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter-python': patch
+---
+
+Make chart classes dataclasses so pydantic and dataclasses.asdict can serialize Result.chart, including SuperChart.

--- a/packages/code-interpreter-python/e2b_code_interpreter/charts.py
+++ b/packages/code-interpreter-python/e2b_code_interpreter/charts.py
@@ -1,4 +1,5 @@
 import enum
+from dataclasses import dataclass
 from typing import Any, List, Tuple, Optional, Union
 
 
@@ -33,6 +34,7 @@ class ScaleType(str, enum.Enum):
     UNKNOWN = "unknown"
 
 
+@dataclass(init=False, repr=False, eq=False)
 class Chart:
     """
     Extracted data from a chart. It's useful for building an interactive charts or custom visualizations.
@@ -53,6 +55,7 @@ class Chart:
         return self._raw_data
 
 
+@dataclass(init=False, repr=False, eq=False)
 class Chart2D(Chart):
     x_label: Optional[str]
     y_label: Optional[str]
@@ -67,6 +70,7 @@ class Chart2D(Chart):
         self.y_unit = kwargs["y_unit"]
 
 
+@dataclass(init=False, repr=False, eq=False)
 class PointData:
     label: str
     points: List[Tuple[Union[str, float], Union[str, float]]]
@@ -76,6 +80,7 @@ class PointData:
         self.points = [(x, y) for x, y in kwargs["points"]]
 
 
+@dataclass(init=False, repr=False, eq=False)
 class PointChart(Chart2D):
     x_ticks: List[Union[str, float]]
     x_tick_labels: List[str]
@@ -112,14 +117,17 @@ class PointChart(Chart2D):
         self.elements = [PointData(**d) for d in kwargs["elements"]]
 
 
+@dataclass(init=False, repr=False, eq=False)
 class LineChart(PointChart):
     type = ChartType.LINE
 
 
+@dataclass(init=False, repr=False, eq=False)
 class ScatterChart(PointChart):
     type = ChartType.SCATTER
 
 
+@dataclass(init=False, repr=False, eq=False)
 class BarData:
     label: str
     group: str
@@ -131,6 +139,7 @@ class BarData:
         self.group = kwargs["group"]
 
 
+@dataclass(init=False, repr=False, eq=False)
 class BarChart(Chart2D):
     type = ChartType.BAR
 
@@ -141,6 +150,7 @@ class BarChart(Chart2D):
         self.elements = [BarData(**d) for d in kwargs["elements"]]
 
 
+@dataclass(init=False, repr=False, eq=False)
 class PieData:
     label: str
     angle: float
@@ -152,6 +162,7 @@ class PieData:
         self.radius = kwargs["radius"]
 
 
+@dataclass(init=False, repr=False, eq=False)
 class PieChart(Chart):
     type = ChartType.PIE
 
@@ -162,6 +173,7 @@ class PieChart(Chart):
         self.elements = [PieData(**d) for d in kwargs["elements"]]
 
 
+@dataclass(init=False, repr=False, eq=False)
 class BoxAndWhiskerData:
     label: str
     min: float
@@ -181,6 +193,7 @@ class BoxAndWhiskerData:
         self.outliers = kwargs.get("outliers") or []
 
 
+@dataclass(init=False, repr=False, eq=False)
 class BoxAndWhiskerChart(Chart2D):
     type = ChartType.BOX_AND_WHISKER
 
@@ -191,6 +204,7 @@ class BoxAndWhiskerChart(Chart2D):
         self.elements = [BoxAndWhiskerData(**d) for d in kwargs["elements"]]
 
 
+@dataclass(init=False, repr=False, eq=False)
 class SuperChart(Chart):
     type = ChartType.SUPERCHART
 

--- a/packages/code-interpreter-python/pyproject.toml
+++ b/packages/code-interpreter-python/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "matplotlib>=3.8.0,<4",
     "ruff>=0.11.12,<0.12",
     "ty>=0.0.15,<0.0.16",
+    "pydantic>=2,<3",
 ]
 
 [build-system]

--- a/packages/code-interpreter-python/tests/charts/test_chart_serialization.py
+++ b/packages/code-interpreter-python/tests/charts/test_chart_serialization.py
@@ -1,0 +1,147 @@
+import json
+from dataclasses import asdict
+from typing import Any
+
+import pytest
+
+from e2b_code_interpreter.charts import (
+    BarChart,
+    BoxAndWhiskerChart,
+    LineChart,
+    PieChart,
+    ScatterChart,
+    SuperChart,
+)
+
+
+def _line_chart_payload():
+    return {
+        "type": "line",
+        "title": "Sine Wave",
+        "x_label": None,
+        "y_label": None,
+        "x_unit": None,
+        "y_unit": None,
+        "x_ticks": [0, 1],
+        "x_tick_labels": ["0", "1"],
+        "x_scale": "linear",
+        "y_ticks": [0, 1],
+        "y_tick_labels": ["0", "1"],
+        "y_scale": "linear",
+        "elements": [{"label": "sin", "points": [(0, 0), (1, 1)]}],
+    }
+
+
+def _scatter_chart_payload():
+    return {
+        "type": "scatter",
+        "title": "Scatter Plot",
+        "x_label": "X",
+        "y_label": "Y",
+        "x_unit": None,
+        "y_unit": None,
+        "x_ticks": [0, 1],
+        "x_tick_labels": ["0", "1"],
+        "x_scale": "linear",
+        "y_ticks": [0, 1],
+        "y_tick_labels": ["0", "1"],
+        "y_scale": "linear",
+        "elements": [{"label": "Dataset 1", "points": [(0.1, 0.2)]}],
+    }
+
+
+def _pie_chart_payload():
+    return {
+        "type": "pie",
+        "title": "Share",
+        "elements": [{"label": "A", "angle": 2.0, "radius": 1.0}],
+    }
+
+
+def _bar_chart_payload():
+    return {
+        "type": "bar",
+        "title": "Counts",
+        "x_label": "X",
+        "y_label": "Y",
+        "x_unit": None,
+        "y_unit": None,
+        "elements": [{"label": "A", "value": "1", "group": "g"}],
+    }
+
+
+def _box_chart_payload():
+    return {
+        "type": "box_and_whisker",
+        "title": "Spread",
+        "x_label": None,
+        "y_label": None,
+        "x_unit": None,
+        "y_unit": None,
+        "elements": [
+            {
+                "label": "s",
+                "min": 0.0,
+                "first_quartile": 1.0,
+                "median": 2.0,
+                "third_quartile": 3.0,
+                "max": 4.0,
+                "outliers": [],
+            }
+        ],
+    }
+
+
+def _superchart():
+    return SuperChart(
+        type="superchart",
+        title="Multiple Charts Example",
+        elements=[
+            _line_chart_payload(),
+            _scatter_chart_payload(),
+            _pie_chart_payload(),
+            _bar_chart_payload(),
+            _box_chart_payload(),
+        ],
+    )
+
+
+def test_superchart_json_dump_keeps_nested_charts():
+    chart = _superchart()
+
+    assert isinstance(chart, SuperChart)
+    assert isinstance(chart.elements[0], LineChart)
+    assert isinstance(chart.elements[1], ScatterChart)
+    assert isinstance(chart.elements[2], PieChart)
+    assert isinstance(chart.elements[3], BarChart)
+    assert isinstance(chart.elements[4], BoxAndWhiskerChart)
+
+    payload = json.loads(json.dumps(asdict(chart)))
+    assert payload["type"] == "superchart"
+    assert payload["title"] == "Multiple Charts Example"
+    assert payload["elements"][0]["type"] == "line"
+    assert payload["elements"][0]["title"] == "Sine Wave"
+    assert payload["elements"][0]["elements"][0]["points"] == [[0, 0], [1, 1]]
+    assert payload["elements"][1]["type"] == "scatter"
+    assert payload["elements"][1]["title"] == "Scatter Plot"
+    assert payload["elements"][2]["type"] == "pie"
+    assert payload["elements"][2]["elements"][0]["angle"] == 2.0
+    assert payload["elements"][3]["type"] == "bar"
+    assert payload["elements"][3]["elements"][0]["value"] == "1"
+    assert payload["elements"][4]["type"] == "box_and_whisker"
+    assert payload["elements"][4]["elements"][0]["median"] == 2.0
+
+
+def test_superchart_pydantic_json_dump():
+    pydantic = pytest.importorskip("pydantic")
+
+    chart = _superchart()
+    payload = json.loads(pydantic.TypeAdapter(Any).dump_json(chart))
+    assert payload["type"] == "superchart"
+    assert payload["title"] == "Multiple Charts Example"
+    assert payload["elements"][0]["type"] == "line"
+    assert payload["elements"][1]["type"] == "scatter"
+    assert payload["elements"][2]["type"] == "pie"
+    assert payload["elements"][3]["type"] == "bar"
+    assert payload["elements"][4]["type"] == "box_and_whisker"
+    assert payload["elements"][0]["elements"][0]["label"] == "sin"

--- a/packages/code-interpreter-python/tests/charts/test_chart_serialization.py
+++ b/packages/code-interpreter-python/tests/charts/test_chart_serialization.py
@@ -2,146 +2,61 @@ import json
 from dataclasses import asdict
 from typing import Any
 
-import pytest
+from pydantic import TypeAdapter
 
-from e2b_code_interpreter.charts import (
-    BarChart,
-    BoxAndWhiskerChart,
-    LineChart,
-    PieChart,
-    ScatterChart,
-    SuperChart,
-)
+from e2b_code_interpreter.charts import LineChart, ScatterChart, SuperChart
+from e2b_code_interpreter.models import Result
+
+_LINE = {
+    "type": "line",
+    "title": "Sine Wave",
+    "x_label": None,
+    "y_label": None,
+    "x_unit": None,
+    "y_unit": None,
+    "x_ticks": [0],
+    "x_tick_labels": ["0"],
+    "x_scale": "linear",
+    "y_ticks": [0],
+    "y_tick_labels": ["0"],
+    "y_scale": "linear",
+    "elements": [{"label": "sin", "points": [(0, 0)]}],
+}
+_SCATTER = {
+    "type": "scatter",
+    "title": "Scatter Plot",
+    "x_label": "X",
+    "y_label": "Y",
+    "x_unit": None,
+    "y_unit": None,
+    "x_ticks": [0],
+    "x_tick_labels": ["0"],
+    "x_scale": "linear",
+    "y_ticks": [0],
+    "y_tick_labels": ["0"],
+    "y_scale": "linear",
+    "elements": [{"label": "Dataset 1", "points": [(0.1, 0.2)]}],
+}
 
 
-def _line_chart_payload():
-    return {
-        "type": "line",
-        "title": "Sine Wave",
-        "x_label": None,
-        "y_label": None,
-        "x_unit": None,
-        "y_unit": None,
-        "x_ticks": [0, 1],
-        "x_tick_labels": ["0", "1"],
-        "x_scale": "linear",
-        "y_ticks": [0, 1],
-        "y_tick_labels": ["0", "1"],
-        "y_scale": "linear",
-        "elements": [{"label": "sin", "points": [(0, 0), (1, 1)]}],
+def test_result_chart_json_dump_keeps_nested_superchart():
+    raw = {
+        "type": "superchart",
+        "title": "Multiple Charts Example",
+        "elements": [_LINE, _SCATTER],
     }
-
-
-def _scatter_chart_payload():
-    return {
-        "type": "scatter",
-        "title": "Scatter Plot",
-        "x_label": "X",
-        "y_label": "Y",
-        "x_unit": None,
-        "y_unit": None,
-        "x_ticks": [0, 1],
-        "x_tick_labels": ["0", "1"],
-        "x_scale": "linear",
-        "y_ticks": [0, 1],
-        "y_tick_labels": ["0", "1"],
-        "y_scale": "linear",
-        "elements": [{"label": "Dataset 1", "points": [(0.1, 0.2)]}],
-    }
-
-
-def _pie_chart_payload():
-    return {
-        "type": "pie",
-        "title": "Share",
-        "elements": [{"label": "A", "angle": 2.0, "radius": 1.0}],
-    }
-
-
-def _bar_chart_payload():
-    return {
-        "type": "bar",
-        "title": "Counts",
-        "x_label": "X",
-        "y_label": "Y",
-        "x_unit": None,
-        "y_unit": None,
-        "elements": [{"label": "A", "value": "1", "group": "g"}],
-    }
-
-
-def _box_chart_payload():
-    return {
-        "type": "box_and_whisker",
-        "title": "Spread",
-        "x_label": None,
-        "y_label": None,
-        "x_unit": None,
-        "y_unit": None,
-        "elements": [
-            {
-                "label": "s",
-                "min": 0.0,
-                "first_quartile": 1.0,
-                "median": 2.0,
-                "third_quartile": 3.0,
-                "max": 4.0,
-                "outliers": [],
-            }
-        ],
-    }
-
-
-def _superchart():
-    return SuperChart(
-        type="superchart",
-        title="Multiple Charts Example",
-        elements=[
-            _line_chart_payload(),
-            _scatter_chart_payload(),
-            _pie_chart_payload(),
-            _bar_chart_payload(),
-            _box_chart_payload(),
-        ],
-    )
-
-
-def test_superchart_json_dump_keeps_nested_charts():
-    chart = _superchart()
-
+    result = Result(text="ok", chart=raw, is_main_result=True)
+    chart = result.chart
     assert isinstance(chart, SuperChart)
     assert isinstance(chart.elements[0], LineChart)
     assert isinstance(chart.elements[1], ScatterChart)
-    assert isinstance(chart.elements[2], PieChart)
-    assert isinstance(chart.elements[3], BarChart)
-    assert isinstance(chart.elements[4], BoxAndWhiskerChart)
+
+    dumped = json.loads(TypeAdapter(Any).dump_json(result))
+    assert dumped["chart"]["type"] == "superchart"
+    assert dumped["chart"]["elements"][0]["title"] == "Sine Wave"
+    assert dumped["chart"]["elements"][1]["title"] == "Scatter Plot"
 
     payload = json.loads(json.dumps(asdict(chart)))
     assert payload["type"] == "superchart"
-    assert payload["title"] == "Multiple Charts Example"
-    assert payload["elements"][0]["type"] == "line"
-    assert payload["elements"][0]["title"] == "Sine Wave"
-    assert payload["elements"][0]["elements"][0]["points"] == [[0, 0], [1, 1]]
-    assert payload["elements"][1]["type"] == "scatter"
-    assert payload["elements"][1]["title"] == "Scatter Plot"
-    assert payload["elements"][2]["type"] == "pie"
-    assert payload["elements"][2]["elements"][0]["angle"] == 2.0
-    assert payload["elements"][3]["type"] == "bar"
-    assert payload["elements"][3]["elements"][0]["value"] == "1"
-    assert payload["elements"][4]["type"] == "box_and_whisker"
-    assert payload["elements"][4]["elements"][0]["median"] == 2.0
-
-
-def test_superchart_pydantic_json_dump():
-    pydantic = pytest.importorskip("pydantic")
-
-    chart = _superchart()
-    payload = json.loads(pydantic.TypeAdapter(Any).dump_json(chart))
-    assert payload["type"] == "superchart"
-    assert payload["title"] == "Multiple Charts Example"
     assert payload["elements"][0]["type"] == "line"
     assert payload["elements"][1]["type"] == "scatter"
-    assert payload["elements"][2]["type"] == "pie"
-    assert payload["elements"][3]["type"] == "bar"
-    assert payload["elements"][4]["type"] == "box_and_whisker"
-    assert payload["elements"][0]["elements"][0]["label"] == "sin"

--- a/packages/code-interpreter-python/uv.lock
+++ b/packages/code-interpreter-python/uv.lock
@@ -168,7 +168,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -240,7 +240,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
@@ -443,6 +443,7 @@ dependencies = [
 dev = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-dotenv" },
@@ -462,6 +463,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "matplotlib", specifier = ">=3.8.0,<4" },
+    { name = "pydantic", specifier = ">=2,<3" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2" },
     { name = "pytest-dotenv", specifier = ">=0.5.2,<0.6" },
@@ -498,7 +500,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -929,15 +931,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "cycler", marker = "python_full_version < '3.11'" },
-    { name = "fonttools", marker = "python_full_version < '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.11'" },
-    { name = "pyparsing", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1007,16 +1009,16 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler", marker = "python_full_version >= '3.11'" },
-    { name = "fonttools", marker = "python_full_version >= '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pillow", marker = "python_full_version >= '3.11'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
 wheels = [


### PR DESCRIPTION
Fixes https://github.com/e2b-dev/E2B/issues/886

`Result` in `models.py` is a dataclass, so pydantic's `TypeAdapter(Any).dump_json` walks into `result.chart` and hits a plain `SuperChart`, raising `PydanticSerializationError: Unable to serialize unknown type: SuperChart` (the Dify plugin error). `Chart.to_dict()` returns the JSON payload, but pydantic never calls it.

Fix: mark the chart classes and the `*Data` holders as dataclasses (`init=False`, `repr=False`, `eq=False`). The `**kwargs` constructors and `to_dict()` are unchanged. Nested LineChart/PointData must be dataclasses too or the dump fails on them. I tried `__get_pydantic_core_schema__` and `collections.abc.Mapping` first; both still fail `TypeAdapter(Any).dump_json`. A pydantic `BaseModel` conversion would add a runtime dependency this package does not have. JS SuperChart is already a plain object, so no JS change.

Patch changeset for `@e2b/code-interpreter-python`. `pydantic>=2,<3` is added to the `dev` dependency group so the dump assertion runs under CI's `uv sync --locked --package e2b-code-interpreter`.

Testing (no sandbox):

```
cd packages/code-interpreter-python && uv sync --locked --package e2b-code-interpreter
.venv/bin/python -m pytest tests/charts/test_chart_serialization.py -q --tb=short -o addopts=
```

1 passed (`TypeAdapter(Any).dump_json(Result(chart=superchart_dict))` plus `asdict`). Restoring `charts.py` from 473d8bf3e makes it fail with the `SuperChart` serialization error above.

Example after the change:

```python
from typing import Any
from pydantic import TypeAdapter
from e2b_code_interpreter.models import Result

result = Result(
    text="ok",
    chart={
        "type": "superchart",
        "title": "Multiple Charts Example",
        "elements": [
            {
                "type": "line",
                "title": "Sine Wave",
                "x_label": None,
                "y_label": None,
                "x_unit": None,
                "y_unit": None,
                "x_ticks": [0],
                "x_tick_labels": ["0"],
                "x_scale": "linear",
                "y_ticks": [0],
                "y_tick_labels": ["0"],
                "y_scale": "linear",
                "elements": [{"label": "sin", "points": [(0, 0)]}],
            }
        ],
    },
)
TypeAdapter(Any).dump_json(result)
```