### PR TITLE
fix(sdk): validate secret names in Secret.create

### DIFF
--- a/.changeset/secret-create-validate-name.md
+++ b/.changeset/secret-create-validate-name.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/python-sdk': patch
+---
+
+Reject unusable secret names in `Secret.create` with `InvalidArgumentError` / `InvalidArgumentException` before constructing the API client, matching `Secret.fill`.

--- a/packages/js-sdk/src/secret.ts
+++ b/packages/js-sdk/src/secret.ts
@@ -163,6 +163,8 @@ export class Secret extends ClientFactory {
    *
    * @returns the secret's ID, name, current version (`1` for a new secret),
    * metadata, and creation and update times.
+   *
+   * @throws {InvalidArgumentError} if `name` is empty or contains `{`, `}` or control characters.
    */
   static async create(
     name: string,

--- a/packages/js-sdk/src/secret.ts
+++ b/packages/js-sdk/src/secret.ts
@@ -169,6 +169,8 @@ export class Secret extends ClientFactory {
     value: string,
     opts?: SecretCreateOpts
   ): Promise<SecretInfo> {
+    validateSecretName(name)
+
     const apiOpts = this.resolveOpts(opts)
     const config = new ConnectionConfig(apiOpts)
     const client = new ApiClient(config)

--- a/packages/js-sdk/tests/secret/createName.test.ts
+++ b/packages/js-sdk/tests/secret/createName.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { http } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { InvalidArgumentError, Secret } from '../../src'
+import { TEST_API_KEY, apiUrl } from '../setup'
+
+const server = setupServer(
+  http.post(apiUrl('/secrets'), () => {
+    throw new Error('POST should not be called')
+  })
+)
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterAll(() => server.close())
+afterEach(() => server.resetHandlers())
+
+describe('Secret.create name validation', () => {
+  it.each(['', '{name', 'name}', 'name\n', 'name\x00'])(
+    'should throw InvalidArgumentError for invalid name %j',
+    async (name) => {
+      await expect(
+        Secret.create(name, 'v', { apiKey: TEST_API_KEY })
+      ).rejects.toThrow(InvalidArgumentError)
+    }
+  )
+
+  it('should throw InvalidArgumentError without an API key', async () => {
+    const previous = process.env.E2B_API_KEY
+    delete process.env.E2B_API_KEY
+    try {
+      await expect(Secret.create('', 'v')).rejects.toThrow(InvalidArgumentError)
+    } finally {
+      if (previous === undefined) {
+        delete process.env.E2B_API_KEY
+      } else {
+        process.env.E2B_API_KEY = previous
+      }
+    }
+  })
+})

--- a/packages/python-sdk/e2b/secret/secret_async.py
+++ b/packages/python-sdk/e2b/secret/secret_async.py
@@ -107,6 +107,9 @@ class AsyncSecret(SecretBase):
 
         :return: The secret's ID, name, current version (`1` for a new
             secret), metadata, and creation and update times.
+
+        :raises InvalidArgumentException: If ``name`` is empty or contains
+            ``{``, ``}`` or control characters.
         """
         _validate_secret_name(name)
         config = ConnectionConfig(**cls._resolve_api_params(**opts))

--- a/packages/python-sdk/e2b/secret/secret_async.py
+++ b/packages/python-sdk/e2b/secret/secret_async.py
@@ -20,7 +20,7 @@ from e2b.api.client.types import UNSET
 from e2b.api.client_async import get_api_client
 from e2b.connection_config import ApiParams, ConnectionConfig, merge_api_params
 from e2b.exceptions import SecretException, SecretNotFoundException
-from e2b.secret.base import SecretBase, SecretPaginatorBase
+from e2b.secret.base import SecretBase, SecretPaginatorBase, _validate_secret_name
 from e2b.secret.types import SecretInfo
 
 
@@ -108,6 +108,7 @@ class AsyncSecret(SecretBase):
         :return: The secret's ID, name, current version (`1` for a new
             secret), metadata, and creation and update times.
         """
+        _validate_secret_name(name)
         config = ConnectionConfig(**cls._resolve_api_params(**opts))
         api_client = get_api_client(config)
         res = await post_secrets.asyncio_detailed(

--- a/packages/python-sdk/e2b/secret/secret_sync.py
+++ b/packages/python-sdk/e2b/secret/secret_sync.py
@@ -107,6 +107,9 @@ class Secret(SecretBase):
 
         :return: The secret's ID, name, current version (`1` for a new
             secret), metadata, and creation and update times.
+
+        :raises InvalidArgumentException: If ``name`` is empty or contains
+            ``{``, ``}`` or control characters.
         """
         _validate_secret_name(name)
         config = ConnectionConfig(**cls._resolve_api_params(**opts))

--- a/packages/python-sdk/e2b/secret/secret_sync.py
+++ b/packages/python-sdk/e2b/secret/secret_sync.py
@@ -20,7 +20,7 @@ from e2b.api.client.types import UNSET
 from e2b.api.client_sync import get_api_client
 from e2b.connection_config import ApiParams, ConnectionConfig, merge_api_params
 from e2b.exceptions import SecretException, SecretNotFoundException
-from e2b.secret.base import SecretBase, SecretPaginatorBase
+from e2b.secret.base import SecretBase, SecretPaginatorBase, _validate_secret_name
 from e2b.secret.types import SecretInfo
 
 
@@ -108,6 +108,7 @@ class Secret(SecretBase):
         :return: The secret's ID, name, current version (`1` for a new
             secret), metadata, and creation and update times.
         """
+        _validate_secret_name(name)
         config = ConnectionConfig(**cls._resolve_api_params(**opts))
         api_client = get_api_client(config)
         res = post_secrets.sync_detailed(

--- a/packages/python-sdk/tests/async/secret_async/test_secret.py
+++ b/packages/python-sdk/tests/async/secret_async/test_secret.py
@@ -204,3 +204,17 @@ def test_fill():
 def test_fill_invalid_name_raises(name):
     with pytest.raises(InvalidArgumentException):
         AsyncSecret.fill(name)
+
+
+@pytest.mark.parametrize("name", ["", "{name", "name}", "name\n", "name\x00"])
+async def test_create_invalid_name_raises(name):
+    with pytest.raises(InvalidArgumentException):
+        await AsyncSecret.create(name, "v")
+    assert _secrets == {}
+
+
+async def test_create_invalid_name_without_api_key(monkeypatch):
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    with pytest.raises(InvalidArgumentException):
+        await AsyncSecret.create("", "v")
+    assert _secrets == {}

--- a/packages/python-sdk/tests/sync/secret_sync/test_secret.py
+++ b/packages/python-sdk/tests/sync/secret_sync/test_secret.py
@@ -202,3 +202,17 @@ def test_fill():
 def test_fill_invalid_name_raises(name):
     with pytest.raises(InvalidArgumentException):
         Secret.fill(name)
+
+
+@pytest.mark.parametrize("name", ["", "{name", "name}", "name\n", "name\x00"])
+def test_create_invalid_name_raises(name):
+    with pytest.raises(InvalidArgumentException):
+        Secret.create(name, "v")
+    assert _secrets == {}
+
+
+def test_create_invalid_name_without_api_key(monkeypatch):
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    with pytest.raises(InvalidArgumentException):
+        Secret.create("", "v")
+    assert _secrets == {}


### PR DESCRIPTION
Fixes https://github.com/e2b-dev/E2B/issues/1833

`Secret.fill` already rejects empty names and names that contain `{`, `}`, or control characters. `Secret.create` constructed `ApiClient` / `get_api_client` first, so the same names raised `AuthenticationError` / `AuthenticationException` when the API key was missing, and a mocked API would store the name. I did not apply the check to update/get/destroy; those selectors can be secret IDs.

Call `validateSecretName` / `_validate_secret_name` at the start of `create` (JS, Python sync, Python async). JSDoc `@throws` and Sphinx `:raises` document that failure mode on `create`.

Testing (no live API):

```
pnpm --dir packages/js-sdk exec vitest run --project unit tests/secret/createName.test.ts
cd packages/python-sdk && .venv/bin/python -m pytest tests/sync/secret_sync/test_secret.py tests/async/secret_async/test_secret.py -q
```

6 JS + 42 Python passed. Removing the three `create` checks makes the new cases fail: JS with `AuthenticationError` or `POST should not be called`, Python with `AuthenticationException` or a stored mock secret.

```ts
await Secret.create('', 'v')
// InvalidArgumentError, including when E2B_API_KEY is unset
```
