### PR TITLE
feat(sdk): add getGrpcTarget for sandbox gRPC over HTTPS

### DIFF
--- a/.changeset/sandbox-public-grpc.md
+++ b/.changeset/sandbox-public-grpc.md
@@ -1,0 +1,6 @@
+---
+'e2b': minor
+'@e2b/python-sdk': minor
+---
+
+Add `getGrpcTarget` / `get_grpc_target` so gRPC clients can dial sandbox servers over the public HTTPS host.

--- a/.changeset/sandbox-public-grpc.md
+++ b/.changeset/sandbox-public-grpc.md
@@ -1,6 +1,8 @@
 ---
 'e2b': minor
 '@e2b/python-sdk': minor
+'@e2b/desktop': patch
+'@e2b/desktop-python': patch
 ---
 
-Add `getGrpcTarget` / `get_grpc_target` so gRPC clients can dial sandbox servers over the public HTTPS host.
+Add `getGrpcTarget` / `get_grpc_target` so gRPC clients can dial sandbox servers over the public HTTPS host. Desktop packages depend on core 2.50.0 so existing Desktop installs pick up the helper on upgrade.

--- a/packages/desktop-js/README.md
+++ b/packages/desktop-js/README.md
@@ -263,6 +263,23 @@ const desktop = await Sandbox.create()
 await desktop.wait(1000) // Wait for 1 second
 ```
 
+### Connecting to a gRPC server from your computer
+
+A gRPC server inside the sandbox is reachable on `localhost` there. From your
+machine, dial the public HTTPS host on port 443 — not a raw `host:50051`
+socket. `getHost` is the hostname; `getGrpcTarget` is the address a gRPC
+client should use:
+
+```javascript
+import { Sandbox } from '@e2b/desktop'
+
+const desktop = await Sandbox.create()
+await desktop.commands.run('python grpc_server.py', { background: true })
+
+const target = desktop.getGrpcTarget(50051)
+// Dial target with TLS credentials (port 443). In debug mode this is localhost:{port}.
+```
+
 ## Under the hood
 
 The desktop-like environment is based on Linux and [Xfce](https://www.xfce.org/) at the moment. We chose Xfce because it's a fast and lightweight environment that's also popular and actively supported. However, this Sandbox template is fully customizable and you can create your own desktop environment.

--- a/packages/desktop-python/README.md
+++ b/packages/desktop-python/README.md
@@ -256,6 +256,27 @@ desktop = Sandbox.create()
 desktop.wait(1000) # Wait for 1 second
 ```
 
+### Connecting to a gRPC server from your computer
+
+A gRPC server inside the sandbox is reachable on `localhost` there. From your
+machine, dial the public HTTPS host on port 443 — not a raw `host:50051`
+socket. `get_host` is the hostname; `get_grpc_target` is the address a gRPC
+client should use:
+
+```python
+from e2b_desktop import Sandbox
+import grpc
+
+desktop = Sandbox.create()
+desktop.commands.run("python grpc_server.py", background=True)
+
+target = desktop.get_grpc_target(50051)
+channel = grpc.secure_channel(target, grpc.ssl_channel_credentials())
+```
+
+In debug mode the target is `localhost:{port}` and you should use an insecure
+channel.
+
 ## Under the hood
 
 The desktop-like environment is based on Linux and [Xfce](https://www.xfce.org/) at the moment. We chose Xfce because it's a fast and lightweight environment that's also popular and actively supported. However, this Sandbox template is fully customizable and you can create your own desktop environment.

--- a/packages/desktop-python/pyproject.toml
+++ b/packages/desktop-python/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "e2b>=2.44.0,<3.0.0",
+    "e2b>=2.50.0,<3.0.0",
     "requests>=2.32.3,<3",
     "pillow>=12.0.0,<13",
 ]

