### PR TITLE
fix(code-interpreter): deserialize SuperChart from elements

### DIFF
--- a/.changeset/superchart-deserialize-elements.md
+++ b/.changeset/superchart-deserialize-elements.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter': patch
+---
+
+Deserialize SuperChart from `elements` and run `Result` through `deserializeChart`, matching the Python SDK.

--- a/packages/code-interpreter-js/src/charts.ts
+++ b/packages/code-interpreter-js/src/charts.ts
@@ -127,13 +127,9 @@ export function deserializeChart(data: any): Chart {
     case ChartType.BOX_AND_WHISKER:
       return { ...data } as BoxAndWhiskerChart
     case ChartType.SUPERCHART: {
-      const nested = data.elements ?? data.data ?? []
-      const charts: Chart[] = nested.map((g: any) => deserializeChart(g))
-      const rest = { ...data }
-      delete rest.data
       return {
-        ...rest,
-        elements: charts,
+        ...data,
+        elements: (data.elements ?? []).map((g: any) => deserializeChart(g)),
       } as SuperChart
     }
     default:

--- a/packages/code-interpreter-js/src/charts.ts
+++ b/packages/code-interpreter-js/src/charts.ts
@@ -127,11 +127,13 @@ export function deserializeChart(data: any): Chart {
     case ChartType.BOX_AND_WHISKER:
       return { ...data } as BoxAndWhiskerChart
     case ChartType.SUPERCHART: {
-      const charts: Chart[] = data.data.map((g: any) => deserializeChart(g))
-      delete data.data
+      const nested = data.elements ?? data.data ?? []
+      const charts: Chart[] = nested.map((g: any) => deserializeChart(g))
+      const rest = { ...data }
+      delete rest.data
       return {
-        ...data,
-        data: charts,
+        ...rest,
+        elements: charts,
       } as SuperChart
     }
     default:

--- a/packages/code-interpreter-js/src/messaging.ts
+++ b/packages/code-interpreter-js/src/messaging.ts
@@ -1,5 +1,5 @@
 import { NotFoundError, SandboxError, TimeoutError } from 'e2b'
-import { ChartTypes } from './charts'
+import { ChartTypes, deserializeChart } from './charts'
 
 export async function extractError(res: Response, includeDiagnostics = false) {
   if (res.ok) {
@@ -183,6 +183,8 @@ export class Result {
 
     this.data = data['data']
     this.chart = data['chart']
+      ? (deserializeChart(data['chart']) as ChartTypes)
+      : data['chart']
 
     this.extra = {}
 

--- a/packages/code-interpreter-js/src/messaging.ts
+++ b/packages/code-interpreter-js/src/messaging.ts
@@ -184,7 +184,7 @@ export class Result {
     this.data = data['data']
     this.chart = data['chart']
       ? (deserializeChart(data['chart']) as ChartTypes)
-      : data['chart']
+      : undefined
 
     this.extra = {}
 

--- a/packages/code-interpreter-js/tests/charts/deserialize.test.ts
+++ b/packages/code-interpreter-js/tests/charts/deserialize.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest'
+
+import { ChartType, deserializeChart } from '../../src/charts'
+import { Result } from '../../src/messaging'
+
+const superchartPayload = {
+  type: ChartType.SUPERCHART,
+  title: 'Multiple Charts Example',
+  elements: [
+    {
+      type: ChartType.LINE,
+      title: 'Sine Wave',
+      elements: [],
+    },
+    {
+      type: 'not-a-chart',
+      title: 'nested',
+      elements: [],
+    },
+  ],
+}
+
+test('deserializeChart walks SuperChart.elements', () => {
+  const chart = deserializeChart(superchartPayload)
+
+  expect(chart.type).toBe(ChartType.SUPERCHART)
+  expect(chart.elements).toHaveLength(2)
+  expect(chart.elements[0].title).toBe('Sine Wave')
+  expect(chart.elements[0].type).toBe(ChartType.LINE)
+  expect(chart.elements[1].type).toBe(ChartType.UNKNOWN)
+  expect(chart).not.toHaveProperty('data')
+})
+
+test('Result tags nested unknown SuperChart members', () => {
+  const result = new Result({ chart: superchartPayload }, true)
+
+  expect(result.chart?.type).toBe(ChartType.SUPERCHART)
+  expect(result.chart?.elements[1].type).toBe(ChartType.UNKNOWN)
+})

--- a/packages/code-interpreter-js/tests/charts/deserialize.test.ts
+++ b/packages/code-interpreter-js/tests/charts/deserialize.test.ts
@@ -37,3 +37,9 @@ test('Result tags nested unknown SuperChart members', () => {
   expect(result.chart?.type).toBe(ChartType.SUPERCHART)
   expect(result.chart?.elements[1].type).toBe(ChartType.UNKNOWN)
 })
+
+test('Result leaves chart undefined when the payload chart is null', () => {
+  const result = new Result({ chart: null } as never, true)
+
+  expect(result.chart).toBeUndefined()
+})


### PR DESCRIPTION
Fixes https://github.com/e2b-dev/E2B/issues/1821

`deserializeChart` mapped SuperChart children from `data.data`. The kernel, the `SuperChart` type, and Python `_deserialize_chart` use `elements`. Calling the helper on a real SuperChart threw `Cannot read properties of undefined (reading 'map')`. `Result` assigned the raw `chart` payload and never called it, so nested unknown types stayed as the raw string.

Walk `elements`, keep `elements` on the result, and run `Result` through `deserializeChart` like Python. I did not export `deserializeChart`; it is still internal. There is no fallback to a `data` key. A null `chart` on the wire becomes `undefined`, not `null`.

Testing (no sandbox):

```
pnpm --dir packages/code-interpreter-js exec vitest run tests/charts/deserialize.test.ts tests/messaging.test.ts
```

7 passed. Restoring `charts.ts` and `messaging.ts` from main makes the SuperChart tests fail (`.map` TypeError, nested `type: 'not-a-chart'`). Restoring only the `chart: null` else-branch to `data['chart']` makes `Result` keep `null` instead of `undefined`.

```ts
const result = new Result(
  {
    chart: {
      type: 'superchart',
      title: 'Multiple Charts Example',
      elements: [
        { type: 'line', title: 'Sine Wave', elements: [] },
        { type: 'not-a-chart', title: 'nested', elements: [] },
      ],
    },
  },
  true
)
result.chart.elements[1].type // 'unknown'
```
