### PR TITLE
fix(sdk): validate Volume.create names against the OpenAPI pattern

### DIFF
--- a/.changeset/volume-create-validate-name.md
+++ b/.changeset/volume-create-validate-name.md
@@ -1,0 +1,6 @@
+---
+'e2b': patch
+'@e2b/python-sdk': patch
+---
+
+Reject volume names outside `^[a-zA-Z0-9_-]+$` in `Volume.create` before constructing the API client.

--- a/packages/js-sdk/src/volume/index.ts
+++ b/packages/js-sdk/src/volume/index.ts
@@ -15,6 +15,7 @@ import {
 } from '../connectionConfig'
 import { isArrayBufferLike, isBlobLike } from '../is'
 import {
+  InvalidArgumentError,
   VolumeError,
   VolumeNotFoundError,
   VolumePathNotFoundError,
@@ -29,6 +30,17 @@ import type {
   VolumeReadOpts,
   VolumeWriteOpts,
 } from './types'
+
+// OpenAPI NewVolume.name pattern.
+const VOLUME_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/
+
+function validateVolumeName(name: string): void {
+  if (typeof name !== 'string' || !VOLUME_NAME_PATTERN.test(name)) {
+    throw new InvalidArgumentError(
+      `volume name ${JSON.stringify(name)} is invalid: must contain only letters, numbers, dashes and underscores.`
+    )
+  }
+}
 
 /**
  * Convert API VolumeEntryStat to SDK VolumeEntryStat.
@@ -122,6 +134,7 @@ export class Volume extends ClientFactory {
     name: string,
     opts?: ConnectionOpts
   ): Promise<InstanceType<V>> {
+    validateVolumeName(name)
     const apiOpts = this.resolveOpts(opts)
     const config = new ConnectionConfig(apiOpts)
     const client = new ApiClient(config)

--- a/packages/js-sdk/tests/volume/createName.test.ts
+++ b/packages/js-sdk/tests/volume/createName.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { http } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { InvalidArgumentError, Volume } from '../../src'
+import { TEST_API_KEY, apiUrl } from '../setup'
+
+const server = setupServer(
+  http.post(apiUrl('/volumes'), () => {
+    throw new Error('POST should not be called')
+  })
+)
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterAll(() => server.close())
+afterEach(() => server.resetHandlers())
+
+describe('Volume.create name validation', () => {
+  it.each(['', 'vol name', 'vol.name', 'vol/a', '{x}'])(
+    'should throw InvalidArgumentError for invalid name %j',
+    async (name) => {
+      await expect(
+        Volume.create(name, { apiKey: TEST_API_KEY })
+      ).rejects.toThrow(InvalidArgumentError)
+    }
+  )
+
+  it('should throw InvalidArgumentError without an API key', async () => {
+    const previous = process.env.E2B_API_KEY
+    delete process.env.E2B_API_KEY
+    try {
+      await expect(Volume.create('')).rejects.toThrow(InvalidArgumentError)
+    } finally {
+      if (previous === undefined) {
+        delete process.env.E2B_API_KEY
+      } else {
+        process.env.E2B_API_KEY = previous
+      }
+    }
+  })
+})

--- a/packages/python-sdk/e2b/volume/utils.py
+++ b/packages/python-sdk/e2b/volume/utils.py
@@ -1,9 +1,22 @@
 import datetime
+import re
 from typing import Optional
 
+from e2b.exceptions import InvalidArgumentException
 from e2b.volume.client.models import VolumeEntryStat as VolumeEntryStatApi
 from e2b.volume.client.types import UNSET
 from e2b.volume.types import VolumeEntryStat
+
+# OpenAPI NewVolume.name pattern.
+VOLUME_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def validate_volume_name(name: str) -> None:
+    if not isinstance(name, str) or not VOLUME_NAME_PATTERN.fullmatch(name):
+        raise InvalidArgumentException(
+            f"volume name {name!r} is invalid: must contain only letters, "
+            "numbers, dashes and underscores."
+        )
 
 
 def _ensure_utc(dt: datetime.datetime) -> datetime.datetime:

--- a/packages/python-sdk/e2b/volume/volume_async.py
+++ b/packages/python-sdk/e2b/volume/volume_async.py
@@ -64,6 +64,7 @@ from e2b.io_utils import aiter_io_chunks
 from e2b.volume.utils import (
     DualMethod,
     convert_volume_entry_stat,
+    validate_volume_name,
 )
 
 
@@ -121,6 +122,7 @@ class AsyncVolume(ClientFactory):
 
         :return: An AsyncVolume instance for the new volume
         """
+        validate_volume_name(name)
         config = ConnectionConfig(**cls._resolve_api_params(**opts))
 
         api_client = get_core_api_client(config)

--- a/packages/python-sdk/e2b/volume/volume_sync.py
+++ b/packages/python-sdk/e2b/volume/volume_sync.py
@@ -63,6 +63,7 @@ from e2b.io_utils import iter_io_chunks
 from e2b.volume.utils import (
     DualMethod,
     convert_volume_entry_stat,
+    validate_volume_name,
 )
 
 
@@ -120,6 +121,7 @@ class Volume(ClientFactory):
 
         :return: A Volume instance for the new volume
         """
+        validate_volume_name(name)
         config = ConnectionConfig(**cls._resolve_api_params(**opts))
 
         api_client = get_core_api_client(config)

--- a/packages/python-sdk/tests/async/volume_async/test_volume.py
+++ b/packages/python-sdk/tests/async/volume_async/test_volume.py
@@ -5,7 +5,11 @@ import pytest
 
 from e2b import AsyncVolume
 from e2b.connection_config import ConnectionConfig
-from e2b.exceptions import NotFoundException, VolumeNotFoundException
+from e2b.exceptions import (
+    InvalidArgumentException,
+    NotFoundException,
+    VolumeNotFoundException,
+)
 from e2b.api.client.models.volume_and_token import VolumeAndToken
 from e2b.api.client.types import Response
 import e2b.api.client.api.volumes.post_volumes as post_volumes_mod
@@ -226,3 +230,17 @@ async def test_volume_full_lifecycle():
     # List again
     volumes = await AsyncVolume.list()
     assert len(volumes) == 0
+
+
+@pytest.mark.parametrize("name", ["", "vol name", "vol.name", "vol/a", "{x}"])
+async def test_create_invalid_name_raises(name):
+    with pytest.raises(InvalidArgumentException):
+        await AsyncVolume.create(name)
+    assert _volumes == {}
+
+
+async def test_create_invalid_name_without_api_key(monkeypatch):
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    with pytest.raises(InvalidArgumentException):
+        await AsyncVolume.create("")
+    assert _volumes == {}

--- a/packages/python-sdk/tests/sync/volume_sync/test_volume.py
+++ b/packages/python-sdk/tests/sync/volume_sync/test_volume.py
@@ -5,7 +5,11 @@ import pytest
 
 from e2b import Volume
 from e2b.connection_config import ConnectionConfig
-from e2b.exceptions import NotFoundException, VolumeNotFoundException
+from e2b.exceptions import (
+    InvalidArgumentException,
+    NotFoundException,
+    VolumeNotFoundException,
+)
 from e2b.api.client.models.volume_and_token import VolumeAndToken
 from e2b.api.client.types import Response
 import e2b.api.client.api.volumes.post_volumes as post_volumes_mod
@@ -224,3 +228,17 @@ def test_volume_full_lifecycle():
     # List again
     volumes = Volume.list()
     assert len(volumes) == 0
+
+
+@pytest.mark.parametrize("name", ["", "vol name", "vol.name", "vol/a", "{x}"])
+def test_create_invalid_name_raises(name):
+    with pytest.raises(InvalidArgumentException):
+        Volume.create(name)
+    assert _volumes == {}
+
+
+def test_create_invalid_name_without_api_key(monkeypatch):
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    with pytest.raises(InvalidArgumentException):
+        Volume.create("")
+    assert _volumes == {}


### PR DESCRIPTION
Fixes https://github.com/e2b-dev/E2B/issues/1841

OpenAPI `NewVolume.name` is `^[a-zA-Z0-9_-]+$`. `Volume.create('')` with no API key raised `AuthenticationException` / `AuthenticationError` from the API client. A name like `vol name` never got a client-side check.

`validateVolumeName` / `validate_volume_name` at the start of `create` (JS, Python sync, Python async). I did not validate `connect` selectors. Those are volume IDs.

Testing (no live API):

```
cd packages/python-sdk && .venv/bin/python -m pytest tests/sync/volume_sync/test_volume.py tests/async/volume_async/test_volume.py -q --tb=short
pnpm --dir packages/js-sdk exec vitest run --project unit tests/volume/createName.test.ts
```

19 sync + 19 async Python passed (6 new name cases each). 6 JS passed. Removing the three `create` checks makes the new cases fail with `AuthenticationException` / `AuthenticationError` or a stored mock volume.

```ts
await Volume.create('')
// InvalidArgumentError, including when E2B_API_KEY is unset
```
