### PR TITLE
docs(sdk): onResume needs a control plane that knows the option

### DIFF
--- a/.changeset/on-resume-control-plane-caveat.md
+++ b/.changeset/on-resume-control-plane-caveat.md
@@ -1,0 +1,6 @@
+---
+"e2b": patch
+"@e2b/python-sdk": patch
+---
+
+Document that `onResume` / `on_resume` needs a control plane that knows the option: an older self-hosted or BYOC control plane drops the `memory` field and restores memory while reporting success, instead of rejecting the request.

--- a/packages/js-sdk/src/sandbox/sandboxApi.ts
+++ b/packages/js-sdk/src/sandbox/sandboxApi.ts
@@ -710,6 +710,12 @@ export type SandboxConnectOpts = ConnectionOpts & {
    * is not enabled; a no-op for a snapshot without memory or a sandbox that is
    * already running.
    *
+   * Needs a control plane that knows this option: E2B Cloud, or a self-hosted
+   * or BYOC deployment built from `e2b-dev/infra` at or after the commit that
+   * added the `memory` field to connect/resume (2026-08-20). An older control
+   * plane drops the field and restores memory while answering as if the
+   * request had succeeded.
+   *
    * @default 'restore'
    * @throws {@link InvalidArgumentError} if the value is outside the two literals.
    */

--- a/packages/python-sdk/e2b/sandbox_async/main.py
+++ b/packages/python-sdk/e2b/sandbox_async/main.py
@@ -284,6 +284,10 @@ class AsyncSandbox(SandboxApi):
             Rejected where filesystem-only resume is not enabled; a no-op for a snapshot
             without memory or a sandbox that is already running. A value outside the two
             literals raises `InvalidArgumentException`.
+            Needs a control plane that knows this option: E2B Cloud, or a self-hosted or BYOC
+            deployment built from `e2b-dev/infra` at or after the commit that added the `memory`
+            field to connect/resume (2026-08-20). An older control plane drops the field and
+            restores memory while answering as if the request had succeeded.
         :return: A running sandbox instance
 
         @example
@@ -322,6 +326,10 @@ class AsyncSandbox(SandboxApi):
             Rejected where filesystem-only resume is not enabled; a no-op for a snapshot
             without memory or a sandbox that is already running. A value outside the two
             literals raises `InvalidArgumentException`.
+            Needs a control plane that knows this option: E2B Cloud, or a self-hosted or BYOC
+            deployment built from `e2b-dev/infra` at or after the commit that added the `memory`
+            field to connect/resume (2026-08-20). An older control plane drops the field and
+            restores memory while answering as if the request had succeeded.
         :return: A running sandbox instance
 
         @example
@@ -356,6 +364,10 @@ class AsyncSandbox(SandboxApi):
             Rejected where filesystem-only resume is not enabled; a no-op for a snapshot
             without memory or a sandbox that is already running. A value outside the two
             literals raises `InvalidArgumentException`.
+            Needs a control plane that knows this option: E2B Cloud, or a self-hosted or BYOC
+            deployment built from `e2b-dev/infra` at or after the commit that added the `memory`
+            field to connect/resume (2026-08-20). An older control plane drops the field and
+            restores memory while answering as if the request had succeeded.
         :return: A running sandbox instance
 
         @example

--- a/packages/python-sdk/e2b/sandbox_sync/main.py
+++ b/packages/python-sdk/e2b/sandbox_sync/main.py
@@ -278,6 +278,10 @@ class Sandbox(SandboxApi):
             Rejected where filesystem-only resume is not enabled; a no-op for a snapshot
             without memory or a sandbox that is already running. A value outside the two
             literals raises `InvalidArgumentException`.
+            Needs a control plane that knows this option: E2B Cloud, or a self-hosted or BYOC
+            deployment built from `e2b-dev/infra` at or after the commit that added the `memory`
+            field to connect/resume (2026-08-20). An older control plane drops the field and
+            restores memory while answering as if the request had succeeded.
         :return: A running sandbox instance
 
         @example
@@ -317,6 +321,10 @@ class Sandbox(SandboxApi):
             Rejected where filesystem-only resume is not enabled; a no-op for a snapshot
             without memory or a sandbox that is already running. A value outside the two
             literals raises `InvalidArgumentException`.
+            Needs a control plane that knows this option: E2B Cloud, or a self-hosted or BYOC
+            deployment built from `e2b-dev/infra` at or after the commit that added the `memory`
+            field to connect/resume (2026-08-20). An older control plane drops the field and
+            restores memory while answering as if the request had succeeded.
         :return: A running sandbox instance
 
         @example
@@ -351,6 +359,10 @@ class Sandbox(SandboxApi):
             Rejected where filesystem-only resume is not enabled; a no-op for a snapshot
             without memory or a sandbox that is already running. A value outside the two
             literals raises `InvalidArgumentException`.
+            Needs a control plane that knows this option: E2B Cloud, or a self-hosted or BYOC
+            deployment built from `e2b-dev/infra` at or after the commit that added the `memory`
+            field to connect/resume (2026-08-20). An older control plane drops the field and
+            restores memory while answering as if the request had succeeded.
         :return: A running sandbox instance
 
         @example


### PR DESCRIPTION
**Gap**: the `onResume` / `on_resume` docstrings say the API rejects `memory: false` wherever the flag is off. On a control plane that predates the field (self-hosted or a lagging BYOC cluster) the resume body is bound without `DisallowUnknownFields`, so the field is dropped and the sandbox resumes memory-restored with a 2xx — the silent downgrade the option exists to avoid. Not client-detectable (no capability handshake), and the SDK is already on npm/PyPI.

**Change**: one deployment-caveat paragraph in the JSDoc and in all six Python `:param on_resume:` docstrings, in the shape the `egressProxy` option already uses: needs E2B Cloud or an `e2b-dev/infra` build at or after the commit that added the `memory` field (2026-08-20); an older control plane drops the field and restores memory while reporting success. Patch changeset for both packages so the published docstrings pick it up.

**Verification**: prettier and ruff format clean; docstring-only, no code paths touched.