### PR TITLE
feat(cli): add `template rebuild --refresh-envd`

### DIFF
--- a/.changeset/template-rebuild-refresh-envd.md
+++ b/.changeset/template-rebuild-refresh-envd.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': minor
+---
+
+Add `e2b template rebuild <template> --refresh-envd`: rebuild an existing template with the host's current envd while keeping its specs and alias. Old templates bake an old envd into their snapshot, which blocks features gated on a newer envd (e.g. volume mounts need envd >= 0.5.14); this rebuilds in place FROM the template's own latest ready build so only the envd binary is swapped. Streams build logs until the new build is ready. Requires the companion `POST /v2/templates/{templateID}/refresh-envd` endpoint (e2b-dev/infra#3624).

--- a/packages/cli/src/commands/template/index.ts
+++ b/packages/cli/src/commands/template/index.ts
@@ -7,6 +7,7 @@ import { initCommand } from './init'
 import { listCommand } from './list'
 import { migrateCommand } from './migrate'
 import { publishCommand, unPublishCommand } from './publish'
+import { rebuildCommand } from './rebuild'
 
 export const templateCommand = new commander.Command('template')
   .description('manage sandbox templates')
@@ -19,3 +20,4 @@ export const templateCommand = new commander.Command('template')
   .addCommand(publishCommand)
   .addCommand(unPublishCommand)
   .addCommand(migrateCommand)
+  .addCommand(rebuildCommand)

--- a/packages/cli/src/commands/template/rebuild.ts
+++ b/packages/cli/src/commands/template/rebuild.ts
@@ -1,0 +1,101 @@
+import * as commander from 'commander'
+import { defaultBuildLogger, Template } from 'e2b'
+
+import { client, ensureAPIKey } from 'src/api'
+import { handleE2BRequestError } from '../../utils/errors'
+import {
+  asBold,
+  asFormattedError,
+  asLocal,
+  asPrimary,
+} from '../../utils/format'
+
+const buildStatusPollFrequencyMs = 2_000
+
+/**
+ * Rebuild a template with the host's current envd. This calls the server-side
+ * refresh-envd endpoint, which derives a new build FROM the template's own
+ * latest ready build (base layer cached, only the envd binary swapped) and
+ * inherits the source build's specs and alias in place. Then it streams build
+ * logs until the new build is ready.
+ */
+async function refreshEnvd(templateID: string) {
+  ensureAPIKey()
+
+  const res = await client.api.POST('/v2/templates/{templateID}/refresh-envd', {
+    params: { path: { templateID } },
+  })
+  handleE2BRequestError(res, 'Error requesting envd refresh')
+
+  const { buildID, fromEnvdVersion, aliases } = res.data
+  const name = aliases && aliases.length > 0 ? aliases[0] : templateID
+
+  console.log(
+    `\nRefreshing envd for ${asBold(name)} (from v${fromEnvdVersion}); rebuilding...\n`
+  )
+
+  const onLog = defaultBuildLogger()
+  let logsOffset = 0
+  // Poll the existing build status endpoint until the derived build settles.
+  // The status endpoint returns at most 100 log entries per call, so keep
+  // draining after a terminal status before deciding the outcome.
+  for (;;) {
+    const status = await Template.getBuildStatus(
+      { templateId: templateID, buildId: buildID },
+      { logsOffset }
+    )
+    logsOffset += status.logEntries.length
+    status.logEntries.forEach(onLog)
+
+    if (status.status === 'ready') {
+      if (status.logEntries.length > 0) continue
+      break
+    }
+    if (status.status === 'error') {
+      if (status.logEntries.length > 0) continue
+      console.error(
+        asFormattedError(status.reason?.message ?? 'Template build failed')
+      )
+      process.exit(1)
+    }
+
+    await new Promise((r) => setTimeout(r, buildStatusPollFrequencyMs))
+  }
+
+  console.log(
+    `\n✅ ${asBold(name)} rebuilt with the current envd.\n\n   Confirm the binary changed: start a sandbox from ${asLocal(
+      name
+    )}, then run ${asPrimary('/usr/bin/envd -version')}.`
+  )
+}
+
+export const rebuildCommand = new commander.Command('rebuild')
+  .description(
+    'rebuild a template with the current envd, keeping its specs and alias. Useful for old templates whose baked-in envd is too old for newer features (e.g. volume mounts need envd >= 0.5.14).'
+  )
+  .argument(
+    '<template>',
+    'template id or alias to rebuild. Its specs and alias are inherited from the latest ready build.'
+  )
+  .option(
+    '--refresh-envd',
+    "swap in the host's current envd binary (the only rebuild mode today; required)."
+  )
+  .alias('rb')
+  .action(async (template: string, opts: { refreshEnvd?: boolean }) => {
+    if (!opts.refreshEnvd) {
+      console.error(
+        `Nothing to rebuild. Pass ${asBold(
+          '--refresh-envd'
+        )} to rebuild the template with the current envd.`
+      )
+      process.exit(1)
+    }
+
+    try {
+      await refreshEnvd(template)
+    } catch (err: any) {
+      console.error(asFormattedError(err.message))
+      process.exit(1)
+    }
+  })

--- a/packages/cli/tests/commands/template/rebuild.test.ts
+++ b/packages/cli/tests/commands/template/rebuild.test.ts
@@ -1,0 +1,36 @@
+import * as path from 'path'
+import { execSync } from 'child_process'
+import { describe, expect, test } from 'vitest'
+
+// Black-box CLI tests (same idiom as publish.test.ts): run the built binary and
+// assert on output up to the network boundary. The --refresh-envd guard and the
+// command registration are deterministic and need no API key or network.
+describe('template rebuild', () => {
+  const cliPath = path.join(process.cwd(), 'dist', 'index.js')
+
+  function run(args: string): string {
+    try {
+      return execSync(`node "${cliPath}" ${args} 2>&1`, {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        timeout: 10_000,
+      })
+    } catch (err: any) {
+      return (err?.stdout ?? '') + (err?.stderr ?? '')
+    }
+  }
+
+  test('without --refresh-envd it refuses and points at the flag', () => {
+    const output = run('template rebuild some-template')
+    expect(output).toContain('--refresh-envd')
+    expect(output).not.toContain('Refreshing envd')
+  })
+
+  test('is registered and documented under template help', () => {
+    const output = run('template rebuild --help')
+    expect(output).toContain('rebuild')
+    expect(output).toContain('--refresh-envd')
+    // The description explains the old-envd motivation.
+    expect(output).toContain('envd')
+  })
+})

--- a/packages/js-sdk/src/api/schema.gen.ts
+++ b/packages/js-sdk/src/api/schema.gen.ts
@@ -1731,6 +1731,57 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/templates/{templateID}/refresh-envd": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Rebuild a template with the current envd
+         * @description Derives a new build of the template FROM the template's own latest ready
+         *     build, forcing the host's current envd binary to replace the one baked in
+         *     by the original build. Specs (cpu, memory) and the alias are inherited
+         *     from the source build. Returns the new build to poll via the existing
+         *     build status/logs endpoints.
+         *
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    templateID: components["parameters"]["templateID"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The refresh build was requested successfully */
+                202: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TemplateRefreshEnvdResponse"];
+                    };
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v3/templates": {
         parameters: {
             query?: never;
@@ -2984,6 +3035,16 @@ export interface components {
              * @description Time when the template was last updated
              */
             updatedAt: string;
+        };
+        TemplateRefreshEnvdResponse: {
+            /** @description Aliases of the template (inherited from the source) */
+            aliases?: string[];
+            /** @description Identifier of the new build; poll its status/logs endpoints */
+            buildID: string;
+            /** @description envd version the source build was baked with */
+            fromEnvdVersion: string;
+            /** @description Identifier of the template being refreshed */
+            templateID: string;
         };
         TemplateRequestResponseV3: {
             /**

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -1063,6 +1063,26 @@ components:
         buildStatus:
           $ref: "#/components/schemas/TemplateBuildStatus"
 
+    TemplateRefreshEnvdResponse:
+      required:
+        - templateID
+        - buildID
+        - fromEnvdVersion
+      properties:
+        templateID:
+          type: string
+          description: Identifier of the template being refreshed
+        buildID:
+          type: string
+          description: Identifier of the new build; poll its status/logs endpoints
+        fromEnvdVersion:
+          type: string
+          description: envd version the source build was baked with
+        aliases:
+          type: array
+          description: Aliases of the template (inherited from the source)
+          items:
+            type: string
     TemplateRequestResponseV3:
       required:
         - templateID
@@ -3237,6 +3257,42 @@ paths:
           description: The build has started
         "401":
           $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /v2/templates/{templateID}/refresh-envd:
+    post:
+      summary: Rebuild a template with the current envd
+      description: |
+        Derives a new build of the template FROM the template's own latest ready
+        build, forcing the host's current envd binary to replace the one baked in
+        by the original build. Specs (cpu, memory) and the alias are inherited
+        from the source build. Returns the new build to poll via the existing
+        build status/logs endpoints.
+      tags: [templates]
+      security:
+        - ApiKeyAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
+        - AdminApiKeyAuth: []
+          AdminTeamAuth: []
+      parameters:
+        - $ref: "#/components/parameters/templateID"
+      responses:
+        "202":
+          description: The refresh build was requested successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TemplateRefreshEnvdResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
         "500":
           $ref: "#/components/responses/500"
 


### PR DESCRIPTION
## Summary

Old templates bake an old envd into their final snapshot, so a sandbox started from one resumes the old envd out of snapshot RAM. That blocks features gated on a newer envd — e.g. volume mounts need **envd ≥ 0.5.14**. The only way to lift such a template is a rebuild, and users have been scripting that by hand against the raw API, which has two footguns:

- omitted specs silently default to **2 vCPU / 1024 MiB**, shrinking the template;
- registering under a fresh template id **orphans the alias**.

## Change

Adds **`e2b template rebuild <template> --refresh-envd`** (alias `rb`). It calls the companion server endpoint `POST /v2/templates/{templateID}/refresh-envd`, which derives a new build **FROM the template's own latest ready build** (base layer cached, only the envd binary swapped) and **inherits the source build's cpu/ram and alias in place**. The command then streams build logs via the existing status endpoint until the new build is ready.

Scope is deliberately **CLI-only**: it calls the raw endpoint through `client.api` (the `publish` command's pattern) and polls with the already-public `Template.getBuildStatus`. No js-sdk / python-sdk public surface changes, so no JS/Python parity work.

## Usage

```console
$ e2b template rebuild my-old-template --refresh-envd

Refreshing envd for my-old-template (from v0.4.1); rebuilding...
  ... build logs ...

✅ my-old-template rebuilt with the current envd.

   Confirm the binary changed: start a sandbox from my-old-template,
   then run /usr/bin/envd -version.
```

Without the flag it refuses (the flag is the only rebuild mode today, and gates a destructive-ish rebuild behind an explicit opt-in):

```console
$ e2b template rebuild my-old-template
Nothing to rebuild. Pass --refresh-envd to rebuild the template with the current envd.
```

## Companion infra PR (server half)

This is the **client half**. The server endpoint it calls is added in **e2b-dev/infra#3624** — https://github.com/e2b-dev/infra/pull/3624. That PR traces the full root cause (memory-snapshot resume keeps the old envd; live-upgrade is gated at envd ≥ 0.6.12; offline-upgrade only runs on the cold-boot path) and implements the endpoint that derives the cached-source-layer build which swaps envd.

**Merge order:** infra#3624 first, then here.

> ⚠️ **Preview files, blocked on the sync.** `spec/openapi.yml` and `packages/js-sdk/src/api/schema.gen.ts` in this PR carry the new endpoint so the CLI typechecks and builds. But per `AGENTS.md`, `spec/` is synced from `e2b-dev/infra` via Copybara at the pin in `spec/infra-ref` — it is not hand-authored. Once infra#3624 merges, the correct final step is: bump `spec/infra-ref` to the merged commit and run `make codegen`, which re-fetches the spec and regenerates `schema.gen.ts` **identically**, dropping the manual preview. This PR should not merge before that sync is possible.

## Tests run

- `pnpm --filter @e2b/cli run typecheck` — OK (new typed path resolves).
- `pnpm --filter @e2b/cli run build` — OK.
- `pnpm --filter @e2b/cli run lint` — 0 warnings / 0 errors.
- `pnpm --filter @e2b/cli run format` — clean.
- `pnpm --filter e2b run typecheck` (js-sdk) — OK (schema change doesn't break the SDK).
- `vitest run tests/commands/template/rebuild.test.ts` — PASS (2 tests: refuses without `--refresh-envd`; command registered + documented). The rest of the CLI suite passes; the only failure in a full run is the pre-existing `create.test.ts` backend-integration test, which is gated on a live `E2B_API_KEY` and unrelated to this change.

A changeset (`@e2b/cli: minor`) is included per `AGENTS.md`.

## AI assistance

AI assistance was used to trace the resume/build call chains, design the command, and draft the code and tests. A human submitter has reviewed every changed line.