--- a/packages/js-sdk/src/sandbox/index.ts
+++ b/packages/js-sdk/src/sandbox/index.ts
@@ -513,7 +513,11 @@ export class Sandbox extends SandboxApi {
 
   /**
    * Get the host address for the specified sandbox port.
-   * You can then use this address to connect to the sandbox port from outside the sandbox via HTTP or WebSocket.
+   * You can then use this address to connect to the sandbox port from outside the sandbox via HTTP, WebSocket, or gRPC.
+   *
+   * HTTP and WebSocket clients should use `https://${host}` (or `http://` in debug mode).
+   * gRPC clients should dial {@link Sandbox.getGrpcTarget} instead: the public hostname
+   * is served on TLS port 443, not as a raw TCP mapping of `port`.
    *
    * @param port number of the port in the sandbox.
    *
@@ -534,6 +538,34 @@ export class Sandbox extends SandboxApi {
       port,
       this.sandboxDomain
     )
+  }
+
+  /**
+   * Address a gRPC client should dial to reach a server listening on `port` inside the sandbox.
+   *
+   * The public sandbox URL is HTTPS on port 443 with Host-based routing, not a raw
+   * `host:port` TCP mapping. Use a TLS channel against this target (plaintext only
+   * in debug mode, where it is `localhost:{port}`).
+   *
+   * @param port number of the port the gRPC server listens on in the sandbox.
+   *
+   * @returns `host:port` suitable for a gRPC client target.
+   *
+   * @example
+   * ```ts
+   * const sandbox = await Sandbox.create()
+   * await sandbox.commands.run('python grpc_server.py', { background: true })
+   * const target = sandbox.getGrpcTarget(50051)
+   * // grpc.credentials.createSsl() against target
+   * ```
+   */
+  getGrpcTarget(port: number) {
+    const host = this.getHost(port)
+    if (this.connectionConfig.debug) {
+      return host
+    }
+
+    return `${host}:443`
   }
 
   /**

--- a/packages/js-sdk/tests/sandbox/urls.test.ts
+++ b/packages/js-sdk/tests/sandbox/urls.test.ts
@@ -21,6 +21,8 @@ describe('sandbox file URLs', () => {
 
     assert.equal(sandbox['envdApiUrl'], 'https://sandbox.e2b.app')
     assert.equal(sandbox['envdDirectUrl'], 'https://49983-sandbox-id.e2b.app')
+    assert.equal(sandbox.getHost(50051), '50051-sandbox-id.e2b.app')
+    assert.equal(sandbox.getGrpcTarget(50051), '50051-sandbox-id.e2b.app:443')
     assert.equal(
       await sandbox.downloadUrl('/tmp/a.txt'),
       'https://49983-sandbox-id.e2b.app/files?path=%2Ftmp%2Fa.txt'
@@ -29,6 +31,20 @@ describe('sandbox file URLs', () => {
       await sandbox.uploadUrl('/tmp/a.txt'),
       'https://49983-sandbox-id.e2b.app/files?path=%2Ftmp%2Fa.txt'
     )
+  })
+
+  test('getGrpcTarget is localhost:port in debug mode', () => {
+    const sandbox = new Sandbox({
+      sandboxId: 'sandbox-id',
+      sandboxDomain: 'e2b.app',
+      envdVersion: '0.4.0',
+      apiKey: TEST_API_KEY,
+      domain: 'e2b.app',
+      debug: true,
+    })
+
+    assert.equal(sandbox.getHost(50051), 'localhost:50051')
+    assert.equal(sandbox.getGrpcTarget(50051), 'localhost:50051')
   })
 
   test('throws when signature expiration is used on unsecured sandbox', async () => {

--- a/packages/python-sdk/e2b/connection_config.py
+++ b/packages/python-sdk/e2b/connection_config.py
@@ -308,7 +308,10 @@ class ConnectionConfig:
     def get_host(self, sandbox_id: str, sandbox_domain: str, port: int) -> str:
         """
         Get the host address to connect to the sandbox.
-        You can then use this address to connect to the sandbox port from outside the sandbox via HTTP or WebSocket.
+        You can then use this address to connect to the sandbox port from outside the sandbox via HTTP, WebSocket, or gRPC.
+
+        HTTP and WebSocket clients should use ``https://{host}``. gRPC clients
+        should dial ``{host}:443`` with TLS (see ``Sandbox.get_grpc_target``).
 
         :param port: Port to connect to
         :param sandbox_domain: Domain to connect to

--- a/packages/python-sdk/e2b/sandbox/main.py
+++ b/packages/python-sdk/e2b/sandbox/main.py
@@ -213,7 +213,13 @@ class SandboxBase(ClientFactory):
     def get_host(self, port: int) -> str:
         """
         Get the host address to connect to the sandbox.
-        You can then use this address to connect to the sandbox port from outside the sandbox via HTTP or WebSocket.
+        You can then use this address to connect to the sandbox port from outside
+        the sandbox via HTTP, WebSocket, or gRPC.
+
+        HTTP and WebSocket clients should use ``https://{host}`` (or ``http://``
+        in debug mode). gRPC clients should dial :meth:`get_grpc_target` instead:
+        the public hostname is served on TLS port 443, not as a raw TCP mapping
+        of *port*.
 
         :param port: Port to connect to
 
@@ -222,6 +228,25 @@ class SandboxBase(ClientFactory):
         return self.connection_config.get_host(
             self.sandbox_id, self.sandbox_domain, port
         )
+
+    def get_grpc_target(self, port: int) -> str:
+        """
+        Address a gRPC client should dial to reach a server listening on *port*
+        inside the sandbox.
+
+        The public sandbox URL is HTTPS on port 443 with Host-based routing, not
+        a raw ``host:port`` TCP mapping. Use a TLS channel against this target
+        (plaintext only in debug mode, where it is ``localhost:{port}``).
+
+        :param port: Port the gRPC server listens on inside the sandbox
+        :return: ``host:port`` suitable for ``grpc.secure_channel`` /
+            ``grpc.insecure_channel``
+        """
+        host = self.get_host(port)
+        if self.connection_config.debug:
+            return host
+
+        return f"{host}:443"
 
     def get_mcp_url(self) -> str:
         """

--- a/packages/python-sdk/tests/test_grpc_target.py
+++ b/packages/python-sdk/tests/test_grpc_target.py
@@ -1,0 +1,22 @@
+from packaging.version import Version
+
+from e2b.connection_config import ConnectionConfig
+from e2b.sandbox.main import SandboxBase
+
+
+def _sandbox(debug: bool) -> SandboxBase:
+    return SandboxBase(
+        sandbox_id="abc123",
+        envd_version=Version("0.1.0"),
+        envd_access_token=None,
+        sandbox_domain="e2b.app",
+        connection_config=ConnectionConfig(domain="e2b.app", debug=debug),
+    )
+
+
+def test_get_grpc_target_uses_tls_port_443():
+    assert _sandbox(debug=False).get_grpc_target(50051) == "50051-abc123.e2b.app:443"
+
+
+def test_get_grpc_target_debug_is_localhost():
+    assert _sandbox(debug=True).get_grpc_target(50051) == "localhost:50051"


### PR DESCRIPTION
## Summary
- Add `Sandbox.getGrpcTarget(port)` / `get_grpc_target(port)` → `{get_host(port)}:443` (debug: `localhost:{port}`). `get_host` stays the hostname; gRPC clients must dial **:443** with TLS.
- Desktop Python floor is `e2b>=2.50.0` because 2.48.0 and 2.49.0 already shipped without the helper. JS Desktop is `workspace:^`. Changeset: core **minor**, Desktop **patch**.
- Docs show `grpc.secure_channel(target, grpc.ssl_channel_credentials())`. This needs the matching infra proxy deploy; the helper alone does not make public gRPC work.

Related to e2b-dev/desktop#114 (runtime fix is e2b-dev/infra; this is the client API).

## Test plan
- [ ] `uv run pytest tests/test_grpc_target.py --noconftest` in `packages/python-sdk`
- [ ] JS `tests/sandbox/urls.test.ts` (`getGrpcTarget` → `:443` / debug localhost)