### PR TITLE
fix(code-interpreter): map unrecognized scale types to UNKNOWN

### DIFF
--- a/.changeset/js-scale-unknown.md
+++ b/.changeset/js-scale-unknown.md
@@ -2,4 +2,4 @@
 '@e2b/code-interpreter': patch
 ---
 
-Map unrecognized chart `x_scale`/`y_scale` to `ScaleType.UNKNOWN`, matching Python.
+Map unrecognized chart `x_scale`/`y_scale` to `ScaleType.UNKNOWN`, matching Python. Deserialize SuperChart from `elements` so `Result` can run `deserializeChart`.

--- a/.changeset/js-scale-unknown.md
+++ b/.changeset/js-scale-unknown.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter': patch
+---
+
+Map unrecognized chart `x_scale`/`y_scale` to `ScaleType.UNKNOWN`, matching Python.

--- a/packages/code-interpreter-js/src/charts.ts
+++ b/packages/code-interpreter-js/src/charts.ts
@@ -24,6 +24,16 @@ export enum ScaleType {
   FUNCTION = 'function',
   FUNCTIONLOG = 'functionlog',
   ASINH = 'asinh',
+  UNKNOWN = 'unknown',
+}
+
+const SCALE_TYPES = new Set<string>(Object.values(ScaleType))
+
+function parseScaleType(value: unknown): ScaleType {
+  if (typeof value === 'string' && SCALE_TYPES.has(value)) {
+    return value as ScaleType
+  }
+  return ScaleType.UNKNOWN
 }
 
 /**
@@ -117,9 +127,17 @@ export type ChartTypes =
 export function deserializeChart(data: any): Chart {
   switch (data.type) {
     case ChartType.LINE:
-      return { ...data } as LineChart
+      return {
+        ...data,
+        x_scale: parseScaleType(data.x_scale),
+        y_scale: parseScaleType(data.y_scale),
+      } as LineChart
     case ChartType.SCATTER:
-      return { ...data } as ScatterChart
+      return {
+        ...data,
+        x_scale: parseScaleType(data.x_scale),
+        y_scale: parseScaleType(data.y_scale),
+      } as ScatterChart
     case ChartType.BAR:
       return { ...data } as BarChart
     case ChartType.PIE:

--- a/packages/code-interpreter-js/src/charts.ts
+++ b/packages/code-interpreter-js/src/charts.ts
@@ -127,31 +127,23 @@ export type ChartTypes =
 export function deserializeChart(data: any): Chart {
   switch (data.type) {
     case ChartType.LINE:
-      return {
-        ...data,
-        x_scale: parseScaleType(data.x_scale),
-        y_scale: parseScaleType(data.y_scale),
-      } as LineChart
     case ChartType.SCATTER:
       return {
         ...data,
         x_scale: parseScaleType(data.x_scale),
         y_scale: parseScaleType(data.y_scale),
-      } as ScatterChart
+      } as LineChart | ScatterChart
     case ChartType.BAR:
       return { ...data } as BarChart
     case ChartType.PIE:
       return { ...data } as PieChart
     case ChartType.BOX_AND_WHISKER:
       return { ...data } as BoxAndWhiskerChart
-    case ChartType.SUPERCHART: {
-      const charts: Chart[] = data.data.map((g: any) => deserializeChart(g))
-      delete data.data
+    case ChartType.SUPERCHART:
       return {
         ...data,
-        data: charts,
+        elements: (data.elements ?? []).map((g: any) => deserializeChart(g)),
       } as SuperChart
-    }
     default:
       return { ...data, type: ChartType.UNKNOWN } as Chart
   }

--- a/packages/code-interpreter-js/src/messaging.ts
+++ b/packages/code-interpreter-js/src/messaging.ts
@@ -1,5 +1,5 @@
 import { NotFoundError, SandboxError, TimeoutError } from 'e2b'
-import { ChartTypes } from './charts'
+import { ChartTypes, deserializeChart } from './charts'
 
 export async function extractError(res: Response, includeDiagnostics = false) {
   if (res.ok) {
@@ -183,6 +183,8 @@ export class Result {
 
     this.data = data['data']
     this.chart = data['chart']
+      ? (deserializeChart(data['chart']) as ChartTypes)
+      : undefined
 
     this.extra = {}
 

--- a/packages/code-interpreter-js/tests/charts/deserializeScale.test.ts
+++ b/packages/code-interpreter-js/tests/charts/deserializeScale.test.ts
@@ -57,3 +57,26 @@ test('Result maps unrecognized scales through deserializeChart', () => {
   expect(result.chart?.x_scale).toBe(ScaleType.UNKNOWN)
   expect(result.chart?.y_scale).toBe(ScaleType.LOG)
 })
+
+test('Result maps unrecognized scales on SuperChart children', () => {
+  const result = new Result(
+    {
+      chart: {
+        type: ChartType.SUPERCHART,
+        title: 't',
+        elements: [
+          {
+            ...pointChart,
+            x_scale: 'not-a-scale',
+          },
+        ],
+      },
+    },
+    true
+  )
+
+  expect(result.chart?.type).toBe(ChartType.SUPERCHART)
+  expect(result.chart?.elements[0]).toMatchObject({
+    x_scale: ScaleType.UNKNOWN,
+  })
+})

--- a/packages/code-interpreter-js/tests/charts/deserializeScale.test.ts
+++ b/packages/code-interpreter-js/tests/charts/deserializeScale.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from 'vitest'
+
+import { ChartType, deserializeChart, ScaleType } from '../../src/charts'
+
+const pointChart = {
+  type: ChartType.LINE,
+  title: 't',
+  elements: [],
+  x_ticks: [],
+  y_ticks: [],
+  x_tick_labels: [],
+  y_tick_labels: [],
+  x_scale: 'linear',
+  y_scale: 'log',
+}
+
+test('deserializeChart maps an unrecognized scale to ScaleType.UNKNOWN', () => {
+  const chart = deserializeChart({
+    ...pointChart,
+    x_scale: 'not-a-scale',
+  })
+
+  expect(chart.x_scale).toBe(ScaleType.UNKNOWN)
+  expect(chart.y_scale).toBe(ScaleType.LOG)
+})
+
+test('deserializeChart keeps a valid scale', () => {
+  const chart = deserializeChart(pointChart)
+
+  expect(chart.x_scale).toBe(ScaleType.LINEAR)
+  expect(chart.y_scale).toBe(ScaleType.LOG)
+})
+
+test('deserializeChart maps unrecognized scatter scales', () => {
+  const chart = deserializeChart({
+    ...pointChart,
+    type: ChartType.SCATTER,
+    y_scale: 'nope',
+  })
+
+  expect(chart.x_scale).toBe(ScaleType.LINEAR)
+  expect(chart.y_scale).toBe(ScaleType.UNKNOWN)
+})

--- a/packages/code-interpreter-js/tests/charts/deserializeScale.test.ts
+++ b/packages/code-interpreter-js/tests/charts/deserializeScale.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 
 import { ChartType, deserializeChart, ScaleType } from '../../src/charts'
+import { Result } from '../../src/messaging'
 
 const pointChart = {
   type: ChartType.LINE,
@@ -40,4 +41,19 @@ test('deserializeChart maps unrecognized scatter scales', () => {
 
   expect(chart.x_scale).toBe(ScaleType.LINEAR)
   expect(chart.y_scale).toBe(ScaleType.UNKNOWN)
+})
+
+test('Result maps unrecognized scales through deserializeChart', () => {
+  const result = new Result(
+    {
+      chart: {
+        ...pointChart,
+        x_scale: 'not-a-scale',
+      },
+    },
+    true
+  )
+
+  expect(result.chart?.x_scale).toBe(ScaleType.UNKNOWN)
+  expect(result.chart?.y_scale).toBe(ScaleType.LOG)
 })


### PR DESCRIPTION
Fixes https://github.com/e2b-dev/E2B/issues/1839

Python `PointChart` maps unrecognized `x_scale` / `y_scale` to `ScaleType.UNKNOWN`. JS `ScaleType` had no UNKNOWN, `deserializeChart` spread the payload, and `Result` assigned `data['chart']` raw, so `runCode` never parsed scales.

Calling `deserializeChart` from `Result` also hit SuperChart. That branch mapped `data.data` and mutated the payload. The kernel and Python SuperChart use `elements`, so a subplot figure threw TypeError in the Result constructor.

Added `ScaleType.UNKNOWN`, parse line/scatter scales, `Result.chart` via `deserializeChart`, and SuperChart `elements` without mutating the input.

```
cd packages/code-interpreter-js && ./node_modules/.bin/vitest run tests/charts/deserializeScale.test.ts
```

5 passed. Restoring `this.chart = data['chart']` fails the line Result case with `not-a-scale`. Restoring SuperChart to `data.data.map` throws on `.map` for the SuperChart Result case.
