### PR TITLE
fix(deps): bump smol-toml override to 1.7.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ overrides:
   '@babel/core@<7.29.6': ^7.29.6
   picomatch@<2.3.2: ^2.3.2
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
-  smol-toml@<1.6.1: ^1.6.1
+  smol-toml@<1.7.1: ^1.7.1
   minimatch@<3.1.3: ^3.1.3
   minimatch@>=5.0.0 <5.1.8: ^5.1.8
   minimatch@>=9.0.0 <9.0.7: ^9.0.7
@@ -3742,8 +3742,8 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  smol-toml@1.6.1:
-    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
@@ -6835,7 +6835,7 @@ snapshots:
       picocolors: 1.1.1
       picomatch: 4.0.4
       pretty-ms: 9.1.0
-      smol-toml: 1.6.1
+      smol-toml: 1.8.0
       strip-json-comments: 5.0.1
       summary: 2.1.0
       typescript: '@typescript/typescript6@6.0.2'
@@ -7515,7 +7515,7 @@ snapshots:
 
   slash@3.0.0: {}
 
-  smol-toml@1.6.1: {}
+  smol-toml@1.8.0: {}
 
   source-map-js@1.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,7 +26,7 @@ overrides:
   '@babel/core@<7.29.6': ^7.29.6
   picomatch@<2.3.2: ^2.3.2
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
-  smol-toml@<1.6.1: ^1.6.1
+  smol-toml@<1.7.1: ^1.7.1
   minimatch@<3.1.3: ^3.1.3
   minimatch@>=5.0.0 <5.1.8: ^5.1.8
   minimatch@>=9.0.0 <9.0.7: ^9.0.7


### PR DESCRIPTION
Resolves Dependabot alert #382 (CVE-2026-85730, high).

`smol-toml` is a transitive dev dependency of `knip@5.43.6`. This PR moves the existing pnpm override from `<1.6.1 -> ^1.6.1` to `<1.7.1 -> ^1.7.1`. The lockfile now resolves `smol-toml@1.8.0`.

Only `pnpm-workspace.yaml` and `pnpm-lock.yaml` change.