### PR TITLE
ci: prevent Lint and Generated files required checks from false-greening

### DIFF
--- a/.github/workflows/generated_files.yml
+++ b/.github/workflows/generated_files.yml
@@ -38,7 +38,14 @@ jobs:
               - '.github/workflows/generated_files.yml'
 
   check-generated:
-    name: Generated files
+    # Not the required check itself (see `status` below): a job skipped via
+    # job-level `if` reports as a *successful* check run, so if this carried
+    # the "Generated files" name directly, a failure in `changes`
+    # (dorny/paths-filter erroring instead of resolving to `false`) would
+    # skip this job and the branch protection required check would show
+    # green without the codegen freshness check ever having run. `status`
+    # exists to close exactly that gap.
+    name: Run generated files check
     needs: changes
     if: ${{ needs.changes.outputs.generated == 'true' }}
     runs-on: ubuntu-latest
@@ -138,3 +145,28 @@ jobs:
           else
             echo "✅ No changes detected."
           fi
+
+  status:
+    name: Generated files
+    # `changes` is included so a failure in change-detection (which would skip
+    # `check-generated`, reporting it as a successful no-op per GitHub Actions
+    # semantics) surfaces as a failed required check instead of a false green.
+    # Mirrors the `status` job in sdk_tests.yml.
+    needs:
+      - changes
+      - check-generated
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report aggregate result
+        run: |
+          echo "Job results: ${{ join(needs.*.result, ', ') }}"
+          if ${{ contains(needs.*.result, 'failure') }}; then
+            echo "::error::Change detection or the generated files check failed."
+            exit 1
+          fi
+          if ${{ contains(needs.*.result, 'cancelled') }}; then
+            echo "::error::Change detection or the generated files check was cancelled; freshness was not verified — re-run before merging."
+            exit 1
+          fi
+          echo "Generated files check passed or was skipped because no relevant files changed."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,13 @@ jobs:
               - '.github/workflows/lint.yml'
 
   lint:
-    name: Lint
+    # Not the required check itself (see `status` below): a job skipped via
+    # job-level `if` reports as a *successful* check run, so if this carried
+    # the "Lint" name directly, a failure in `changes` (dorny/paths-filter
+    # erroring instead of resolving to `false`) would skip this job and the
+    # branch protection required check would show green without lint ever
+    # having run. `status` exists to close exactly that gap.
+    name: Run Lint
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
@@ -99,3 +105,28 @@ jobs:
           else
             echo "✅ No changes detected."
           fi
+
+  status:
+    name: Lint
+    # `changes` is included so a failure in change-detection (which would skip
+    # `lint`, reporting it as a successful no-op per GitHub Actions semantics)
+    # surfaces as a failed required check instead of a false green. Mirrors
+    # the `status` job in sdk_tests.yml.
+    needs:
+      - changes
+      - lint
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report aggregate result
+        run: |
+          echo "Job results: ${{ join(needs.*.result, ', ') }}"
+          if ${{ contains(needs.*.result, 'failure') }}; then
+            echo "::error::Change detection or Lint failed."
+            exit 1
+          fi
+          if ${{ contains(needs.*.result, 'cancelled') }}; then
+            echo "::error::Change detection or Lint was cancelled; linting was not verified — re-run before merging."
+            exit 1
+          fi
+          echo "Lint passed or was skipped because no relevant files changed."


### PR DESCRIPTION
## Summary

`lint.yml` and `generated_files.yml` gate their real work job (`lint`, `check-generated`) with `needs: changes` plus a job-level `if` on the `dorny/paths-filter` output, and the *work job itself* carries the required-check name ("Lint" / "Generated files").

GitHub Actions reports a job skipped via a job-level `if` as a **successful** check run (this is documented GitHub behavior, not workflow-specific: https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/using-conditions-to-control-job-execution, and written up concretely at https://emmer.dev/blog/skippable-github-status-checks-aren-t-really-required/).

So if the `changes` job ever errors instead of cleanly resolving to `false` — a `dorny/paths-filter` bug, an API hiccup, or a diff large enough to hit the action's known limits — `lint` / `check-generated` are skipped as a side effect (a job only runs if all of its `needs` succeeded), and the required checks named **"Lint"** and **"Generated files"** report green on `main`'s branch protection without linting or the codegen freshness check ever having actually run.

`sdk_tests.yml` already guards against exactly this failure mode, with its own `status` job explicitly commenting on it:

> `changes` is included so a failure in change-detection (which would skip the suites) surfaces as a failed required check instead of a false green.

That guard was never applied to the other two required checks configured on `main` (`Lint`, `Generated files` — confirmed via `GET /repos/e2b-dev/E2B/rulesets/5078477`, alongside `SDK Tests Status`), so this PR brings them in line with the same, already-established pattern.

## Change

- Rename the real work jobs off the required-check names: `lint` → *Run Lint*, `check-generated` → *Run generated files check*.
- Add a `status` job to each workflow, structurally identical to `sdk_tests.yml`'s: `needs: [changes, <work job>]`, `if: always()`, fails if either result is `failure` or `cancelled`. This job takes over the "Lint" / "Generated files" name, so branch protection needs no changes — GitHub Actions rulesets match required checks by name.

No behavior change on the common paths: a passing run still passes, a docs-only PR still skips cleanly (skip is still success — only an actual `changes` failure now surfaces), and a real lint/codegen-drift failure still fails the same required-check name it always did.

## Test plan

- [x] Both files parse as valid YAML (`yaml.safe_load`).
- [x] Expression syntax (`join(needs.*.result, ', ')`, `contains(needs.*.result, 'failure'|'cancelled')`) copied verbatim from `sdk_tests.yml`'s already-running `status` job.
- [x] Traced all `changes`/work-job result combinations by hand (success/success, success/skipped-on-docs-only-PR, failure/skipped — the bug this fixes, success/failure, success/cancelled) against the new `status` job logic.
- [ ] Not verified: an actual CI run on this PR (will show once opened) and a live `changes`-job failure, since I didn't want to sabotage the action on a real PR just to reproduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)