### PR TITLE
fix(code-interpreter): map unrecognized chart type to UNKNOWN

### DIFF
--- a/.changeset/chart-unknown-type.md
+++ b/.changeset/chart-unknown-type.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter-python': patch
+---
+
+Map an unrecognized chart `type` to `ChartType.UNKNOWN` instead of raising `ValueError`, matching the JS deserializer.

--- a/packages/code-interpreter-python/e2b_code_interpreter/charts.py
+++ b/packages/code-interpreter-python/e2b_code_interpreter/charts.py
@@ -45,7 +45,10 @@ class Chart:
 
     def __init__(self, **kwargs):
         self._raw_data = kwargs
-        self.type = ChartType(kwargs["type"] or ChartType.UNKNOWN)
+        try:
+            self.type = ChartType(kwargs["type"] or ChartType.UNKNOWN)
+        except ValueError:
+            self.type = ChartType.UNKNOWN
         self.title = kwargs["title"]
         self.elements = kwargs["elements"]
 

--- a/packages/code-interpreter-python/tests/charts/test_deserialize_unknown_type.py
+++ b/packages/code-interpreter-python/tests/charts/test_deserialize_unknown_type.py
@@ -1,0 +1,34 @@
+from e2b_code_interpreter.charts import (
+    Chart,
+    ChartType,
+    SuperChart,
+    _deserialize_chart,
+)
+
+
+def test_unrecognized_type_becomes_unknown():
+    chart = _deserialize_chart({"type": "not-a-chart", "title": "x", "elements": []})
+    assert isinstance(chart, Chart)
+    assert chart.type == ChartType.UNKNOWN
+    assert chart.title == "x"
+
+
+def test_unknown_literal_stays_unknown():
+    chart = _deserialize_chart({"type": "unknown", "title": "x", "elements": []})
+    assert chart.type == ChartType.UNKNOWN
+
+
+def test_superchart_nested_unrecognized_type():
+    chart = _deserialize_chart(
+        {
+            "type": "superchart",
+            "title": "s",
+            "elements": [
+                {"type": "not-a-chart", "title": "nested", "elements": []},
+            ],
+        }
+    )
+    assert isinstance(chart, SuperChart)
+    assert len(chart.elements) == 1
+    assert chart.elements[0].type == ChartType.UNKNOWN
+    assert chart.elements[0].title == "nested"


### PR DESCRIPTION
Fixes https://github.com/e2b-dev/E2B/issues/1834

Python `_deserialize_chart` maps an unrecognized type to `Chart(**data)`. `Chart.__init__` then did `ChartType(kwargs["type"])`, which raised `ValueError: 'not-a-chart' is not a valid ChartType`. The JS default branch already sets `ChartType.UNKNOWN`. Python `PointChart` already catches `ValueError` for `ScaleType`.

Same try/except on the `ChartType` parse. A SuperChart child with a bad type now becomes `ChartType.UNKNOWN` instead of aborting the parent.

Testing (no sandbox):

```
cd packages/code-interpreter-python && .venv/bin/python -m pytest tests/charts/test_deserialize_unknown_type.py -q --tb=short -o addopts=
```

3 passed. Restoring `Chart.__init__` to `ChartType(kwargs["type"] or ChartType.UNKNOWN)` makes the unrecognized-type and nested SuperChart cases fail with that ValueError.

```python
chart = _deserialize_chart({"type": "not-a-chart", "title": "x", "elements": []})
chart.type  # ChartType.UNKNOWN
```
