### PR TITLE
Add an experimental Windows-in-sandbox template (nested QEMU/KVM)

### DIFF
--- a/templates/windows-nested/README.md
+++ b/templates/windows-nested/README.md
@@ -1,0 +1,162 @@
+# windows-nested — a Windows desktop inside an E2B sandbox (experimental)
+
+**Status: experimental.** This template is a working proof of concept, not a supported
+product feature. It runs on a self-hosted [E2B Local](https://github.com/e2b-dev/infra-local)
+stack with the changes listed under Prerequisites; it does not build on E2B Cloud today.
+Numbers below come from one lab host at three levels of virtualization and are not a
+performance promise.
+
+The sandbox is a Debian 12 Linux VM, as always. Inside it, QEMU/KVM boots a pre-installed
+Windows disk; noVNC serves the Windows console over HTTP on port 6080 and Windows answers
+RDP on port 3389. Nothing in the E2B platform changes: the whole thing is a template with a
+start command.
+
+```
+templates/windows-nested/
+├── e2b.Dockerfile        Debian 12 + qemu-system-x86 + noVNC + the Windows disk + win/
+├── win/                  scripts that run inside the sandbox
+│   ├── qemu-common.sh    the QEMU command line (env: WIN_MEM, WIN_SMP, WIN_RDP_PORT, WIN_DIR)
+│   ├── build-snapshot.sh relaunch mode: build-time boot, RDP wait, `savevm`, quit
+│   ├── winctl.py         relaunch mode: start command, relaunches Windows on sandbox start
+│   ├── start-live.sh     live mode: start command, boots Windows and leaves it running
+│   ├── rdpcheck.py       X.224 RDP liveness probe (a TCP connect is not enough behind QEMU's hostfwd)
+│   └── qmp.py            minimal QMP client (savevm, quit, screendump)
+├── template.py           template definition, Python SDK
+├── template.ts           template definition, JavaScript SDK
+└── image/                build-disk.sh + README: producing the Windows disk (never committed)
+```
+
+## Prerequisites
+
+1. **A guest kernel with KVM built in.** Stock E2B sandbox kernels do not enable
+   `CONFIG_KVM_INTEL`, so a sandbox has no `/dev/kvm` and the `vmx` CPU flag is masked. The
+   kernel has to be rebuilt from infra's `packages/fc-kernels` with
+   `CONFIG_VIRTUALIZATION=y CONFIG_KVM=y CONFIG_KVM_INTEL=y` (the only config change),
+   installed next to the stock kernels, and selected for the build (`DEFAULT_KERNEL_VERSION`
+   on E2B Local; the `build-kernel-version` feature flag in the platform). VMX itself passes
+   through Firecracker with no CPU template. Nested virtualization must be on in the host
+   (`kvm_intel nested=Y`).
+2. **A registry the template builder can pull from.** The image built from `e2b.Dockerfile`
+   is about 10 GB. Sandboxes cannot reach RFC 1918 addresses, but the template builder runs
+   in the host network and can, so on E2B Local a plain registry on the bridge address works
+   (push with `skopeo copy --dest-tls-verify=false`; Docker's own push insists on TLS).
+3. **Sandbox size and disk.** 8 vCPU and 8 GiB (6 GiB is enough when Windows gets 4 GiB); the
+   template's free disk has to fit the Windows disk plus, in relaunch mode, the saved guest memory
+   (about 2.3 GiB): 16 GB of free disk in the tier is comfortable. The **node** needs about 40 GB
+   free per build (base layer, RUN layer and memory snapshots of a 26 GB rootfs); a build that
+   fills the node's disk takes the orchestrator down with it.
+4. **Hugepages on the node** for an 8 GiB sandbox: an 8 GiB memfd cannot be mapped from the
+   stock E2B Local 4 GiB pool (`uffd ... mmap memfd: cannot allocate memory`).
+5. **The Windows disk** — see [image/README.md](image/README.md). Evaluation media only, with
+   the licence limits that implies.
+
+Live mode adds two more (below).
+
+## Two modes
+
+| | relaunch (default) | live |
+|---|---|---|
+| what the snapshot holds | Linux only; Windows saved with QEMU's own `savevm` at build time | a live nested VM: QEMU with Windows running |
+| start command | `winctl.py` waits for the sandbox start and runs `qemu -loadvm win` | `start-live.sh` cold-boots Windows; the ready command is the RDP probe |
+| Firecracker | stock | a build that saves and restores KVM nested state (`KVM_GET/SET_NESTED_STATE`); not in any release |
+| guest kernel | KVM-enabled | KVM-enabled **and** booted with `no-kvmapf` (built-in command line, or the `build-kernel-cmdline-args` feature flag) |
+| RDP answers after `Sandbox.create()` | **4.4–8.4 s** (see Measured) | **0.8–1.5 s** |
+| pause / resume | not safe: Firecracker drops the nested VM's state; Windows in the old QEMU is dead after resume and is not relaunched | works; RDP back about 1.4 s after `connect` |
+| build time | 6.5–10 min, of which Windows cold boot to RDP is about 5 min | about 8.5 min |
+
+**Relaunch mode** exists because stock Firecracker does not save KVM nested (VMX) state: a
+snapshot taken while QEMU runs restores to a guest kernel panic. So the build boots Windows
+once, waits for a real RDP answer, takes a QEMU internal snapshot (`savevm win`, about 2.3 GiB
+of non-zero guest pages into the qcow2) and quits QEMU before the sandbox snapshot is taken.
+On every sandbox start `winctl.py` notices the start and launches a fresh QEMU with
+`-loadvm win`. The start signal is the jump in `CLOCK_REALTIME - CLOCK_MONOTONIC`: envd sets
+the wall clock to host time on every start while the monotonic clock continues from the
+snapshot, so the offset jumps by exactly the time the template spent frozen. It fires within
+0.1 s of `create()`. `touch /opt/win/start-now` from `sandbox.commands.run` is the fallback.
+
+**Live mode** leaves Windows running through the Firecracker snapshot, so a sandbox comes up
+with Windows already there. It was verified on 2026-09-08 with a nested-state Firecracker
+build plus `no-kvmapf` in the guest kernel command line (E2B's internal experiment report
+`ASYNC-PF-RESULT.md`): four of four sandboxes resumed with the build-time QEMU process still
+running, RDP answering 0.84–1.54 s after `create()`, pause and resume kept the same QEMU with
+RDP back 1.36 s after `connect()`, and the guest kernel logged nothing. Without `no-kvmapf` the
+resumed guest panics with `Host injected async #PF in kernel mode` (E2B's lazy memory restore
+meets KVM's paravirtual async page faults on a vCPU that has been in nested-guest mode);
+without the nested-state Firecracker it panics in `kvm_spurious_fault`. Neither piece is in
+a released Firecracker or in the E2B Cloud, which is why live mode is documented here and not
+re-verified by the relaunch-mode steps below.
+
+## Build
+
+```sh
+cd templates/windows-nested
+WIN_PASSWORD='...' image/build-disk.sh                      # once, on a KVM host: image/{win.qcow2,OVMF_CODE.fd,OVMF_VARS.qcow2}
+docker build -f e2b.Dockerfile -t REGISTRY/windows-nested:1 .
+docker save REGISTRY/windows-nested:1 -o /tmp/wn.tar && skopeo copy --dest-tls-verify=false docker-archive:/tmp/wn.tar docker://REGISTRY/windows-nested:1
+
+python template.py REGISTRY/windows-nested:1 windows-nested                 # relaunch mode, 8 vCPU / 8192 MB
+python template.py REGISTRY/windows-nested:1 windows-nested-live --mode live
+npx tsx template.ts REGISTRY/windows-nested:1 windows-nested                # same, JavaScript SDK
+```
+
+`template.py` and `template.ts` take the image reference and the template name, plus
+`--mode relaunch|live`, `--cpu`, `--memory-mb` and `--skip-cache` (rebuild the `savevm`
+layer even when the image reference did not change). The Dockerfile's `COPY` sources are
+build args (`WIN_DISK`, `OVMF_CODE`, `OVMF_VARS`) for a disk kept elsewhere.
+
+## Use
+
+```python
+from e2b import Sandbox
+
+sbx = Sandbox.create(template="windows-nested", timeout=1800)
+print(f"https://{sbx.get_host(6080)}/vnc.html")   # noVNC, the Windows console in a browser
+sbx.commands.run("python3 /opt/win/rdpcheck.py")  # "rdp up" once Windows answers
+```
+
+- **noVNC** is the browser path: `get_host(6080)` goes through the sandbox HTTP proxy. In
+  relaunch mode the page is up about 0.5 s after RDP; before that the console is blank.
+- **RDP** is TCP on port 3389 inside the sandbox. The sandbox proxy is HTTP-only, so an RDP
+  client needs its own TCP path into the sandbox (a tunnel through a command in the sandbox,
+  or a client run inside it); the local administrator is the one baked in by `build-disk.sh`.
+- `/opt/win/state.json` (relaunch) and `/opt/win/heartbeat` (live) carry the start command's
+  timeline: `resume_detected`, `qemu_started`, `rdp_up`.
+
+## Measured
+
+Relaunch mode, E2B Local on one bare-metal host. Windows there is a third-level guest
+(host → E2B Local VM → Firecracker sandbox → QEMU), the same depth as a cloud VM node. `t = 0`
+is the `Sandbox.create()` call; in-sandbox stamps are wall-clock after envd set the guest clock.
+
+| run | sandbox up (envd) | start detected | QEMU `-loadvm` started | RDP answers (X.224) | in-sandbox `rdpcheck.py` | noVNC `/vnc.html` 200 via `get_host(6080)` |
+|---|---|---|---|---|---|---|
+| 1 | 0.10 s | 0.11 s | 0.12 s | **4.73 s** | up @ 6.22 s | 200 @ 6.27 s |
+| 2 | 0.07 s | 0.07 s | 0.08 s | **4.40 s** | up @ 5.62 s | 200 @ 5.64 s |
+| 3 | 0.09 s | 0.11 s | 0.11 s | **4.48 s** | up @ 5.54 s | 200 @ 5.55 s |
+
+Three consecutive sandboxes from the same build, quiet host (2026-09-08). The probe and noVNC
+columns are when the sequential test script got round to them, not when the service came up.
+
+Build of the same template: Windows cold boot to RDP 290–292 s at this nesting depth
+(6.2 s on the bare host with the same QEMU arguments), `savevm` 2–3 s, whole build
+6 m 36 s with the 10 GB base layer already cached (about 10 min when the image is pulled first). The PoC that this template generalises measured 5.0–8.4 s to RDP over six
+sandboxes and 16 s under CPU contention from a concurrent build.
+
+Footprint per running Windows sandbox: about 2.5 GiB of hugepages resident on the node
+(Windows' 1 GiB of non-zero pages after `-loadvm`, Debian, page cache); the sandbox's 8 GiB
+is reserved, not resident.
+
+## Known limits
+
+- **Not sub-second, not on E2B Cloud.** Relaunch mode restores 2.3 GiB of guest memory on
+  every create and pays the nested-virtualization tax: the warm path is 4–6× the bare-host
+  number, cold boot about 50×. The prerequisites are not available on E2B Cloud today.
+- **Pause is unsafe in relaunch mode** and `winctl.py` does not relaunch Windows after a second
+  start. Live mode handles pause, but on a 26 GB-rootfs template the orchestrator's rootfs
+  export on pause timed out 2 of 3 times on E2B Local — a template-size limit, not a
+  Windows one.
+- **Long-running stability is unproven.** The longest hold measured was a few minutes; one
+  early run (with a different Hyper-V enlightenment set, since replaced) stalled after 25 min.
+- **`savevm` stores the vmstate in the first snapshot-capable drive**, which is
+  `OVMF_VARS.qcow2` here. Harmless; both files live in `/opt/win`.
+- **Licence.** Evaluation media, 180-day trial, unactivated. See `image/README.md`.

--- a/templates/windows-nested/e2b.Dockerfile
+++ b/templates/windows-nested/e2b.Dockerfile
@@ -1,0 +1,19 @@
+# Experimental: a Windows guest under QEMU/KVM inside the sandbox, reachable
+# over noVNC (:6080) and RDP (:3389). See README.md for the prerequisites.
+FROM debian:12
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  qemu-system-x86 qemu-utils novnc websockify python3 procps ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
+
+# Produced by image/build-disk.sh; never committed.
+ARG WIN_DISK=image/win.qcow2
+ARG OVMF_CODE=image/OVMF_CODE.fd
+ARG OVMF_VARS=image/OVMF_VARS.qcow2
+
+# The disk layer first so script edits below do not re-copy it.
+COPY ${WIN_DISK} /opt/win/win.qcow2
+COPY ${OVMF_CODE} /opt/win/OVMF_CODE.fd
+COPY ${OVMF_VARS} /opt/win/OVMF_VARS.qcow2
+COPY win/ /opt/win/
+RUN chmod +x /opt/win/*.sh /opt/win/*.py

--- a/templates/windows-nested/image/.gitignore
+++ b/templates/windows-nested/image/.gitignore
@@ -1,0 +1,7 @@
+*.qcow2
+*.fd
+*.img
+*.raw
+*.rom
+*.vars
+dockur-storage/

--- a/templates/windows-nested/image/README.md
+++ b/templates/windows-nested/image/README.md
@@ -1,0 +1,47 @@
+# Windows disk for the windows-nested template
+
+`e2b.Dockerfile` copies three files from this directory, none of which are
+committed (see `.gitignore`):
+
+| file | what |
+|---|---|
+| `win.qcow2` | the installed Windows system disk, qcow2, zstd-compressed (about 10 GB for a 32 GiB virtual disk) |
+| `OVMF_CODE.fd` | UEFI firmware code the install booted with (read-only pflash) |
+| `OVMF_VARS.qcow2` | UEFI variables holding the "Windows Boot Manager" entry, as qcow2 so QEMU `savevm` accepts the drive |
+
+`build-disk.sh` produces them with [dockur/windows](https://github.com/dockur/windows),
+which downloads the installer from Microsoft and runs an unattended install under
+KVM. It needs a Linux host with `/dev/kvm`, Docker, `qemu-img`, `python3`, about
+20 GB of free disk and roughly 15 to 30 minutes, most of it the ISO download and
+the install.
+
+```sh
+WIN_PASSWORD='choose-one' ./build-disk.sh
+```
+
+The script waits until the installed Windows answers RDP (that is when the unattended
+install, first logon and the auto-configured RDP are all done), lets it settle,
+shuts it down over ACPI, and converts the raw disk. You can watch the install in a
+browser at `http://127.0.0.1:8006` on the host while it runs.
+
+Settings, all environment variables with defaults:
+
+| variable | default | notes |
+|---|---|---|
+| `WIN_VERSION` | `2025` | dockur version code; `2025` is Windows Server 2025, `11` is Windows 11. Server needs no TPM, which is what the template's QEMU configuration assumes |
+| `WIN_USERNAME` / `WIN_PASSWORD` | `e2b` / required | local administrator baked into the disk; auto-logon and RDP are enabled by dockur |
+| `WIN_DISK_SIZE` | `32G` | virtual size; the qcow2 only stores used blocks |
+| `WIN_RAM_SIZE` / `WIN_CPU_CORES` | `6G` / `4` | install-time sizing; the template boots the disk with `WIN_MEM=4096` and `WIN_SMP=4` (see `win/qemu-common.sh`) |
+| `DOCKUR_WEB_PORT` / `DOCKUR_RDP_PORT` | `8006` / `3389` | loopback ports for the installer's web view and for the RDP readiness probe |
+| `WIN_INSTALL_TIMEOUT` / `WIN_SETTLE` | `7200` / `180` | seconds |
+
+The disk is installed with the virtio drivers dockur ships: virtio-scsi system disk,
+virtio-net, virtio VGA, USB tablet. `win/qemu-common.sh` presents the same devices, so the
+disk boots unchanged inside the sandbox.
+
+## Licence
+
+dockur downloads **evaluation media**: a 180-day trial, unactivated. That is fine for
+trying this template out and it is not a licence to run Windows in production. Bring
+your own licensing and media before using this for anything else, and never commit or
+publish the disk you produce.

--- a/templates/windows-nested/image/build-disk.sh
+++ b/templates/windows-nested/image/build-disk.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Produce the Windows disk and UEFI firmware pair that e2b.Dockerfile copies:
+# an unattended dockur/windows install on a KVM host, shut down cleanly and
+# converted to a compressed qcow2. See README.md in this directory.
+#
+# usage: build-disk.sh [OUTDIR]   (default: the directory of this script)
+# env:   WIN_VERSION=2025 WIN_USERNAME=e2b WIN_PASSWORD=... WIN_DISK_SIZE=32G
+#        WIN_RAM_SIZE=6G WIN_CPU_CORES=4 DOCKUR_IMAGE=ghcr.io/dockur/windows
+#        DOCKUR_WEB_PORT=8006 DOCKUR_RDP_PORT=3389 WIN_INSTALL_TIMEOUT=7200 WIN_SETTLE=180
+set -euo pipefail
+OUT=$(realpath "${1:-$(dirname "$0")}")
+: "${WIN_PASSWORD:?set WIN_PASSWORD (the local admin password baked into the disk)}"
+WIN_VERSION=${WIN_VERSION:-2025}
+WIN_USERNAME=${WIN_USERNAME:-e2b}
+WIN_DISK_SIZE=${WIN_DISK_SIZE:-32G}
+WIN_RAM_SIZE=${WIN_RAM_SIZE:-6G}
+WIN_CPU_CORES=${WIN_CPU_CORES:-4}
+DOCKUR_IMAGE=${DOCKUR_IMAGE:-ghcr.io/dockur/windows}
+DOCKUR_WEB_PORT=${DOCKUR_WEB_PORT:-8006}
+DOCKUR_RDP_PORT=${DOCKUR_RDP_PORT:-3389}
+WIN_INSTALL_TIMEOUT=${WIN_INSTALL_TIMEOUT:-7200}
+WIN_SETTLE=${WIN_SETTLE:-180}
+NAME=windows-nested-build
+STORAGE=$OUT/dockur-storage
+RDPCHECK=$(dirname "$0")/../win/rdpcheck.py
+
+[ -c /dev/kvm ] || { echo "/dev/kvm missing: dockur needs a KVM host"; exit 1; }
+mkdir -p "$STORAGE"
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+docker run -d --name "$NAME" \
+  -e VERSION="$WIN_VERSION" -e DISK_SIZE="$WIN_DISK_SIZE" -e RAM_SIZE="$WIN_RAM_SIZE" -e CPU_CORES="$WIN_CPU_CORES" \
+  -e USERNAME="$WIN_USERNAME" -e PASSWORD="$WIN_PASSWORD" -e LANGUAGE=English -e REGION=en-US -e KEYBOARD=en-US \
+  -p 127.0.0.1:"$DOCKUR_WEB_PORT":8006 -p 127.0.0.1:"$DOCKUR_RDP_PORT":3389/tcp \
+  -v "$STORAGE":/storage \
+  --device=/dev/kvm --device=/dev/net/tun --cap-add NET_ADMIN --stop-timeout 180 \
+  "$DOCKUR_IMAGE" >/dev/null
+echo "installer running; watch it at http://127.0.0.1:$DOCKUR_WEB_PORT"
+
+T0=$(date +%s)
+until python3 "$RDPCHECK" 127.0.0.1 "$DOCKUR_RDP_PORT" >/dev/null 2>&1; do
+  sleep 15
+  if (( $(date +%s) - T0 > WIN_INSTALL_TIMEOUT )); then echo "timeout waiting for the installed Windows to answer RDP"; exit 1; fi
+  docker ps -q -f name="$NAME" | grep -q . || { echo "installer container exited"; docker logs --tail 20 "$NAME"; exit 1; }
+done
+echo "Windows answers RDP after $(( $(date +%s) - T0 ))s; settling for ${WIN_SETTLE}s"
+sleep "$WIN_SETTLE"
+
+echo "shutting Windows down (ACPI)"
+docker stop -t 180 "$NAME" >/dev/null
+docker rm "$NAME" >/dev/null
+
+echo "converting to compressed qcow2"
+qemu-img convert -p -f raw -O qcow2 -c -o compression_type=zstd "$STORAGE/data.img" "$OUT/win.qcow2"
+cp "$STORAGE/windows.rom" "$OUT/OVMF_CODE.fd"
+qemu-img convert -f raw -O qcow2 "$STORAGE/windows.vars" "$OUT/OVMF_VARS.qcow2"
+rm -rf "$STORAGE"
+qemu-img info "$OUT/win.qcow2" | grep -E "virtual size|disk size"
+ls -la "$OUT"/win.qcow2 "$OUT"/OVMF_CODE.fd "$OUT"/OVMF_VARS.qcow2

--- a/templates/windows-nested/template.py
+++ b/templates/windows-nested/template.py
@@ -1,0 +1,47 @@
+"""Build the windows-nested template from a pushed image.
+
+usage: python template.py IMAGE NAME [--mode relaunch|live] [--cpu N] [--memory-mb N] [--skip-cache]
+
+  IMAGE  OCI reference of the image built from e2b.Dockerfile, in a registry the
+         template builder can pull from
+  NAME   template name (or name:tag)
+"""
+
+import argparse
+import time
+
+from e2b import Template, wait_for_file
+
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+)
+parser.add_argument("image")
+parser.add_argument("name")
+parser.add_argument("--mode", choices=["relaunch", "live"], default="relaunch")
+parser.add_argument("--cpu", type=int, default=8)
+parser.add_argument("--memory-mb", type=int, default=8192)
+parser.add_argument("--skip-cache", action="store_true")
+args = parser.parse_args()
+
+template = Template().from_image(args.image).set_user("root").set_workdir("/opt/win")
+if args.mode == "relaunch":
+    template = template.run_cmd("bash /opt/win/build-snapshot.sh").set_start_cmd(
+        "python3 /opt/win/winctl.py", wait_for_file("/opt/win/winctl.ready")
+    )
+else:
+    template = template.set_start_cmd(
+        "bash /opt/win/start-live.sh", "python3 /opt/win/rdpcheck.py"
+    )
+
+t0 = time.monotonic()
+info = Template.build(
+    template,
+    args.name,
+    cpu_count=args.cpu,
+    memory_mb=args.memory_mb,
+    skip_cache=args.skip_cache,
+    on_build_logs=lambda entry: print(entry, flush=True),
+)
+print(
+    f"built {args.name} ({args.mode}) template_id={info.template_id} build_id={info.build_id} in {time.monotonic() - t0:.0f}s"
+)

--- a/templates/windows-nested/template.ts
+++ b/templates/windows-nested/template.ts
@@ -1,0 +1,53 @@
+// Build the windows-nested template from a pushed image.
+//
+// usage: npx tsx template.ts IMAGE NAME [--mode relaunch|live] [--cpu N] [--memory-mb N] [--skip-cache]
+//
+//   IMAGE  OCI reference of the image built from e2b.Dockerfile, in a registry the
+//          template builder can pull from
+//   NAME   template name (or name:tag)
+
+import { Template, waitForFile } from 'e2b'
+
+const argv = process.argv.slice(2)
+const positional = argv.filter((a) => !a.startsWith('--'))
+const option = (name: string) => {
+  const i = argv.indexOf(`--${name}`)
+  return i === -1 ? undefined : argv[i + 1]
+}
+const [image, name] = positional
+if (!image || !name) {
+  console.error(
+    'usage: template.ts IMAGE NAME [--mode relaunch|live] [--cpu N] [--memory-mb N] [--skip-cache]'
+  )
+  process.exit(2)
+}
+const mode = option('mode') ?? 'relaunch'
+if (mode !== 'relaunch' && mode !== 'live') {
+  console.error(`unknown mode ${mode}`)
+  process.exit(2)
+}
+
+const base = Template().fromImage(image).setUser('root').setWorkdir('/opt/win')
+const template =
+  mode === 'relaunch'
+    ? base
+        .runCmd('bash /opt/win/build-snapshot.sh')
+        .setStartCmd(
+          'python3 /opt/win/winctl.py',
+          waitForFile('/opt/win/winctl.ready')
+        )
+    : base.setStartCmd(
+        'bash /opt/win/start-live.sh',
+        'python3 /opt/win/rdpcheck.py'
+      )
+
+const t0 = performance.now()
+const info = await Template.build(template, name, {
+  cpuCount: Number(option('cpu') ?? 8),
+  memoryMB: Number(option('memory-mb') ?? 8192),
+  skipCache: argv.includes('--skip-cache'),
+  onBuildLogs: (entry) => console.log(entry.toString()),
+})
+console.log(
+  `built ${name} (${mode}) templateId=${info.templateId} buildId=${info.buildId} in ${((performance.now() - t0) / 1000).toFixed(0)}s`
+)

--- a/templates/windows-nested/win/build-snapshot.sh
+++ b/templates/windows-nested/win/build-snapshot.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Relaunch mode, build-time RUN step: boot Windows, wait for RDP, QEMU `savevm win`,
+# quit. No nested VM may be alive when the sandbox snapshot is taken.
+set -euo pipefail
+WIN_DIR=${WIN_DIR:-/opt/win}
+WIN_BOOT_TIMEOUT=${WIN_BOOT_TIMEOUT:-2700}
+WIN_SETTLE=${WIN_SETTLE:-60}
+cd "$WIN_DIR"; source ./qemu-common.sh
+T0=$(date +%s)
+log(){ echo "[$(date -u +%FT%TZ) +$(( $(date +%s) - T0 ))s] $*" | tee -a build.log; }
+
+log "kvm=$(ls /dev/kvm 2>&1) vmx=$(grep -c vmx /proc/cpuinfo) nproc=$(nproc) mem_mb=$(free -m | awk '/Mem/{print $2}') free=$(df -h / | awk 'NR==2{print $4}')"
+rm -f qmp.sock qemu.pid
+qemu-system-x86_64 "${QEMU_ARGS[@]}" -daemonize
+log "qemu started pid=$(cat qemu.pid)"
+until python3 rdpcheck.py 127.0.0.1 "$WIN_RDP_PORT" >/dev/null 2>&1; do
+  sleep 3
+  if (( $(date +%s) - T0 > WIN_BOOT_TIMEOUT )); then
+    log "TIMEOUT waiting for RDP"; python3 qmp.py screendump "$WIN_DIR/build-fail.ppm" || true; exit 1
+  fi
+done
+log "RDP answers"
+sleep "$WIN_SETTLE"
+T1=$(date +%s)
+python3 qmp.py hmp "savevm win"
+log "savevm done in $(( $(date +%s) - T1 ))s"
+python3 qmp.py quit || true
+while kill -0 "$(cat qemu.pid 2>/dev/null)" 2>/dev/null; do sleep 1; done
+log "qemu exited"
+qemu-img snapshot -l win.qcow2 | tee -a build.log
+df -h / | tee -a build.log

--- a/templates/windows-nested/win/qemu-common.sh
+++ b/templates/windows-nested/win/qemu-common.sh
@@ -1,0 +1,21 @@
+# QEMU invocation shared by build (savevm) and run (loadvm): a loadvm needs the same machine.
+WIN_DIR=${WIN_DIR:-/opt/win}
+WIN_MEM=${WIN_MEM:-4096}
+WIN_SMP=${WIN_SMP:-4}
+WIN_RDP_PORT=${WIN_RDP_PORT:-3389}
+
+# Explicit Hyper-V enlightenments: hv_passthrough and migratable=no make the vCPU
+# non-migratable and QEMU refuses savevm. -vmx hides nesting from Windows.
+QEMU_ARGS=(
+  -name win -machine q35,smm=off,accel=kvm,graphics=off,vmport=off,hpet=off -enable-kvm
+  -cpu host,kvm=on,-vmx,+hypervisor,hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_time,hv_frequencies,hv_vpindex,hv_runtime
+  -smp "$WIN_SMP" -m "$WIN_MEM"
+  -drive if=pflash,unit=0,format=raw,readonly=on,file="$WIN_DIR/OVMF_CODE.fd"
+  -drive if=pflash,unit=1,format=qcow2,file="$WIN_DIR/OVMF_VARS.qcow2"
+  -drive file="$WIN_DIR/win.qcow2",id=data,format=qcow2,cache=writeback,if=none
+  -device virtio-scsi-pci,id=scsi0 -device scsi-hd,drive=data,bus=scsi0.0,bootindex=1
+  -netdev user,id=n0,hostfwd=tcp:0.0.0.0:"$WIN_RDP_PORT"-:3389 -device virtio-net-pci,netdev=n0
+  -device qemu-xhci -device usb-tablet -vga virtio -vnc 127.0.0.1:0
+  -qmp unix:"$WIN_DIR/qmp.sock",server,nowait -display none -pidfile "$WIN_DIR/qemu.pid"
+  -rtc base=localtime -global ICH9-LPC.disable_s3=1 -global ICH9-LPC.disable_s4=1
+)

--- a/templates/windows-nested/win/qmp.py
+++ b/templates/windows-nested/win/qmp.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Minimal QMP client. usage: qmp.py hmp "<monitor command>" | screendump <file.ppm> | quit | query-status"""
+
+import json
+import os
+import socket
+import sys
+
+SOCK = os.environ.get(
+    "QMP_SOCK", os.path.join(os.environ.get("WIN_DIR", "/opt/win"), "qmp.sock")
+)
+
+
+def cmd(execute, **args):
+    return (
+        json.dumps(
+            {"execute": execute, **({"arguments": args} if args else {})}
+        ).encode()
+        + b"\n"
+    )
+
+
+s = socket.socket(socket.AF_UNIX)
+s.settimeout(1800)
+s.connect(SOCK)
+f = s.makefile("rb")
+f.readline()
+s.sendall(cmd("qmp_capabilities"))
+f.readline()
+what = sys.argv[1]
+if what == "hmp":
+    s.sendall(cmd("human-monitor-command", **{"command-line": sys.argv[2]}))
+elif what == "screendump":
+    s.sendall(cmd("screendump", filename=sys.argv[2]))
+else:
+    s.sendall(cmd(what))
+while True:
+    line = f.readline()
+    if not line:
+        break
+    msg = json.loads(line)
+    if "return" in msg or "error" in msg:
+        print(json.dumps(msg))
+        sys.exit(1 if "error" in msg else 0)

--- a/templates/windows-nested/win/rdpcheck.py
+++ b/templates/windows-nested/win/rdpcheck.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""RDP liveness: an X.224 Connection Request answered by a Connection Confirm.
+A bare TCP connect is not enough: QEMU's user-mode hostfwd accepts before the
+guest port is open. usage: rdpcheck.py [host] [port]"""
+
+import socket
+import sys
+
+host = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
+port = int(sys.argv[2]) if len(sys.argv) > 2 else 3389
+cookie = b"Cookie: mstshash=e2b\r\n"
+neg = bytes.fromhex("0100080003000000")  # RDP_NEG_REQ: PROTOCOL_SSL|HYBRID
+x224 = bytes([6 + len(cookie) + len(neg), 0xE0, 0, 0, 0, 0, 0]) + cookie + neg
+tpkt = bytes([3, 0]) + (4 + len(x224)).to_bytes(2, "big") + x224
+try:
+    s = socket.create_connection((host, port), timeout=3)
+    s.settimeout(5)
+    s.sendall(tpkt)
+    r = s.recv(64)
+    s.close()
+    ok = len(r) >= 7 and r[0] == 0x03 and r[5] == 0xD0
+    print("rdp", "up" if ok else f"odd-reply {r.hex()}")
+    sys.exit(0 if ok else 1)
+except OSError as e:
+    print("rdp down", e)
+    sys.exit(1)

--- a/templates/windows-nested/win/start-live.sh
+++ b/templates/windows-nested/win/start-live.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Live mode start command: cold-boot Windows and leave QEMU running, so the
+# template snapshot holds a live nested VM. The ready command (rdpcheck.py) gates
+# the snapshot. Needs a Firecracker that restores KVM nested state and a guest
+# kernel booted with no-kvmapf; with stock Firecracker the resumed sandbox panics.
+set -uo pipefail
+WIN_DIR=${WIN_DIR:-/opt/win}
+cd "$WIN_DIR"; source ./qemu-common.sh
+log(){ echo "[$(date -u +%FT%TZ) mono=$(cut -d' ' -f1 /proc/uptime)] $*" >> live.log; }
+
+rm -f qmp.sock qemu.pid
+qemu-system-x86_64 "${QEMU_ARGS[@]}" -daemonize
+log "qemu started pid=$(cat qemu.pid)"
+setsid websockify --web /usr/share/novnc 0.0.0.0:6080 127.0.0.1:5900 </dev/null >websockify.out 2>&1 &
+while true; do
+  st=$(python3 rdpcheck.py 127.0.0.1 "$WIN_RDP_PORT" 2>&1)
+  q=$(kill -0 "$(cat qemu.pid 2>/dev/null)" 2>/dev/null && echo qemu-alive || echo qemu-dead)
+  echo "$(date -u +%s) $(cut -d' ' -f1 /proc/uptime) $q $st" >> heartbeat
+  sleep 5
+done

--- a/templates/windows-nested/win/winctl.py
+++ b/templates/windows-nested/win/winctl.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Relaunch mode start command: idle at build time; on sandbox create it launches
+Windows from the QEMU snapshot (-loadvm win) plus noVNC and records timings.
+
+Resume signal: envd sets CLOCK_REALTIME to host time on every start while
+CLOCK_MONOTONIC continues from the snapshot, so (realtime - monotonic) jumps by
+the time the template spent frozen. `touch $WIN_DIR/start-now` is the fallback."""
+
+import json
+import os
+import subprocess
+import time
+
+D = os.environ.get("WIN_DIR", "/opt/win")
+LOG, STATE, TRIGGER = f"{D}/winctl.log", f"{D}/state.json", f"{D}/start-now"
+RDP_PORT = os.environ.get("WIN_RDP_PORT", "3389")
+JUMP_S = 3.0
+RDP_TIMEOUT_S = 1800
+state = {"events": []}
+
+
+def log(msg, **kv):
+    w, m = time.time(), time.monotonic()
+    state["events"].append({"event": msg, "wall": w, "mono": m, **kv})
+    with open(LOG, "a") as f:
+        f.write(
+            f"{time.strftime('%FT%TZ', time.gmtime(w))} mono={m:.3f} {msg} {kv or ''}\n"
+        )
+    with open(STATE + ".tmp", "w") as f:
+        json.dump(state, f)
+    os.replace(STATE + ".tmp", STATE)
+
+
+def qemu_args():
+    out = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'source "{D}/qemu-common.sh"; printf "%s\\n" "${{QEMU_ARGS[@]}}"',
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return out.rstrip("\n").split("\n")
+
+
+def rdp_up():
+    return (
+        subprocess.run(
+            ["python3", f"{D}/rdpcheck.py", "127.0.0.1", RDP_PORT], capture_output=True
+        ).returncode
+        == 0
+    )
+
+
+def launch(reason):
+    for p in ("qmp.sock", "qemu.pid"):
+        try:
+            os.remove(f"{D}/{p}")
+        except FileNotFoundError:
+            pass
+    q = subprocess.Popen(
+        ["qemu-system-x86_64", *qemu_args(), "-loadvm", "win"],
+        stdout=open(f"{D}/qemu.out", "a"),
+        stderr=subprocess.STDOUT,
+    )
+    log("qemu_started", reason=reason, pid=q.pid)
+    subprocess.Popen(
+        ["websockify", "--web", "/usr/share/novnc", "0.0.0.0:6080", "127.0.0.1:5900"],
+        stdout=open(f"{D}/websockify.out", "a"),
+        stderr=subprocess.STDOUT,
+    )
+    log("websockify_started")
+    t0 = time.monotonic()
+    while time.monotonic() - t0 < RDP_TIMEOUT_S:
+        if q.poll() is not None:
+            log("qemu_exited", rc=q.returncode)
+            return
+        if rdp_up():
+            log("rdp_up", after_s=round(time.monotonic() - t0, 2))
+            return
+        time.sleep(0.5)
+    log("rdp_timeout")
+
+
+open(LOG, "a").close()
+log("watcher_started", pid=os.getpid(), kvm=os.path.exists("/dev/kvm"))
+base = time.time() - time.monotonic()
+open(f"{D}/winctl.ready", "w").close()
+launched = False
+while True:
+    off = time.time() - time.monotonic()
+    jump = off - base
+    trig = os.path.exists(TRIGGER)
+    if abs(jump) > JUMP_S or trig:
+        reason = "trigger-file" if trig else f"clock-jump {jump:.1f}s"
+        if trig:
+            os.remove(TRIGGER)
+        log("resume_detected", reason=reason, jump_s=round(jump, 3))
+        base = off
+        if launched:
+            log("already_launched_ignoring")
+        else:
+            launched = True
+            launch(reason)
+    time.sleep(0.2)


### PR DESCRIPTION
Adds `templates/windows-nested/`: a Debian + QEMU/KVM + noVNC template that boots a pre-installed Windows disk inside the sandbox, in two modes — saved-state relaunch (stock Firecracker; RDP answers 4.4–4.7 s after `Sandbox.create()` on E2B Local, verified from these files) and live (Windows kept running through the snapshot; needs a nested-state Firecracker and `no-kvmapf`, documented only) — plus the dockur/windows recipe for the disk. Not added to `templates.yml` and no SDK code or binaries: CI cannot build it.

Prerequisites: a guest kernel with `CONFIG_KVM_INTEL`, a registry the template builder can pull the ~10 GB image from, 8 vCPU / 8 GiB sandboxes with ~40 GB of node disk per build, and Windows evaluation media (180-day trial, unactivated). Sponsor: Tomas Srnka.