### PR TITLE
feat(cli): honor NO_UPDATE_NOTIFIER to skip the update check

### DIFF
--- a/.changeset/quiet-nix-notifier.md
+++ b/.changeset/quiet-nix-notifier.md
@@ -1,0 +1,5 @@
+---
+'@e2b/cli': patch
+---
+
+Skip the update check when the `NO_UPDATE_NOTIFIER` environment variable is set, so system package managers (for example Nix) can install the CLI without it suggesting updates they cannot apply. Help output now always names the program `e2b` instead of echoing the entrypoint file name.

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -6,6 +6,9 @@ import { sandboxCommand } from './sandbox'
 import { authCommand } from './auth'
 
 export const program = new commander.Command()
+  // Fixed so help reads `e2b` however the entrypoint is invoked (npm bin
+  // symlink, `node dist/index.js`, or a distro wrapper script).
+  .name('e2b')
   .enablePositionalOptions()
   .description(
     `Create sandbox templates from Dockerfiles by running ${asPrimary(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,14 +8,18 @@ import { commands2md } from './utils/commands2md'
 
 export const pkg = packageJSON
 
-const updateCheck = simpleUpdateNotifier({
-  pkg,
-  updateCheckInterval: 1000 * 60 * 60 * 8, // 8 hours
-}).catch((e) => {
-  if (process.env.DEBUG) {
-    console.error('Update check failed:', e)
-  }
-})
+// NO_UPDATE_NOTIFIER is the opt-out shared with `update-notifier`; distro
+// packagers set it because "install the new version" doesn't apply there.
+const updateCheck = process.env.NO_UPDATE_NOTIFIER
+  ? Promise.resolve()
+  : simpleUpdateNotifier({
+      pkg,
+      updateCheckInterval: 1000 * 60 * 60 * 8, // 8 hours
+    }).catch((e) => {
+      if (process.env.DEBUG) {
+        console.error('Update check failed:', e)
+      }
+    })
 
 const prog = program.version(
   packageJSON.version,


### PR DESCRIPTION
## Summary

The CLI runs `simple-update-notifier` on every invocation. When the CLI is installed through a system package manager (nixpkgs, Homebrew), the "New version of @e2b/cli available" box points at an update the user cannot apply through npm, and the check contacts registry.npmjs.org and writes to `~/.config/simple-update-notifier`.

This honors the `NO_UPDATE_NOTIFIER` environment variable, the opt-out convention from `update-notifier`, so packaging wrappers can disable the check without patching the source. An empty value counts as unset.

It also pins the commander program name to `e2b`. Wrappers that invoke `dist/index.js` directly otherwise get `Usage: index [options] [command]` in help output.

The nixpkgs package for the CLI ([NixOS/nixpkgs#560988](https://github.com/NixOS/nixpkgs/pull/560988)) sets this variable in its wrapper; it takes effect from the first CLI release that includes this change.

Linear: SDK-376

## Usage

```sh
# No update check, no network call, nothing written under ~/.config
NO_UPDATE_NOTIFIER=1 e2b template list
```

## Test plan

- [x] `pnpm run format`, `pnpm run lint`, `pnpm run typecheck` in `packages/cli`
- [x] `pnpm test` in `packages/cli`: 118 passed; the only failing file needs `E2B_API_KEY` and is unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
