### PR TITLE
fix(js-sdk): validate sandbox create options before requiring an API key

### DIFF
--- a/.changeset/lifecycle-validate-before-auth.md
+++ b/.changeset/lifecycle-validate-before-auth.md
@@ -1,0 +1,5 @@
+---
+'e2b': patch
+---
+
+Reject invalid `Sandbox.create` lifecycle options before requiring an API key, matching the Python SDK.

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -1634,7 +1634,6 @@ export class SandboxApi extends ClientFactory {
   ) {
     const apiOpts = this.resolveOpts(opts)
     const config = new ConnectionConfig(apiOpts)
-    const client = new ApiClient(config)
     // onTimeout accepts a bare action (`'pause'` / `'kill'`) or the object form
     // `{ action, keepMemory }`. The discriminated union type forbids `keepMemory`
     // on `action: 'kill'`; re-check at runtime for untyped callers.
@@ -1704,6 +1703,7 @@ export class SandboxApi extends ClientFactory {
       )
     }
 
+    const client = new ApiClient(config)
     const res = await client.api.POST('/sandboxes', {
       body,
       signal: config.getSignal(apiOpts?.requestTimeoutMs, apiOpts?.signal),

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -1632,8 +1632,6 @@ export class SandboxApi extends ClientFactory {
     timeoutMs: number,
     opts?: SandboxOpts
   ) {
-    const apiOpts = this.resolveOpts(opts)
-    const config = new ConnectionConfig(apiOpts)
     // onTimeout accepts a bare action (`'pause'` / `'kill'`) or the object form
     // `{ action, keepMemory }`. The discriminated union type forbids `keepMemory`
     // on `action: 'kill'`; re-check at runtime for untyped callers.
@@ -1703,6 +1701,8 @@ export class SandboxApi extends ClientFactory {
       )
     }
 
+    const apiOpts = this.resolveOpts(opts)
+    const config = new ConnectionConfig(apiOpts)
     const client = new ApiClient(config)
     const res = await client.api.POST('/sandboxes', {
       body,

--- a/packages/js-sdk/tests/sandbox/lifecycleRequest.test.ts
+++ b/packages/js-sdk/tests/sandbox/lifecycleRequest.test.ts
@@ -127,6 +127,39 @@ test('Sandbox.create rejects autoResume without a timeout action', async () => {
   expect(lastCreateBody).toBeUndefined()
 })
 
+async function expectInvalidLifecycleWithoutApiKey(
+  lifecycle: NonNullable<Parameters<typeof Sandbox.create>[1]>['lifecycle']
+) {
+  const previous = process.env.E2B_API_KEY
+  delete process.env.E2B_API_KEY
+  try {
+    await expect(Sandbox.create('base', { lifecycle })).rejects.toThrowError(
+      InvalidArgumentError
+    )
+  } finally {
+    if (previous === undefined) {
+      delete process.env.E2B_API_KEY
+    } else {
+      process.env.E2B_API_KEY = previous
+    }
+  }
+  expect(lastCreateBody).toBeUndefined()
+}
+
+test('filesystem-only auto-pause with auto-resume is InvalidArgumentError without an API key', async () => {
+  await expectInvalidLifecycleWithoutApiKey({
+    onTimeout: { action: 'pause', keepMemory: false },
+    autoResume: true,
+  })
+})
+
+test('keepMemory on kill is InvalidArgumentError without an API key', async () => {
+  await expectInvalidLifecycleWithoutApiKey({
+    // @ts-expect-error keepMemory is not allowed with action: 'kill'
+    onTimeout: { action: 'kill', keepMemory: false },
+  })
+})
+
 test('an explicit autoResume: false is sent', async () => {
   await Sandbox.create('base', {
     apiKey: TEST_API_KEY,


### PR DESCRIPTION
Fixes https://github.com/e2b-dev/E2B/issues/1820

`createSandbox` built `ApiClient` before validating `lifecycle`, so with no API key the client-side guards (`keepMemory: false` with `autoResume: true`, and `keepMemory` on `kill`) threw `AuthenticationError` instead of `InvalidArgumentError`. Python already calls `build_lifecycle_config` before `get_api_client`. `forkSandbox` already validates `count` before constructing the client.

The lifecycle guards and create body run first. `resolveOpts`, `ConnectionConfig`, and `ApiClient` sit together immediately before POST.

Two new cases in `lifecycleRequest.test.ts` unset `E2B_API_KEY` and expect `InvalidArgumentError`.

```
pnpm --dir packages/js-sdk exec vitest run --project unit tests/sandbox/lifecycleRequest.test.ts
```

12 passed. Restoring `createSandbox` to construct `ApiClient` first makes the two new tests fail with `AuthenticationError`.

```ts
await Sandbox.create('base', {
  lifecycle: { onTimeout: { action: 'pause', keepMemory: false }, autoResume: true },
})
// throws InvalidArgumentError with no E2B_API_KEY set
```
