### PR TITLE
fix(sdk): reject unrecognized files.read format

### DIFF
--- a/.changeset/read-format-validate.md
+++ b/.changeset/read-format-validate.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/python-sdk': patch
+---
+
+Reject an unrecognized `format` on `files.read` / `Volume.readFile` (`read_file`) with `InvalidArgumentError` / `InvalidArgumentException` instead of returning None or the file as text.

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -53,7 +53,7 @@ import {
   TemplateError,
 } from '../../errors'
 import { isReadableStreamLike } from '../../is'
-import { runtime, toBlob, toUploadBody } from '../../utils'
+import { runtime, toBlob, toUploadBody, assertReadFormat } from '../../utils'
 
 const FILESYSTEM_HTTP_ERROR_MAP: Record<number, (message: string) => Error> = {
   404: (message: string) => new FileNotFoundError(message),
@@ -202,16 +202,6 @@ const METADATA_HEADER_PREFIX = 'X-Metadata-'
 // printable US-ASCII.
 const METADATA_KEY_REGEX = /^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$/
 const METADATA_VALUE_REGEX = /^[\x20-\x7e]*$/
-
-const READ_FORMATS = ['text', 'bytes', 'blob', 'stream']
-
-function assertReadFormat(format: string): void {
-  if (!READ_FORMATS.includes(format)) {
-    throw new InvalidArgumentError(
-      `format must be one of ${READ_FORMATS.join(', ')}.`
-    )
-  }
-}
 
 function validateMetadata(metadata: Record<string, string> | undefined): void {
   if (!metadata) return

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -203,6 +203,16 @@ const METADATA_HEADER_PREFIX = 'X-Metadata-'
 const METADATA_KEY_REGEX = /^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$/
 const METADATA_VALUE_REGEX = /^[\x20-\x7e]*$/
 
+const READ_FORMATS = ['text', 'bytes', 'blob', 'stream']
+
+function assertReadFormat(format: string): void {
+  if (!READ_FORMATS.includes(format)) {
+    throw new InvalidArgumentError(
+      `format must be one of ${READ_FORMATS.join(', ')}.`
+    )
+  }
+}
+
 function validateMetadata(metadata: Record<string, string> | undefined): void {
   if (!metadata) return
   for (const [key, value] of Object.entries(metadata)) {
@@ -457,6 +467,7 @@ export class Filesystem {
     }
   ): Promise<unknown> {
     const format = opts?.format ?? 'text'
+    assertReadFormat(format)
 
     let user = opts?.user
     if (

--- a/packages/js-sdk/src/sandbox/filesystem/index.ts
+++ b/packages/js-sdk/src/sandbox/filesystem/index.ts
@@ -53,7 +53,13 @@ import {
   TemplateError,
 } from '../../errors'
 import { isReadableStreamLike } from '../../is'
-import { runtime, toBlob, toUploadBody, assertReadFormat } from '../../utils'
+import {
+  runtime,
+  toBlob,
+  toUploadBody,
+  assertReadFormat,
+  type ReadFormat,
+} from '../../utils'
 
 const FILESYSTEM_HTTP_ERROR_MAP: Record<number, (message: string) => Error> = {
   404: (message: string) => new FileNotFoundError(message),
@@ -453,10 +459,10 @@ export class Filesystem {
   async read(
     path: string,
     opts?: FilesystemReadOpts & {
-      format?: 'text' | 'bytes' | 'blob' | 'stream'
+      format?: ReadFormat
     }
   ): Promise<unknown> {
-    const format = opts?.format ?? 'text'
+    const format = opts?.format === undefined ? 'text' : opts.format
     assertReadFormat(format)
 
     let user = opts?.user

--- a/packages/js-sdk/src/utils.ts
+++ b/packages/js-sdk/src/utils.ts
@@ -243,10 +243,12 @@ export async function toUploadBody(
   return { body: await toBlob(data), streamed: false }
 }
 
-const READ_FORMATS = ['text', 'bytes', 'blob', 'stream']
+export const READ_FORMATS = ['text', 'bytes', 'blob', 'stream'] as const
 
-export function assertReadFormat(format: string): void {
-  if (!READ_FORMATS.includes(format)) {
+export type ReadFormat = (typeof READ_FORMATS)[number]
+
+export function assertReadFormat(format: string): asserts format is ReadFormat {
+  if (!(READ_FORMATS as readonly string[]).includes(format)) {
     throw new InvalidArgumentError(
       `format must be one of ${READ_FORMATS.join(', ')}.`
     )

--- a/packages/js-sdk/src/utils.ts
+++ b/packages/js-sdk/src/utils.ts
@@ -1,6 +1,7 @@
 import platform from 'platform'
 
 import { isBlobLike, isReadableStreamLike } from './is'
+import { InvalidArgumentError } from './errors'
 
 declare let window: any
 
@@ -240,4 +241,14 @@ export async function toUploadBody(
   }
 
   return { body: await toBlob(data), streamed: false }
+}
+
+const READ_FORMATS = ['text', 'bytes', 'blob', 'stream']
+
+export function assertReadFormat(format: string): void {
+  if (!READ_FORMATS.includes(format)) {
+    throw new InvalidArgumentError(
+      `format must be one of ${READ_FORMATS.join(', ')}.`
+    )
+  }
 }

--- a/packages/js-sdk/src/volume/index.ts
+++ b/packages/js-sdk/src/volume/index.ts
@@ -15,6 +15,7 @@ import {
 } from '../connectionConfig'
 import { isArrayBufferLike, isBlobLike } from '../is'
 import {
+  InvalidArgumentError,
   VolumeError,
   VolumeNotFoundError,
   VolumePathNotFoundError,
@@ -29,6 +30,16 @@ import type {
   VolumeReadOpts,
   VolumeWriteOpts,
 } from './types'
+
+const READ_FORMATS = ['text', 'bytes', 'blob', 'stream']
+
+function assertReadFormat(format: string): void {
+  if (!READ_FORMATS.includes(format)) {
+    throw new InvalidArgumentError(
+      `format must be one of ${READ_FORMATS.join(', ')}.`
+    )
+  }
+}
 
 /**
  * Convert API VolumeEntryStat to SDK VolumeEntryStat.
@@ -557,6 +568,7 @@ export class Volume extends ClientFactory {
     }
   ): Promise<unknown> {
     const format = opts?.format ?? 'text'
+    assertReadFormat(format)
     const config = new VolumeConnectionConfig(this, {
       ...opts,
       requestTimeoutMs: opts?.requestTimeoutMs ?? FILE_TIMEOUT_MS,

--- a/packages/js-sdk/src/volume/index.ts
+++ b/packages/js-sdk/src/volume/index.ts
@@ -19,7 +19,7 @@ import {
   VolumeNotFoundError,
   VolumePathNotFoundError,
 } from '../errors'
-import { toUploadBody, assertReadFormat } from '../utils'
+import { toUploadBody, assertReadFormat, type ReadFormat } from '../utils'
 import { VolumeFileType } from './types'
 import type {
   VolumeAndToken,
@@ -553,10 +553,10 @@ export class Volume extends ClientFactory {
   async readFile(
     path: string,
     opts?: VolumeReadOpts & {
-      format?: 'text' | 'stream' | 'bytes' | 'blob'
+      format?: ReadFormat
     }
   ): Promise<unknown> {
-    const format = opts?.format ?? 'text'
+    const format = opts?.format === undefined ? 'text' : opts.format
     assertReadFormat(format)
     const config = new VolumeConnectionConfig(this, {
       ...opts,

--- a/packages/js-sdk/src/volume/index.ts
+++ b/packages/js-sdk/src/volume/index.ts
@@ -15,12 +15,11 @@ import {
 } from '../connectionConfig'
 import { isArrayBufferLike, isBlobLike } from '../is'
 import {
-  InvalidArgumentError,
   VolumeError,
   VolumeNotFoundError,
   VolumePathNotFoundError,
 } from '../errors'
-import { toUploadBody } from '../utils'
+import { toUploadBody, assertReadFormat } from '../utils'
 import { VolumeFileType } from './types'
 import type {
   VolumeAndToken,
@@ -30,16 +29,6 @@ import type {
   VolumeReadOpts,
   VolumeWriteOpts,
 } from './types'
-
-const READ_FORMATS = ['text', 'bytes', 'blob', 'stream']
-
-function assertReadFormat(format: string): void {
-  if (!READ_FORMATS.includes(format)) {
-    throw new InvalidArgumentError(
-      `format must be one of ${READ_FORMATS.join(', ')}.`
-    )
-  }
-}
 
 /**
  * Convert API VolumeEntryStat to SDK VolumeEntryStat.

--- a/packages/js-sdk/tests/readFormat.test.ts
+++ b/packages/js-sdk/tests/readFormat.test.ts
@@ -30,12 +30,32 @@ test('files.read throws InvalidArgumentError on an unrecognized format', async (
   expect(get).not.toHaveBeenCalled()
 })
 
+test('files.read throws InvalidArgumentError on an explicit null format', async () => {
+  const { fs, get } = stubFilesystem()
+  await expect(fs.read('/tmp/x', { format: null as never })).rejects.toThrow(
+    InvalidArgumentError
+  )
+  expect(get).not.toHaveBeenCalled()
+})
+
 test('volume.readFile throws InvalidArgumentError on an unrecognized format', async () => {
   const vol = new Volume('vol-id', 'name', 'tok')
   const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
     throw new Error('GET should not be called')
   })
   await expect(vol.readFile('/x', { format: 'Text' as never })).rejects.toThrow(
+    InvalidArgumentError
+  )
+  expect(fetchSpy).not.toHaveBeenCalled()
+  fetchSpy.mockRestore()
+})
+
+test('volume.readFile throws InvalidArgumentError on an explicit null format', async () => {
+  const vol = new Volume('vol-id', 'name', 'tok')
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+    throw new Error('GET should not be called')
+  })
+  await expect(vol.readFile('/x', { format: null as never })).rejects.toThrow(
     InvalidArgumentError
   )
   expect(fetchSpy).not.toHaveBeenCalled()

--- a/packages/js-sdk/tests/readFormat.test.ts
+++ b/packages/js-sdk/tests/readFormat.test.ts
@@ -1,0 +1,43 @@
+import { expect, test, vi } from 'vitest'
+import type { Transport } from '@connectrpc/connect'
+
+import { Filesystem } from '../src/sandbox/filesystem'
+import { ConnectionConfig } from '../src/connectionConfig'
+import { InvalidArgumentError, Volume } from '../src'
+import type { EnvdApiClient } from '../src/envd/api'
+
+function stubFilesystem() {
+  const get = vi.fn(() => {
+    throw new Error('GET should not be called')
+  })
+  const envdApi = {
+    version: '1.0.0',
+    api: { GET: get },
+  } as unknown as EnvdApiClient
+  const fs = new Filesystem(
+    {} as Transport,
+    envdApi,
+    new ConnectionConfig({ apiKey: 'e2b_' + '0'.repeat(40) })
+  )
+  return { fs, get }
+}
+
+test('files.read throws InvalidArgumentError on an unrecognized format', async () => {
+  const { fs, get } = stubFilesystem()
+  await expect(fs.read('/tmp/x', { format: 'Text' as never })).rejects.toThrow(
+    InvalidArgumentError
+  )
+  expect(get).not.toHaveBeenCalled()
+})
+
+test('volume.readFile throws InvalidArgumentError on an unrecognized format', async () => {
+  const vol = new Volume('vol-id', 'name', 'tok')
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+    throw new Error('GET should not be called')
+  })
+  await expect(vol.readFile('/x', { format: 'Text' as never })).rejects.toThrow(
+    InvalidArgumentError
+  )
+  expect(fetchSpy).not.toHaveBeenCalled()
+  fetchSpy.mockRestore()
+})

--- a/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
@@ -5,7 +5,18 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from io import IOBase, TextIOBase
-from typing import IO, AsyncIterator, Dict, Iterator, List, Optional, Union, TypedDict
+from typing import (
+    IO,
+    AsyncIterator,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Union,
+    TypedDict,
+    get_args,
+)
 
 import httpx
 
@@ -345,7 +356,8 @@ METADATA_HEADER_PREFIX = "X-Metadata-"
 _METADATA_KEY_REGEX = re.compile(r"\A[A-Za-z0-9!#$%&'*+\-.^_`|~]+\Z")
 _METADATA_VALUE_REGEX = re.compile(r"\A[\x20-\x7e]*\Z")
 
-_READ_FORMATS = ("text", "bytes", "stream")
+ReadFormat = Literal["text", "bytes", "stream"]
+_READ_FORMATS = get_args(ReadFormat)
 
 
 def validate_read_format(format: str) -> None:

--- a/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox/filesystem/filesystem.py
@@ -345,6 +345,16 @@ METADATA_HEADER_PREFIX = "X-Metadata-"
 _METADATA_KEY_REGEX = re.compile(r"\A[A-Za-z0-9!#$%&'*+\-.^_`|~]+\Z")
 _METADATA_VALUE_REGEX = re.compile(r"\A[\x20-\x7e]*\Z")
 
+_READ_FORMATS = ("text", "bytes", "stream")
+
+
+def validate_read_format(format: str) -> None:
+    """Reject a read format that is not one of the documented literals."""
+    if format not in _READ_FORMATS:
+        raise InvalidArgumentException(
+            f"format must be one of {', '.join(_READ_FORMATS)}."
+        )
+
 
 def validate_metadata(metadata: Optional[Dict[str, str]]) -> None:
     """Validate metadata keys/values before they are sent as upload headers."""

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
@@ -44,6 +44,7 @@ from e2b.exceptions import (
 from e2b.sandbox.filesystem.filesystem import (
     AsyncFileStreamReader,
     EntryInfo,
+    ReadFormat,
     WriteEntry,
     WriteInfo,
     _to_httpx_file,
@@ -192,7 +193,7 @@ class Filesystem:
     async def read(
         self,
         path: str,
-        format: Literal["text", "bytes", "stream"] = "text",
+        format: ReadFormat = "text",
         user: Optional[Username] = None,
         request_timeout: Optional[float] = None,
         gzip: bool = False,

--- a/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_async/filesystem/filesystem.py
@@ -53,6 +53,7 @@ from e2b.sandbox.filesystem.filesystem import (
     metadata_to_headers,
     to_upload_body_async,
     validate_metadata,
+    validate_read_format,
 )
 from e2b.sandbox.filesystem.watch_handle import FilesystemEvent
 from e2b.sandbox_async.filesystem.watch_handle import AsyncWatchHandle
@@ -197,6 +198,7 @@ class Filesystem:
         gzip: bool = False,
         stream_idle_timeout: Optional[float] = None,
     ):
+        validate_read_format(format)
         username = user
         if username is None and self._envd_version < ENVD_DEFAULT_USER:
             username = default_username

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -41,6 +41,7 @@ from e2b.exceptions import (
 from e2b.sandbox.filesystem.filesystem import (
     EntryInfo,
     FileStreamReader,
+    ReadFormat,
     WriteEntry,
     WriteInfo,
     _to_httpx_file,
@@ -185,7 +186,7 @@ class Filesystem:
     def read(
         self,
         path: str,
-        format: Literal["text", "bytes", "stream"] = "text",
+        format: ReadFormat = "text",
         user: Optional[Username] = None,
         request_timeout: Optional[float] = None,
         gzip: bool = False,

--- a/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
+++ b/packages/python-sdk/e2b/sandbox_sync/filesystem/filesystem.py
@@ -50,6 +50,7 @@ from e2b.sandbox.filesystem.filesystem import (
     metadata_to_headers,
     to_upload_body,
     validate_metadata,
+    validate_read_format,
 )
 from e2b.sandbox_sync.filesystem.watch_handle import WatchHandle
 
@@ -190,6 +191,7 @@ class Filesystem:
         gzip: bool = False,
         stream_idle_timeout: Optional[float] = None,
     ):
+        validate_read_format(format)
         username = user
         if username is None and self._envd_version < ENVD_DEFAULT_USER:
             username = default_username

--- a/packages/python-sdk/e2b/volume/volume_async.py
+++ b/packages/python-sdk/e2b/volume/volume_async.py
@@ -32,6 +32,7 @@ from e2b.exceptions import (
     VolumeNotFoundException,
     VolumePathNotFoundException,
 )
+from e2b.sandbox.filesystem.filesystem import validate_read_format
 from e2b.volume.client.api.volumes import (
     get_volumecontent_volume_id_path as get_path,
     get_volumecontent_volume_id_dir as get_dir,
@@ -503,6 +504,7 @@ class AsyncVolume(ClientFactory):
 
         :return: File content as string, bytes, or async iterator of bytes
         """
+        validate_read_format(format)
         config = self._get_volume_config(**opts)
         api_client = get_volume_api_client(config)
 

--- a/packages/python-sdk/e2b/volume/volume_async.py
+++ b/packages/python-sdk/e2b/volume/volume_async.py
@@ -32,7 +32,7 @@ from e2b.exceptions import (
     VolumeNotFoundException,
     VolumePathNotFoundException,
 )
-from e2b.sandbox.filesystem.filesystem import validate_read_format
+from e2b.sandbox.filesystem.filesystem import ReadFormat, validate_read_format
 from e2b.volume.client.api.volumes import (
     get_volumecontent_volume_id_path as get_path,
     get_volumecontent_volume_id_dir as get_dir,
@@ -482,7 +482,7 @@ class AsyncVolume(ClientFactory):
     async def read_file(
         self,
         path: str,
-        format: Literal["text", "bytes", "stream"] = "text",
+        format: ReadFormat = "text",
         stream_idle_timeout: Optional[float] = None,
         **opts: Unpack[VolumeApiParams],
     ) -> Union[str, bytes, AsyncIterator[bytes]]:

--- a/packages/python-sdk/e2b/volume/volume_sync.py
+++ b/packages/python-sdk/e2b/volume/volume_sync.py
@@ -31,7 +31,7 @@ from e2b.exceptions import (
     VolumeNotFoundException,
     VolumePathNotFoundException,
 )
-from e2b.sandbox.filesystem.filesystem import validate_read_format
+from e2b.sandbox.filesystem.filesystem import ReadFormat, validate_read_format
 from e2b.volume.client.api.volumes import (
     get_volumecontent_volume_id_path as get_path,
     get_volumecontent_volume_id_dir as get_dir,
@@ -481,7 +481,7 @@ class Volume(ClientFactory):
     def read_file(
         self,
         path: str,
-        format: Literal["text", "bytes", "stream"] = "text",
+        format: ReadFormat = "text",
         stream_idle_timeout: Optional[float] = None,
         **opts: Unpack[VolumeApiParams],
     ) -> Union[str, bytes, Iterator[bytes]]:

--- a/packages/python-sdk/e2b/volume/volume_sync.py
+++ b/packages/python-sdk/e2b/volume/volume_sync.py
@@ -31,6 +31,7 @@ from e2b.exceptions import (
     VolumeNotFoundException,
     VolumePathNotFoundException,
 )
+from e2b.sandbox.filesystem.filesystem import validate_read_format
 from e2b.volume.client.api.volumes import (
     get_volumecontent_volume_id_path as get_path,
     get_volumecontent_volume_id_dir as get_dir,
@@ -500,6 +501,7 @@ class Volume(ClientFactory):
 
         :return: File content as string, bytes, or iterator of bytes
         """
+        validate_read_format(format)
         config = self._get_volume_config(**opts)
         api_client = get_volume_api_client(config)
 

--- a/packages/python-sdk/tests/test_read_format.py
+++ b/packages/python-sdk/tests/test_read_format.py
@@ -38,6 +38,8 @@ def test_sync_filesystem_read_rejects_unrecognized_format():
     fs = _sync_fs()
     with pytest.raises(InvalidArgumentException, match="format must be one of"):
         fs.read("/tmp/x", cast(Any, "Text"))
+    with pytest.raises(InvalidArgumentException, match="format must be one of"):
+        fs.read("/tmp/x", cast(Any, None))
 
 
 async def test_async_filesystem_read_rejects_unrecognized_format():

--- a/packages/python-sdk/tests/test_read_format.py
+++ b/packages/python-sdk/tests/test_read_format.py
@@ -1,0 +1,68 @@
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from packaging.version import Version
+
+from e2b import AsyncVolume, InvalidArgumentException, Volume
+from e2b.connection_config import ConnectionConfig
+from e2b.sandbox_async.filesystem.filesystem import Filesystem as AsyncFilesystem
+from e2b.sandbox_sync.filesystem.filesystem import Filesystem
+
+API_KEY = "e2b_" + "0" * 40
+
+
+def _sync_fs() -> Filesystem:
+    envd = Mock()
+    envd.get.side_effect = AssertionError("GET should not be called")
+    return Filesystem(
+        "http://127.0.0.1:9",
+        Version("1.0.0"),
+        ConnectionConfig(api_key=API_KEY),
+        envd,
+    )
+
+
+def _async_fs() -> AsyncFilesystem:
+    envd = Mock()
+    envd.get = AsyncMock(side_effect=AssertionError("GET should not be called"))
+    return AsyncFilesystem(
+        "http://127.0.0.1:9",
+        Version("1.0.0"),
+        ConnectionConfig(api_key=API_KEY),
+        envd,
+    )
+
+
+def test_sync_filesystem_read_rejects_unrecognized_format():
+    fs = _sync_fs()
+    with pytest.raises(InvalidArgumentException, match="format must be one of"):
+        fs.read("/tmp/x", cast(Any, "Text"))
+
+
+async def test_async_filesystem_read_rejects_unrecognized_format():
+    fs = _async_fs()
+    with pytest.raises(InvalidArgumentException, match="format must be one of"):
+        await fs.read("/tmp/x", cast(Any, "Text"))
+
+
+def test_sync_volume_read_file_rejects_unrecognized_format():
+    vol = Volume("vol", "name", "tok")
+    with patch(
+        "e2b.volume.volume_sync.get_volume_api_client",
+        side_effect=AssertionError("GET should not be called"),
+    ) as client:
+        with pytest.raises(InvalidArgumentException, match="format must be one of"):
+            vol.read_file("/x", cast(Any, "Text"))
+        client.assert_not_called()
+
+
+async def test_async_volume_read_file_rejects_unrecognized_format():
+    vol = AsyncVolume("vol", "name", "tok")
+    with patch(
+        "e2b.volume.volume_async.get_volume_api_client",
+        side_effect=AssertionError("GET should not be called"),
+    ) as client:
+        with pytest.raises(InvalidArgumentException, match="format must be one of"):
+            await vol.read_file("/x", cast(Any, "Text"))
+        client.assert_not_called()


### PR DESCRIPTION
Fixes https://github.com/e2b-dev/E2B/issues/1823

`files.read` / `Filesystem.read` and `Volume.readFile` / `read_file` dispatch on `format` with no fallback. A value outside the documented literals (`Text`, `txt`) returned `None` from the Python filesystem after a successful GET, and Python volume returned the file as text. JS passed the string through to `parseAs` and did not throw.

Validate immediately after resolving `format`, before the GET. `InvalidArgumentError` / `InvalidArgumentException`: `format must be one of text, bytes, stream.` (JS also allows `blob`). The accepted set is one `ReadFormat` alias per SDK (`get_args` / `as const`). JS defaults only when `format` is `undefined`, so `null` is rejected like Python `None`.

Python shares `validate_read_format` next to `validate_metadata`. JS shares `assertReadFormat` from `src/utils.ts` (named exports, not `export *`).

Testing (no sandbox):

```
cd packages/python-sdk && .venv/bin/python -m pytest tests/test_read_format.py -q
pnpm --dir packages/js-sdk exec vitest run --project unit tests/readFormat.test.ts
```

4 python + 4 JS passed. No-op `validate_read_format` / `assertReadFormat` and the unrecognized-format cases fail with `GET should not be called`.

```py
sandbox.files.read('/tmp/x', format='Text')
```

InvalidArgumentException: format must be one of text, bytes, stream.
